### PR TITLE
test: Don't check for mysqli spans in WordPress tests

### DIFF
--- a/tests/Integrations/WordPress/V4_8/CommonScenariosCallbacksTest.php
+++ b/tests/Integrations/WordPress/V4_8/CommonScenariosCallbacksTest.php
@@ -7,7 +7,8 @@ class CommonScenariosCallbacksTest extends CommonScenariosTest
     protected static function getEnvs()
     {
         return array_merge(parent::getEnvs(), [
-            'DD_TRACE_WORDPRESS_CALLBACKS' => '1'
+            'DD_TRACE_WORDPRESS_CALLBACKS' => '1',
+            'DD_TRACE_MYSQLI_ENABLED' => '0'
         ]);
     }
 }

--- a/tests/Integrations/WordPress/V4_8/CommonScenariosLegacyTest.php
+++ b/tests/Integrations/WordPress/V4_8/CommonScenariosLegacyTest.php
@@ -7,7 +7,8 @@ class CommonScenariosLegacyTest extends CommonScenariosTest
     protected static function getEnvs()
     {
         return array_merge(parent::getEnvs(), [
-            'DD_TRACE_WORDPRESS_ENHANCED_INTEGRATION' => '0'
+            'DD_TRACE_WORDPRESS_ENHANCED_INTEGRATION' => '0',
+            'DD_TRACE_MYSQLI_ENABLED' => '0'
         ]);
     }
 }

--- a/tests/Integrations/WordPress/V4_8/CommonScenariosTest.php
+++ b/tests/Integrations/WordPress/V4_8/CommonScenariosTest.php
@@ -26,7 +26,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
     {
         return array_merge(parent::getEnvs(), [
             'DD_SERVICE' => 'wordpress_test_app',
-            'DD_TRACE_WORDPRESS_ENHANCED_INTEGRATION' => '1'
+            'DD_TRACE_WORDPRESS_ENHANCED_INTEGRATION' => '1',
+            'DD_TRACE_MYSQLI_ENABLED' => '0'
         ]);
     }
 

--- a/tests/Integrations/WordPress/V5_5/CommonScenariosCallbacksTest.php
+++ b/tests/Integrations/WordPress/V5_5/CommonScenariosCallbacksTest.php
@@ -7,7 +7,8 @@ final class CommonScenariosCallbacksTest extends CommonScenariosTest
     protected static function getEnvs()
     {
         return array_merge(parent::getEnvs(), [
-            'DD_TRACE_WORDPRESS_CALLBACKS' => '1'
+            'DD_TRACE_WORDPRESS_CALLBACKS' => '1',
+            'DD_TRACE_MYSQLI_ENABLED' => '0'
         ]);
     }
 }

--- a/tests/Integrations/WordPress/V5_5/CommonScenariosLegacyTest.php
+++ b/tests/Integrations/WordPress/V5_5/CommonScenariosLegacyTest.php
@@ -9,7 +9,8 @@ class CommonScenariosLegacyTest extends CommonScenariosTest
     protected static function getEnvs()
     {
         return array_merge(parent::getEnvs(), [
-            'DD_TRACE_WORDPRESS_ENHANCED_INTEGRATION' => '0'
+            'DD_TRACE_WORDPRESS_ENHANCED_INTEGRATION' => '0',
+            'DD_TRACE_MYSQLI_ENABLED' => '0'
         ]);
     }
 }

--- a/tests/Integrations/WordPress/V5_5/CommonScenariosTest.php
+++ b/tests/Integrations/WordPress/V5_5/CommonScenariosTest.php
@@ -27,7 +27,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
     {
         return array_merge(parent::getEnvs(), [
             'DD_SERVICE' => 'wordpress_55_test_app',
-            'DD_TRACE_WORDPRESS_ENHANCED_INTEGRATION' => '1'
+            'DD_TRACE_WORDPRESS_ENHANCED_INTEGRATION' => '1',
+            'DD_TRACE_MYSQLI_ENABLED' => '0'
         ]);
     }
 

--- a/tests/Integrations/WordPress/V5_9/CommonScenariosCallbacksTest.php
+++ b/tests/Integrations/WordPress/V5_9/CommonScenariosCallbacksTest.php
@@ -7,7 +7,8 @@ final class CommonScenariosCallbacksTest extends CommonScenariosTest
     protected static function getEnvs()
     {
         return array_merge(parent::getEnvs(), [
-            'DD_TRACE_WORDPRESS_CALLBACKS' => '1'
+            'DD_TRACE_WORDPRESS_CALLBACKS' => '1',
+            'DD_TRACE_MYSQLI_ENABLED' => '0'
         ]);
     }
 }

--- a/tests/Integrations/WordPress/V5_9/CommonScenariosLegacyTest.php
+++ b/tests/Integrations/WordPress/V5_9/CommonScenariosLegacyTest.php
@@ -9,7 +9,8 @@ class CommonScenariosLegacyTest extends CommonScenariosTest
     protected static function getEnvs()
     {
         return array_merge(parent::getEnvs(), [
-            'DD_TRACE_WORDPRESS_ENHANCED_INTEGRATION' => '0'
+            'DD_TRACE_WORDPRESS_ENHANCED_INTEGRATION' => '0',
+            'DD_TRACE_MYSQLI_ENABLED' => '0'
         ]);
     }
 }

--- a/tests/Integrations/WordPress/V5_9/CommonScenariosTest.php
+++ b/tests/Integrations/WordPress/V5_9/CommonScenariosTest.php
@@ -27,7 +27,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
     {
         return array_merge(parent::getEnvs(), [
             'DD_SERVICE' => 'wordpress_59_test_app',
-            'DD_TRACE_WORDPRESS_ENHANCED_INTEGRATION' => '1'
+            'DD_TRACE_WORDPRESS_ENHANCED_INTEGRATION' => '1',
+            'DD_TRACE_MYSQLI_ENABLED' => '0'
         ]);
     }
 

--- a/tests/Integrations/WordPress/V6_1/CommonScenariosCallbacksTest.php
+++ b/tests/Integrations/WordPress/V6_1/CommonScenariosCallbacksTest.php
@@ -9,6 +9,7 @@ class CommonScenariosCallbacksTest extends CommonScenariosTest
         return array_merge(parent::getEnvs(), [
             'DD_SERVICE' => 'wordpress_61_test_app',
             'DD_TRACE_WORDPRESS_CALLBACKS' => '1',
+            'DD_TRACE_MYSQLI_ENABLED' => '0'
         ]);
     }
 }

--- a/tests/Integrations/WordPress/V6_1/CommonScenariosTest.php
+++ b/tests/Integrations/WordPress/V6_1/CommonScenariosTest.php
@@ -23,7 +23,8 @@ class CommonScenariosTest extends WebFrameworkTestCase
     {
         return array_merge(parent::getEnvs(), [
             'DD_SERVICE' => 'wordpress_61_test_app',
-            'DD_TRACE_WORDPRESS_ENHANCED_INTEGRATION' => '1'
+            'DD_TRACE_WORDPRESS_ENHANCED_INTEGRATION' => '1',
+            'DD_TRACE_MYSQLI_ENABLED' => '0'
         ]);
     }
 

--- a/tests/snapshots/tests.integrations.word_press.v4_8.common_scenarios_callbacks_test.test_scenario_get_return_string.json
+++ b/tests/snapshots/tests.integrations.word_press.v4_8.common_scenarios_callbacks_test.test_scenario_get_return_string.json
@@ -5,16 +5,17 @@
     "resource": "GET /simple",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 2587331881374610944,
+    "parent_id": 4770998710470923641,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e7017c00000000",
       "component": "wordpress",
       "http.method": "GET",
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/simple?key=value&<redacted>",
-      "runtime-id": "ca4d22f2-9347-458f-be03-e9defbc1af52",
+      "runtime-id": "b4ee1995-4afb-4457-9e9d-b361460bfa16",
       "span.kind": "server"
     },
     "metrics": {
@@ -22,108 +23,11 @@
     }
   },
      {
-       "name": "mysqli_real_connect",
-       "service": "mysqli",
-       "resource": "mysqli_real_connect",
-       "trace_id": 0,
-       "span_id": 2,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-       "trace_id": 0,
-       "span_id": 3,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT @@SESSION.sql_mode",
-       "trace_id": 0,
-       "span_id": 4,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 1.0
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-       "trace_id": 0,
-       "span_id": 5,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_name, option_value FROM wp_options WHERE autoload = 'yes'",
-       "trace_id": 0,
-       "span_id": 6,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 108.0
-       }
-     },
-     {
        "name": "create_initial_taxonomies",
        "service": "wordpress_test_app",
        "resource": "create_initial_taxonomies",
        "trace_id": 0,
-       "span_id": 7,
+       "span_id": 2,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -137,7 +41,7 @@
        "service": "wordpress_test_app",
        "resource": "create_initial_post_types",
        "trace_id": 0,
-       "span_id": 8,
+       "span_id": 3,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -151,7 +55,7 @@
        "service": "wordpress_test_app",
        "resource": "datadog (plugin)",
        "trace_id": 0,
-       "span_id": 9,
+       "span_id": 4,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -164,7 +68,7 @@
        "service": "wordpress_test_app",
        "resource": "plugins_loaded (hook)",
        "trace_id": 0,
-       "span_id": 10,
+       "span_id": 5,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -177,8 +81,8 @@
           "service": "wordpress_test_app",
           "resource": "wp_maybe_load_widgets",
           "trace_id": 0,
-          "span_id": 19,
-          "parent_id": 10,
+          "span_id": 13,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -191,8 +95,8 @@
           "service": "wordpress_test_app",
           "resource": "wp_maybe_load_embeds",
           "trace_id": 0,
-          "span_id": 20,
-          "parent_id": 10,
+          "span_id": 14,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -205,8 +109,8 @@
           "service": "wordpress_test_app",
           "resource": "_wp_customize_include",
           "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 10,
+          "span_id": 15,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -219,7 +123,7 @@
        "service": "wordpress_test_app",
        "resource": "setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 11,
+       "span_id": 6,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -228,33 +132,11 @@
        }
      },
      {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_value FROM wp_options WHERE option_name = 'WPLANG' LIMIT 1",
-       "trace_id": 0,
-       "span_id": 12,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 0.0
-       }
-     },
-     {
        "name": "action",
        "service": "wordpress_test_app",
        "resource": "after_setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 13,
+       "span_id": 7,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -267,8 +149,8 @@
           "service": "wordpress_test_app",
           "resource": "twentyseventeen_setup (callback)",
           "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 13,
+          "span_id": 16,
+          "parent_id": 7,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -281,8 +163,8 @@
           "service": "wordpress_test_app",
           "resource": "twentyseventeen_custom_header_setup (callback)",
           "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 13,
+          "span_id": 17,
+          "parent_id": 7,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -295,7 +177,7 @@
        "service": "wordpress_test_app",
        "resource": "WP.init",
        "trace_id": 0,
-       "span_id": 14,
+       "span_id": 8,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -307,8 +189,8 @@
           "service": "wordpress_test_app",
           "resource": "kses_init (callback)",
           "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 14,
+          "span_id": 18,
+          "parent_id": 8,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -321,7 +203,7 @@
        "service": "wordpress_test_app",
        "resource": "init (hook)",
        "trace_id": 0,
-       "span_id": 15,
+       "span_id": 9,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -334,8 +216,8 @@
           "service": "wordpress_test_app",
           "resource": "create_initial_post_types",
           "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 15,
+          "span_id": 19,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -346,8 +228,8 @@
           "service": "wordpress_test_app",
           "resource": "create_initial_taxonomies",
           "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 15,
+          "span_id": 20,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -358,8 +240,8 @@
           "service": "wordpress_test_app",
           "resource": "wp_widgets_init",
           "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 15,
+          "span_id": 21,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -372,8 +254,8 @@
              "service": "wordpress_test_app",
              "resource": "WP_Widget_Factory._register_widgets",
              "trace_id": 0,
-             "span_id": 38,
-             "parent_id": 27,
+             "span_id": 32,
+             "parent_id": 21,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -384,8 +266,8 @@
           "service": "wordpress_test_app",
           "resource": "smilies_init (callback)",
           "trace_id": 0,
-          "span_id": 28,
-          "parent_id": 15,
+          "span_id": 22,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -398,8 +280,8 @@
           "service": "wordpress_test_app",
           "resource": "wp_cron (callback)",
           "trace_id": 0,
-          "span_id": 29,
-          "parent_id": 15,
+          "span_id": 23,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -412,8 +294,8 @@
           "service": "wordpress_test_app",
           "resource": "_show_post_preview (callback)",
           "trace_id": 0,
-          "span_id": 30,
-          "parent_id": 15,
+          "span_id": 24,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -426,8 +308,8 @@
           "service": "wordpress_test_app",
           "resource": "rest_api_init (callback)",
           "trace_id": 0,
-          "span_id": 31,
-          "parent_id": 15,
+          "span_id": 25,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -440,8 +322,8 @@
           "service": "wordpress_test_app",
           "resource": "wp_schedule_update_checks (callback)",
           "trace_id": 0,
-          "span_id": 32,
-          "parent_id": 15,
+          "span_id": 26,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -454,8 +336,8 @@
           "service": "wordpress_test_app",
           "resource": "check_theme_switched (callback)",
           "trace_id": 0,
-          "span_id": 33,
-          "parent_id": 15,
+          "span_id": 27,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -463,34 +345,12 @@
             "wordpress.hook": "init"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp_options WHERE option_name = 'theme_switched' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 39,
-             "parent_id": 33,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_test_app",
        "resource": "wp_loaded (hook)",
        "trace_id": 0,
-       "span_id": 16,
+       "span_id": 10,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -503,8 +363,8 @@
           "service": "wordpress_test_app",
           "resource": "_custom_header_background_just_in_time (callback)",
           "trace_id": 0,
-          "span_id": 34,
-          "parent_id": 16,
+          "span_id": 28,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -517,7 +377,7 @@
        "service": "wordpress_test_app",
        "resource": "WP.main",
        "trace_id": 0,
-       "span_id": 17,
+       "span_id": 11,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -529,8 +389,8 @@
           "service": "wordpress_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 35,
-          "parent_id": 17,
+          "span_id": 29,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -541,41 +401,19 @@
           "service": "wordpress_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 36,
-          "parent_id": 17,
+          "span_id": 30,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp_posts\n\t\tWHERE post_name IN ('simple')\n\t\tAND post_type IN ('page','attachment')\n\t",
-             "trace_id": 0,
-             "span_id": 40,
-             "parent_id": 36,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_test_app",
        "resource": "shutdown (hook)",
        "trace_id": 0,
-       "span_id": 18,
+       "span_id": 12,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -588,8 +426,8 @@
           "service": "wordpress_test_app",
           "resource": "wp_ob_end_flush_all (callback)",
           "trace_id": 0,
-          "span_id": 37,
-          "parent_id": 18,
+          "span_id": 31,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress",

--- a/tests/snapshots/tests.integrations.word_press.v4_8.common_scenarios_callbacks_test.test_scenario_get_with_exception.json
+++ b/tests/snapshots/tests.integrations.word_press.v4_8.common_scenarios_callbacks_test.test_scenario_get_with_exception.json
@@ -5,11 +5,12 @@
     "resource": "GET /error",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 18022806032057549178,
+    "parent_id": 3478127716332401474,
     "type": "web",
     "error": 1,
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e7019100000000",
       "component": "wordpress",
       "error.message": "Uncaught Exception: Oops! in /home/circleci/datadog/tests/Frameworks/WordPress/Version_4_8/wp-content/plugins/datadog/datadog.php:23",
       "error.stack": "#0 /home/circleci/datadog/tests/Frameworks/WordPress/Version_4_8/wp-includes/class-wp-hook.php(298): datadog_parse_request()\n#1 /home/circleci/datadog/tests/Frameworks/WordPress/Version_4_8/wp-includes/class-wp-hook.php(323): WP_Hook->apply_filters()\n#2 /home/circleci/datadog/tests/Frameworks/WordPress/Version_4_8/wp-includes/plugin.php(515): WP_Hook->do_action()\n#3 /home/circleci/datadog/tests/Frameworks/WordPress/Version_4_8/wp-includes/class-wp.php(388): do_action_ref_array()\n#4 /home/circleci/datadog/tests/Frameworks/WordPress/Version_4_8/wp-includes/class-wp.php(735): WP->parse_request()\n#5 /home/circleci/datadog/tests/Frameworks/WordPress/Version_4_8/wp-includes/functions.php(955): WP->main()\n#6 /home/circleci/datadog/tests/Frameworks/WordPress/Version_4_8/wp-blog-header.php(16): wp()\n#7 /home/circleci/datadog/tests/Frameworks/WordPress/Version_4_8/index.php(17): require()\n#8 {main}",
@@ -18,7 +19,7 @@
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/error?key=value&<redacted>",
-      "runtime-id": "2ee1d558-5813-4a2b-a74e-1404119c4473",
+      "runtime-id": "b4ee1995-4afb-4457-9e9d-b361460bfa16",
       "span.kind": "server"
     },
     "metrics": {
@@ -26,108 +27,11 @@
     }
   },
      {
-       "name": "mysqli_real_connect",
-       "service": "mysqli",
-       "resource": "mysqli_real_connect",
-       "trace_id": 0,
-       "span_id": 2,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-       "trace_id": 0,
-       "span_id": 3,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT @@SESSION.sql_mode",
-       "trace_id": 0,
-       "span_id": 4,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 1.0
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-       "trace_id": 0,
-       "span_id": 5,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_name, option_value FROM wp_options WHERE autoload = 'yes'",
-       "trace_id": 0,
-       "span_id": 6,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 108.0
-       }
-     },
-     {
        "name": "create_initial_taxonomies",
        "service": "wordpress_test_app",
        "resource": "create_initial_taxonomies",
        "trace_id": 0,
-       "span_id": 7,
+       "span_id": 2,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -141,7 +45,7 @@
        "service": "wordpress_test_app",
        "resource": "create_initial_post_types",
        "trace_id": 0,
-       "span_id": 8,
+       "span_id": 3,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -155,7 +59,7 @@
        "service": "wordpress_test_app",
        "resource": "datadog (plugin)",
        "trace_id": 0,
-       "span_id": 9,
+       "span_id": 4,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -168,7 +72,7 @@
        "service": "wordpress_test_app",
        "resource": "plugins_loaded (hook)",
        "trace_id": 0,
-       "span_id": 10,
+       "span_id": 5,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -181,8 +85,8 @@
           "service": "wordpress_test_app",
           "resource": "wp_maybe_load_widgets",
           "trace_id": 0,
-          "span_id": 19,
-          "parent_id": 10,
+          "span_id": 13,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -195,8 +99,8 @@
           "service": "wordpress_test_app",
           "resource": "wp_maybe_load_embeds",
           "trace_id": 0,
-          "span_id": 20,
-          "parent_id": 10,
+          "span_id": 14,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -209,8 +113,8 @@
           "service": "wordpress_test_app",
           "resource": "_wp_customize_include",
           "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 10,
+          "span_id": 15,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -223,7 +127,7 @@
        "service": "wordpress_test_app",
        "resource": "setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 11,
+       "span_id": 6,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -232,33 +136,11 @@
        }
      },
      {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_value FROM wp_options WHERE option_name = 'WPLANG' LIMIT 1",
-       "trace_id": 0,
-       "span_id": 12,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 0.0
-       }
-     },
-     {
        "name": "action",
        "service": "wordpress_test_app",
        "resource": "after_setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 13,
+       "span_id": 7,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -271,8 +153,8 @@
           "service": "wordpress_test_app",
           "resource": "twentyseventeen_setup (callback)",
           "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 13,
+          "span_id": 16,
+          "parent_id": 7,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -285,8 +167,8 @@
           "service": "wordpress_test_app",
           "resource": "twentyseventeen_custom_header_setup (callback)",
           "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 13,
+          "span_id": 17,
+          "parent_id": 7,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -299,7 +181,7 @@
        "service": "wordpress_test_app",
        "resource": "WP.init",
        "trace_id": 0,
-       "span_id": 14,
+       "span_id": 8,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -311,8 +193,8 @@
           "service": "wordpress_test_app",
           "resource": "kses_init (callback)",
           "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 14,
+          "span_id": 18,
+          "parent_id": 8,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -325,7 +207,7 @@
        "service": "wordpress_test_app",
        "resource": "init (hook)",
        "trace_id": 0,
-       "span_id": 15,
+       "span_id": 9,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -338,8 +220,8 @@
           "service": "wordpress_test_app",
           "resource": "create_initial_post_types",
           "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 15,
+          "span_id": 19,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -350,8 +232,8 @@
           "service": "wordpress_test_app",
           "resource": "create_initial_taxonomies",
           "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 15,
+          "span_id": 20,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -362,8 +244,8 @@
           "service": "wordpress_test_app",
           "resource": "wp_widgets_init",
           "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 15,
+          "span_id": 21,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -376,8 +258,8 @@
              "service": "wordpress_test_app",
              "resource": "WP_Widget_Factory._register_widgets",
              "trace_id": 0,
-             "span_id": 38,
-             "parent_id": 27,
+             "span_id": 32,
+             "parent_id": 21,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -388,8 +270,8 @@
           "service": "wordpress_test_app",
           "resource": "smilies_init (callback)",
           "trace_id": 0,
-          "span_id": 28,
-          "parent_id": 15,
+          "span_id": 22,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -402,8 +284,8 @@
           "service": "wordpress_test_app",
           "resource": "wp_cron (callback)",
           "trace_id": 0,
-          "span_id": 29,
-          "parent_id": 15,
+          "span_id": 23,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -416,8 +298,8 @@
           "service": "wordpress_test_app",
           "resource": "_show_post_preview (callback)",
           "trace_id": 0,
-          "span_id": 30,
-          "parent_id": 15,
+          "span_id": 24,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -430,8 +312,8 @@
           "service": "wordpress_test_app",
           "resource": "rest_api_init (callback)",
           "trace_id": 0,
-          "span_id": 31,
-          "parent_id": 15,
+          "span_id": 25,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -444,8 +326,8 @@
           "service": "wordpress_test_app",
           "resource": "wp_schedule_update_checks (callback)",
           "trace_id": 0,
-          "span_id": 32,
-          "parent_id": 15,
+          "span_id": 26,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -458,8 +340,8 @@
           "service": "wordpress_test_app",
           "resource": "check_theme_switched (callback)",
           "trace_id": 0,
-          "span_id": 33,
-          "parent_id": 15,
+          "span_id": 27,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -467,34 +349,12 @@
             "wordpress.hook": "init"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp_options WHERE option_name = 'theme_switched' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 39,
-             "parent_id": 33,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_test_app",
        "resource": "wp_loaded (hook)",
        "trace_id": 0,
-       "span_id": 16,
+       "span_id": 10,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -507,8 +367,8 @@
           "service": "wordpress_test_app",
           "resource": "_custom_header_background_just_in_time (callback)",
           "trace_id": 0,
-          "span_id": 34,
-          "parent_id": 16,
+          "span_id": 28,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -521,7 +381,7 @@
        "service": "wordpress_test_app",
        "resource": "WP.main",
        "trace_id": 0,
-       "span_id": 17,
+       "span_id": 11,
        "parent_id": 1,
        "type": "web",
        "error": 1,
@@ -537,8 +397,8 @@
           "service": "wordpress_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 35,
-          "parent_id": 17,
+          "span_id": 29,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -549,8 +409,8 @@
           "service": "wordpress_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 36,
-          "parent_id": 17,
+          "span_id": 30,
+          "parent_id": 11,
           "type": "web",
           "error": 1,
           "meta": {
@@ -560,34 +420,12 @@
             "error.type": "Exception"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp_posts\n\t\tWHERE post_name IN ('error')\n\t\tAND post_type IN ('page','attachment')\n\t",
-             "trace_id": 0,
-             "span_id": 40,
-             "parent_id": 36,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_test_app",
        "resource": "shutdown (hook)",
        "trace_id": 0,
-       "span_id": 18,
+       "span_id": 12,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -600,8 +438,8 @@
           "service": "wordpress_test_app",
           "resource": "wp_ob_end_flush_all (callback)",
           "trace_id": 0,
-          "span_id": 37,
-          "parent_id": 18,
+          "span_id": 31,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress",

--- a/tests/snapshots/tests.integrations.word_press.v4_8.common_scenarios_callbacks_test.test_scenario_get_with_view.json
+++ b/tests/snapshots/tests.integrations.word_press.v4_8.common_scenarios_callbacks_test.test_scenario_get_with_view.json
@@ -5,16 +5,17 @@
     "resource": "GET /simple_view",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 1480301274519110725,
+    "parent_id": 6586295672945863082,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e7018c00000000",
       "component": "wordpress",
       "http.method": "GET",
       "http.route": "(.?.+?)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/simple_view?key=value&<redacted>",
-      "runtime-id": "6732cc6a-78ad-4ca4-b1ea-5eb516ff75f0",
+      "runtime-id": "b4ee1995-4afb-4457-9e9d-b361460bfa16",
       "span.kind": "server"
     },
     "metrics": {
@@ -22,108 +23,11 @@
     }
   },
      {
-       "name": "mysqli_real_connect",
-       "service": "mysqli",
-       "resource": "mysqli_real_connect",
-       "trace_id": 0,
-       "span_id": 2,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-       "trace_id": 0,
-       "span_id": 3,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT @@SESSION.sql_mode",
-       "trace_id": 0,
-       "span_id": 4,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 1.0
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-       "trace_id": 0,
-       "span_id": 5,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_name, option_value FROM wp_options WHERE autoload = 'yes'",
-       "trace_id": 0,
-       "span_id": 6,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 108.0
-       }
-     },
-     {
        "name": "create_initial_taxonomies",
        "service": "wordpress_test_app",
        "resource": "create_initial_taxonomies",
        "trace_id": 0,
-       "span_id": 7,
+       "span_id": 2,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -137,7 +41,7 @@
        "service": "wordpress_test_app",
        "resource": "create_initial_post_types",
        "trace_id": 0,
-       "span_id": 8,
+       "span_id": 3,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -151,7 +55,7 @@
        "service": "wordpress_test_app",
        "resource": "datadog (plugin)",
        "trace_id": 0,
-       "span_id": 9,
+       "span_id": 4,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -164,7 +68,7 @@
        "service": "wordpress_test_app",
        "resource": "plugins_loaded (hook)",
        "trace_id": 0,
-       "span_id": 10,
+       "span_id": 5,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -177,8 +81,8 @@
           "service": "wordpress_test_app",
           "resource": "wp_maybe_load_widgets",
           "trace_id": 0,
-          "span_id": 20,
-          "parent_id": 10,
+          "span_id": 14,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -191,8 +95,8 @@
           "service": "wordpress_test_app",
           "resource": "wp_maybe_load_embeds",
           "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 10,
+          "span_id": 15,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -205,8 +109,8 @@
           "service": "wordpress_test_app",
           "resource": "_wp_customize_include",
           "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 10,
+          "span_id": 16,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -219,7 +123,7 @@
        "service": "wordpress_test_app",
        "resource": "setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 11,
+       "span_id": 6,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -228,33 +132,11 @@
        }
      },
      {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_value FROM wp_options WHERE option_name = 'WPLANG' LIMIT 1",
-       "trace_id": 0,
-       "span_id": 12,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 0.0
-       }
-     },
-     {
        "name": "action",
        "service": "wordpress_test_app",
        "resource": "after_setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 13,
+       "span_id": 7,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -267,8 +149,8 @@
           "service": "wordpress_test_app",
           "resource": "twentyseventeen_setup (callback)",
           "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 13,
+          "span_id": 17,
+          "parent_id": 7,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -281,8 +163,8 @@
           "service": "wordpress_test_app",
           "resource": "twentyseventeen_custom_header_setup (callback)",
           "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 13,
+          "span_id": 18,
+          "parent_id": 7,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -295,7 +177,7 @@
        "service": "wordpress_test_app",
        "resource": "WP.init",
        "trace_id": 0,
-       "span_id": 14,
+       "span_id": 8,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -307,8 +189,8 @@
           "service": "wordpress_test_app",
           "resource": "kses_init (callback)",
           "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 14,
+          "span_id": 19,
+          "parent_id": 8,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -321,7 +203,7 @@
        "service": "wordpress_test_app",
        "resource": "init (hook)",
        "trace_id": 0,
-       "span_id": 15,
+       "span_id": 9,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -334,8 +216,8 @@
           "service": "wordpress_test_app",
           "resource": "create_initial_post_types",
           "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 15,
+          "span_id": 20,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -346,8 +228,8 @@
           "service": "wordpress_test_app",
           "resource": "create_initial_taxonomies",
           "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 15,
+          "span_id": 21,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -358,8 +240,8 @@
           "service": "wordpress_test_app",
           "resource": "wp_widgets_init",
           "trace_id": 0,
-          "span_id": 28,
-          "parent_id": 15,
+          "span_id": 22,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -372,8 +254,8 @@
              "service": "wordpress_test_app",
              "resource": "WP_Widget_Factory._register_widgets",
              "trace_id": 0,
-             "span_id": 50,
-             "parent_id": 28,
+             "span_id": 44,
+             "parent_id": 22,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -384,8 +266,8 @@
           "service": "wordpress_test_app",
           "resource": "smilies_init (callback)",
           "trace_id": 0,
-          "span_id": 29,
-          "parent_id": 15,
+          "span_id": 23,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -398,8 +280,8 @@
           "service": "wordpress_test_app",
           "resource": "wp_cron (callback)",
           "trace_id": 0,
-          "span_id": 30,
-          "parent_id": 15,
+          "span_id": 24,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -412,8 +294,8 @@
           "service": "wordpress_test_app",
           "resource": "_show_post_preview (callback)",
           "trace_id": 0,
-          "span_id": 31,
-          "parent_id": 15,
+          "span_id": 25,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -426,8 +308,8 @@
           "service": "wordpress_test_app",
           "resource": "rest_api_init (callback)",
           "trace_id": 0,
-          "span_id": 32,
-          "parent_id": 15,
+          "span_id": 26,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -440,8 +322,8 @@
           "service": "wordpress_test_app",
           "resource": "wp_schedule_update_checks (callback)",
           "trace_id": 0,
-          "span_id": 33,
-          "parent_id": 15,
+          "span_id": 27,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -454,8 +336,8 @@
           "service": "wordpress_test_app",
           "resource": "check_theme_switched (callback)",
           "trace_id": 0,
-          "span_id": 34,
-          "parent_id": 15,
+          "span_id": 28,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -463,34 +345,12 @@
             "wordpress.hook": "init"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp_options WHERE option_name = 'theme_switched' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 51,
-             "parent_id": 34,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_test_app",
        "resource": "wp_loaded (hook)",
        "trace_id": 0,
-       "span_id": 16,
+       "span_id": 10,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -503,8 +363,8 @@
           "service": "wordpress_test_app",
           "resource": "_custom_header_background_just_in_time (callback)",
           "trace_id": 0,
-          "span_id": 35,
-          "parent_id": 16,
+          "span_id": 29,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -517,7 +377,7 @@
        "service": "wordpress_test_app",
        "resource": "WP.main",
        "trace_id": 0,
-       "span_id": 17,
+       "span_id": 11,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -529,8 +389,8 @@
           "service": "wordpress_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 36,
-          "parent_id": 17,
+          "span_id": 30,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -541,64 +401,20 @@
           "service": "wordpress_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 37,
-          "parent_id": 17,
+          "span_id": 31,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp_posts\n\t\tWHERE post_name IN ('simple_view')\n\t\tAND post_type IN ('page','attachment')\n\t",
-             "trace_id": 0,
-             "span_id": 52,
-             "parent_id": 37,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT * FROM wp_posts WHERE ID = 2 LIMIT 1",
-             "trace_id": 0,
-             "span_id": 53,
-             "parent_id": 37,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
         {
           "name": "WP.send_headers",
           "service": "wordpress_test_app",
           "resource": "WP.send_headers",
           "trace_id": 0,
-          "span_id": 38,
-          "parent_id": 17,
+          "span_id": 32,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -609,64 +425,20 @@
           "service": "wordpress_test_app",
           "resource": "WP.query_posts",
           "trace_id": 0,
-          "span_id": 39,
-          "parent_id": 17,
+          "span_id": 33,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT   wp_posts.* FROM wp_posts  WHERE 1=1  AND (wp_posts.ID = '2') AND wp_posts.post_type = 'page'  ORDER BY wp_posts.post_date DESC ",
-             "trace_id": 0,
-             "span_id": 54,
-             "parent_id": 39,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT post_id, meta_key, meta_value FROM wp_postmeta WHERE post_id IN (2) ORDER BY meta_id ASC",
-             "trace_id": 0,
-             "span_id": 55,
-             "parent_id": 39,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 3.0
-             }
-           },
         {
           "name": "WP.handle_404",
           "service": "wordpress_test_app",
           "resource": "WP.handle_404",
           "trace_id": 0,
-          "span_id": 40,
-          "parent_id": 17,
+          "span_id": 34,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -677,8 +449,8 @@
           "service": "wordpress_test_app",
           "resource": "WP.register_globals",
           "trace_id": 0,
-          "span_id": 41,
-          "parent_id": 17,
+          "span_id": 35,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -689,8 +461,8 @@
           "service": "wordpress_test_app",
           "resource": "wp (hook)",
           "trace_id": 0,
-          "span_id": 42,
-          "parent_id": 17,
+          "span_id": 36,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -702,7 +474,7 @@
        "service": "wordpress_test_app",
        "resource": "load_template_loader",
        "trace_id": 0,
-       "span_id": 18,
+       "span_id": 12,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -714,8 +486,8 @@
           "service": "wordpress_test_app",
           "resource": "template_redirect (hook)",
           "trace_id": 0,
-          "span_id": 43,
-          "parent_id": 18,
+          "span_id": 37,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -727,8 +499,8 @@
              "service": "wordpress_test_app",
              "resource": "_wp_admin_bar_init (callback)",
              "trace_id": 0,
-             "span_id": 56,
-             "parent_id": 43,
+             "span_id": 45,
+             "parent_id": 37,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -741,8 +513,8 @@
              "service": "wordpress_test_app",
              "resource": "twentyseventeen_content_width (callback)",
              "trace_id": 0,
-             "span_id": 57,
-             "parent_id": 43,
+             "span_id": 46,
+             "parent_id": 37,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -755,8 +527,8 @@
              "service": "wordpress_test_app",
              "resource": "wp_old_slug_redirect (callback)",
              "trace_id": 0,
-             "span_id": 58,
-             "parent_id": 43,
+             "span_id": 47,
+             "parent_id": 37,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -769,8 +541,8 @@
              "service": "wordpress_test_app",
              "resource": "rest_output_link_header (callback)",
              "trace_id": 0,
-             "span_id": 59,
-             "parent_id": 43,
+             "span_id": 48,
+             "parent_id": 37,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -783,8 +555,8 @@
              "service": "wordpress_test_app",
              "resource": "wp_shortlink_header (callback)",
              "trace_id": 0,
-             "span_id": 60,
-             "parent_id": 43,
+             "span_id": 49,
+             "parent_id": 37,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -797,8 +569,8 @@
              "service": "wordpress_test_app",
              "resource": "wp_redirect_admin_locations (callback)",
              "trace_id": 0,
-             "span_id": 61,
-             "parent_id": 43,
+             "span_id": 50,
+             "parent_id": 37,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -811,8 +583,8 @@
           "service": "wordpress_test_app",
           "resource": "page (type)",
           "trace_id": 0,
-          "span_id": 44,
-          "parent_id": 18,
+          "span_id": 38,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -825,8 +597,8 @@
           "service": "wordpress_test_app",
           "resource": "get_header",
           "trace_id": 0,
-          "span_id": 45,
-          "parent_id": 18,
+          "span_id": 39,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -837,8 +609,8 @@
              "service": "wordpress_test_app",
              "resource": "header (template)",
              "trace_id": 0,
-             "span_id": 62,
-             "parent_id": 45,
+             "span_id": 51,
+             "parent_id": 39,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -851,8 +623,8 @@
                 "service": "wordpress_test_app",
                 "resource": "wp_head (hook)",
                 "trace_id": 0,
-                "span_id": 67,
-                "parent_id": 62,
+                "span_id": 54,
+                "parent_id": 51,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -864,8 +636,8 @@
                    "service": "wordpress_test_app",
                    "resource": "twentyseventeen_javascript_detection (callback)",
                    "trace_id": 0,
-                   "span_id": 71,
-                   "parent_id": 67,
+                   "span_id": 58,
+                   "parent_id": 54,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -878,8 +650,8 @@
                    "service": "wordpress_test_app",
                    "resource": "_wp_render_title_tag (callback)",
                    "trace_id": 0,
-                   "span_id": 72,
-                   "parent_id": 67,
+                   "span_id": 59,
+                   "parent_id": 54,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -892,8 +664,8 @@
                    "service": "wordpress_test_app",
                    "resource": "wp_enqueue_scripts (callback)",
                    "trace_id": 0,
-                   "span_id": 73,
-                   "parent_id": 67,
+                   "span_id": 60,
+                   "parent_id": 54,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -906,8 +678,8 @@
                    "service": "wordpress_test_app",
                    "resource": "noindex (callback)",
                    "trace_id": 0,
-                   "span_id": 74,
-                   "parent_id": 67,
+                   "span_id": 61,
+                   "parent_id": 54,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -920,8 +692,8 @@
                    "service": "wordpress_test_app",
                    "resource": "wp_post_preview_js (callback)",
                    "trace_id": 0,
-                   "span_id": 75,
-                   "parent_id": 67,
+                   "span_id": 62,
+                   "parent_id": 54,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -934,8 +706,8 @@
                    "service": "wordpress_test_app",
                    "resource": "wp_resource_hints (callback)",
                    "trace_id": 0,
-                   "span_id": 76,
-                   "parent_id": 67,
+                   "span_id": 63,
+                   "parent_id": 54,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -948,8 +720,8 @@
                    "service": "wordpress_test_app",
                    "resource": "feed_links (callback)",
                    "trace_id": 0,
-                   "span_id": 77,
-                   "parent_id": 67,
+                   "span_id": 64,
+                   "parent_id": 54,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -962,8 +734,8 @@
                    "service": "wordpress_test_app",
                    "resource": "feed_links_extra (callback)",
                    "trace_id": 0,
-                   "span_id": 78,
-                   "parent_id": 67,
+                   "span_id": 65,
+                   "parent_id": 54,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -976,8 +748,8 @@
                    "service": "wordpress_test_app",
                    "resource": "print_emoji_detection_script (callback)",
                    "trace_id": 0,
-                   "span_id": 79,
-                   "parent_id": 67,
+                   "span_id": 66,
+                   "parent_id": 54,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -990,8 +762,8 @@
                    "service": "wordpress_test_app",
                    "resource": "wp_print_styles (callback)",
                    "trace_id": 0,
-                   "span_id": 80,
-                   "parent_id": 67,
+                   "span_id": 67,
+                   "parent_id": 54,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1004,8 +776,8 @@
                    "service": "wordpress_test_app",
                    "resource": "wp_print_head_scripts",
                    "trace_id": 0,
-                   "span_id": 81,
-                   "parent_id": 67,
+                   "span_id": 68,
+                   "parent_id": 54,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1013,35 +785,13 @@
                      "wordpress.hook": "wp_head"
                    }
                  },
-                    {
-                      "name": "mysqli_query",
-                      "service": "mysqli",
-                      "resource": "SELECT option_value FROM wp_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-                      "trace_id": 0,
-                      "span_id": 103,
-                      "parent_id": 81,
-                      "type": "sql",
-                      "meta": {
-                        "_dd.base_service": "wordpress_test_app",
-                        "component": "mysqli",
-                        "db.name": "test",
-                        "db.system": "mysql",
-                        "db.type": "mysql",
-                        "out.host": "mysql_integration",
-                        "out.port": "3306",
-                        "span.kind": "client"
-                      },
-                      "metrics": {
-                        "db.row_count": 1.0
-                      }
-                    },
                  {
                    "name": "callback",
                    "service": "wordpress_test_app",
                    "resource": "rest_output_link_wp_head (callback)",
                    "trace_id": 0,
-                   "span_id": 82,
-                   "parent_id": 67,
+                   "span_id": 69,
+                   "parent_id": 54,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1054,8 +804,8 @@
                    "service": "wordpress_test_app",
                    "resource": "rsd_link (callback)",
                    "trace_id": 0,
-                   "span_id": 83,
-                   "parent_id": 67,
+                   "span_id": 70,
+                   "parent_id": 54,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1068,8 +818,8 @@
                    "service": "wordpress_test_app",
                    "resource": "wlwmanifest_link (callback)",
                    "trace_id": 0,
-                   "span_id": 84,
-                   "parent_id": 67,
+                   "span_id": 71,
+                   "parent_id": 54,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1082,8 +832,8 @@
                    "service": "wordpress_test_app",
                    "resource": "adjacent_posts_rel_link_wp_head (callback)",
                    "trace_id": 0,
-                   "span_id": 85,
-                   "parent_id": 67,
+                   "span_id": 72,
+                   "parent_id": 54,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1096,8 +846,8 @@
                    "service": "wordpress_test_app",
                    "resource": "locale_stylesheet (callback)",
                    "trace_id": 0,
-                   "span_id": 86,
-                   "parent_id": 67,
+                   "span_id": 73,
+                   "parent_id": 54,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1110,8 +860,8 @@
                    "service": "wordpress_test_app",
                    "resource": "wp_generator (callback)",
                    "trace_id": 0,
-                   "span_id": 87,
-                   "parent_id": 67,
+                   "span_id": 74,
+                   "parent_id": 54,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1124,8 +874,8 @@
                    "service": "wordpress_test_app",
                    "resource": "rel_canonical (callback)",
                    "trace_id": 0,
-                   "span_id": 88,
-                   "parent_id": 67,
+                   "span_id": 75,
+                   "parent_id": 54,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1138,8 +888,8 @@
                    "service": "wordpress_test_app",
                    "resource": "wp_shortlink_wp_head (callback)",
                    "trace_id": 0,
-                   "span_id": 89,
-                   "parent_id": 67,
+                   "span_id": 76,
+                   "parent_id": 54,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1152,8 +902,8 @@
                    "service": "wordpress_test_app",
                    "resource": "_custom_logo_header_styles (callback)",
                    "trace_id": 0,
-                   "span_id": 90,
-                   "parent_id": 67,
+                   "span_id": 77,
+                   "parent_id": 54,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1166,8 +916,8 @@
                    "service": "wordpress_test_app",
                    "resource": "wp_oembed_add_discovery_links (callback)",
                    "trace_id": 0,
-                   "span_id": 91,
-                   "parent_id": 67,
+                   "span_id": 78,
+                   "parent_id": 54,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1180,8 +930,8 @@
                    "service": "wordpress_test_app",
                    "resource": "wp_oembed_add_host_js (callback)",
                    "trace_id": 0,
-                   "span_id": 92,
-                   "parent_id": 67,
+                   "span_id": 79,
+                   "parent_id": 54,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1194,8 +944,8 @@
                    "service": "wordpress_test_app",
                    "resource": "twentyseventeen_pingback_header (callback)",
                    "trace_id": 0,
-                   "span_id": 93,
-                   "parent_id": 67,
+                   "span_id": 80,
+                   "parent_id": 54,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1208,8 +958,8 @@
                    "service": "wordpress_test_app",
                    "resource": "twentyseventeen_colors_css_wrap (callback)",
                    "trace_id": 0,
-                   "span_id": 94,
-                   "parent_id": 67,
+                   "span_id": 81,
+                   "parent_id": 54,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1222,8 +972,8 @@
                    "service": "wordpress_test_app",
                    "resource": "WP_Widget_Recent_Comments::recent_comments_style (callback)",
                    "trace_id": 0,
-                   "span_id": 95,
-                   "parent_id": 67,
+                   "span_id": 82,
+                   "parent_id": 54,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1236,8 +986,8 @@
                    "service": "wordpress_test_app",
                    "resource": "twentyseventeen_header_style (callback)",
                    "trace_id": 0,
-                   "span_id": 96,
-                   "parent_id": 67,
+                   "span_id": 83,
+                   "parent_id": 54,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1250,8 +1000,8 @@
                    "service": "wordpress_test_app",
                    "resource": "wp_site_icon (callback)",
                    "trace_id": 0,
-                   "span_id": 97,
-                   "parent_id": 67,
+                   "span_id": 84,
+                   "parent_id": 54,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1264,8 +1014,8 @@
                    "service": "wordpress_test_app",
                    "resource": "wp_custom_css_cb (callback)",
                    "trace_id": 0,
-                   "span_id": 98,
-                   "parent_id": 67,
+                   "span_id": 85,
+                   "parent_id": 54,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1278,42 +1028,20 @@
                 "service": "wordpress_test_app",
                 "resource": "body_class",
                 "trace_id": 0,
-                "span_id": 68,
-                "parent_id": 62,
+                "span_id": 55,
+                "parent_id": 51,
                 "type": "web",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT * FROM wp_posts  WHERE (post_type = 'page' AND post_status = 'publish')    AND post_parent = 2   ORDER BY wp_posts.post_title ASC LIMIT 0,1",
-                   "trace_id": 0,
-                   "span_id": 99,
-                   "parent_id": 68,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
               {
                 "name": "the_custom_header_markup",
                 "service": "wordpress_test_app",
                 "resource": "the_custom_header_markup",
                 "trace_id": 0,
-                "span_id": 69,
-                "parent_id": 62,
+                "span_id": 56,
+                "parent_id": 51,
                 "type": "web",
                 "meta": {
                   "component": "wordpress"
@@ -1324,64 +1052,20 @@
           "service": "wordpress_test_app",
           "resource": "the_post",
           "trace_id": 0,
-          "span_id": 46,
-          "parent_id": 18,
+          "span_id": 40,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT * FROM wp_users WHERE ID = '1'",
-             "trace_id": 0,
-             "span_id": 63,
-             "parent_id": 46,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT user_id, meta_key, meta_value FROM wp_usermeta WHERE user_id IN (1) ORDER BY umeta_id ASC",
-             "trace_id": 0,
-             "span_id": 64,
-             "parent_id": 46,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 17.0
-             }
-           },
         {
           "name": "load_template",
           "service": "wordpress_test_app",
           "resource": "content-page (template)",
           "trace_id": 0,
-          "span_id": 47,
-          "parent_id": 18,
+          "span_id": 41,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1394,8 +1078,8 @@
              "service": "wordpress_test_app",
              "resource": "the_content",
              "trace_id": 0,
-             "span_id": 65,
-             "parent_id": 47,
+             "span_id": 52,
+             "parent_id": 41,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1407,8 +1091,8 @@
           "service": "wordpress_test_app",
           "resource": "get_footer",
           "trace_id": 0,
-          "span_id": 48,
-          "parent_id": 18,
+          "span_id": 42,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -1419,8 +1103,8 @@
              "service": "wordpress_test_app",
              "resource": "footer (template)",
              "trace_id": 0,
-             "span_id": 66,
-             "parent_id": 48,
+             "span_id": 53,
+             "parent_id": 42,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1433,8 +1117,8 @@
                 "service": "wordpress_test_app",
                 "resource": "wp_footer (hook)",
                 "trace_id": 0,
-                "span_id": 70,
-                "parent_id": 66,
+                "span_id": 57,
+                "parent_id": 53,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -1446,8 +1130,8 @@
                    "service": "wordpress_test_app",
                    "resource": "wp_print_footer_scripts (callback)",
                    "trace_id": 0,
-                   "span_id": 100,
-                   "parent_id": 70,
+                   "span_id": 86,
+                   "parent_id": 57,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1460,8 +1144,8 @@
                    "service": "wordpress_test_app",
                    "resource": "wp_admin_bar_render (callback)",
                    "trace_id": 0,
-                   "span_id": 101,
-                   "parent_id": 70,
+                   "span_id": 87,
+                   "parent_id": 57,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1474,8 +1158,8 @@
                    "service": "wordpress_test_app",
                    "resource": "twentyseventeen_include_svg_icons (callback)",
                    "trace_id": 0,
-                   "span_id": 102,
-                   "parent_id": 70,
+                   "span_id": 88,
+                   "parent_id": 57,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1488,7 +1172,7 @@
        "service": "wordpress_test_app",
        "resource": "shutdown (hook)",
        "trace_id": 0,
-       "span_id": 19,
+       "span_id": 13,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -1501,8 +1185,8 @@
           "service": "wordpress_test_app",
           "resource": "wp_ob_end_flush_all (callback)",
           "trace_id": 0,
-          "span_id": 49,
-          "parent_id": 19,
+          "span_id": 43,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",

--- a/tests/snapshots/tests.integrations.word_press.v4_8.common_scenarios_legacy_test.test_scenario_get_return_string.json
+++ b/tests/snapshots/tests.integrations.word_press.v4_8.common_scenarios_legacy_test.test_scenario_get_return_string.json
@@ -5,16 +5,17 @@
     "resource": "GET /simple",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 9477166790255416813,
+    "parent_id": 17447991236263136389,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e7019800000000",
       "component": "wordpress",
       "http.method": "GET",
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/simple?key=value&<redacted>",
-      "runtime-id": "dccda1ae-615d-4300-bae1-1ba83e60ac15",
+      "runtime-id": "28038d40-52e5-4599-b85c-fbe379306871",
       "span.kind": "server"
     },
     "metrics": {
@@ -37,81 +38,6 @@
          "db.user": "test"
        }
      },
-        {
-          "name": "mysqli_real_connect",
-          "service": "mysqli",
-          "resource": "mysqli_real_connect",
-          "trace_id": 0,
-          "span_id": 16,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-          "trace_id": 0,
-          "span_id": 17,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT @@SESSION.sql_mode",
-          "trace_id": 0,
-          "span_id": 18,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 1.0
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-          "trace_id": 0,
-          "span_id": 19,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_test_app",
@@ -124,28 +50,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_name, option_value FROM wp_options WHERE autoload = 'yes'",
-          "trace_id": 0,
-          "span_id": 20,
-          "parent_id": 3,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 108.0
-          }
-        },
      {
        "name": "create_initial_taxonomies",
        "service": "wordpress_test_app",
@@ -218,28 +122,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'WPLANG' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 9,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.init",
        "service": "wordpress_test_app",
@@ -300,28 +182,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'theme_switched' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 14,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.main",
        "service": "wordpress_test_app",
@@ -339,7 +199,7 @@
           "service": "wordpress_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 23,
+          "span_id": 16,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -351,7 +211,7 @@
           "service": "wordpress_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 24,
+          "span_id": 17,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -363,32 +223,10 @@
              "service": "wordpress_test_app",
              "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp_posts\n\t\tWHERE post_name IN ('simple')\n\t\tAND post_type IN ('page','attachment')\n\t",
              "trace_id": 0,
-             "span_id": 25,
-             "parent_id": 24,
+             "span_id": 18,
+             "parent_id": 17,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
-           },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp_posts\n\t\tWHERE post_name IN ('simple')\n\t\tAND post_type IN ('page','attachment')\n\t",
-                "trace_id": 0,
-                "span_id": 26,
-                "parent_id": 25,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              }]]
+           }]]

--- a/tests/snapshots/tests.integrations.word_press.v4_8.common_scenarios_legacy_test.test_scenario_get_with_exception.json
+++ b/tests/snapshots/tests.integrations.word_press.v4_8.common_scenarios_legacy_test.test_scenario_get_with_exception.json
@@ -5,11 +5,12 @@
     "resource": "GET /error",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 6128902903823080457,
+    "parent_id": 15401321867187644270,
     "type": "web",
     "error": 1,
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e701ad00000000",
       "component": "wordpress",
       "error.message": "Uncaught Exception: Oops! in /home/circleci/datadog/tests/Frameworks/WordPress/Version_4_8/wp-content/plugins/datadog/datadog.php:23",
       "error.stack": "#0 /home/circleci/datadog/tests/Frameworks/WordPress/Version_4_8/wp-includes/class-wp-hook.php(298): datadog_parse_request()\n#1 /home/circleci/datadog/tests/Frameworks/WordPress/Version_4_8/wp-includes/class-wp-hook.php(323): WP_Hook->apply_filters()\n#2 /home/circleci/datadog/tests/Frameworks/WordPress/Version_4_8/wp-includes/plugin.php(515): WP_Hook->do_action()\n#3 /home/circleci/datadog/tests/Frameworks/WordPress/Version_4_8/wp-includes/class-wp.php(388): do_action_ref_array()\n#4 /home/circleci/datadog/tests/Frameworks/WordPress/Version_4_8/wp-includes/class-wp.php(735): WP->parse_request()\n#5 /home/circleci/datadog/tests/Frameworks/WordPress/Version_4_8/wp-includes/functions.php(955): WP->main()\n#6 /home/circleci/datadog/tests/Frameworks/WordPress/Version_4_8/wp-blog-header.php(16): wp()\n#7 /home/circleci/datadog/tests/Frameworks/WordPress/Version_4_8/index.php(17): require()\n#8 {main}",
@@ -18,7 +19,7 @@
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/error?key=value&<redacted>",
-      "runtime-id": "dccda1ae-615d-4300-bae1-1ba83e60ac15",
+      "runtime-id": "28038d40-52e5-4599-b85c-fbe379306871",
       "span.kind": "server"
     },
     "metrics": {
@@ -41,81 +42,6 @@
          "db.user": "test"
        }
      },
-        {
-          "name": "mysqli_real_connect",
-          "service": "mysqli",
-          "resource": "mysqli_real_connect",
-          "trace_id": 0,
-          "span_id": 16,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-          "trace_id": 0,
-          "span_id": 17,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT @@SESSION.sql_mode",
-          "trace_id": 0,
-          "span_id": 18,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 1.0
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-          "trace_id": 0,
-          "span_id": 19,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_test_app",
@@ -128,28 +54,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_name, option_value FROM wp_options WHERE autoload = 'yes'",
-          "trace_id": 0,
-          "span_id": 20,
-          "parent_id": 3,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 108.0
-          }
-        },
      {
        "name": "create_initial_taxonomies",
        "service": "wordpress_test_app",
@@ -222,28 +126,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'WPLANG' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 9,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.init",
        "service": "wordpress_test_app",
@@ -304,28 +186,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'theme_switched' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 14,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.main",
        "service": "wordpress_test_app",
@@ -347,7 +207,7 @@
           "service": "wordpress_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 23,
+          "span_id": 16,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -359,7 +219,7 @@
           "service": "wordpress_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 24,
+          "span_id": 17,
           "parent_id": 15,
           "type": "web",
           "error": 1,
@@ -375,32 +235,10 @@
              "service": "wordpress_test_app",
              "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp_posts\n\t\tWHERE post_name IN ('error')\n\t\tAND post_type IN ('page','attachment')\n\t",
              "trace_id": 0,
-             "span_id": 25,
-             "parent_id": 24,
+             "span_id": 18,
+             "parent_id": 17,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
-           },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp_posts\n\t\tWHERE post_name IN ('error')\n\t\tAND post_type IN ('page','attachment')\n\t",
-                "trace_id": 0,
-                "span_id": 26,
-                "parent_id": 25,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              }]]
+           }]]

--- a/tests/snapshots/tests.integrations.word_press.v4_8.common_scenarios_legacy_test.test_scenario_get_with_view.json
+++ b/tests/snapshots/tests.integrations.word_press.v4_8.common_scenarios_legacy_test.test_scenario_get_with_view.json
@@ -5,16 +5,17 @@
     "resource": "GET /simple_view",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 729478495814728347,
+    "parent_id": 778394510285668164,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e701a700000000",
       "component": "wordpress",
       "http.method": "GET",
       "http.route": "(.?.+?)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/simple_view?key=value&<redacted>",
-      "runtime-id": "dccda1ae-615d-4300-bae1-1ba83e60ac15",
+      "runtime-id": "28038d40-52e5-4599-b85c-fbe379306871",
       "span.kind": "server"
     },
     "metrics": {
@@ -37,81 +38,6 @@
          "db.user": "test"
        }
      },
-        {
-          "name": "mysqli_real_connect",
-          "service": "mysqli",
-          "resource": "mysqli_real_connect",
-          "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-          "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT @@SESSION.sql_mode",
-          "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 1.0
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-          "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_test_app",
@@ -124,28 +50,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_name, option_value FROM wp_options WHERE autoload = 'yes'",
-          "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 3,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 108.0
-          }
-        },
      {
        "name": "create_initial_taxonomies",
        "service": "wordpress_test_app",
@@ -218,28 +122,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'WPLANG' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 9,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.init",
        "service": "wordpress_test_app",
@@ -300,28 +182,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'theme_switched' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 14,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.main",
        "service": "wordpress_test_app",
@@ -339,7 +199,7 @@
           "service": "wordpress_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 28,
+          "span_id": 21,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -351,7 +211,7 @@
           "service": "wordpress_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 29,
+          "span_id": 22,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -363,75 +223,31 @@
              "service": "wordpress_test_app",
              "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp_posts\n\t\tWHERE post_name IN ('simple_view')\n\t\tAND post_type IN ('page','attachment')\n\t",
              "trace_id": 0,
-             "span_id": 38,
-             "parent_id": 29,
+             "span_id": 29,
+             "parent_id": 22,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp_posts\n\t\tWHERE post_name IN ('simple_view')\n\t\tAND post_type IN ('page','attachment')\n\t",
-                "trace_id": 0,
-                "span_id": 46,
-                "parent_id": 38,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
            {
              "name": "wpdb.query",
              "service": "wordpress_test_app",
              "resource": "SELECT * FROM wp_posts WHERE ID = 2 LIMIT 1",
              "trace_id": 0,
-             "span_id": 39,
-             "parent_id": 29,
+             "span_id": 30,
+             "parent_id": 22,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT * FROM wp_posts WHERE ID = 2 LIMIT 1",
-                "trace_id": 0,
-                "span_id": 47,
-                "parent_id": 39,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
         {
           "name": "WP.send_headers",
           "service": "wordpress_test_app",
           "resource": "WP.send_headers",
           "trace_id": 0,
-          "span_id": 30,
+          "span_id": 23,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -443,7 +259,7 @@
           "service": "wordpress_test_app",
           "resource": "WP.query_posts",
           "trace_id": 0,
-          "span_id": 31,
+          "span_id": 24,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -455,75 +271,31 @@
              "service": "wordpress_test_app",
              "resource": "SELECT   wp_posts.* FROM wp_posts  WHERE 1=1  AND (wp_posts.ID = '2') AND wp_posts.post_type = 'page'  ORDER BY wp_posts.post_date DESC ",
              "trace_id": 0,
-             "span_id": 40,
-             "parent_id": 31,
+             "span_id": 31,
+             "parent_id": 24,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT   wp_posts.* FROM wp_posts  WHERE 1=1  AND (wp_posts.ID = '2') AND wp_posts.post_type = 'page'  ORDER BY wp_posts.post_date DESC ",
-                "trace_id": 0,
-                "span_id": 48,
-                "parent_id": 40,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
            {
              "name": "wpdb.query",
              "service": "wordpress_test_app",
              "resource": "SELECT post_id, meta_key, meta_value FROM wp_postmeta WHERE post_id IN (2) ORDER BY meta_id ASC",
              "trace_id": 0,
-             "span_id": 41,
-             "parent_id": 31,
+             "span_id": 32,
+             "parent_id": 24,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT post_id, meta_key, meta_value FROM wp_postmeta WHERE post_id IN (2) ORDER BY meta_id ASC",
-                "trace_id": 0,
-                "span_id": 49,
-                "parent_id": 41,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 3.0
-                }
-              },
         {
           "name": "WP.handle_404",
           "service": "wordpress_test_app",
           "resource": "WP.handle_404",
           "trace_id": 0,
-          "span_id": 32,
+          "span_id": 25,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -535,7 +307,7 @@
           "service": "wordpress_test_app",
           "resource": "WP.register_globals",
           "trace_id": 0,
-          "span_id": 33,
+          "span_id": 26,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -559,7 +331,7 @@
           "service": "wordpress_test_app",
           "resource": "/home/circleci/datadog/tests/Frameworks/WordPress/Version_4_8/wp-content/themes/twentyseventeen/header.php",
           "trace_id": 0,
-          "span_id": 34,
+          "span_id": 27,
           "parent_id": 16,
           "type": "web",
           "meta": {
@@ -571,8 +343,8 @@
              "service": "wordpress_test_app",
              "resource": "wp_head",
              "trace_id": 0,
-             "span_id": 42,
-             "parent_id": 34,
+             "span_id": 33,
+             "parent_id": 27,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -583,8 +355,8 @@
                 "service": "wordpress_test_app",
                 "resource": "wp_print_head_scripts",
                 "trace_id": 0,
-                "span_id": 50,
-                "parent_id": 42,
+                "span_id": 37,
+                "parent_id": 33,
                 "type": "web",
                 "meta": {
                   "component": "wordpress"
@@ -595,42 +367,20 @@
                    "service": "wordpress_test_app",
                    "resource": "SELECT option_value FROM wp_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
                    "trace_id": 0,
-                   "span_id": 52,
-                   "parent_id": 50,
+                   "span_id": 39,
+                   "parent_id": 37,
                    "type": "sql",
                    "meta": {
                      "component": "wordpress"
                    }
                  },
-                    {
-                      "name": "mysqli_query",
-                      "service": "mysqli",
-                      "resource": "SELECT option_value FROM wp_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-                      "trace_id": 0,
-                      "span_id": 54,
-                      "parent_id": 52,
-                      "type": "sql",
-                      "meta": {
-                        "_dd.base_service": "wordpress_test_app",
-                        "component": "mysqli",
-                        "db.name": "test",
-                        "db.system": "mysql",
-                        "db.type": "mysql",
-                        "out.host": "mysql_integration",
-                        "out.port": "3306",
-                        "span.kind": "client"
-                      },
-                      "metrics": {
-                        "db.row_count": 1.0
-                      }
-                    },
            {
              "name": "body_class",
              "service": "wordpress_test_app",
              "resource": "body_class",
              "trace_id": 0,
-             "span_id": 43,
-             "parent_id": 34,
+             "span_id": 34,
+             "parent_id": 27,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -641,42 +391,20 @@
                 "service": "wordpress_test_app",
                 "resource": "SELECT * FROM wp_posts  WHERE (post_type = 'page' AND post_status = 'publish')    AND post_parent = 2   ORDER BY wp_posts.post_title ASC LIMIT 0,1",
                 "trace_id": 0,
-                "span_id": 51,
-                "parent_id": 43,
+                "span_id": 38,
+                "parent_id": 34,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT * FROM wp_posts  WHERE (post_type = 'page' AND post_status = 'publish')    AND post_parent = 2   ORDER BY wp_posts.post_title ASC LIMIT 0,1",
-                   "trace_id": 0,
-                   "span_id": 53,
-                   "parent_id": 51,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
            {
              "name": "the_custom_header_markup",
              "service": "wordpress_test_app",
              "resource": "the_custom_header_markup",
              "trace_id": 0,
-             "span_id": 44,
-             "parent_id": 34,
+             "span_id": 35,
+             "parent_id": 27,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -694,28 +422,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT * FROM wp_users WHERE ID = '1'",
-          "trace_id": 0,
-          "span_id": 35,
-          "parent_id": 17,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 1.0
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_test_app",
@@ -728,28 +434,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT user_id, meta_key, meta_value FROM wp_usermeta WHERE user_id IN (1) ORDER BY umeta_id ASC",
-          "trace_id": 0,
-          "span_id": 36,
-          "parent_id": 18,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 17.0
-          }
-        },
      {
        "name": "load_template",
        "service": "wordpress_test_app",
@@ -779,7 +463,7 @@
           "service": "wordpress_test_app",
           "resource": "/home/circleci/datadog/tests/Frameworks/WordPress/Version_4_8/wp-content/themes/twentyseventeen/footer.php",
           "trace_id": 0,
-          "span_id": 37,
+          "span_id": 28,
           "parent_id": 20,
           "type": "web",
           "meta": {
@@ -791,8 +475,8 @@
              "service": "wordpress_test_app",
              "resource": "wp_print_footer_scripts",
              "trace_id": 0,
-             "span_id": 45,
-             "parent_id": 37,
+             "span_id": 36,
+             "parent_id": 28,
              "type": "web",
              "meta": {
                "component": "wordpress"

--- a/tests/snapshots/tests.integrations.word_press.v4_8.common_scenarios_test.test_scenario_get_return_string.json
+++ b/tests/snapshots/tests.integrations.word_press.v4_8.common_scenarios_test.test_scenario_get_return_string.json
@@ -5,16 +5,17 @@
     "resource": "GET /simple",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 10805381678613173804,
+    "parent_id": 16024124213196171998,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e701be00000000",
       "component": "wordpress",
       "http.method": "GET",
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/simple?key=value&<redacted>",
-      "runtime-id": "a4fe8a3c-397d-4da6-afb8-53617be50dbe",
+      "runtime-id": "8fdcf6ef-7cd9-4910-b426-c7c9809f3dd4",
       "span.kind": "server"
     },
     "metrics": {
@@ -22,108 +23,11 @@
     }
   },
      {
-       "name": "mysqli_real_connect",
-       "service": "mysqli",
-       "resource": "mysqli_real_connect",
-       "trace_id": 0,
-       "span_id": 2,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-       "trace_id": 0,
-       "span_id": 3,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT @@SESSION.sql_mode",
-       "trace_id": 0,
-       "span_id": 4,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 1.0
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-       "trace_id": 0,
-       "span_id": 5,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_name, option_value FROM wp_options WHERE autoload = 'yes'",
-       "trace_id": 0,
-       "span_id": 6,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 108.0
-       }
-     },
-     {
        "name": "create_initial_taxonomies",
        "service": "wordpress_test_app",
        "resource": "create_initial_taxonomies",
        "trace_id": 0,
-       "span_id": 7,
+       "span_id": 2,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -135,7 +39,7 @@
        "service": "wordpress_test_app",
        "resource": "create_initial_post_types",
        "trace_id": 0,
-       "span_id": 8,
+       "span_id": 3,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -147,7 +51,7 @@
        "service": "wordpress_test_app",
        "resource": "datadog (plugin)",
        "trace_id": 0,
-       "span_id": 9,
+       "span_id": 4,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -160,7 +64,7 @@
        "service": "wordpress_test_app",
        "resource": "plugins_loaded (hook)",
        "trace_id": 0,
-       "span_id": 10,
+       "span_id": 5,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -173,8 +77,8 @@
           "service": "wordpress_test_app",
           "resource": "wp_maybe_load_widgets",
           "trace_id": 0,
-          "span_id": 19,
-          "parent_id": 10,
+          "span_id": 13,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -185,8 +89,8 @@
           "service": "wordpress_test_app",
           "resource": "wp_maybe_load_embeds",
           "trace_id": 0,
-          "span_id": 20,
-          "parent_id": 10,
+          "span_id": 14,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -197,8 +101,8 @@
           "service": "wordpress_test_app",
           "resource": "_wp_customize_include",
           "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 10,
+          "span_id": 15,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -209,7 +113,7 @@
        "service": "wordpress_test_app",
        "resource": "setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 11,
+       "span_id": 6,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -218,33 +122,11 @@
        }
      },
      {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_value FROM wp_options WHERE option_name = 'WPLANG' LIMIT 1",
-       "trace_id": 0,
-       "span_id": 12,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 0.0
-       }
-     },
-     {
        "name": "action",
        "service": "wordpress_test_app",
        "resource": "after_setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 13,
+       "span_id": 7,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -257,7 +139,7 @@
        "service": "wordpress_test_app",
        "resource": "WP.init",
        "trace_id": 0,
-       "span_id": 14,
+       "span_id": 8,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -269,7 +151,7 @@
        "service": "wordpress_test_app",
        "resource": "init (hook)",
        "trace_id": 0,
-       "span_id": 15,
+       "span_id": 9,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -282,8 +164,8 @@
           "service": "wordpress_test_app",
           "resource": "create_initial_post_types",
           "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 15,
+          "span_id": 16,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -294,8 +176,8 @@
           "service": "wordpress_test_app",
           "resource": "create_initial_taxonomies",
           "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 15,
+          "span_id": 17,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -306,8 +188,8 @@
           "service": "wordpress_test_app",
           "resource": "wp_widgets_init",
           "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 15,
+          "span_id": 18,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -318,41 +200,19 @@
              "service": "wordpress_test_app",
              "resource": "WP_Widget_Factory._register_widgets",
              "trace_id": 0,
-             "span_id": 28,
-             "parent_id": 24,
+             "span_id": 21,
+             "parent_id": 18,
              "type": "web",
              "meta": {
                "component": "wordpress"
              }
            },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'theme_switched' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 15,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "action",
        "service": "wordpress_test_app",
        "resource": "wp_loaded (hook)",
        "trace_id": 0,
-       "span_id": 16,
+       "span_id": 10,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -365,7 +225,7 @@
        "service": "wordpress_test_app",
        "resource": "WP.main",
        "trace_id": 0,
-       "span_id": 17,
+       "span_id": 11,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -377,8 +237,8 @@
           "service": "wordpress_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 17,
+          "span_id": 19,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -389,41 +249,19 @@
           "service": "wordpress_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 17,
+          "span_id": 20,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp_posts\n\t\tWHERE post_name IN ('simple')\n\t\tAND post_type IN ('page','attachment')\n\t",
-             "trace_id": 0,
-             "span_id": 29,
-             "parent_id": 27,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_test_app",
        "resource": "shutdown (hook)",
        "trace_id": 0,
-       "span_id": 18,
+       "span_id": 12,
        "parent_id": 1,
        "type": "web",
        "meta": {

--- a/tests/snapshots/tests.integrations.word_press.v4_8.common_scenarios_test.test_scenario_get_with_exception.json
+++ b/tests/snapshots/tests.integrations.word_press.v4_8.common_scenarios_test.test_scenario_get_with_exception.json
@@ -5,11 +5,12 @@
     "resource": "GET /error",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 3237573194482752146,
+    "parent_id": 531117979348210975,
     "type": "web",
     "error": 1,
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e701c900000000",
       "component": "wordpress",
       "error.message": "Uncaught Exception: Oops! in /home/circleci/datadog/tests/Frameworks/WordPress/Version_4_8/wp-content/plugins/datadog/datadog.php:23",
       "error.stack": "#0 /home/circleci/datadog/tests/Frameworks/WordPress/Version_4_8/wp-includes/class-wp-hook.php(298): datadog_parse_request()\n#1 /home/circleci/datadog/tests/Frameworks/WordPress/Version_4_8/wp-includes/class-wp-hook.php(323): WP_Hook->apply_filters()\n#2 /home/circleci/datadog/tests/Frameworks/WordPress/Version_4_8/wp-includes/plugin.php(515): WP_Hook->do_action()\n#3 /home/circleci/datadog/tests/Frameworks/WordPress/Version_4_8/wp-includes/class-wp.php(388): do_action_ref_array()\n#4 /home/circleci/datadog/tests/Frameworks/WordPress/Version_4_8/wp-includes/class-wp.php(735): WP->parse_request()\n#5 /home/circleci/datadog/tests/Frameworks/WordPress/Version_4_8/wp-includes/functions.php(955): WP->main()\n#6 /home/circleci/datadog/tests/Frameworks/WordPress/Version_4_8/wp-blog-header.php(16): wp()\n#7 /home/circleci/datadog/tests/Frameworks/WordPress/Version_4_8/index.php(17): require()\n#8 {main}",
@@ -18,7 +19,7 @@
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/error?key=value&<redacted>",
-      "runtime-id": "06e879d2-e97d-4420-81ec-30074239cf68",
+      "runtime-id": "8fdcf6ef-7cd9-4910-b426-c7c9809f3dd4",
       "span.kind": "server"
     },
     "metrics": {
@@ -26,108 +27,11 @@
     }
   },
      {
-       "name": "mysqli_real_connect",
-       "service": "mysqli",
-       "resource": "mysqli_real_connect",
-       "trace_id": 0,
-       "span_id": 2,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-       "trace_id": 0,
-       "span_id": 3,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT @@SESSION.sql_mode",
-       "trace_id": 0,
-       "span_id": 4,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 1.0
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-       "trace_id": 0,
-       "span_id": 5,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_name, option_value FROM wp_options WHERE autoload = 'yes'",
-       "trace_id": 0,
-       "span_id": 6,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 108.0
-       }
-     },
-     {
        "name": "create_initial_taxonomies",
        "service": "wordpress_test_app",
        "resource": "create_initial_taxonomies",
        "trace_id": 0,
-       "span_id": 7,
+       "span_id": 2,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -139,7 +43,7 @@
        "service": "wordpress_test_app",
        "resource": "create_initial_post_types",
        "trace_id": 0,
-       "span_id": 8,
+       "span_id": 3,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -151,7 +55,7 @@
        "service": "wordpress_test_app",
        "resource": "datadog (plugin)",
        "trace_id": 0,
-       "span_id": 9,
+       "span_id": 4,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -164,7 +68,7 @@
        "service": "wordpress_test_app",
        "resource": "plugins_loaded (hook)",
        "trace_id": 0,
-       "span_id": 10,
+       "span_id": 5,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -177,8 +81,8 @@
           "service": "wordpress_test_app",
           "resource": "wp_maybe_load_widgets",
           "trace_id": 0,
-          "span_id": 19,
-          "parent_id": 10,
+          "span_id": 13,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -189,8 +93,8 @@
           "service": "wordpress_test_app",
           "resource": "wp_maybe_load_embeds",
           "trace_id": 0,
-          "span_id": 20,
-          "parent_id": 10,
+          "span_id": 14,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -201,8 +105,8 @@
           "service": "wordpress_test_app",
           "resource": "_wp_customize_include",
           "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 10,
+          "span_id": 15,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -213,7 +117,7 @@
        "service": "wordpress_test_app",
        "resource": "setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 11,
+       "span_id": 6,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -222,33 +126,11 @@
        }
      },
      {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_value FROM wp_options WHERE option_name = 'WPLANG' LIMIT 1",
-       "trace_id": 0,
-       "span_id": 12,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 0.0
-       }
-     },
-     {
        "name": "action",
        "service": "wordpress_test_app",
        "resource": "after_setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 13,
+       "span_id": 7,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -261,7 +143,7 @@
        "service": "wordpress_test_app",
        "resource": "WP.init",
        "trace_id": 0,
-       "span_id": 14,
+       "span_id": 8,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -273,7 +155,7 @@
        "service": "wordpress_test_app",
        "resource": "init (hook)",
        "trace_id": 0,
-       "span_id": 15,
+       "span_id": 9,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -286,8 +168,8 @@
           "service": "wordpress_test_app",
           "resource": "create_initial_post_types",
           "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 15,
+          "span_id": 16,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -298,8 +180,8 @@
           "service": "wordpress_test_app",
           "resource": "create_initial_taxonomies",
           "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 15,
+          "span_id": 17,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -310,8 +192,8 @@
           "service": "wordpress_test_app",
           "resource": "wp_widgets_init",
           "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 15,
+          "span_id": 18,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -322,41 +204,19 @@
              "service": "wordpress_test_app",
              "resource": "WP_Widget_Factory._register_widgets",
              "trace_id": 0,
-             "span_id": 28,
-             "parent_id": 24,
+             "span_id": 21,
+             "parent_id": 18,
              "type": "web",
              "meta": {
                "component": "wordpress"
              }
            },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'theme_switched' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 15,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "action",
        "service": "wordpress_test_app",
        "resource": "wp_loaded (hook)",
        "trace_id": 0,
-       "span_id": 16,
+       "span_id": 10,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -369,7 +229,7 @@
        "service": "wordpress_test_app",
        "resource": "WP.main",
        "trace_id": 0,
-       "span_id": 17,
+       "span_id": 11,
        "parent_id": 1,
        "type": "web",
        "error": 1,
@@ -385,8 +245,8 @@
           "service": "wordpress_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 17,
+          "span_id": 19,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -397,8 +257,8 @@
           "service": "wordpress_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 17,
+          "span_id": 20,
+          "parent_id": 11,
           "type": "web",
           "error": 1,
           "meta": {
@@ -408,34 +268,12 @@
             "error.type": "Exception"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp_posts\n\t\tWHERE post_name IN ('error')\n\t\tAND post_type IN ('page','attachment')\n\t",
-             "trace_id": 0,
-             "span_id": 29,
-             "parent_id": 27,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_test_app",
        "resource": "shutdown (hook)",
        "trace_id": 0,
-       "span_id": 18,
+       "span_id": 12,
        "parent_id": 1,
        "type": "web",
        "meta": {

--- a/tests/snapshots/tests.integrations.word_press.v4_8.common_scenarios_test.test_scenario_get_with_view.json
+++ b/tests/snapshots/tests.integrations.word_press.v4_8.common_scenarios_test.test_scenario_get_with_view.json
@@ -5,16 +5,17 @@
     "resource": "GET /simple_view",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 11949161841683561835,
+    "parent_id": 12932843346065002616,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e701c900000000",
       "component": "wordpress",
       "http.method": "GET",
       "http.route": "(.?.+?)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/simple_view?key=value&<redacted>",
-      "runtime-id": "06e879d2-e97d-4420-81ec-30074239cf68",
+      "runtime-id": "8fdcf6ef-7cd9-4910-b426-c7c9809f3dd4",
       "span.kind": "server"
     },
     "metrics": {
@@ -22,108 +23,11 @@
     }
   },
      {
-       "name": "mysqli_real_connect",
-       "service": "mysqli",
-       "resource": "mysqli_real_connect",
-       "trace_id": 0,
-       "span_id": 2,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-       "trace_id": 0,
-       "span_id": 3,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT @@SESSION.sql_mode",
-       "trace_id": 0,
-       "span_id": 4,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 1.0
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-       "trace_id": 0,
-       "span_id": 5,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_name, option_value FROM wp_options WHERE autoload = 'yes'",
-       "trace_id": 0,
-       "span_id": 6,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 108.0
-       }
-     },
-     {
        "name": "create_initial_taxonomies",
        "service": "wordpress_test_app",
        "resource": "create_initial_taxonomies",
        "trace_id": 0,
-       "span_id": 7,
+       "span_id": 2,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -135,7 +39,7 @@
        "service": "wordpress_test_app",
        "resource": "create_initial_post_types",
        "trace_id": 0,
-       "span_id": 8,
+       "span_id": 3,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -147,7 +51,7 @@
        "service": "wordpress_test_app",
        "resource": "datadog (plugin)",
        "trace_id": 0,
-       "span_id": 9,
+       "span_id": 4,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -160,7 +64,7 @@
        "service": "wordpress_test_app",
        "resource": "plugins_loaded (hook)",
        "trace_id": 0,
-       "span_id": 10,
+       "span_id": 5,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -173,8 +77,8 @@
           "service": "wordpress_test_app",
           "resource": "wp_maybe_load_widgets",
           "trace_id": 0,
-          "span_id": 20,
-          "parent_id": 10,
+          "span_id": 14,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -185,8 +89,8 @@
           "service": "wordpress_test_app",
           "resource": "wp_maybe_load_embeds",
           "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 10,
+          "span_id": 15,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -197,8 +101,8 @@
           "service": "wordpress_test_app",
           "resource": "_wp_customize_include",
           "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 10,
+          "span_id": 16,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -209,7 +113,7 @@
        "service": "wordpress_test_app",
        "resource": "setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 11,
+       "span_id": 6,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -218,33 +122,11 @@
        }
      },
      {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_value FROM wp_options WHERE option_name = 'WPLANG' LIMIT 1",
-       "trace_id": 0,
-       "span_id": 12,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 0.0
-       }
-     },
-     {
        "name": "action",
        "service": "wordpress_test_app",
        "resource": "after_setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 13,
+       "span_id": 7,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -257,7 +139,7 @@
        "service": "wordpress_test_app",
        "resource": "WP.init",
        "trace_id": 0,
-       "span_id": 14,
+       "span_id": 8,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -269,7 +151,7 @@
        "service": "wordpress_test_app",
        "resource": "init (hook)",
        "trace_id": 0,
-       "span_id": 15,
+       "span_id": 9,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -282,8 +164,8 @@
           "service": "wordpress_test_app",
           "resource": "create_initial_post_types",
           "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 15,
+          "span_id": 17,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -294,8 +176,8 @@
           "service": "wordpress_test_app",
           "resource": "create_initial_taxonomies",
           "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 15,
+          "span_id": 18,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -306,8 +188,8 @@
           "service": "wordpress_test_app",
           "resource": "wp_widgets_init",
           "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 15,
+          "span_id": 19,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -318,41 +200,19 @@
              "service": "wordpress_test_app",
              "resource": "WP_Widget_Factory._register_widgets",
              "trace_id": 0,
-             "span_id": 40,
-             "parent_id": 25,
+             "span_id": 33,
+             "parent_id": 19,
              "type": "web",
              "meta": {
                "component": "wordpress"
              }
            },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'theme_switched' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 15,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "action",
        "service": "wordpress_test_app",
        "resource": "wp_loaded (hook)",
        "trace_id": 0,
-       "span_id": 16,
+       "span_id": 10,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -365,7 +225,7 @@
        "service": "wordpress_test_app",
        "resource": "WP.main",
        "trace_id": 0,
-       "span_id": 17,
+       "span_id": 11,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -377,8 +237,8 @@
           "service": "wordpress_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 17,
+          "span_id": 20,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -389,64 +249,20 @@
           "service": "wordpress_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 28,
-          "parent_id": 17,
+          "span_id": 21,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp_posts\n\t\tWHERE post_name IN ('simple_view')\n\t\tAND post_type IN ('page','attachment')\n\t",
-             "trace_id": 0,
-             "span_id": 41,
-             "parent_id": 28,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT * FROM wp_posts WHERE ID = 2 LIMIT 1",
-             "trace_id": 0,
-             "span_id": 42,
-             "parent_id": 28,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
         {
           "name": "WP.send_headers",
           "service": "wordpress_test_app",
           "resource": "WP.send_headers",
           "trace_id": 0,
-          "span_id": 29,
-          "parent_id": 17,
+          "span_id": 22,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -457,64 +273,20 @@
           "service": "wordpress_test_app",
           "resource": "WP.query_posts",
           "trace_id": 0,
-          "span_id": 30,
-          "parent_id": 17,
+          "span_id": 23,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT   wp_posts.* FROM wp_posts  WHERE 1=1  AND (wp_posts.ID = '2') AND wp_posts.post_type = 'page'  ORDER BY wp_posts.post_date DESC ",
-             "trace_id": 0,
-             "span_id": 43,
-             "parent_id": 30,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT post_id, meta_key, meta_value FROM wp_postmeta WHERE post_id IN (2) ORDER BY meta_id ASC",
-             "trace_id": 0,
-             "span_id": 44,
-             "parent_id": 30,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 3.0
-             }
-           },
         {
           "name": "WP.handle_404",
           "service": "wordpress_test_app",
           "resource": "WP.handle_404",
           "trace_id": 0,
-          "span_id": 31,
-          "parent_id": 17,
+          "span_id": 24,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -525,8 +297,8 @@
           "service": "wordpress_test_app",
           "resource": "WP.register_globals",
           "trace_id": 0,
-          "span_id": 32,
-          "parent_id": 17,
+          "span_id": 25,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -537,8 +309,8 @@
           "service": "wordpress_test_app",
           "resource": "wp (hook)",
           "trace_id": 0,
-          "span_id": 33,
-          "parent_id": 17,
+          "span_id": 26,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -550,7 +322,7 @@
        "service": "wordpress_test_app",
        "resource": "load_template_loader",
        "trace_id": 0,
-       "span_id": 18,
+       "span_id": 12,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -562,8 +334,8 @@
           "service": "wordpress_test_app",
           "resource": "template_redirect (hook)",
           "trace_id": 0,
-          "span_id": 34,
-          "parent_id": 18,
+          "span_id": 27,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -575,8 +347,8 @@
           "service": "wordpress_test_app",
           "resource": "page (type)",
           "trace_id": 0,
-          "span_id": 35,
-          "parent_id": 18,
+          "span_id": 28,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -589,8 +361,8 @@
           "service": "wordpress_test_app",
           "resource": "get_header",
           "trace_id": 0,
-          "span_id": 36,
-          "parent_id": 18,
+          "span_id": 29,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -601,8 +373,8 @@
              "service": "wordpress_test_app",
              "resource": "header (template)",
              "trace_id": 0,
-             "span_id": 45,
-             "parent_id": 36,
+             "span_id": 34,
+             "parent_id": 29,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -615,8 +387,8 @@
                 "service": "wordpress_test_app",
                 "resource": "wp_head (hook)",
                 "trace_id": 0,
-                "span_id": 50,
-                "parent_id": 45,
+                "span_id": 37,
+                "parent_id": 34,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -628,76 +400,32 @@
                    "service": "wordpress_test_app",
                    "resource": "wp_print_head_scripts",
                    "trace_id": 0,
-                   "span_id": 54,
-                   "parent_id": 50,
+                   "span_id": 41,
+                   "parent_id": 37,
                    "type": "web",
                    "meta": {
                      "component": "wordpress"
                    }
                  },
-                    {
-                      "name": "mysqli_query",
-                      "service": "mysqli",
-                      "resource": "SELECT option_value FROM wp_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-                      "trace_id": 0,
-                      "span_id": 56,
-                      "parent_id": 54,
-                      "type": "sql",
-                      "meta": {
-                        "_dd.base_service": "wordpress_test_app",
-                        "component": "mysqli",
-                        "db.name": "test",
-                        "db.system": "mysql",
-                        "db.type": "mysql",
-                        "out.host": "mysql_integration",
-                        "out.port": "3306",
-                        "span.kind": "client"
-                      },
-                      "metrics": {
-                        "db.row_count": 1.0
-                      }
-                    },
               {
                 "name": "body_class",
                 "service": "wordpress_test_app",
                 "resource": "body_class",
                 "trace_id": 0,
-                "span_id": 51,
-                "parent_id": 45,
+                "span_id": 38,
+                "parent_id": 34,
                 "type": "web",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT * FROM wp_posts  WHERE (post_type = 'page' AND post_status = 'publish')    AND post_parent = 2   ORDER BY wp_posts.post_title ASC LIMIT 0,1",
-                   "trace_id": 0,
-                   "span_id": 55,
-                   "parent_id": 51,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
               {
                 "name": "the_custom_header_markup",
                 "service": "wordpress_test_app",
                 "resource": "the_custom_header_markup",
                 "trace_id": 0,
-                "span_id": 52,
-                "parent_id": 45,
+                "span_id": 39,
+                "parent_id": 34,
                 "type": "web",
                 "meta": {
                   "component": "wordpress"
@@ -708,64 +436,20 @@
           "service": "wordpress_test_app",
           "resource": "the_post",
           "trace_id": 0,
-          "span_id": 37,
-          "parent_id": 18,
+          "span_id": 30,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT * FROM wp_users WHERE ID = '1'",
-             "trace_id": 0,
-             "span_id": 46,
-             "parent_id": 37,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT user_id, meta_key, meta_value FROM wp_usermeta WHERE user_id IN (1) ORDER BY umeta_id ASC",
-             "trace_id": 0,
-             "span_id": 47,
-             "parent_id": 37,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 17.0
-             }
-           },
         {
           "name": "load_template",
           "service": "wordpress_test_app",
           "resource": "content-page (template)",
           "trace_id": 0,
-          "span_id": 38,
-          "parent_id": 18,
+          "span_id": 31,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -778,8 +462,8 @@
              "service": "wordpress_test_app",
              "resource": "the_content",
              "trace_id": 0,
-             "span_id": 48,
-             "parent_id": 38,
+             "span_id": 35,
+             "parent_id": 31,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -791,8 +475,8 @@
           "service": "wordpress_test_app",
           "resource": "get_footer",
           "trace_id": 0,
-          "span_id": 39,
-          "parent_id": 18,
+          "span_id": 32,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -803,8 +487,8 @@
              "service": "wordpress_test_app",
              "resource": "footer (template)",
              "trace_id": 0,
-             "span_id": 49,
-             "parent_id": 39,
+             "span_id": 36,
+             "parent_id": 32,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -817,8 +501,8 @@
                 "service": "wordpress_test_app",
                 "resource": "wp_footer (hook)",
                 "trace_id": 0,
-                "span_id": 53,
-                "parent_id": 49,
+                "span_id": 40,
+                "parent_id": 36,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -830,7 +514,7 @@
        "service": "wordpress_test_app",
        "resource": "shutdown (hook)",
        "trace_id": 0,
-       "span_id": 19,
+       "span_id": 13,
        "parent_id": 1,
        "type": "web",
        "meta": {

--- a/tests/snapshots/tests.integrations.word_press.v5_5.common_scenarios_callbacks_test.test_scenario_get_return_string.json
+++ b/tests/snapshots/tests.integrations.word_press.v5_5.common_scenarios_callbacks_test.test_scenario_get_return_string.json
@@ -5,16 +5,17 @@
     "resource": "GET /simple",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 18156728975759963063,
+    "parent_id": 1414476306619716436,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e700f500000000",
       "component": "wordpress",
       "http.method": "GET",
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/simple?key=value&<redacted>",
-      "runtime-id": "bb23676d-44d0-4bd7-8c2a-fc5a5c89985a",
+      "runtime-id": "4ad4333f-2e0b-4278-a6f7-2182e7771b34",
       "span.kind": "server"
     },
     "metrics": {
@@ -22,108 +23,11 @@
     }
   },
      {
-       "name": "mysqli_real_connect",
-       "service": "mysqli",
-       "resource": "mysqli_real_connect",
-       "trace_id": 0,
-       "span_id": 2,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-       "trace_id": 0,
-       "span_id": 3,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT @@SESSION.sql_mode",
-       "trace_id": 0,
-       "span_id": 4,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 1.0
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-       "trace_id": 0,
-       "span_id": 5,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_name, option_value FROM wp55_options WHERE autoload = 'yes'",
-       "trace_id": 0,
-       "span_id": 6,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 111.0
-       }
-     },
-     {
        "name": "create_initial_taxonomies",
        "service": "wordpress_55_test_app",
        "resource": "create_initial_taxonomies",
        "trace_id": 0,
-       "span_id": 7,
+       "span_id": 2,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -137,7 +41,7 @@
        "service": "wordpress_55_test_app",
        "resource": "create_initial_post_types",
        "trace_id": 0,
-       "span_id": 8,
+       "span_id": 3,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -151,7 +55,7 @@
        "service": "wordpress_55_test_app",
        "resource": "datadog (plugin)",
        "trace_id": 0,
-       "span_id": 9,
+       "span_id": 4,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -164,7 +68,7 @@
        "service": "wordpress_55_test_app",
        "resource": "plugins_loaded (hook)",
        "trace_id": 0,
-       "span_id": 10,
+       "span_id": 5,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -177,8 +81,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_maybe_load_widgets",
           "trace_id": 0,
-          "span_id": 20,
-          "parent_id": 10,
+          "span_id": 14,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -191,8 +95,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_maybe_load_embeds",
           "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 10,
+          "span_id": 15,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -205,8 +109,8 @@
           "service": "wordpress_55_test_app",
           "resource": "_wp_add_additional_image_sizes (callback)",
           "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 10,
+          "span_id": 16,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -219,8 +123,8 @@
           "service": "wordpress_55_test_app",
           "resource": "_wp_customize_include",
           "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 10,
+          "span_id": 17,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -233,7 +137,7 @@
        "service": "wordpress_55_test_app",
        "resource": "setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 11,
+       "span_id": 6,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -246,8 +150,8 @@
           "service": "wordpress_55_test_app",
           "resource": "create_initial_theme_features (callback)",
           "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 11,
+          "span_id": 18,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -256,33 +160,11 @@
           }
         },
      {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'WPLANG' LIMIT 1",
-       "trace_id": 0,
-       "span_id": 12,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 0.0
-       }
-     },
-     {
        "name": "load_theme",
        "service": "wordpress_55_test_app",
        "resource": "Twentytwenty (theme)",
        "trace_id": 0,
-       "span_id": 13,
+       "span_id": 7,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -295,7 +177,7 @@
        "service": "wordpress_55_test_app",
        "resource": "after_setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 14,
+       "span_id": 8,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -308,8 +190,8 @@
           "service": "wordpress_55_test_app",
           "resource": "twentytwenty_theme_support (callback)",
           "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 14,
+          "span_id": 19,
+          "parent_id": 8,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -322,8 +204,8 @@
           "service": "wordpress_55_test_app",
           "resource": "twentytwenty_block_editor_settings (callback)",
           "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 14,
+          "span_id": 20,
+          "parent_id": 8,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -336,7 +218,7 @@
        "service": "wordpress_55_test_app",
        "resource": "WP.init",
        "trace_id": 0,
-       "span_id": 15,
+       "span_id": 9,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -348,8 +230,8 @@
           "service": "wordpress_55_test_app",
           "resource": "kses_init (callback)",
           "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 15,
+          "span_id": 21,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -362,7 +244,7 @@
        "service": "wordpress_55_test_app",
        "resource": "init (hook)",
        "trace_id": 0,
-       "span_id": 16,
+       "span_id": 10,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -375,8 +257,8 @@
           "service": "wordpress_55_test_app",
           "resource": "create_initial_post_types",
           "trace_id": 0,
-          "span_id": 28,
-          "parent_id": 16,
+          "span_id": 22,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -387,8 +269,8 @@
           "service": "wordpress_55_test_app",
           "resource": "create_initial_taxonomies",
           "trace_id": 0,
-          "span_id": 29,
-          "parent_id": 16,
+          "span_id": 23,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -399,8 +281,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_widgets_init",
           "trace_id": 0,
-          "span_id": 30,
-          "parent_id": 16,
+          "span_id": 24,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -413,42 +295,20 @@
              "service": "wordpress_55_test_app",
              "resource": "WP_Widget_Factory._register_widgets",
              "trace_id": 0,
-             "span_id": 59,
-             "parent_id": 30,
+             "span_id": 53,
+             "parent_id": 24,
              "type": "web",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-                "trace_id": 0,
-                "span_id": 62,
-                "parent_id": 59,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_55_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
         {
           "name": "callback",
           "service": "wordpress_55_test_app",
           "resource": "smilies_init (callback)",
           "trace_id": 0,
-          "span_id": 31,
-          "parent_id": 16,
+          "span_id": 25,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -461,8 +321,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_init_targeted_link_rel_filters (callback)",
           "trace_id": 0,
-          "span_id": 32,
-          "parent_id": 16,
+          "span_id": 26,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -475,8 +335,8 @@
           "service": "wordpress_55_test_app",
           "resource": "_register_core_block_patterns_and_categories (callback)",
           "trace_id": 0,
-          "span_id": 33,
-          "parent_id": 16,
+          "span_id": 27,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -489,8 +349,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_cron (callback)",
           "trace_id": 0,
-          "span_id": 34,
-          "parent_id": 16,
+          "span_id": 28,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -503,8 +363,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_schedule_delete_old_privacy_export_files (callback)",
           "trace_id": 0,
-          "span_id": 35,
-          "parent_id": 16,
+          "span_id": 29,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -517,8 +377,8 @@
           "service": "wordpress_55_test_app",
           "resource": "_show_post_preview (callback)",
           "trace_id": 0,
-          "span_id": 36,
-          "parent_id": 16,
+          "span_id": 30,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -531,8 +391,8 @@
           "service": "wordpress_55_test_app",
           "resource": "rest_api_init (callback)",
           "trace_id": 0,
-          "span_id": 37,
-          "parent_id": 16,
+          "span_id": 31,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -545,8 +405,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_sitemaps_get_server (callback)",
           "trace_id": 0,
-          "span_id": 38,
-          "parent_id": 16,
+          "span_id": 32,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -559,8 +419,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_schedule_update_checks (callback)",
           "trace_id": 0,
-          "span_id": 39,
-          "parent_id": 16,
+          "span_id": 33,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -573,8 +433,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_archives (callback)",
           "trace_id": 0,
-          "span_id": 40,
-          "parent_id": 16,
+          "span_id": 34,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -587,8 +447,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_block (callback)",
           "trace_id": 0,
-          "span_id": 41,
-          "parent_id": 16,
+          "span_id": 35,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -601,8 +461,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_calendar (callback)",
           "trace_id": 0,
-          "span_id": 42,
-          "parent_id": 16,
+          "span_id": 36,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -615,8 +475,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_categories (callback)",
           "trace_id": 0,
-          "span_id": 43,
-          "parent_id": 16,
+          "span_id": 37,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -629,8 +489,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_latest_comments (callback)",
           "trace_id": 0,
-          "span_id": 44,
-          "parent_id": 16,
+          "span_id": 38,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -643,8 +503,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_latest_posts (callback)",
           "trace_id": 0,
-          "span_id": 45,
-          "parent_id": 16,
+          "span_id": 39,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -657,8 +517,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_rss (callback)",
           "trace_id": 0,
-          "span_id": 46,
-          "parent_id": 16,
+          "span_id": 40,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -671,8 +531,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_search (callback)",
           "trace_id": 0,
-          "span_id": 47,
-          "parent_id": 16,
+          "span_id": 41,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -685,8 +545,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_shortcode (callback)",
           "trace_id": 0,
-          "span_id": 48,
-          "parent_id": 16,
+          "span_id": 42,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -699,8 +559,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_social_link (callback)",
           "trace_id": 0,
-          "span_id": 49,
-          "parent_id": 16,
+          "span_id": 43,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -713,8 +573,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_tag_cloud (callback)",
           "trace_id": 0,
-          "span_id": 50,
-          "parent_id": 16,
+          "span_id": 44,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -727,8 +587,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_core_block_types_from_metadata (callback)",
           "trace_id": 0,
-          "span_id": 51,
-          "parent_id": 16,
+          "span_id": 45,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -741,8 +601,8 @@
           "service": "wordpress_55_test_app",
           "resource": "twentytwenty_menus (callback)",
           "trace_id": 0,
-          "span_id": 52,
-          "parent_id": 16,
+          "span_id": 46,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -755,8 +615,8 @@
           "service": "wordpress_55_test_app",
           "resource": "twentytwenty_classic_editor_styles (callback)",
           "trace_id": 0,
-          "span_id": 53,
-          "parent_id": 16,
+          "span_id": 47,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -769,8 +629,8 @@
           "service": "wordpress_55_test_app",
           "resource": "check_theme_switched (callback)",
           "trace_id": 0,
-          "span_id": 54,
-          "parent_id": 16,
+          "span_id": 48,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -778,34 +638,12 @@
             "wordpress.hook": "init"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'theme_switched' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 60,
-             "parent_id": 54,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_55_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_55_test_app",
        "resource": "wp_loaded (hook)",
        "trace_id": 0,
-       "span_id": 17,
+       "span_id": 11,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -818,8 +656,8 @@
           "service": "wordpress_55_test_app",
           "resource": "_custom_header_background_just_in_time (callback)",
           "trace_id": 0,
-          "span_id": 55,
-          "parent_id": 17,
+          "span_id": 49,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -832,7 +670,7 @@
        "service": "wordpress_55_test_app",
        "resource": "WP.main",
        "trace_id": 0,
-       "span_id": 18,
+       "span_id": 12,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -844,8 +682,8 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 56,
-          "parent_id": 18,
+          "span_id": 50,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -856,41 +694,19 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 57,
-          "parent_id": 18,
+          "span_id": 51,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('simple')\n\t\tAND post_type IN ('page','attachment')\n\t",
-             "trace_id": 0,
-             "span_id": 61,
-             "parent_id": 57,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_55_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_55_test_app",
        "resource": "shutdown (hook)",
        "trace_id": 0,
-       "span_id": 19,
+       "span_id": 13,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -903,8 +719,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_ob_end_flush_all (callback)",
           "trace_id": 0,
-          "span_id": 58,
-          "parent_id": 19,
+          "span_id": 52,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",

--- a/tests/snapshots/tests.integrations.word_press.v5_5.common_scenarios_callbacks_test.test_scenario_get_to_missing_route.json
+++ b/tests/snapshots/tests.integrations.word_press.v5_5.common_scenarios_callbacks_test.test_scenario_get_to_missing_route.json
@@ -5,15 +5,16 @@
     "resource": "GET /does_not_exist",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 7496115614704111489,
+    "parent_id": 15843270837327387183,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e7012200000000",
       "component": "wordpress",
       "http.method": "GET",
       "http.status_code": "404",
       "http.url": "http://localhost:9999/does_not_exist?key=value&<redacted>",
-      "runtime-id": "bb23676d-44d0-4bd7-8c2a-fc5a5c89985a",
+      "runtime-id": "4ad4333f-2e0b-4278-a6f7-2182e7771b34",
       "span.kind": "server"
     },
     "metrics": {
@@ -21,108 +22,11 @@
     }
   },
      {
-       "name": "mysqli_real_connect",
-       "service": "mysqli",
-       "resource": "mysqli_real_connect",
-       "trace_id": 0,
-       "span_id": 2,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-       "trace_id": 0,
-       "span_id": 3,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT @@SESSION.sql_mode",
-       "trace_id": 0,
-       "span_id": 4,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 1.0
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-       "trace_id": 0,
-       "span_id": 5,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_name, option_value FROM wp55_options WHERE autoload = 'yes'",
-       "trace_id": 0,
-       "span_id": 6,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 111.0
-       }
-     },
-     {
        "name": "create_initial_taxonomies",
        "service": "wordpress_55_test_app",
        "resource": "create_initial_taxonomies",
        "trace_id": 0,
-       "span_id": 7,
+       "span_id": 2,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -136,7 +40,7 @@
        "service": "wordpress_55_test_app",
        "resource": "create_initial_post_types",
        "trace_id": 0,
-       "span_id": 8,
+       "span_id": 3,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -150,7 +54,7 @@
        "service": "wordpress_55_test_app",
        "resource": "datadog (plugin)",
        "trace_id": 0,
-       "span_id": 9,
+       "span_id": 4,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -163,7 +67,7 @@
        "service": "wordpress_55_test_app",
        "resource": "plugins_loaded (hook)",
        "trace_id": 0,
-       "span_id": 10,
+       "span_id": 5,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -176,8 +80,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_maybe_load_widgets",
           "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 10,
+          "span_id": 15,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -190,8 +94,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_maybe_load_embeds",
           "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 10,
+          "span_id": 16,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -204,8 +108,8 @@
           "service": "wordpress_55_test_app",
           "resource": "_wp_add_additional_image_sizes (callback)",
           "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 10,
+          "span_id": 17,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -218,8 +122,8 @@
           "service": "wordpress_55_test_app",
           "resource": "_wp_customize_include",
           "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 10,
+          "span_id": 18,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -232,7 +136,7 @@
        "service": "wordpress_55_test_app",
        "resource": "setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 11,
+       "span_id": 6,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -245,8 +149,8 @@
           "service": "wordpress_55_test_app",
           "resource": "create_initial_theme_features (callback)",
           "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 11,
+          "span_id": 19,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -255,33 +159,11 @@
           }
         },
      {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'WPLANG' LIMIT 1",
-       "trace_id": 0,
-       "span_id": 12,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 0.0
-       }
-     },
-     {
        "name": "load_theme",
        "service": "wordpress_55_test_app",
        "resource": "Twentytwenty (theme)",
        "trace_id": 0,
-       "span_id": 13,
+       "span_id": 7,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -294,7 +176,7 @@
        "service": "wordpress_55_test_app",
        "resource": "after_setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 14,
+       "span_id": 8,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -307,8 +189,8 @@
           "service": "wordpress_55_test_app",
           "resource": "twentytwenty_theme_support (callback)",
           "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 14,
+          "span_id": 20,
+          "parent_id": 8,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -321,8 +203,8 @@
           "service": "wordpress_55_test_app",
           "resource": "twentytwenty_block_editor_settings (callback)",
           "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 14,
+          "span_id": 21,
+          "parent_id": 8,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -335,7 +217,7 @@
        "service": "wordpress_55_test_app",
        "resource": "WP.init",
        "trace_id": 0,
-       "span_id": 15,
+       "span_id": 9,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -347,8 +229,8 @@
           "service": "wordpress_55_test_app",
           "resource": "kses_init (callback)",
           "trace_id": 0,
-          "span_id": 28,
-          "parent_id": 15,
+          "span_id": 22,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -361,7 +243,7 @@
        "service": "wordpress_55_test_app",
        "resource": "init (hook)",
        "trace_id": 0,
-       "span_id": 16,
+       "span_id": 10,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -374,8 +256,8 @@
           "service": "wordpress_55_test_app",
           "resource": "create_initial_post_types",
           "trace_id": 0,
-          "span_id": 29,
-          "parent_id": 16,
+          "span_id": 23,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -386,8 +268,8 @@
           "service": "wordpress_55_test_app",
           "resource": "create_initial_taxonomies",
           "trace_id": 0,
-          "span_id": 30,
-          "parent_id": 16,
+          "span_id": 24,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -398,8 +280,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_widgets_init",
           "trace_id": 0,
-          "span_id": 31,
-          "parent_id": 16,
+          "span_id": 25,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -412,42 +294,20 @@
              "service": "wordpress_55_test_app",
              "resource": "WP_Widget_Factory._register_widgets",
              "trace_id": 0,
-             "span_id": 70,
-             "parent_id": 31,
+             "span_id": 64,
+             "parent_id": 25,
              "type": "web",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-                "trace_id": 0,
-                "span_id": 85,
-                "parent_id": 70,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_55_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
         {
           "name": "callback",
           "service": "wordpress_55_test_app",
           "resource": "smilies_init (callback)",
           "trace_id": 0,
-          "span_id": 32,
-          "parent_id": 16,
+          "span_id": 26,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -460,8 +320,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_init_targeted_link_rel_filters (callback)",
           "trace_id": 0,
-          "span_id": 33,
-          "parent_id": 16,
+          "span_id": 27,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -474,8 +334,8 @@
           "service": "wordpress_55_test_app",
           "resource": "_register_core_block_patterns_and_categories (callback)",
           "trace_id": 0,
-          "span_id": 34,
-          "parent_id": 16,
+          "span_id": 28,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -488,8 +348,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_cron (callback)",
           "trace_id": 0,
-          "span_id": 35,
-          "parent_id": 16,
+          "span_id": 29,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -502,8 +362,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_schedule_delete_old_privacy_export_files (callback)",
           "trace_id": 0,
-          "span_id": 36,
-          "parent_id": 16,
+          "span_id": 30,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -516,8 +376,8 @@
           "service": "wordpress_55_test_app",
           "resource": "_show_post_preview (callback)",
           "trace_id": 0,
-          "span_id": 37,
-          "parent_id": 16,
+          "span_id": 31,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -530,8 +390,8 @@
           "service": "wordpress_55_test_app",
           "resource": "rest_api_init (callback)",
           "trace_id": 0,
-          "span_id": 38,
-          "parent_id": 16,
+          "span_id": 32,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -544,8 +404,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_sitemaps_get_server (callback)",
           "trace_id": 0,
-          "span_id": 39,
-          "parent_id": 16,
+          "span_id": 33,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -558,8 +418,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_schedule_update_checks (callback)",
           "trace_id": 0,
-          "span_id": 40,
-          "parent_id": 16,
+          "span_id": 34,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -572,8 +432,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_archives (callback)",
           "trace_id": 0,
-          "span_id": 41,
-          "parent_id": 16,
+          "span_id": 35,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -586,8 +446,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_block (callback)",
           "trace_id": 0,
-          "span_id": 42,
-          "parent_id": 16,
+          "span_id": 36,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -600,8 +460,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_calendar (callback)",
           "trace_id": 0,
-          "span_id": 43,
-          "parent_id": 16,
+          "span_id": 37,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -614,8 +474,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_categories (callback)",
           "trace_id": 0,
-          "span_id": 44,
-          "parent_id": 16,
+          "span_id": 38,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -628,8 +488,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_latest_comments (callback)",
           "trace_id": 0,
-          "span_id": 45,
-          "parent_id": 16,
+          "span_id": 39,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -642,8 +502,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_latest_posts (callback)",
           "trace_id": 0,
-          "span_id": 46,
-          "parent_id": 16,
+          "span_id": 40,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -656,8 +516,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_rss (callback)",
           "trace_id": 0,
-          "span_id": 47,
-          "parent_id": 16,
+          "span_id": 41,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -670,8 +530,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_search (callback)",
           "trace_id": 0,
-          "span_id": 48,
-          "parent_id": 16,
+          "span_id": 42,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -684,8 +544,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_shortcode (callback)",
           "trace_id": 0,
-          "span_id": 49,
-          "parent_id": 16,
+          "span_id": 43,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -698,8 +558,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_social_link (callback)",
           "trace_id": 0,
-          "span_id": 50,
-          "parent_id": 16,
+          "span_id": 44,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -712,8 +572,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_tag_cloud (callback)",
           "trace_id": 0,
-          "span_id": 51,
-          "parent_id": 16,
+          "span_id": 45,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -726,8 +586,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_core_block_types_from_metadata (callback)",
           "trace_id": 0,
-          "span_id": 52,
-          "parent_id": 16,
+          "span_id": 46,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -740,8 +600,8 @@
           "service": "wordpress_55_test_app",
           "resource": "twentytwenty_menus (callback)",
           "trace_id": 0,
-          "span_id": 53,
-          "parent_id": 16,
+          "span_id": 47,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -754,8 +614,8 @@
           "service": "wordpress_55_test_app",
           "resource": "twentytwenty_classic_editor_styles (callback)",
           "trace_id": 0,
-          "span_id": 54,
-          "parent_id": 16,
+          "span_id": 48,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -768,8 +628,8 @@
           "service": "wordpress_55_test_app",
           "resource": "check_theme_switched (callback)",
           "trace_id": 0,
-          "span_id": 55,
-          "parent_id": 16,
+          "span_id": 49,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -777,34 +637,12 @@
             "wordpress.hook": "init"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'theme_switched' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 71,
-             "parent_id": 55,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_55_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_55_test_app",
        "resource": "wp_loaded (hook)",
        "trace_id": 0,
-       "span_id": 17,
+       "span_id": 11,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -817,8 +655,8 @@
           "service": "wordpress_55_test_app",
           "resource": "_custom_header_background_just_in_time (callback)",
           "trace_id": 0,
-          "span_id": 56,
-          "parent_id": 17,
+          "span_id": 50,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -831,7 +669,7 @@
        "service": "wordpress_55_test_app",
        "resource": "WP.main",
        "trace_id": 0,
-       "span_id": 18,
+       "span_id": 12,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -843,8 +681,8 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 57,
-          "parent_id": 18,
+          "span_id": 51,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -855,42 +693,20 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 58,
-          "parent_id": 18,
+          "span_id": 52,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('does_not_exist')\n\t\tAND post_type IN ('page','attachment')\n\t",
-             "trace_id": 0,
-             "span_id": 72,
-             "parent_id": 58,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_55_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
         {
           "name": "WP.send_headers",
           "service": "wordpress_55_test_app",
           "resource": "WP.send_headers",
           "trace_id": 0,
-          "span_id": 59,
-          "parent_id": 18,
+          "span_id": 53,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -901,42 +717,20 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.query_posts",
           "trace_id": 0,
-          "span_id": 60,
-          "parent_id": 18,
+          "span_id": 54,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT   wp55_posts.* FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_name = 'does_not_exist' AND wp55_posts.post_type = 'post'  ORDER BY wp55_posts.post_date DESC ",
-             "trace_id": 0,
-             "span_id": 73,
-             "parent_id": 60,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_55_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
         {
           "name": "WP.handle_404",
           "service": "wordpress_55_test_app",
           "resource": "WP.handle_404",
           "trace_id": 0,
-          "span_id": 61,
-          "parent_id": 18,
+          "span_id": 55,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -947,8 +741,8 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.register_globals",
           "trace_id": 0,
-          "span_id": 62,
-          "parent_id": 18,
+          "span_id": 56,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -959,8 +753,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp (hook)",
           "trace_id": 0,
-          "span_id": 63,
-          "parent_id": 18,
+          "span_id": 57,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -972,7 +766,7 @@
        "service": "wordpress_55_test_app",
        "resource": "load_template_loader",
        "trace_id": 0,
-       "span_id": 19,
+       "span_id": 13,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -984,8 +778,8 @@
           "service": "wordpress_55_test_app",
           "resource": "template_redirect (hook)",
           "trace_id": 0,
-          "span_id": 64,
-          "parent_id": 19,
+          "span_id": 58,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -997,8 +791,8 @@
              "service": "wordpress_55_test_app",
              "resource": "_wp_admin_bar_init (callback)",
              "trace_id": 0,
-             "span_id": 74,
-             "parent_id": 64,
+             "span_id": 65,
+             "parent_id": 58,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1011,8 +805,8 @@
              "service": "wordpress_55_test_app",
              "resource": "wp_old_slug_redirect (callback)",
              "trace_id": 0,
-             "span_id": 75,
-             "parent_id": 64,
+             "span_id": 66,
+             "parent_id": 58,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1020,35 +814,13 @@
                "wordpress.hook": "template_redirect"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT post_id FROM wp55_postmeta, wp55_posts WHERE ID = post_id AND post_type = 'post' AND meta_key = '_wp_old_slug' AND meta_value = 'does_not_exist'",
-                "trace_id": 0,
-                "span_id": 86,
-                "parent_id": 75,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_55_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              },
            {
              "name": "callback",
              "service": "wordpress_55_test_app",
              "resource": "redirect_canonical (callback)",
              "trace_id": 0,
-             "span_id": 76,
-             "parent_id": 64,
+             "span_id": 67,
+             "parent_id": 58,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1056,35 +828,13 @@
                "wordpress.hook": "template_redirect"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT ID FROM wp55_posts WHERE post_name LIKE 'does\\\\_not\\\\_exist%' AND post_type IN ('post', 'page', 'attachment') AND post_status = 'publish'",
-                "trace_id": 0,
-                "span_id": 87,
-                "parent_id": 76,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_55_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              },
            {
              "name": "callback",
              "service": "wordpress_55_test_app",
              "resource": "WP_Sitemaps::render_sitemaps (callback)",
              "trace_id": 0,
-             "span_id": 77,
-             "parent_id": 64,
+             "span_id": 68,
+             "parent_id": 58,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1097,8 +847,8 @@
              "service": "wordpress_55_test_app",
              "resource": "rest_output_link_header (callback)",
              "trace_id": 0,
-             "span_id": 78,
-             "parent_id": 64,
+             "span_id": 69,
+             "parent_id": 58,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1111,8 +861,8 @@
              "service": "wordpress_55_test_app",
              "resource": "wp_shortlink_header (callback)",
              "trace_id": 0,
-             "span_id": 79,
-             "parent_id": 64,
+             "span_id": 70,
+             "parent_id": 58,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1125,8 +875,8 @@
              "service": "wordpress_55_test_app",
              "resource": "wp_redirect_admin_locations (callback)",
              "trace_id": 0,
-             "span_id": 80,
-             "parent_id": 64,
+             "span_id": 71,
+             "parent_id": 58,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1139,8 +889,8 @@
           "service": "wordpress_55_test_app",
           "resource": "404 (type)",
           "trace_id": 0,
-          "span_id": 65,
-          "parent_id": 19,
+          "span_id": 59,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1153,8 +903,8 @@
           "service": "wordpress_55_test_app",
           "resource": "get_header",
           "trace_id": 0,
-          "span_id": 66,
-          "parent_id": 19,
+          "span_id": 60,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -1165,8 +915,8 @@
              "service": "wordpress_55_test_app",
              "resource": "header (template)",
              "trace_id": 0,
-             "span_id": 81,
-             "parent_id": 66,
+             "span_id": 72,
+             "parent_id": 60,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1179,8 +929,8 @@
                 "service": "wordpress_55_test_app",
                 "resource": "wp_head (hook)",
                 "trace_id": 0,
-                "span_id": 88,
-                "parent_id": 81,
+                "span_id": 76,
+                "parent_id": 72,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -1192,8 +942,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "_wp_render_title_tag (callback)",
                    "trace_id": 0,
-                   "span_id": 99,
-                   "parent_id": 88,
+                   "span_id": 86,
+                   "parent_id": 76,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1206,8 +956,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "wp_enqueue_scripts (callback)",
                    "trace_id": 0,
-                   "span_id": 100,
-                   "parent_id": 88,
+                   "span_id": 87,
+                   "parent_id": 76,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1220,8 +970,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "noindex (callback)",
                    "trace_id": 0,
-                   "span_id": 101,
-                   "parent_id": 88,
+                   "span_id": 88,
+                   "parent_id": 76,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1234,8 +984,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "wp_post_preview_js (callback)",
                    "trace_id": 0,
-                   "span_id": 102,
-                   "parent_id": 88,
+                   "span_id": 89,
+                   "parent_id": 76,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1248,8 +998,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "wp_resource_hints (callback)",
                    "trace_id": 0,
-                   "span_id": 103,
-                   "parent_id": 88,
+                   "span_id": 90,
+                   "parent_id": 76,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1262,8 +1012,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "feed_links (callback)",
                    "trace_id": 0,
-                   "span_id": 104,
-                   "parent_id": 88,
+                   "span_id": 91,
+                   "parent_id": 76,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1276,8 +1026,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "feed_links_extra (callback)",
                    "trace_id": 0,
-                   "span_id": 105,
-                   "parent_id": 88,
+                   "span_id": 92,
+                   "parent_id": 76,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1290,8 +1040,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "print_emoji_detection_script (callback)",
                    "trace_id": 0,
-                   "span_id": 106,
-                   "parent_id": 88,
+                   "span_id": 93,
+                   "parent_id": 76,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1304,8 +1054,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "wp_print_styles (callback)",
                    "trace_id": 0,
-                   "span_id": 107,
-                   "parent_id": 88,
+                   "span_id": 94,
+                   "parent_id": 76,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1318,8 +1068,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "wp_print_head_scripts",
                    "trace_id": 0,
-                   "span_id": 108,
-                   "parent_id": 88,
+                   "span_id": 95,
+                   "parent_id": 76,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1332,8 +1082,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "rest_output_link_wp_head (callback)",
                    "trace_id": 0,
-                   "span_id": 109,
-                   "parent_id": 88,
+                   "span_id": 96,
+                   "parent_id": 76,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1346,8 +1096,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "rsd_link (callback)",
                    "trace_id": 0,
-                   "span_id": 110,
-                   "parent_id": 88,
+                   "span_id": 97,
+                   "parent_id": 76,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1360,8 +1110,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "wlwmanifest_link (callback)",
                    "trace_id": 0,
-                   "span_id": 111,
-                   "parent_id": 88,
+                   "span_id": 98,
+                   "parent_id": 76,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1374,8 +1124,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "adjacent_posts_rel_link_wp_head (callback)",
                    "trace_id": 0,
-                   "span_id": 112,
-                   "parent_id": 88,
+                   "span_id": 99,
+                   "parent_id": 76,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1388,8 +1138,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "locale_stylesheet (callback)",
                    "trace_id": 0,
-                   "span_id": 113,
-                   "parent_id": 88,
+                   "span_id": 100,
+                   "parent_id": 76,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1402,8 +1152,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "wp_generator (callback)",
                    "trace_id": 0,
-                   "span_id": 114,
-                   "parent_id": 88,
+                   "span_id": 101,
+                   "parent_id": 76,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1416,8 +1166,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "rel_canonical (callback)",
                    "trace_id": 0,
-                   "span_id": 115,
-                   "parent_id": 88,
+                   "span_id": 102,
+                   "parent_id": 76,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1430,8 +1180,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "wp_shortlink_wp_head (callback)",
                    "trace_id": 0,
-                   "span_id": 116,
-                   "parent_id": 88,
+                   "span_id": 103,
+                   "parent_id": 76,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1444,8 +1194,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "_custom_logo_header_styles (callback)",
                    "trace_id": 0,
-                   "span_id": 117,
-                   "parent_id": 88,
+                   "span_id": 104,
+                   "parent_id": 76,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1458,8 +1208,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "wp_oembed_add_discovery_links (callback)",
                    "trace_id": 0,
-                   "span_id": 118,
-                   "parent_id": 88,
+                   "span_id": 105,
+                   "parent_id": 76,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1472,8 +1222,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "wp_oembed_add_host_js (callback)",
                    "trace_id": 0,
-                   "span_id": 119,
-                   "parent_id": 88,
+                   "span_id": 106,
+                   "parent_id": 76,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1486,8 +1236,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "twentytwenty_no_js_class (callback)",
                    "trace_id": 0,
-                   "span_id": 120,
-                   "parent_id": 88,
+                   "span_id": 107,
+                   "parent_id": 76,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1500,8 +1250,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "WP_Widget_Recent_Comments::recent_comments_style (callback)",
                    "trace_id": 0,
-                   "span_id": 121,
-                   "parent_id": 88,
+                   "span_id": 108,
+                   "parent_id": 76,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1514,8 +1264,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "_custom_background_cb (callback)",
                    "trace_id": 0,
-                   "span_id": 122,
-                   "parent_id": 88,
+                   "span_id": 109,
+                   "parent_id": 76,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1528,8 +1278,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "wp_site_icon (callback)",
                    "trace_id": 0,
-                   "span_id": 123,
-                   "parent_id": 88,
+                   "span_id": 110,
+                   "parent_id": 76,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1542,8 +1292,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "wp_custom_css_cb (callback)",
                    "trace_id": 0,
-                   "span_id": 124,
-                   "parent_id": 88,
+                   "span_id": 111,
+                   "parent_id": 76,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1556,8 +1306,8 @@
                 "service": "wordpress_55_test_app",
                 "resource": "body_class",
                 "trace_id": 0,
-                "span_id": 89,
-                "parent_id": 81,
+                "span_id": 77,
+                "parent_id": 72,
                 "type": "web",
                 "meta": {
                   "component": "wordpress"
@@ -1568,8 +1318,8 @@
                 "service": "wordpress_55_test_app",
                 "resource": "wp_admin_bar_render (callback)",
                 "trace_id": 0,
-                "span_id": 90,
-                "parent_id": 81,
+                "span_id": 78,
+                "parent_id": 72,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -1577,35 +1327,13 @@
                   "wordpress.hook": "wp_footer"
                 }
               },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT * FROM wp55_posts  WHERE (post_type = 'page' AND post_status = 'publish')     ORDER BY menu_order,wp55_posts.post_title ASC",
-                "trace_id": 0,
-                "span_id": 91,
-                "parent_id": 81,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_55_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
         {
           "name": "load_template",
           "service": "wordpress_55_test_app",
           "resource": "footer-menus-widgets (template)",
           "trace_id": 0,
-          "span_id": 67,
-          "parent_id": 19,
+          "span_id": 61,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1618,8 +1346,8 @@
              "service": "wordpress_55_test_app",
              "resource": "sidebar-1",
              "trace_id": 0,
-             "span_id": 82,
-             "parent_id": 67,
+             "span_id": 73,
+             "parent_id": 61,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -1630,8 +1358,8 @@
                 "service": "wordpress_55_test_app",
                 "resource": "Search (widget)",
                 "trace_id": 0,
-                "span_id": 92,
-                "parent_id": 82,
+                "span_id": 79,
+                "parent_id": 73,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -1643,188 +1371,34 @@
                 "service": "wordpress_55_test_app",
                 "resource": "Recent Posts (widget)",
                 "trace_id": 0,
-                "span_id": 93,
-                "parent_id": 82,
+                "span_id": 80,
+                "parent_id": 73,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Recent Posts"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT   wp55_posts.ID FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_type = 'post' AND ((wp55_posts.post_status = 'publish'))  ORDER BY wp55_posts.post_date DESC LIMIT 0, 5",
-                   "trace_id": 0,
-                   "span_id": 125,
-                   "parent_id": 93,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 2.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT wp55_posts.* FROM wp55_posts WHERE ID IN (5,1)",
-                   "trace_id": 0,
-                   "span_id": 126,
-                   "parent_id": 93,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 2.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  t.*, tt.*, tr.object_id FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id INNER JOIN wp55_term_relationships AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy IN ('category', 'post_tag', 'post_format') AND tr.object_id IN (1, 5) ORDER BY t.name ASC ",
-                   "trace_id": 0,
-                   "span_id": 127,
-                   "parent_id": 93,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 2.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT post_id, meta_key, meta_value FROM wp55_postmeta WHERE post_id IN (1,5) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 128,
-                   "parent_id": 93,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 3.0
-                   }
-                 },
               {
                 "name": "widget",
                 "service": "wordpress_55_test_app",
                 "resource": "Recent Comments (widget)",
                 "trace_id": 0,
-                "span_id": 94,
-                "parent_id": 82,
+                "span_id": 81,
+                "parent_id": 73,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Recent Comments"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  wp55_comments.comment_ID FROM wp55_comments JOIN wp55_posts ON wp55_posts.ID = wp55_comments.comment_post_ID WHERE ( comment_approved = '1' ) AND  wp55_posts.post_status IN ('publish')  ORDER BY wp55_comments.comment_date_gmt DESC LIMIT 0,5",
-                   "trace_id": 0,
-                   "span_id": 129,
-                   "parent_id": 94,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT wp55_comments.* FROM wp55_comments WHERE comment_ID IN (1)",
-                   "trace_id": 0,
-                   "span_id": 130,
-                   "parent_id": 94,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT comment_id, meta_key, meta_value FROM wp55_commentmeta WHERE comment_id IN (1) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 131,
-                   "parent_id": 94,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
            {
              "name": "dynamic_sidebar",
              "service": "wordpress_55_test_app",
              "resource": "sidebar-2",
              "trace_id": 0,
-             "span_id": 83,
-             "parent_id": 67,
+             "span_id": 74,
+             "parent_id": 61,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -1835,100 +1409,34 @@
                 "service": "wordpress_55_test_app",
                 "resource": "Archives (widget)",
                 "trace_id": 0,
-                "span_id": 95,
-                "parent_id": 83,
+                "span_id": 82,
+                "parent_id": 74,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Archives"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT YEAR(post_date) AS `year`, MONTH(post_date) AS `month`, count(ID) as posts FROM wp55_posts  WHERE post_type = 'post' AND post_status = 'publish' GROUP BY YEAR(post_date), MONTH(post_date) ORDER BY post_date DESC ",
-                   "trace_id": 0,
-                   "span_id": 132,
-                   "parent_id": 95,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
               {
                 "name": "widget",
                 "service": "wordpress_55_test_app",
                 "resource": "Categories (widget)",
                 "trace_id": 0,
-                "span_id": 96,
-                "parent_id": 83,
+                "span_id": 83,
+                "parent_id": 74,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Categories"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  t.*, tt.* FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id WHERE tt.taxonomy IN ('category') AND tt.count > 0 ORDER BY t.name ASC ",
-                   "trace_id": 0,
-                   "span_id": 133,
-                   "parent_id": 96,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT term_id, meta_key, meta_value FROM wp55_termmeta WHERE term_id IN (1) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 134,
-                   "parent_id": 96,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
               {
                 "name": "widget",
                 "service": "wordpress_55_test_app",
                 "resource": "Meta (widget)",
                 "trace_id": 0,
-                "span_id": 97,
-                "parent_id": 83,
+                "span_id": 84,
+                "parent_id": 74,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -1940,8 +1448,8 @@
           "service": "wordpress_55_test_app",
           "resource": "get_footer",
           "trace_id": 0,
-          "span_id": 68,
-          "parent_id": 19,
+          "span_id": 62,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -1952,8 +1460,8 @@
              "service": "wordpress_55_test_app",
              "resource": "footer (template)",
              "trace_id": 0,
-             "span_id": 84,
-             "parent_id": 68,
+             "span_id": 75,
+             "parent_id": 62,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1966,8 +1474,8 @@
                 "service": "wordpress_55_test_app",
                 "resource": "wp_footer (hook)",
                 "trace_id": 0,
-                "span_id": 98,
-                "parent_id": 84,
+                "span_id": 85,
+                "parent_id": 75,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -1979,8 +1487,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "wp_print_footer_scripts (callback)",
                    "trace_id": 0,
-                   "span_id": 135,
-                   "parent_id": 98,
+                   "span_id": 112,
+                   "parent_id": 85,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1993,7 +1501,7 @@
        "service": "wordpress_55_test_app",
        "resource": "shutdown (hook)",
        "trace_id": 0,
-       "span_id": 20,
+       "span_id": 14,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -2006,8 +1514,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_ob_end_flush_all (callback)",
           "trace_id": 0,
-          "span_id": 69,
-          "parent_id": 20,
+          "span_id": 63,
+          "parent_id": 14,
           "type": "web",
           "meta": {
             "component": "wordpress",

--- a/tests/snapshots/tests.integrations.word_press.v5_5.common_scenarios_callbacks_test.test_scenario_get_with_exception.json
+++ b/tests/snapshots/tests.integrations.word_press.v5_5.common_scenarios_callbacks_test.test_scenario_get_with_exception.json
@@ -5,11 +5,12 @@
     "resource": "GET /error",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 18133808272059380524,
+    "parent_id": 140838815579349469,
     "type": "web",
     "error": 1,
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e7011700000000",
       "component": "wordpress",
       "error.message": "Uncaught Exception: Oops! in /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/wp-content/plugins/datadog/datadog.php:23",
       "error.stack": "#0 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/wp-includes/class-wp-hook.php(287): datadog_parse_request()\n#1 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/wp-includes/class-wp-hook.php(311): WP_Hook->apply_filters()\n#2 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/wp-includes/plugin.php(544): WP_Hook->do_action()\n#3 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/wp-includes/class-wp.php(388): do_action_ref_array()\n#4 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/wp-includes/class-wp.php(745): WP->parse_request()\n#5 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/wp-includes/functions.php(1285): WP->main()\n#6 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/wp-blog-header.php(16): wp()\n#7 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/index.php(17): require()\n#8 {main}",
@@ -18,7 +19,7 @@
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/error?key=value&<redacted>",
-      "runtime-id": "7b42d084-3a90-4688-9319-30e9724039bb",
+      "runtime-id": "4ad4333f-2e0b-4278-a6f7-2182e7771b34",
       "span.kind": "server"
     },
     "metrics": {
@@ -26,108 +27,11 @@
     }
   },
      {
-       "name": "mysqli_real_connect",
-       "service": "mysqli",
-       "resource": "mysqli_real_connect",
-       "trace_id": 0,
-       "span_id": 2,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-       "trace_id": 0,
-       "span_id": 3,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT @@SESSION.sql_mode",
-       "trace_id": 0,
-       "span_id": 4,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 1.0
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-       "trace_id": 0,
-       "span_id": 5,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_name, option_value FROM wp55_options WHERE autoload = 'yes'",
-       "trace_id": 0,
-       "span_id": 6,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 111.0
-       }
-     },
-     {
        "name": "create_initial_taxonomies",
        "service": "wordpress_55_test_app",
        "resource": "create_initial_taxonomies",
        "trace_id": 0,
-       "span_id": 7,
+       "span_id": 2,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -141,7 +45,7 @@
        "service": "wordpress_55_test_app",
        "resource": "create_initial_post_types",
        "trace_id": 0,
-       "span_id": 8,
+       "span_id": 3,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -155,7 +59,7 @@
        "service": "wordpress_55_test_app",
        "resource": "datadog (plugin)",
        "trace_id": 0,
-       "span_id": 9,
+       "span_id": 4,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -168,7 +72,7 @@
        "service": "wordpress_55_test_app",
        "resource": "plugins_loaded (hook)",
        "trace_id": 0,
-       "span_id": 10,
+       "span_id": 5,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -181,8 +85,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_maybe_load_widgets",
           "trace_id": 0,
-          "span_id": 20,
-          "parent_id": 10,
+          "span_id": 14,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -195,8 +99,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_maybe_load_embeds",
           "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 10,
+          "span_id": 15,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -209,8 +113,8 @@
           "service": "wordpress_55_test_app",
           "resource": "_wp_add_additional_image_sizes (callback)",
           "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 10,
+          "span_id": 16,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -223,8 +127,8 @@
           "service": "wordpress_55_test_app",
           "resource": "_wp_customize_include",
           "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 10,
+          "span_id": 17,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -237,7 +141,7 @@
        "service": "wordpress_55_test_app",
        "resource": "setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 11,
+       "span_id": 6,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -250,8 +154,8 @@
           "service": "wordpress_55_test_app",
           "resource": "create_initial_theme_features (callback)",
           "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 11,
+          "span_id": 18,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -260,33 +164,11 @@
           }
         },
      {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'WPLANG' LIMIT 1",
-       "trace_id": 0,
-       "span_id": 12,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 0.0
-       }
-     },
-     {
        "name": "load_theme",
        "service": "wordpress_55_test_app",
        "resource": "Twentytwenty (theme)",
        "trace_id": 0,
-       "span_id": 13,
+       "span_id": 7,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -299,7 +181,7 @@
        "service": "wordpress_55_test_app",
        "resource": "after_setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 14,
+       "span_id": 8,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -312,8 +194,8 @@
           "service": "wordpress_55_test_app",
           "resource": "twentytwenty_theme_support (callback)",
           "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 14,
+          "span_id": 19,
+          "parent_id": 8,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -326,8 +208,8 @@
           "service": "wordpress_55_test_app",
           "resource": "twentytwenty_block_editor_settings (callback)",
           "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 14,
+          "span_id": 20,
+          "parent_id": 8,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -340,7 +222,7 @@
        "service": "wordpress_55_test_app",
        "resource": "WP.init",
        "trace_id": 0,
-       "span_id": 15,
+       "span_id": 9,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -352,8 +234,8 @@
           "service": "wordpress_55_test_app",
           "resource": "kses_init (callback)",
           "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 15,
+          "span_id": 21,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -366,7 +248,7 @@
        "service": "wordpress_55_test_app",
        "resource": "init (hook)",
        "trace_id": 0,
-       "span_id": 16,
+       "span_id": 10,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -379,8 +261,8 @@
           "service": "wordpress_55_test_app",
           "resource": "create_initial_post_types",
           "trace_id": 0,
-          "span_id": 28,
-          "parent_id": 16,
+          "span_id": 22,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -391,8 +273,8 @@
           "service": "wordpress_55_test_app",
           "resource": "create_initial_taxonomies",
           "trace_id": 0,
-          "span_id": 29,
-          "parent_id": 16,
+          "span_id": 23,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -403,8 +285,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_widgets_init",
           "trace_id": 0,
-          "span_id": 30,
-          "parent_id": 16,
+          "span_id": 24,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -417,42 +299,20 @@
              "service": "wordpress_55_test_app",
              "resource": "WP_Widget_Factory._register_widgets",
              "trace_id": 0,
-             "span_id": 59,
-             "parent_id": 30,
+             "span_id": 53,
+             "parent_id": 24,
              "type": "web",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-                "trace_id": 0,
-                "span_id": 62,
-                "parent_id": 59,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_55_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
         {
           "name": "callback",
           "service": "wordpress_55_test_app",
           "resource": "smilies_init (callback)",
           "trace_id": 0,
-          "span_id": 31,
-          "parent_id": 16,
+          "span_id": 25,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -465,8 +325,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_init_targeted_link_rel_filters (callback)",
           "trace_id": 0,
-          "span_id": 32,
-          "parent_id": 16,
+          "span_id": 26,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -479,8 +339,8 @@
           "service": "wordpress_55_test_app",
           "resource": "_register_core_block_patterns_and_categories (callback)",
           "trace_id": 0,
-          "span_id": 33,
-          "parent_id": 16,
+          "span_id": 27,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -493,8 +353,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_cron (callback)",
           "trace_id": 0,
-          "span_id": 34,
-          "parent_id": 16,
+          "span_id": 28,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -507,8 +367,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_schedule_delete_old_privacy_export_files (callback)",
           "trace_id": 0,
-          "span_id": 35,
-          "parent_id": 16,
+          "span_id": 29,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -521,8 +381,8 @@
           "service": "wordpress_55_test_app",
           "resource": "_show_post_preview (callback)",
           "trace_id": 0,
-          "span_id": 36,
-          "parent_id": 16,
+          "span_id": 30,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -535,8 +395,8 @@
           "service": "wordpress_55_test_app",
           "resource": "rest_api_init (callback)",
           "trace_id": 0,
-          "span_id": 37,
-          "parent_id": 16,
+          "span_id": 31,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -549,8 +409,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_sitemaps_get_server (callback)",
           "trace_id": 0,
-          "span_id": 38,
-          "parent_id": 16,
+          "span_id": 32,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -563,8 +423,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_schedule_update_checks (callback)",
           "trace_id": 0,
-          "span_id": 39,
-          "parent_id": 16,
+          "span_id": 33,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -577,8 +437,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_archives (callback)",
           "trace_id": 0,
-          "span_id": 40,
-          "parent_id": 16,
+          "span_id": 34,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -591,8 +451,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_block (callback)",
           "trace_id": 0,
-          "span_id": 41,
-          "parent_id": 16,
+          "span_id": 35,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -605,8 +465,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_calendar (callback)",
           "trace_id": 0,
-          "span_id": 42,
-          "parent_id": 16,
+          "span_id": 36,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -619,8 +479,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_categories (callback)",
           "trace_id": 0,
-          "span_id": 43,
-          "parent_id": 16,
+          "span_id": 37,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -633,8 +493,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_latest_comments (callback)",
           "trace_id": 0,
-          "span_id": 44,
-          "parent_id": 16,
+          "span_id": 38,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -647,8 +507,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_latest_posts (callback)",
           "trace_id": 0,
-          "span_id": 45,
-          "parent_id": 16,
+          "span_id": 39,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -661,8 +521,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_rss (callback)",
           "trace_id": 0,
-          "span_id": 46,
-          "parent_id": 16,
+          "span_id": 40,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -675,8 +535,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_search (callback)",
           "trace_id": 0,
-          "span_id": 47,
-          "parent_id": 16,
+          "span_id": 41,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -689,8 +549,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_shortcode (callback)",
           "trace_id": 0,
-          "span_id": 48,
-          "parent_id": 16,
+          "span_id": 42,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -703,8 +563,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_social_link (callback)",
           "trace_id": 0,
-          "span_id": 49,
-          "parent_id": 16,
+          "span_id": 43,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -717,8 +577,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_tag_cloud (callback)",
           "trace_id": 0,
-          "span_id": 50,
-          "parent_id": 16,
+          "span_id": 44,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -731,8 +591,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_core_block_types_from_metadata (callback)",
           "trace_id": 0,
-          "span_id": 51,
-          "parent_id": 16,
+          "span_id": 45,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -745,8 +605,8 @@
           "service": "wordpress_55_test_app",
           "resource": "twentytwenty_menus (callback)",
           "trace_id": 0,
-          "span_id": 52,
-          "parent_id": 16,
+          "span_id": 46,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -759,8 +619,8 @@
           "service": "wordpress_55_test_app",
           "resource": "twentytwenty_classic_editor_styles (callback)",
           "trace_id": 0,
-          "span_id": 53,
-          "parent_id": 16,
+          "span_id": 47,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -773,8 +633,8 @@
           "service": "wordpress_55_test_app",
           "resource": "check_theme_switched (callback)",
           "trace_id": 0,
-          "span_id": 54,
-          "parent_id": 16,
+          "span_id": 48,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -782,34 +642,12 @@
             "wordpress.hook": "init"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'theme_switched' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 60,
-             "parent_id": 54,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_55_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_55_test_app",
        "resource": "wp_loaded (hook)",
        "trace_id": 0,
-       "span_id": 17,
+       "span_id": 11,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -822,8 +660,8 @@
           "service": "wordpress_55_test_app",
           "resource": "_custom_header_background_just_in_time (callback)",
           "trace_id": 0,
-          "span_id": 55,
-          "parent_id": 17,
+          "span_id": 49,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -836,7 +674,7 @@
        "service": "wordpress_55_test_app",
        "resource": "WP.main",
        "trace_id": 0,
-       "span_id": 18,
+       "span_id": 12,
        "parent_id": 1,
        "type": "web",
        "error": 1,
@@ -852,8 +690,8 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 56,
-          "parent_id": 18,
+          "span_id": 50,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -864,8 +702,8 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 57,
-          "parent_id": 18,
+          "span_id": 51,
+          "parent_id": 12,
           "type": "web",
           "error": 1,
           "meta": {
@@ -875,34 +713,12 @@
             "error.type": "Exception"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('error')\n\t\tAND post_type IN ('page','attachment')\n\t",
-             "trace_id": 0,
-             "span_id": 61,
-             "parent_id": 57,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_55_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_55_test_app",
        "resource": "shutdown (hook)",
        "trace_id": 0,
-       "span_id": 19,
+       "span_id": 13,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -915,8 +731,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_ob_end_flush_all (callback)",
           "trace_id": 0,
-          "span_id": 58,
-          "parent_id": 19,
+          "span_id": 52,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",

--- a/tests/snapshots/tests.integrations.word_press.v5_5.common_scenarios_callbacks_test.test_scenario_get_with_view.json
+++ b/tests/snapshots/tests.integrations.word_press.v5_5.common_scenarios_callbacks_test.test_scenario_get_with_view.json
@@ -5,16 +5,17 @@
     "resource": "GET /simple_view",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 14874721839110430327,
+    "parent_id": 2788545403858610743,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e7010700000000",
       "component": "wordpress",
       "http.method": "GET",
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/simple_view?key=value&<redacted>",
-      "runtime-id": "7b42d084-3a90-4688-9319-30e9724039bb",
+      "runtime-id": "4ad4333f-2e0b-4278-a6f7-2182e7771b34",
       "span.kind": "server"
     },
     "metrics": {
@@ -22,108 +23,11 @@
     }
   },
      {
-       "name": "mysqli_real_connect",
-       "service": "mysqli",
-       "resource": "mysqli_real_connect",
-       "trace_id": 0,
-       "span_id": 2,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-       "trace_id": 0,
-       "span_id": 3,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT @@SESSION.sql_mode",
-       "trace_id": 0,
-       "span_id": 4,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 1.0
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-       "trace_id": 0,
-       "span_id": 5,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_name, option_value FROM wp55_options WHERE autoload = 'yes'",
-       "trace_id": 0,
-       "span_id": 6,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 111.0
-       }
-     },
-     {
        "name": "create_initial_taxonomies",
        "service": "wordpress_55_test_app",
        "resource": "create_initial_taxonomies",
        "trace_id": 0,
-       "span_id": 7,
+       "span_id": 2,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -137,7 +41,7 @@
        "service": "wordpress_55_test_app",
        "resource": "create_initial_post_types",
        "trace_id": 0,
-       "span_id": 8,
+       "span_id": 3,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -151,7 +55,7 @@
        "service": "wordpress_55_test_app",
        "resource": "datadog (plugin)",
        "trace_id": 0,
-       "span_id": 9,
+       "span_id": 4,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -164,7 +68,7 @@
        "service": "wordpress_55_test_app",
        "resource": "plugins_loaded (hook)",
        "trace_id": 0,
-       "span_id": 10,
+       "span_id": 5,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -177,8 +81,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_maybe_load_widgets",
           "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 10,
+          "span_id": 15,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -191,8 +95,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_maybe_load_embeds",
           "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 10,
+          "span_id": 16,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -205,8 +109,8 @@
           "service": "wordpress_55_test_app",
           "resource": "_wp_add_additional_image_sizes (callback)",
           "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 10,
+          "span_id": 17,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -219,8 +123,8 @@
           "service": "wordpress_55_test_app",
           "resource": "_wp_customize_include",
           "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 10,
+          "span_id": 18,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -233,7 +137,7 @@
        "service": "wordpress_55_test_app",
        "resource": "setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 11,
+       "span_id": 6,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -246,8 +150,8 @@
           "service": "wordpress_55_test_app",
           "resource": "create_initial_theme_features (callback)",
           "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 11,
+          "span_id": 19,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -256,33 +160,11 @@
           }
         },
      {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'WPLANG' LIMIT 1",
-       "trace_id": 0,
-       "span_id": 12,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 0.0
-       }
-     },
-     {
        "name": "load_theme",
        "service": "wordpress_55_test_app",
        "resource": "Twentytwenty (theme)",
        "trace_id": 0,
-       "span_id": 13,
+       "span_id": 7,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -295,7 +177,7 @@
        "service": "wordpress_55_test_app",
        "resource": "after_setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 14,
+       "span_id": 8,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -308,8 +190,8 @@
           "service": "wordpress_55_test_app",
           "resource": "twentytwenty_theme_support (callback)",
           "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 14,
+          "span_id": 20,
+          "parent_id": 8,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -322,8 +204,8 @@
           "service": "wordpress_55_test_app",
           "resource": "twentytwenty_block_editor_settings (callback)",
           "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 14,
+          "span_id": 21,
+          "parent_id": 8,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -336,7 +218,7 @@
        "service": "wordpress_55_test_app",
        "resource": "WP.init",
        "trace_id": 0,
-       "span_id": 15,
+       "span_id": 9,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -348,8 +230,8 @@
           "service": "wordpress_55_test_app",
           "resource": "kses_init (callback)",
           "trace_id": 0,
-          "span_id": 28,
-          "parent_id": 15,
+          "span_id": 22,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -362,7 +244,7 @@
        "service": "wordpress_55_test_app",
        "resource": "init (hook)",
        "trace_id": 0,
-       "span_id": 16,
+       "span_id": 10,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -375,8 +257,8 @@
           "service": "wordpress_55_test_app",
           "resource": "create_initial_post_types",
           "trace_id": 0,
-          "span_id": 29,
-          "parent_id": 16,
+          "span_id": 23,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -387,8 +269,8 @@
           "service": "wordpress_55_test_app",
           "resource": "create_initial_taxonomies",
           "trace_id": 0,
-          "span_id": 30,
-          "parent_id": 16,
+          "span_id": 24,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -399,8 +281,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_widgets_init",
           "trace_id": 0,
-          "span_id": 31,
-          "parent_id": 16,
+          "span_id": 25,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -413,42 +295,20 @@
              "service": "wordpress_55_test_app",
              "resource": "WP_Widget_Factory._register_widgets",
              "trace_id": 0,
-             "span_id": 73,
-             "parent_id": 31,
+             "span_id": 67,
+             "parent_id": 25,
              "type": "web",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-                "trace_id": 0,
-                "span_id": 94,
-                "parent_id": 73,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_55_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
         {
           "name": "callback",
           "service": "wordpress_55_test_app",
           "resource": "smilies_init (callback)",
           "trace_id": 0,
-          "span_id": 32,
-          "parent_id": 16,
+          "span_id": 26,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -461,8 +321,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_init_targeted_link_rel_filters (callback)",
           "trace_id": 0,
-          "span_id": 33,
-          "parent_id": 16,
+          "span_id": 27,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -475,8 +335,8 @@
           "service": "wordpress_55_test_app",
           "resource": "_register_core_block_patterns_and_categories (callback)",
           "trace_id": 0,
-          "span_id": 34,
-          "parent_id": 16,
+          "span_id": 28,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -489,8 +349,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_cron (callback)",
           "trace_id": 0,
-          "span_id": 35,
-          "parent_id": 16,
+          "span_id": 29,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -503,8 +363,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_schedule_delete_old_privacy_export_files (callback)",
           "trace_id": 0,
-          "span_id": 36,
-          "parent_id": 16,
+          "span_id": 30,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -517,8 +377,8 @@
           "service": "wordpress_55_test_app",
           "resource": "_show_post_preview (callback)",
           "trace_id": 0,
-          "span_id": 37,
-          "parent_id": 16,
+          "span_id": 31,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -531,8 +391,8 @@
           "service": "wordpress_55_test_app",
           "resource": "rest_api_init (callback)",
           "trace_id": 0,
-          "span_id": 38,
-          "parent_id": 16,
+          "span_id": 32,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -545,8 +405,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_sitemaps_get_server (callback)",
           "trace_id": 0,
-          "span_id": 39,
-          "parent_id": 16,
+          "span_id": 33,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -559,8 +419,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_schedule_update_checks (callback)",
           "trace_id": 0,
-          "span_id": 40,
-          "parent_id": 16,
+          "span_id": 34,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -573,8 +433,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_archives (callback)",
           "trace_id": 0,
-          "span_id": 41,
-          "parent_id": 16,
+          "span_id": 35,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -587,8 +447,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_block (callback)",
           "trace_id": 0,
-          "span_id": 42,
-          "parent_id": 16,
+          "span_id": 36,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -601,8 +461,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_calendar (callback)",
           "trace_id": 0,
-          "span_id": 43,
-          "parent_id": 16,
+          "span_id": 37,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -615,8 +475,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_categories (callback)",
           "trace_id": 0,
-          "span_id": 44,
-          "parent_id": 16,
+          "span_id": 38,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -629,8 +489,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_latest_comments (callback)",
           "trace_id": 0,
-          "span_id": 45,
-          "parent_id": 16,
+          "span_id": 39,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -643,8 +503,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_latest_posts (callback)",
           "trace_id": 0,
-          "span_id": 46,
-          "parent_id": 16,
+          "span_id": 40,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -657,8 +517,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_rss (callback)",
           "trace_id": 0,
-          "span_id": 47,
-          "parent_id": 16,
+          "span_id": 41,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -671,8 +531,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_search (callback)",
           "trace_id": 0,
-          "span_id": 48,
-          "parent_id": 16,
+          "span_id": 42,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -685,8 +545,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_shortcode (callback)",
           "trace_id": 0,
-          "span_id": 49,
-          "parent_id": 16,
+          "span_id": 43,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -699,8 +559,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_social_link (callback)",
           "trace_id": 0,
-          "span_id": 50,
-          "parent_id": 16,
+          "span_id": 44,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -713,8 +573,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_block_core_tag_cloud (callback)",
           "trace_id": 0,
-          "span_id": 51,
-          "parent_id": 16,
+          "span_id": 45,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -727,8 +587,8 @@
           "service": "wordpress_55_test_app",
           "resource": "register_core_block_types_from_metadata (callback)",
           "trace_id": 0,
-          "span_id": 52,
-          "parent_id": 16,
+          "span_id": 46,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -741,8 +601,8 @@
           "service": "wordpress_55_test_app",
           "resource": "twentytwenty_menus (callback)",
           "trace_id": 0,
-          "span_id": 53,
-          "parent_id": 16,
+          "span_id": 47,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -755,8 +615,8 @@
           "service": "wordpress_55_test_app",
           "resource": "twentytwenty_classic_editor_styles (callback)",
           "trace_id": 0,
-          "span_id": 54,
-          "parent_id": 16,
+          "span_id": 48,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -769,8 +629,8 @@
           "service": "wordpress_55_test_app",
           "resource": "check_theme_switched (callback)",
           "trace_id": 0,
-          "span_id": 55,
-          "parent_id": 16,
+          "span_id": 49,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -778,34 +638,12 @@
             "wordpress.hook": "init"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'theme_switched' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 74,
-             "parent_id": 55,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_55_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_55_test_app",
        "resource": "wp_loaded (hook)",
        "trace_id": 0,
-       "span_id": 17,
+       "span_id": 11,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -818,8 +656,8 @@
           "service": "wordpress_55_test_app",
           "resource": "_custom_header_background_just_in_time (callback)",
           "trace_id": 0,
-          "span_id": 56,
-          "parent_id": 17,
+          "span_id": 50,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -832,7 +670,7 @@
        "service": "wordpress_55_test_app",
        "resource": "WP.main",
        "trace_id": 0,
-       "span_id": 18,
+       "span_id": 12,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -844,8 +682,8 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 57,
-          "parent_id": 18,
+          "span_id": 51,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -856,42 +694,20 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 58,
-          "parent_id": 18,
+          "span_id": 52,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('simple_view')\n\t\tAND post_type IN ('page','attachment')\n\t",
-             "trace_id": 0,
-             "span_id": 75,
-             "parent_id": 58,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_55_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
         {
           "name": "WP.send_headers",
           "service": "wordpress_55_test_app",
           "resource": "WP.send_headers",
           "trace_id": 0,
-          "span_id": 59,
-          "parent_id": 18,
+          "span_id": 53,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -902,86 +718,20 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.query_posts",
           "trace_id": 0,
-          "span_id": 60,
-          "parent_id": 18,
+          "span_id": 54,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT   wp55_posts.* FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_name = 'simple_view' AND wp55_posts.post_type = 'post'  ORDER BY wp55_posts.post_date DESC ",
-             "trace_id": 0,
-             "span_id": 76,
-             "parent_id": 60,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_55_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT  t.*, tt.*, tr.object_id FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id INNER JOIN wp55_term_relationships AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy IN ('category', 'post_tag', 'post_format') AND tr.object_id IN (5) ORDER BY t.name ASC ",
-             "trace_id": 0,
-             "span_id": 77,
-             "parent_id": 60,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_55_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT post_id, meta_key, meta_value FROM wp55_postmeta WHERE post_id IN (5) ORDER BY meta_id ASC",
-             "trace_id": 0,
-             "span_id": 78,
-             "parent_id": 60,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_55_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 3.0
-             }
-           },
         {
           "name": "WP.handle_404",
           "service": "wordpress_55_test_app",
           "resource": "WP.handle_404",
           "trace_id": 0,
-          "span_id": 61,
-          "parent_id": 18,
+          "span_id": 55,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -992,8 +742,8 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.register_globals",
           "trace_id": 0,
-          "span_id": 62,
-          "parent_id": 18,
+          "span_id": 56,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -1004,8 +754,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp (hook)",
           "trace_id": 0,
-          "span_id": 63,
-          "parent_id": 18,
+          "span_id": 57,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1017,7 +767,7 @@
        "service": "wordpress_55_test_app",
        "resource": "load_template_loader",
        "trace_id": 0,
-       "span_id": 19,
+       "span_id": 13,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -1029,8 +779,8 @@
           "service": "wordpress_55_test_app",
           "resource": "template_redirect (hook)",
           "trace_id": 0,
-          "span_id": 64,
-          "parent_id": 19,
+          "span_id": 58,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1042,8 +792,8 @@
              "service": "wordpress_55_test_app",
              "resource": "_wp_admin_bar_init (callback)",
              "trace_id": 0,
-             "span_id": 79,
-             "parent_id": 64,
+             "span_id": 68,
+             "parent_id": 58,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1056,8 +806,8 @@
              "service": "wordpress_55_test_app",
              "resource": "wp_old_slug_redirect (callback)",
              "trace_id": 0,
-             "span_id": 80,
-             "parent_id": 64,
+             "span_id": 69,
+             "parent_id": 58,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1070,8 +820,8 @@
              "service": "wordpress_55_test_app",
              "resource": "redirect_canonical (callback)",
              "trace_id": 0,
-             "span_id": 81,
-             "parent_id": 64,
+             "span_id": 70,
+             "parent_id": 58,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1084,8 +834,8 @@
              "service": "wordpress_55_test_app",
              "resource": "WP_Sitemaps::render_sitemaps (callback)",
              "trace_id": 0,
-             "span_id": 82,
-             "parent_id": 64,
+             "span_id": 71,
+             "parent_id": 58,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1098,8 +848,8 @@
              "service": "wordpress_55_test_app",
              "resource": "rest_output_link_header (callback)",
              "trace_id": 0,
-             "span_id": 83,
-             "parent_id": 64,
+             "span_id": 72,
+             "parent_id": 58,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1112,8 +862,8 @@
              "service": "wordpress_55_test_app",
              "resource": "wp_shortlink_header (callback)",
              "trace_id": 0,
-             "span_id": 84,
-             "parent_id": 64,
+             "span_id": 73,
+             "parent_id": 58,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1126,8 +876,8 @@
              "service": "wordpress_55_test_app",
              "resource": "wp_redirect_admin_locations (callback)",
              "trace_id": 0,
-             "span_id": 85,
-             "parent_id": 64,
+             "span_id": 74,
+             "parent_id": 58,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1140,8 +890,8 @@
           "service": "wordpress_55_test_app",
           "resource": "single (type)",
           "trace_id": 0,
-          "span_id": 65,
-          "parent_id": 19,
+          "span_id": 59,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1153,8 +903,8 @@
           "service": "wordpress_55_test_app",
           "resource": "singular (type)",
           "trace_id": 0,
-          "span_id": 66,
-          "parent_id": 19,
+          "span_id": 60,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1167,8 +917,8 @@
           "service": "wordpress_55_test_app",
           "resource": "get_header",
           "trace_id": 0,
-          "span_id": 67,
-          "parent_id": 19,
+          "span_id": 61,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -1179,8 +929,8 @@
              "service": "wordpress_55_test_app",
              "resource": "header (template)",
              "trace_id": 0,
-             "span_id": 86,
-             "parent_id": 67,
+             "span_id": 75,
+             "parent_id": 61,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1193,8 +943,8 @@
                 "service": "wordpress_55_test_app",
                 "resource": "wp_head (hook)",
                 "trace_id": 0,
-                "span_id": 95,
-                "parent_id": 86,
+                "span_id": 81,
+                "parent_id": 75,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -1206,8 +956,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "_wp_render_title_tag (callback)",
                    "trace_id": 0,
-                   "span_id": 108,
-                   "parent_id": 95,
+                   "span_id": 92,
+                   "parent_id": 81,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1220,8 +970,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "wp_enqueue_scripts (callback)",
                    "trace_id": 0,
-                   "span_id": 109,
-                   "parent_id": 95,
+                   "span_id": 93,
+                   "parent_id": 81,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1234,8 +984,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "noindex (callback)",
                    "trace_id": 0,
-                   "span_id": 110,
-                   "parent_id": 95,
+                   "span_id": 94,
+                   "parent_id": 81,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1248,8 +998,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "wp_post_preview_js (callback)",
                    "trace_id": 0,
-                   "span_id": 111,
-                   "parent_id": 95,
+                   "span_id": 95,
+                   "parent_id": 81,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1262,8 +1012,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "wp_resource_hints (callback)",
                    "trace_id": 0,
-                   "span_id": 112,
-                   "parent_id": 95,
+                   "span_id": 96,
+                   "parent_id": 81,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1276,8 +1026,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "feed_links (callback)",
                    "trace_id": 0,
-                   "span_id": 113,
-                   "parent_id": 95,
+                   "span_id": 97,
+                   "parent_id": 81,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1290,8 +1040,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "feed_links_extra (callback)",
                    "trace_id": 0,
-                   "span_id": 114,
-                   "parent_id": 95,
+                   "span_id": 98,
+                   "parent_id": 81,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1304,8 +1054,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "print_emoji_detection_script (callback)",
                    "trace_id": 0,
-                   "span_id": 115,
-                   "parent_id": 95,
+                   "span_id": 99,
+                   "parent_id": 81,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1318,8 +1068,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "wp_print_styles (callback)",
                    "trace_id": 0,
-                   "span_id": 116,
-                   "parent_id": 95,
+                   "span_id": 100,
+                   "parent_id": 81,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1332,8 +1082,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "wp_print_head_scripts",
                    "trace_id": 0,
-                   "span_id": 117,
-                   "parent_id": 95,
+                   "span_id": 101,
+                   "parent_id": 81,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1346,8 +1096,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "rest_output_link_wp_head (callback)",
                    "trace_id": 0,
-                   "span_id": 118,
-                   "parent_id": 95,
+                   "span_id": 102,
+                   "parent_id": 81,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1360,8 +1110,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "rsd_link (callback)",
                    "trace_id": 0,
-                   "span_id": 119,
-                   "parent_id": 95,
+                   "span_id": 103,
+                   "parent_id": 81,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1374,8 +1124,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "wlwmanifest_link (callback)",
                    "trace_id": 0,
-                   "span_id": 120,
-                   "parent_id": 95,
+                   "span_id": 104,
+                   "parent_id": 81,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1388,8 +1138,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "adjacent_posts_rel_link_wp_head (callback)",
                    "trace_id": 0,
-                   "span_id": 121,
-                   "parent_id": 95,
+                   "span_id": 105,
+                   "parent_id": 81,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1397,79 +1147,13 @@
                      "wordpress.hook": "wp_head"
                    }
                  },
-                    {
-                      "name": "mysqli_query",
-                      "service": "mysqli",
-                      "resource": "SELECT p.ID FROM wp55_posts AS p  WHERE p.post_date < '2020-10-22 16:32:26' AND p.post_type = 'post'  AND p.post_status = 'publish' ORDER BY p.post_date DESC LIMIT 1",
-                      "trace_id": 0,
-                      "span_id": 144,
-                      "parent_id": 121,
-                      "type": "sql",
-                      "meta": {
-                        "_dd.base_service": "wordpress_55_test_app",
-                        "component": "mysqli",
-                        "db.name": "test",
-                        "db.system": "mysql",
-                        "db.type": "mysql",
-                        "out.host": "mysql_integration",
-                        "out.port": "3306",
-                        "span.kind": "client"
-                      },
-                      "metrics": {
-                        "db.row_count": 1.0
-                      }
-                    },
-                    {
-                      "name": "mysqli_query",
-                      "service": "mysqli",
-                      "resource": "SELECT * FROM wp55_posts WHERE ID = 1 LIMIT 1",
-                      "trace_id": 0,
-                      "span_id": 145,
-                      "parent_id": 121,
-                      "type": "sql",
-                      "meta": {
-                        "_dd.base_service": "wordpress_55_test_app",
-                        "component": "mysqli",
-                        "db.name": "test",
-                        "db.system": "mysql",
-                        "db.type": "mysql",
-                        "out.host": "mysql_integration",
-                        "out.port": "3306",
-                        "span.kind": "client"
-                      },
-                      "metrics": {
-                        "db.row_count": 1.0
-                      }
-                    },
-                    {
-                      "name": "mysqli_query",
-                      "service": "mysqli",
-                      "resource": "SELECT p.ID FROM wp55_posts AS p  WHERE p.post_date > '2020-10-22 16:32:26' AND p.post_type = 'post'  AND p.post_status = 'publish' ORDER BY p.post_date ASC LIMIT 1",
-                      "trace_id": 0,
-                      "span_id": 146,
-                      "parent_id": 121,
-                      "type": "sql",
-                      "meta": {
-                        "_dd.base_service": "wordpress_55_test_app",
-                        "component": "mysqli",
-                        "db.name": "test",
-                        "db.system": "mysql",
-                        "db.type": "mysql",
-                        "out.host": "mysql_integration",
-                        "out.port": "3306",
-                        "span.kind": "client"
-                      },
-                      "metrics": {
-                        "db.row_count": 0.0
-                      }
-                    },
                  {
                    "name": "callback",
                    "service": "wordpress_55_test_app",
                    "resource": "locale_stylesheet (callback)",
                    "trace_id": 0,
-                   "span_id": 122,
-                   "parent_id": 95,
+                   "span_id": 106,
+                   "parent_id": 81,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1482,8 +1166,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "wp_generator (callback)",
                    "trace_id": 0,
-                   "span_id": 123,
-                   "parent_id": 95,
+                   "span_id": 107,
+                   "parent_id": 81,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1496,8 +1180,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "rel_canonical (callback)",
                    "trace_id": 0,
-                   "span_id": 124,
-                   "parent_id": 95,
+                   "span_id": 108,
+                   "parent_id": 81,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1510,8 +1194,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "wp_shortlink_wp_head (callback)",
                    "trace_id": 0,
-                   "span_id": 125,
-                   "parent_id": 95,
+                   "span_id": 109,
+                   "parent_id": 81,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1524,8 +1208,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "_custom_logo_header_styles (callback)",
                    "trace_id": 0,
-                   "span_id": 126,
-                   "parent_id": 95,
+                   "span_id": 110,
+                   "parent_id": 81,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1538,8 +1222,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "wp_oembed_add_discovery_links (callback)",
                    "trace_id": 0,
-                   "span_id": 127,
-                   "parent_id": 95,
+                   "span_id": 111,
+                   "parent_id": 81,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1552,8 +1236,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "wp_oembed_add_host_js (callback)",
                    "trace_id": 0,
-                   "span_id": 128,
-                   "parent_id": 95,
+                   "span_id": 112,
+                   "parent_id": 81,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1566,8 +1250,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "twentytwenty_no_js_class (callback)",
                    "trace_id": 0,
-                   "span_id": 129,
-                   "parent_id": 95,
+                   "span_id": 113,
+                   "parent_id": 81,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1580,8 +1264,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "WP_Widget_Recent_Comments::recent_comments_style (callback)",
                    "trace_id": 0,
-                   "span_id": 130,
-                   "parent_id": 95,
+                   "span_id": 114,
+                   "parent_id": 81,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1594,8 +1278,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "_custom_background_cb (callback)",
                    "trace_id": 0,
-                   "span_id": 131,
-                   "parent_id": 95,
+                   "span_id": 115,
+                   "parent_id": 81,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1608,8 +1292,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "wp_site_icon (callback)",
                    "trace_id": 0,
-                   "span_id": 132,
-                   "parent_id": 95,
+                   "span_id": 116,
+                   "parent_id": 81,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1622,8 +1306,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "wp_custom_css_cb (callback)",
                    "trace_id": 0,
-                   "span_id": 133,
-                   "parent_id": 95,
+                   "span_id": 117,
+                   "parent_id": 81,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1636,8 +1320,8 @@
                 "service": "wordpress_55_test_app",
                 "resource": "body_class",
                 "trace_id": 0,
-                "span_id": 96,
-                "parent_id": 86,
+                "span_id": 82,
+                "parent_id": 75,
                 "type": "web",
                 "meta": {
                   "component": "wordpress"
@@ -1648,8 +1332,8 @@
                 "service": "wordpress_55_test_app",
                 "resource": "wp_admin_bar_render (callback)",
                 "trace_id": 0,
-                "span_id": 97,
-                "parent_id": 86,
+                "span_id": 83,
+                "parent_id": 75,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -1657,91 +1341,25 @@
                   "wordpress.hook": "wp_footer"
                 }
               },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT * FROM wp55_posts  WHERE (post_type = 'page' AND post_status = 'publish')     ORDER BY menu_order,wp55_posts.post_title ASC",
-                "trace_id": 0,
-                "span_id": 98,
-                "parent_id": 86,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_55_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
         {
           "name": "the_post",
           "service": "wordpress_55_test_app",
           "resource": "the_post",
           "trace_id": 0,
-          "span_id": 68,
-          "parent_id": 19,
+          "span_id": 62,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT * FROM wp55_users WHERE ID = '1' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 87,
-             "parent_id": 68,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_55_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT user_id, meta_key, meta_value FROM wp55_usermeta WHERE user_id IN (1) ORDER BY umeta_id ASC",
-             "trace_id": 0,
-             "span_id": 88,
-             "parent_id": 68,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_55_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 18.0
-             }
-           },
         {
           "name": "load_template",
           "service": "wordpress_55_test_app",
           "resource": "content (template)",
           "trace_id": 0,
-          "span_id": 69,
-          "parent_id": 19,
+          "span_id": 63,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1754,8 +1372,8 @@
              "service": "wordpress_55_test_app",
              "resource": "the_content",
              "trace_id": 0,
-             "span_id": 89,
-             "parent_id": 69,
+             "span_id": 76,
+             "parent_id": 63,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1767,8 +1385,8 @@
                 "service": "wordpress_55_test_app",
                 "resource": "core/paragraph (block)",
                 "trace_id": 0,
-                "span_id": 99,
-                "parent_id": 89,
+                "span_id": 84,
+                "parent_id": 76,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -1780,42 +1398,20 @@
              "service": "wordpress_55_test_app",
              "resource": "comments_template",
              "trace_id": 0,
-             "span_id": 90,
-             "parent_id": 69,
+             "span_id": 77,
+             "parent_id": 63,
              "type": "web",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT SQL_CALC_FOUND_ROWS wp55_comments.comment_ID FROM wp55_comments  WHERE ( comment_approved = '1' ) AND comment_post_ID = 5 AND comment_parent = 0  ORDER BY wp55_comments.comment_date_gmt ASC, wp55_comments.comment_ID ASC ",
-                "trace_id": 0,
-                "span_id": 100,
-                "parent_id": 90,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_55_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              },
         {
           "name": "load_template",
           "service": "wordpress_55_test_app",
           "resource": "footer-menus-widgets (template)",
           "trace_id": 0,
-          "span_id": 70,
-          "parent_id": 19,
+          "span_id": 64,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1828,8 +1424,8 @@
              "service": "wordpress_55_test_app",
              "resource": "sidebar-1",
              "trace_id": 0,
-             "span_id": 91,
-             "parent_id": 70,
+             "span_id": 78,
+             "parent_id": 64,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -1840,8 +1436,8 @@
                 "service": "wordpress_55_test_app",
                 "resource": "Search (widget)",
                 "trace_id": 0,
-                "span_id": 101,
-                "parent_id": 91,
+                "span_id": 85,
+                "parent_id": 78,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -1853,166 +1449,34 @@
                 "service": "wordpress_55_test_app",
                 "resource": "Recent Posts (widget)",
                 "trace_id": 0,
-                "span_id": 102,
-                "parent_id": 91,
+                "span_id": 86,
+                "parent_id": 78,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Recent Posts"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT   wp55_posts.ID FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_type = 'post' AND ((wp55_posts.post_status = 'publish'))  ORDER BY wp55_posts.post_date DESC LIMIT 0, 5",
-                   "trace_id": 0,
-                   "span_id": 134,
-                   "parent_id": 102,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 2.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  t.*, tt.*, tr.object_id FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id INNER JOIN wp55_term_relationships AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy IN ('category', 'post_tag', 'post_format') AND tr.object_id IN (1) ORDER BY t.name ASC ",
-                   "trace_id": 0,
-                   "span_id": 135,
-                   "parent_id": 102,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT post_id, meta_key, meta_value FROM wp55_postmeta WHERE post_id IN (1) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 136,
-                   "parent_id": 102,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
               {
                 "name": "widget",
                 "service": "wordpress_55_test_app",
                 "resource": "Recent Comments (widget)",
                 "trace_id": 0,
-                "span_id": 103,
-                "parent_id": 91,
+                "span_id": 87,
+                "parent_id": 78,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Recent Comments"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  wp55_comments.comment_ID FROM wp55_comments JOIN wp55_posts ON wp55_posts.ID = wp55_comments.comment_post_ID WHERE ( comment_approved = '1' ) AND  wp55_posts.post_status IN ('publish')  ORDER BY wp55_comments.comment_date_gmt DESC LIMIT 0,5",
-                   "trace_id": 0,
-                   "span_id": 137,
-                   "parent_id": 103,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT wp55_comments.* FROM wp55_comments WHERE comment_ID IN (1)",
-                   "trace_id": 0,
-                   "span_id": 138,
-                   "parent_id": 103,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT comment_id, meta_key, meta_value FROM wp55_commentmeta WHERE comment_id IN (1) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 139,
-                   "parent_id": 103,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
            {
              "name": "dynamic_sidebar",
              "service": "wordpress_55_test_app",
              "resource": "sidebar-2",
              "trace_id": 0,
-             "span_id": 92,
-             "parent_id": 70,
+             "span_id": 79,
+             "parent_id": 64,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -2023,100 +1487,34 @@
                 "service": "wordpress_55_test_app",
                 "resource": "Archives (widget)",
                 "trace_id": 0,
-                "span_id": 104,
-                "parent_id": 92,
+                "span_id": 88,
+                "parent_id": 79,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Archives"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT YEAR(post_date) AS `year`, MONTH(post_date) AS `month`, count(ID) as posts FROM wp55_posts  WHERE post_type = 'post' AND post_status = 'publish' GROUP BY YEAR(post_date), MONTH(post_date) ORDER BY post_date DESC ",
-                   "trace_id": 0,
-                   "span_id": 140,
-                   "parent_id": 104,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
               {
                 "name": "widget",
                 "service": "wordpress_55_test_app",
                 "resource": "Categories (widget)",
                 "trace_id": 0,
-                "span_id": 105,
-                "parent_id": 92,
+                "span_id": 89,
+                "parent_id": 79,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Categories"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  t.*, tt.* FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id WHERE tt.taxonomy IN ('category') AND tt.count > 0 ORDER BY t.name ASC ",
-                   "trace_id": 0,
-                   "span_id": 141,
-                   "parent_id": 105,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT term_id, meta_key, meta_value FROM wp55_termmeta WHERE term_id IN (1) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 142,
-                   "parent_id": 105,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
               {
                 "name": "widget",
                 "service": "wordpress_55_test_app",
                 "resource": "Meta (widget)",
                 "trace_id": 0,
-                "span_id": 106,
-                "parent_id": 92,
+                "span_id": 90,
+                "parent_id": 79,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -2128,8 +1526,8 @@
           "service": "wordpress_55_test_app",
           "resource": "get_footer",
           "trace_id": 0,
-          "span_id": 71,
-          "parent_id": 19,
+          "span_id": 65,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -2140,8 +1538,8 @@
              "service": "wordpress_55_test_app",
              "resource": "footer (template)",
              "trace_id": 0,
-             "span_id": 93,
-             "parent_id": 71,
+             "span_id": 80,
+             "parent_id": 65,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -2154,8 +1552,8 @@
                 "service": "wordpress_55_test_app",
                 "resource": "wp_footer (hook)",
                 "trace_id": 0,
-                "span_id": 107,
-                "parent_id": 93,
+                "span_id": 91,
+                "parent_id": 80,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -2167,8 +1565,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "wp_print_footer_scripts (callback)",
                    "trace_id": 0,
-                   "span_id": 143,
-                   "parent_id": 107,
+                   "span_id": 118,
+                   "parent_id": 91,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2181,7 +1579,7 @@
        "service": "wordpress_55_test_app",
        "resource": "shutdown (hook)",
        "trace_id": 0,
-       "span_id": 20,
+       "span_id": 14,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -2194,8 +1592,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_ob_end_flush_all (callback)",
           "trace_id": 0,
-          "span_id": 72,
-          "parent_id": 20,
+          "span_id": 66,
+          "parent_id": 14,
           "type": "web",
           "meta": {
             "component": "wordpress",

--- a/tests/snapshots/tests.integrations.word_press.v5_5.common_scenarios_legacy_test.test_scenario_get_return_string.json
+++ b/tests/snapshots/tests.integrations.word_press.v5_5.common_scenarios_legacy_test.test_scenario_get_return_string.json
@@ -5,16 +5,17 @@
     "resource": "GET /simple",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 2376336973316687556,
+    "parent_id": 14947875171746865970,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e7012900000000",
       "component": "wordpress",
       "http.method": "GET",
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/simple?key=value&<redacted>",
-      "runtime-id": "0ff18d67-3374-49ef-aadd-4a242ab14a9d",
+      "runtime-id": "e132a040-b09a-4307-9552-d026b9045d3d",
       "span.kind": "server"
     },
     "metrics": {
@@ -37,81 +38,6 @@
          "db.user": "test"
        }
      },
-        {
-          "name": "mysqli_real_connect",
-          "service": "mysqli",
-          "resource": "mysqli_real_connect",
-          "trace_id": 0,
-          "span_id": 16,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-          "trace_id": 0,
-          "span_id": 17,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT @@SESSION.sql_mode",
-          "trace_id": 0,
-          "span_id": 18,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 1.0
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-          "trace_id": 0,
-          "span_id": 19,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_55_test_app",
@@ -124,28 +50,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_name, option_value FROM wp55_options WHERE autoload = 'yes'",
-          "trace_id": 0,
-          "span_id": 20,
-          "parent_id": 3,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 111.0
-          }
-        },
      {
        "name": "create_initial_taxonomies",
        "service": "wordpress_55_test_app",
@@ -218,28 +122,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'WPLANG' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 9,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.init",
        "service": "wordpress_55_test_app",
@@ -293,35 +175,13 @@
           "service": "wordpress_55_test_app",
           "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
           "trace_id": 0,
-          "span_id": 22,
+          "span_id": 16,
           "parent_id": 13,
           "type": "sql",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 26,
-             "parent_id": 22,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_55_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
      {
        "name": "wpdb.query",
        "service": "wordpress_55_test_app",
@@ -334,28 +194,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'theme_switched' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 14,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.main",
        "service": "wordpress_55_test_app",
@@ -373,7 +211,7 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 24,
+          "span_id": 17,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -385,7 +223,7 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 25,
+          "span_id": 18,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -397,32 +235,10 @@
              "service": "wordpress_55_test_app",
              "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('simple')\n\t\tAND post_type IN ('page','attachment')\n\t",
              "trace_id": 0,
-             "span_id": 27,
-             "parent_id": 25,
+             "span_id": 19,
+             "parent_id": 18,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
-           },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('simple')\n\t\tAND post_type IN ('page','attachment')\n\t",
-                "trace_id": 0,
-                "span_id": 28,
-                "parent_id": 27,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_55_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              }]]
+           }]]

--- a/tests/snapshots/tests.integrations.word_press.v5_5.common_scenarios_legacy_test.test_scenario_get_to_missing_route.json
+++ b/tests/snapshots/tests.integrations.word_press.v5_5.common_scenarios_legacy_test.test_scenario_get_to_missing_route.json
@@ -5,15 +5,16 @@
     "resource": "GET /does_not_exist",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 7208281282619085399,
+    "parent_id": 18133810881284993130,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e7014300000000",
       "component": "wordpress",
       "http.method": "GET",
       "http.status_code": "404",
       "http.url": "http://localhost:9999/does_not_exist?key=value&<redacted>",
-      "runtime-id": "0ff18d67-3374-49ef-aadd-4a242ab14a9d",
+      "runtime-id": "e132a040-b09a-4307-9552-d026b9045d3d",
       "span.kind": "server"
     },
     "metrics": {
@@ -36,81 +37,6 @@
          "db.user": "test"
        }
      },
-        {
-          "name": "mysqli_real_connect",
-          "service": "mysqli",
-          "resource": "mysqli_real_connect",
-          "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-          "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT @@SESSION.sql_mode",
-          "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 1.0
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-          "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_55_test_app",
@@ -123,28 +49,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_name, option_value FROM wp55_options WHERE autoload = 'yes'",
-          "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 3,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 111.0
-          }
-        },
      {
        "name": "create_initial_taxonomies",
        "service": "wordpress_55_test_app",
@@ -217,28 +121,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'WPLANG' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 9,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.init",
        "service": "wordpress_55_test_app",
@@ -292,35 +174,13 @@
           "service": "wordpress_55_test_app",
           "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
           "trace_id": 0,
-          "span_id": 27,
+          "span_id": 21,
           "parent_id": 13,
           "type": "sql",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 41,
-             "parent_id": 27,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_55_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
      {
        "name": "wpdb.query",
        "service": "wordpress_55_test_app",
@@ -333,28 +193,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'theme_switched' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 28,
-          "parent_id": 14,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.main",
        "service": "wordpress_55_test_app",
@@ -372,7 +210,7 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 29,
+          "span_id": 22,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -384,7 +222,7 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 30,
+          "span_id": 23,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -396,41 +234,19 @@
              "service": "wordpress_55_test_app",
              "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('does_not_exist')\n\t\tAND post_type IN ('page','attachment')\n\t",
              "trace_id": 0,
-             "span_id": 42,
-             "parent_id": 30,
+             "span_id": 32,
+             "parent_id": 23,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('does_not_exist')\n\t\tAND post_type IN ('page','attachment')\n\t",
-                "trace_id": 0,
-                "span_id": 54,
-                "parent_id": 42,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_55_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              },
         {
           "name": "WP.send_headers",
           "service": "wordpress_55_test_app",
           "resource": "WP.send_headers",
           "trace_id": 0,
-          "span_id": 31,
+          "span_id": 24,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -442,7 +258,7 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.query_posts",
           "trace_id": 0,
-          "span_id": 32,
+          "span_id": 25,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -454,41 +270,19 @@
              "service": "wordpress_55_test_app",
              "resource": "SELECT   wp55_posts.* FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_name = 'does_not_exist' AND wp55_posts.post_type = 'post'  ORDER BY wp55_posts.post_date DESC ",
              "trace_id": 0,
-             "span_id": 43,
-             "parent_id": 32,
+             "span_id": 33,
+             "parent_id": 25,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT   wp55_posts.* FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_name = 'does_not_exist' AND wp55_posts.post_type = 'post'  ORDER BY wp55_posts.post_date DESC ",
-                "trace_id": 0,
-                "span_id": 55,
-                "parent_id": 43,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_55_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              },
         {
           "name": "WP.handle_404",
           "service": "wordpress_55_test_app",
           "resource": "WP.handle_404",
           "trace_id": 0,
-          "span_id": 33,
+          "span_id": 26,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -500,7 +294,7 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.register_globals",
           "trace_id": 0,
-          "span_id": 34,
+          "span_id": 27,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -519,28 +313,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT post_id FROM wp55_postmeta, wp55_posts WHERE ID = post_id AND post_type = 'post' AND meta_key = '_wp_old_slug' AND meta_value = 'does_not_exist'",
-          "trace_id": 0,
-          "span_id": 35,
-          "parent_id": 16,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_55_test_app",
@@ -553,28 +325,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT ID FROM wp55_posts WHERE post_name LIKE 'does\\\\_not\\\\_exist%' AND post_type IN ('post', 'page', 'attachment') AND post_status = 'publish'",
-          "trace_id": 0,
-          "span_id": 36,
-          "parent_id": 17,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "get_header",
        "service": "wordpress_55_test_app",
@@ -592,7 +342,7 @@
           "service": "wordpress_55_test_app",
           "resource": "/home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/wp-content/themes/twentytwenty/header.php",
           "trace_id": 0,
-          "span_id": 37,
+          "span_id": 28,
           "parent_id": 18,
           "type": "web",
           "meta": {
@@ -604,8 +354,8 @@
              "service": "wordpress_55_test_app",
              "resource": "wp_head",
              "trace_id": 0,
-             "span_id": 44,
-             "parent_id": 37,
+             "span_id": 34,
+             "parent_id": 28,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -616,8 +366,8 @@
                 "service": "wordpress_55_test_app",
                 "resource": "wp_print_head_scripts",
                 "trace_id": 0,
-                "span_id": 56,
-                "parent_id": 44,
+                "span_id": 44,
+                "parent_id": 34,
                 "type": "web",
                 "meta": {
                   "component": "wordpress"
@@ -628,8 +378,8 @@
              "service": "wordpress_55_test_app",
              "resource": "body_class",
              "trace_id": 0,
-             "span_id": 45,
-             "parent_id": 37,
+             "span_id": 35,
+             "parent_id": 28,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -640,35 +390,13 @@
              "service": "wordpress_55_test_app",
              "resource": "SELECT * FROM wp55_posts  WHERE (post_type = 'page' AND post_status = 'publish')     ORDER BY menu_order,wp55_posts.post_title ASC",
              "trace_id": 0,
-             "span_id": 46,
-             "parent_id": 37,
+             "span_id": 36,
+             "parent_id": 28,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT * FROM wp55_posts  WHERE (post_type = 'page' AND post_status = 'publish')     ORDER BY menu_order,wp55_posts.post_title ASC",
-                "trace_id": 0,
-                "span_id": 57,
-                "parent_id": 46,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_55_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
      {
        "name": "load_template",
        "service": "wordpress_55_test_app",
@@ -686,7 +414,7 @@
           "service": "wordpress_55_test_app",
           "resource": "sidebar-1",
           "trace_id": 0,
-          "span_id": 38,
+          "span_id": 29,
           "parent_id": 19,
           "type": "web",
           "meta": {
@@ -698,8 +426,8 @@
              "service": "wordpress_55_test_app",
              "resource": "WP_Widget.display_callback",
              "trace_id": 0,
-             "span_id": 47,
-             "parent_id": 38,
+             "span_id": 37,
+             "parent_id": 29,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -710,8 +438,8 @@
              "service": "wordpress_55_test_app",
              "resource": "WP_Widget.display_callback",
              "trace_id": 0,
-             "span_id": 48,
-             "parent_id": 38,
+             "span_id": 38,
+             "parent_id": 29,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -722,144 +450,56 @@
                 "service": "wordpress_55_test_app",
                 "resource": "SELECT   wp55_posts.ID FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_type = 'post' AND ((wp55_posts.post_status = 'publish'))  ORDER BY wp55_posts.post_date DESC LIMIT 0, 5",
                 "trace_id": 0,
-                "span_id": 58,
-                "parent_id": 48,
+                "span_id": 45,
+                "parent_id": 38,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT   wp55_posts.ID FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_type = 'post' AND ((wp55_posts.post_status = 'publish'))  ORDER BY wp55_posts.post_date DESC LIMIT 0, 5",
-                   "trace_id": 0,
-                   "span_id": 68,
-                   "parent_id": 58,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 2.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_55_test_app",
                 "resource": "SELECT wp55_posts.* FROM wp55_posts WHERE ID IN (5,1)",
                 "trace_id": 0,
-                "span_id": 59,
-                "parent_id": 48,
+                "span_id": 46,
+                "parent_id": 38,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT wp55_posts.* FROM wp55_posts WHERE ID IN (5,1)",
-                   "trace_id": 0,
-                   "span_id": 69,
-                   "parent_id": 59,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 2.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_55_test_app",
                 "resource": "SELECT  t.*, tt.*, tr.object_id FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id INNER JOIN wp55_term_relationships AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy IN ('category', 'post_tag', 'post_format') AND tr.object_id IN (1, 5) ORDER BY t.name ASC ",
                 "trace_id": 0,
-                "span_id": 60,
-                "parent_id": 48,
+                "span_id": 47,
+                "parent_id": 38,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  t.*, tt.*, tr.object_id FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id INNER JOIN wp55_term_relationships AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy IN ('category', 'post_tag', 'post_format') AND tr.object_id IN (1, 5) ORDER BY t.name ASC ",
-                   "trace_id": 0,
-                   "span_id": 70,
-                   "parent_id": 60,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 2.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_55_test_app",
                 "resource": "SELECT post_id, meta_key, meta_value FROM wp55_postmeta WHERE post_id IN (1,5) ORDER BY meta_id ASC",
                 "trace_id": 0,
-                "span_id": 61,
-                "parent_id": 48,
+                "span_id": 48,
+                "parent_id": 38,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT post_id, meta_key, meta_value FROM wp55_postmeta WHERE post_id IN (1,5) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 71,
-                   "parent_id": 61,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 3.0
-                   }
-                 },
            {
              "name": "WP_Widget.display_callback",
              "service": "wordpress_55_test_app",
              "resource": "WP_Widget.display_callback",
              "trace_id": 0,
-             "span_id": 49,
-             "parent_id": 38,
+             "span_id": 39,
+             "parent_id": 29,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -870,109 +510,43 @@
                 "service": "wordpress_55_test_app",
                 "resource": "SELECT  wp55_comments.comment_ID FROM wp55_comments JOIN wp55_posts ON wp55_posts.ID = wp55_comments.comment_post_ID WHERE ( comment_approved = '1' ) AND  wp55_posts.post_status IN ('publish')  ORDER BY wp55_comments.comment_date_gmt DESC LIMIT 0,5",
                 "trace_id": 0,
-                "span_id": 62,
-                "parent_id": 49,
+                "span_id": 49,
+                "parent_id": 39,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  wp55_comments.comment_ID FROM wp55_comments JOIN wp55_posts ON wp55_posts.ID = wp55_comments.comment_post_ID WHERE ( comment_approved = '1' ) AND  wp55_posts.post_status IN ('publish')  ORDER BY wp55_comments.comment_date_gmt DESC LIMIT 0,5",
-                   "trace_id": 0,
-                   "span_id": 72,
-                   "parent_id": 62,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_55_test_app",
                 "resource": "SELECT wp55_comments.* FROM wp55_comments WHERE comment_ID IN (1)",
                 "trace_id": 0,
-                "span_id": 63,
-                "parent_id": 49,
+                "span_id": 50,
+                "parent_id": 39,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT wp55_comments.* FROM wp55_comments WHERE comment_ID IN (1)",
-                   "trace_id": 0,
-                   "span_id": 73,
-                   "parent_id": 63,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_55_test_app",
                 "resource": "SELECT comment_id, meta_key, meta_value FROM wp55_commentmeta WHERE comment_id IN (1) ORDER BY meta_id ASC",
                 "trace_id": 0,
-                "span_id": 64,
-                "parent_id": 49,
+                "span_id": 51,
+                "parent_id": 39,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT comment_id, meta_key, meta_value FROM wp55_commentmeta WHERE comment_id IN (1) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 74,
-                   "parent_id": 64,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
         {
           "name": "dynamic_sidebar",
           "service": "wordpress_55_test_app",
           "resource": "sidebar-2",
           "trace_id": 0,
-          "span_id": 39,
+          "span_id": 30,
           "parent_id": 19,
           "type": "web",
           "meta": {
@@ -984,8 +558,8 @@
              "service": "wordpress_55_test_app",
              "resource": "WP_Widget.display_callback",
              "trace_id": 0,
-             "span_id": 50,
-             "parent_id": 39,
+             "span_id": 40,
+             "parent_id": 30,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -996,42 +570,20 @@
                 "service": "wordpress_55_test_app",
                 "resource": "SELECT YEAR(post_date) AS `year`, MONTH(post_date) AS `month`, count(ID) as posts FROM wp55_posts  WHERE post_type = 'post' AND post_status = 'publish' GROUP BY YEAR(post_date), MONTH(post_date) ORDER BY post_date DESC ",
                 "trace_id": 0,
-                "span_id": 65,
-                "parent_id": 50,
+                "span_id": 52,
+                "parent_id": 40,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT YEAR(post_date) AS `year`, MONTH(post_date) AS `month`, count(ID) as posts FROM wp55_posts  WHERE post_type = 'post' AND post_status = 'publish' GROUP BY YEAR(post_date), MONTH(post_date) ORDER BY post_date DESC ",
-                   "trace_id": 0,
-                   "span_id": 75,
-                   "parent_id": 65,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
            {
              "name": "WP_Widget.display_callback",
              "service": "wordpress_55_test_app",
              "resource": "WP_Widget.display_callback",
              "trace_id": 0,
-             "span_id": 51,
-             "parent_id": 39,
+             "span_id": 41,
+             "parent_id": 30,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -1042,76 +594,32 @@
                 "service": "wordpress_55_test_app",
                 "resource": "SELECT  t.*, tt.* FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id WHERE tt.taxonomy IN ('category') AND tt.count > 0 ORDER BY t.name ASC ",
                 "trace_id": 0,
-                "span_id": 66,
-                "parent_id": 51,
+                "span_id": 53,
+                "parent_id": 41,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  t.*, tt.* FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id WHERE tt.taxonomy IN ('category') AND tt.count > 0 ORDER BY t.name ASC ",
-                   "trace_id": 0,
-                   "span_id": 76,
-                   "parent_id": 66,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_55_test_app",
                 "resource": "SELECT term_id, meta_key, meta_value FROM wp55_termmeta WHERE term_id IN (1) ORDER BY meta_id ASC",
                 "trace_id": 0,
-                "span_id": 67,
-                "parent_id": 51,
+                "span_id": 54,
+                "parent_id": 41,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT term_id, meta_key, meta_value FROM wp55_termmeta WHERE term_id IN (1) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 77,
-                   "parent_id": 67,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
            {
              "name": "WP_Widget.display_callback",
              "service": "wordpress_55_test_app",
              "resource": "WP_Widget.display_callback",
              "trace_id": 0,
-             "span_id": 52,
-             "parent_id": 39,
+             "span_id": 42,
+             "parent_id": 30,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -1134,7 +642,7 @@
           "service": "wordpress_55_test_app",
           "resource": "/home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/wp-content/themes/twentytwenty/footer.php",
           "trace_id": 0,
-          "span_id": 40,
+          "span_id": 31,
           "parent_id": 20,
           "type": "web",
           "meta": {
@@ -1146,8 +654,8 @@
              "service": "wordpress_55_test_app",
              "resource": "wp_print_footer_scripts",
              "trace_id": 0,
-             "span_id": 53,
-             "parent_id": 40,
+             "span_id": 43,
+             "parent_id": 31,
              "type": "web",
              "meta": {
                "component": "wordpress"

--- a/tests/snapshots/tests.integrations.word_press.v5_5.common_scenarios_legacy_test.test_scenario_get_with_exception.json
+++ b/tests/snapshots/tests.integrations.word_press.v5_5.common_scenarios_legacy_test.test_scenario_get_with_exception.json
@@ -5,11 +5,12 @@
     "resource": "GET /error",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 15414759100422969302,
+    "parent_id": 10502036490766355768,
     "type": "web",
     "error": 1,
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e7013900000000",
       "component": "wordpress",
       "error.message": "Uncaught Exception: Oops! in /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/wp-content/plugins/datadog/datadog.php:23",
       "error.stack": "#0 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/wp-includes/class-wp-hook.php(287): datadog_parse_request()\n#1 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/wp-includes/class-wp-hook.php(311): WP_Hook->apply_filters()\n#2 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/wp-includes/plugin.php(544): WP_Hook->do_action()\n#3 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/wp-includes/class-wp.php(388): do_action_ref_array()\n#4 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/wp-includes/class-wp.php(745): WP->parse_request()\n#5 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/wp-includes/functions.php(1285): WP->main()\n#6 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/wp-blog-header.php(16): wp()\n#7 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/index.php(17): require()\n#8 {main}",
@@ -18,7 +19,7 @@
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/error?key=value&<redacted>",
-      "runtime-id": "0ff18d67-3374-49ef-aadd-4a242ab14a9d",
+      "runtime-id": "e132a040-b09a-4307-9552-d026b9045d3d",
       "span.kind": "server"
     },
     "metrics": {
@@ -41,81 +42,6 @@
          "db.user": "test"
        }
      },
-        {
-          "name": "mysqli_real_connect",
-          "service": "mysqli",
-          "resource": "mysqli_real_connect",
-          "trace_id": 0,
-          "span_id": 16,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-          "trace_id": 0,
-          "span_id": 17,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT @@SESSION.sql_mode",
-          "trace_id": 0,
-          "span_id": 18,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 1.0
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-          "trace_id": 0,
-          "span_id": 19,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_55_test_app",
@@ -128,28 +54,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_name, option_value FROM wp55_options WHERE autoload = 'yes'",
-          "trace_id": 0,
-          "span_id": 20,
-          "parent_id": 3,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 111.0
-          }
-        },
      {
        "name": "create_initial_taxonomies",
        "service": "wordpress_55_test_app",
@@ -222,28 +126,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'WPLANG' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 9,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.init",
        "service": "wordpress_55_test_app",
@@ -297,35 +179,13 @@
           "service": "wordpress_55_test_app",
           "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
           "trace_id": 0,
-          "span_id": 22,
+          "span_id": 16,
           "parent_id": 13,
           "type": "sql",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 26,
-             "parent_id": 22,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_55_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
      {
        "name": "wpdb.query",
        "service": "wordpress_55_test_app",
@@ -338,28 +198,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'theme_switched' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 14,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.main",
        "service": "wordpress_55_test_app",
@@ -381,7 +219,7 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 24,
+          "span_id": 17,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -393,7 +231,7 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 25,
+          "span_id": 18,
           "parent_id": 15,
           "type": "web",
           "error": 1,
@@ -409,32 +247,10 @@
              "service": "wordpress_55_test_app",
              "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('error')\n\t\tAND post_type IN ('page','attachment')\n\t",
              "trace_id": 0,
-             "span_id": 27,
-             "parent_id": 25,
+             "span_id": 19,
+             "parent_id": 18,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
-           },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('error')\n\t\tAND post_type IN ('page','attachment')\n\t",
-                "trace_id": 0,
-                "span_id": 28,
-                "parent_id": 27,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_55_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              }]]
+           }]]

--- a/tests/snapshots/tests.integrations.word_press.v5_5.common_scenarios_legacy_test.test_scenario_get_with_view.json
+++ b/tests/snapshots/tests.integrations.word_press.v5_5.common_scenarios_legacy_test.test_scenario_get_with_view.json
@@ -5,16 +5,17 @@
     "resource": "GET /simple_view",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 4277338660967823217,
+    "parent_id": 7052580003456301255,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e7013300000000",
       "component": "wordpress",
       "http.method": "GET",
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/simple_view?key=value&<redacted>",
-      "runtime-id": "0ff18d67-3374-49ef-aadd-4a242ab14a9d",
+      "runtime-id": "e132a040-b09a-4307-9552-d026b9045d3d",
       "span.kind": "server"
     },
     "metrics": {
@@ -37,81 +38,6 @@
          "db.user": "test"
        }
      },
-        {
-          "name": "mysqli_real_connect",
-          "service": "mysqli",
-          "resource": "mysqli_real_connect",
-          "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-          "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT @@SESSION.sql_mode",
-          "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 1.0
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-          "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_55_test_app",
@@ -124,28 +50,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_name, option_value FROM wp55_options WHERE autoload = 'yes'",
-          "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 3,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 111.0
-          }
-        },
      {
        "name": "create_initial_taxonomies",
        "service": "wordpress_55_test_app",
@@ -218,28 +122,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'WPLANG' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 9,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.init",
        "service": "wordpress_55_test_app",
@@ -293,35 +175,13 @@
           "service": "wordpress_55_test_app",
           "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
           "trace_id": 0,
-          "span_id": 28,
+          "span_id": 22,
           "parent_id": 13,
           "type": "sql",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 43,
-             "parent_id": 28,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_55_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
      {
        "name": "wpdb.query",
        "service": "wordpress_55_test_app",
@@ -334,28 +194,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'theme_switched' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 29,
-          "parent_id": 14,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.main",
        "service": "wordpress_55_test_app",
@@ -373,7 +211,7 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 30,
+          "span_id": 23,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -385,7 +223,7 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 31,
+          "span_id": 24,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -397,41 +235,19 @@
              "service": "wordpress_55_test_app",
              "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('simple_view')\n\t\tAND post_type IN ('page','attachment')\n\t",
              "trace_id": 0,
-             "span_id": 44,
-             "parent_id": 31,
+             "span_id": 34,
+             "parent_id": 24,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('simple_view')\n\t\tAND post_type IN ('page','attachment')\n\t",
-                "trace_id": 0,
-                "span_id": 59,
-                "parent_id": 44,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_55_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              },
         {
           "name": "WP.send_headers",
           "service": "wordpress_55_test_app",
           "resource": "WP.send_headers",
           "trace_id": 0,
-          "span_id": 32,
+          "span_id": 25,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -443,7 +259,7 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.query_posts",
           "trace_id": 0,
-          "span_id": 33,
+          "span_id": 26,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -455,109 +271,43 @@
              "service": "wordpress_55_test_app",
              "resource": "SELECT   wp55_posts.* FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_name = 'simple_view' AND wp55_posts.post_type = 'post'  ORDER BY wp55_posts.post_date DESC ",
              "trace_id": 0,
-             "span_id": 45,
-             "parent_id": 33,
+             "span_id": 35,
+             "parent_id": 26,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT   wp55_posts.* FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_name = 'simple_view' AND wp55_posts.post_type = 'post'  ORDER BY wp55_posts.post_date DESC ",
-                "trace_id": 0,
-                "span_id": 60,
-                "parent_id": 45,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_55_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
            {
              "name": "wpdb.query",
              "service": "wordpress_55_test_app",
              "resource": "SELECT  t.*, tt.*, tr.object_id FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id INNER JOIN wp55_term_relationships AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy IN ('category', 'post_tag', 'post_format') AND tr.object_id IN (5) ORDER BY t.name ASC ",
              "trace_id": 0,
-             "span_id": 46,
-             "parent_id": 33,
+             "span_id": 36,
+             "parent_id": 26,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT  t.*, tt.*, tr.object_id FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id INNER JOIN wp55_term_relationships AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy IN ('category', 'post_tag', 'post_format') AND tr.object_id IN (5) ORDER BY t.name ASC ",
-                "trace_id": 0,
-                "span_id": 61,
-                "parent_id": 46,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_55_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
            {
              "name": "wpdb.query",
              "service": "wordpress_55_test_app",
              "resource": "SELECT post_id, meta_key, meta_value FROM wp55_postmeta WHERE post_id IN (5) ORDER BY meta_id ASC",
              "trace_id": 0,
-             "span_id": 47,
-             "parent_id": 33,
+             "span_id": 37,
+             "parent_id": 26,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT post_id, meta_key, meta_value FROM wp55_postmeta WHERE post_id IN (5) ORDER BY meta_id ASC",
-                "trace_id": 0,
-                "span_id": 62,
-                "parent_id": 47,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_55_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 3.0
-                }
-              },
         {
           "name": "WP.handle_404",
           "service": "wordpress_55_test_app",
           "resource": "WP.handle_404",
           "trace_id": 0,
-          "span_id": 34,
+          "span_id": 27,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -569,7 +319,7 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.register_globals",
           "trace_id": 0,
-          "span_id": 35,
+          "span_id": 28,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -593,7 +343,7 @@
           "service": "wordpress_55_test_app",
           "resource": "/home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/wp-content/themes/twentytwenty/header.php",
           "trace_id": 0,
-          "span_id": 36,
+          "span_id": 29,
           "parent_id": 16,
           "type": "web",
           "meta": {
@@ -605,8 +355,8 @@
              "service": "wordpress_55_test_app",
              "resource": "wp_head",
              "trace_id": 0,
-             "span_id": 48,
-             "parent_id": 36,
+             "span_id": 38,
+             "parent_id": 29,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -617,8 +367,8 @@
                 "service": "wordpress_55_test_app",
                 "resource": "wp_print_head_scripts",
                 "trace_id": 0,
-                "span_id": 63,
-                "parent_id": 48,
+                "span_id": 49,
+                "parent_id": 38,
                 "type": "web",
                 "meta": {
                   "component": "wordpress"
@@ -629,110 +379,44 @@
                 "service": "wordpress_55_test_app",
                 "resource": "SELECT p.ID FROM wp55_posts AS p  WHERE p.post_date < '2020-10-22 16:32:26' AND p.post_type = 'post'  AND p.post_status = 'publish' ORDER BY p.post_date DESC LIMIT 1",
                 "trace_id": 0,
-                "span_id": 64,
-                "parent_id": 48,
+                "span_id": 50,
+                "parent_id": 38,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT p.ID FROM wp55_posts AS p  WHERE p.post_date < '2020-10-22 16:32:26' AND p.post_type = 'post'  AND p.post_status = 'publish' ORDER BY p.post_date DESC LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 78,
-                   "parent_id": 64,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_55_test_app",
                 "resource": "SELECT * FROM wp55_posts WHERE ID = 1 LIMIT 1",
                 "trace_id": 0,
-                "span_id": 65,
-                "parent_id": 48,
+                "span_id": 51,
+                "parent_id": 38,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT * FROM wp55_posts WHERE ID = 1 LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 79,
-                   "parent_id": 65,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_55_test_app",
                 "resource": "SELECT p.ID FROM wp55_posts AS p  WHERE p.post_date > '2020-10-22 16:32:26' AND p.post_type = 'post'  AND p.post_status = 'publish' ORDER BY p.post_date ASC LIMIT 1",
                 "trace_id": 0,
-                "span_id": 66,
-                "parent_id": 48,
+                "span_id": 52,
+                "parent_id": 38,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT p.ID FROM wp55_posts AS p  WHERE p.post_date > '2020-10-22 16:32:26' AND p.post_type = 'post'  AND p.post_status = 'publish' ORDER BY p.post_date ASC LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 80,
-                   "parent_id": 66,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
            {
              "name": "body_class",
              "service": "wordpress_55_test_app",
              "resource": "body_class",
              "trace_id": 0,
-             "span_id": 49,
-             "parent_id": 36,
+             "span_id": 39,
+             "parent_id": 29,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -743,35 +427,13 @@
              "service": "wordpress_55_test_app",
              "resource": "SELECT * FROM wp55_posts  WHERE (post_type = 'page' AND post_status = 'publish')     ORDER BY menu_order,wp55_posts.post_title ASC",
              "trace_id": 0,
-             "span_id": 50,
-             "parent_id": 36,
+             "span_id": 40,
+             "parent_id": 29,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT * FROM wp55_posts  WHERE (post_type = 'page' AND post_status = 'publish')     ORDER BY menu_order,wp55_posts.post_title ASC",
-                "trace_id": 0,
-                "span_id": 67,
-                "parent_id": 50,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_55_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
      {
        "name": "wpdb.query",
        "service": "wordpress_55_test_app",
@@ -784,28 +446,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT * FROM wp55_users WHERE ID = '1' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 37,
-          "parent_id": 17,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 1.0
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_55_test_app",
@@ -818,28 +458,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT user_id, meta_key, meta_value FROM wp55_usermeta WHERE user_id IN (1) ORDER BY umeta_id ASC",
-          "trace_id": 0,
-          "span_id": 38,
-          "parent_id": 18,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 18.0
-          }
-        },
      {
        "name": "load_template",
        "service": "wordpress_55_test_app",
@@ -857,7 +475,7 @@
           "service": "wordpress_55_test_app",
           "resource": "comments_template",
           "trace_id": 0,
-          "span_id": 39,
+          "span_id": 30,
           "parent_id": 19,
           "type": "web",
           "meta": {
@@ -869,35 +487,13 @@
              "service": "wordpress_55_test_app",
              "resource": "SELECT SQL_CALC_FOUND_ROWS wp55_comments.comment_ID FROM wp55_comments  WHERE ( comment_approved = '1' ) AND comment_post_ID = 5 AND comment_parent = 0  ORDER BY wp55_comments.comment_date_gmt ASC, wp55_comments.comment_ID ASC ",
              "trace_id": 0,
-             "span_id": 51,
-             "parent_id": 39,
+             "span_id": 41,
+             "parent_id": 30,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT SQL_CALC_FOUND_ROWS wp55_comments.comment_ID FROM wp55_comments  WHERE ( comment_approved = '1' ) AND comment_post_ID = 5 AND comment_parent = 0  ORDER BY wp55_comments.comment_date_gmt ASC, wp55_comments.comment_ID ASC ",
-                "trace_id": 0,
-                "span_id": 68,
-                "parent_id": 51,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_55_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              },
      {
        "name": "load_template",
        "service": "wordpress_55_test_app",
@@ -915,7 +511,7 @@
           "service": "wordpress_55_test_app",
           "resource": "sidebar-1",
           "trace_id": 0,
-          "span_id": 40,
+          "span_id": 31,
           "parent_id": 20,
           "type": "web",
           "meta": {
@@ -927,8 +523,8 @@
              "service": "wordpress_55_test_app",
              "resource": "WP_Widget.display_callback",
              "trace_id": 0,
-             "span_id": 52,
-             "parent_id": 40,
+             "span_id": 42,
+             "parent_id": 31,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -939,8 +535,8 @@
              "service": "wordpress_55_test_app",
              "resource": "WP_Widget.display_callback",
              "trace_id": 0,
-             "span_id": 53,
-             "parent_id": 40,
+             "span_id": 43,
+             "parent_id": 31,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -951,110 +547,44 @@
                 "service": "wordpress_55_test_app",
                 "resource": "SELECT   wp55_posts.ID FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_type = 'post' AND ((wp55_posts.post_status = 'publish'))  ORDER BY wp55_posts.post_date DESC LIMIT 0, 5",
                 "trace_id": 0,
-                "span_id": 69,
-                "parent_id": 53,
+                "span_id": 53,
+                "parent_id": 43,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT   wp55_posts.ID FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_type = 'post' AND ((wp55_posts.post_status = 'publish'))  ORDER BY wp55_posts.post_date DESC LIMIT 0, 5",
-                   "trace_id": 0,
-                   "span_id": 81,
-                   "parent_id": 69,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 2.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_55_test_app",
                 "resource": "SELECT  t.*, tt.*, tr.object_id FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id INNER JOIN wp55_term_relationships AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy IN ('category', 'post_tag', 'post_format') AND tr.object_id IN (1) ORDER BY t.name ASC ",
                 "trace_id": 0,
-                "span_id": 70,
-                "parent_id": 53,
+                "span_id": 54,
+                "parent_id": 43,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  t.*, tt.*, tr.object_id FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id INNER JOIN wp55_term_relationships AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy IN ('category', 'post_tag', 'post_format') AND tr.object_id IN (1) ORDER BY t.name ASC ",
-                   "trace_id": 0,
-                   "span_id": 82,
-                   "parent_id": 70,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_55_test_app",
                 "resource": "SELECT post_id, meta_key, meta_value FROM wp55_postmeta WHERE post_id IN (1) ORDER BY meta_id ASC",
                 "trace_id": 0,
-                "span_id": 71,
-                "parent_id": 53,
+                "span_id": 55,
+                "parent_id": 43,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT post_id, meta_key, meta_value FROM wp55_postmeta WHERE post_id IN (1) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 83,
-                   "parent_id": 71,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
            {
              "name": "WP_Widget.display_callback",
              "service": "wordpress_55_test_app",
              "resource": "WP_Widget.display_callback",
              "trace_id": 0,
-             "span_id": 54,
-             "parent_id": 40,
+             "span_id": 44,
+             "parent_id": 31,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -1065,109 +595,43 @@
                 "service": "wordpress_55_test_app",
                 "resource": "SELECT  wp55_comments.comment_ID FROM wp55_comments JOIN wp55_posts ON wp55_posts.ID = wp55_comments.comment_post_ID WHERE ( comment_approved = '1' ) AND  wp55_posts.post_status IN ('publish')  ORDER BY wp55_comments.comment_date_gmt DESC LIMIT 0,5",
                 "trace_id": 0,
-                "span_id": 72,
-                "parent_id": 54,
+                "span_id": 56,
+                "parent_id": 44,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  wp55_comments.comment_ID FROM wp55_comments JOIN wp55_posts ON wp55_posts.ID = wp55_comments.comment_post_ID WHERE ( comment_approved = '1' ) AND  wp55_posts.post_status IN ('publish')  ORDER BY wp55_comments.comment_date_gmt DESC LIMIT 0,5",
-                   "trace_id": 0,
-                   "span_id": 84,
-                   "parent_id": 72,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_55_test_app",
                 "resource": "SELECT wp55_comments.* FROM wp55_comments WHERE comment_ID IN (1)",
                 "trace_id": 0,
-                "span_id": 73,
-                "parent_id": 54,
+                "span_id": 57,
+                "parent_id": 44,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT wp55_comments.* FROM wp55_comments WHERE comment_ID IN (1)",
-                   "trace_id": 0,
-                   "span_id": 85,
-                   "parent_id": 73,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_55_test_app",
                 "resource": "SELECT comment_id, meta_key, meta_value FROM wp55_commentmeta WHERE comment_id IN (1) ORDER BY meta_id ASC",
                 "trace_id": 0,
-                "span_id": 74,
-                "parent_id": 54,
+                "span_id": 58,
+                "parent_id": 44,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT comment_id, meta_key, meta_value FROM wp55_commentmeta WHERE comment_id IN (1) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 86,
-                   "parent_id": 74,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
         {
           "name": "dynamic_sidebar",
           "service": "wordpress_55_test_app",
           "resource": "sidebar-2",
           "trace_id": 0,
-          "span_id": 41,
+          "span_id": 32,
           "parent_id": 20,
           "type": "web",
           "meta": {
@@ -1179,8 +643,8 @@
              "service": "wordpress_55_test_app",
              "resource": "WP_Widget.display_callback",
              "trace_id": 0,
-             "span_id": 55,
-             "parent_id": 41,
+             "span_id": 45,
+             "parent_id": 32,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -1191,42 +655,20 @@
                 "service": "wordpress_55_test_app",
                 "resource": "SELECT YEAR(post_date) AS `year`, MONTH(post_date) AS `month`, count(ID) as posts FROM wp55_posts  WHERE post_type = 'post' AND post_status = 'publish' GROUP BY YEAR(post_date), MONTH(post_date) ORDER BY post_date DESC ",
                 "trace_id": 0,
-                "span_id": 75,
-                "parent_id": 55,
+                "span_id": 59,
+                "parent_id": 45,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT YEAR(post_date) AS `year`, MONTH(post_date) AS `month`, count(ID) as posts FROM wp55_posts  WHERE post_type = 'post' AND post_status = 'publish' GROUP BY YEAR(post_date), MONTH(post_date) ORDER BY post_date DESC ",
-                   "trace_id": 0,
-                   "span_id": 87,
-                   "parent_id": 75,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
            {
              "name": "WP_Widget.display_callback",
              "service": "wordpress_55_test_app",
              "resource": "WP_Widget.display_callback",
              "trace_id": 0,
-             "span_id": 56,
-             "parent_id": 41,
+             "span_id": 46,
+             "parent_id": 32,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -1237,76 +679,32 @@
                 "service": "wordpress_55_test_app",
                 "resource": "SELECT  t.*, tt.* FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id WHERE tt.taxonomy IN ('category') AND tt.count > 0 ORDER BY t.name ASC ",
                 "trace_id": 0,
-                "span_id": 76,
-                "parent_id": 56,
+                "span_id": 60,
+                "parent_id": 46,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  t.*, tt.* FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id WHERE tt.taxonomy IN ('category') AND tt.count > 0 ORDER BY t.name ASC ",
-                   "trace_id": 0,
-                   "span_id": 88,
-                   "parent_id": 76,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_55_test_app",
                 "resource": "SELECT term_id, meta_key, meta_value FROM wp55_termmeta WHERE term_id IN (1) ORDER BY meta_id ASC",
                 "trace_id": 0,
-                "span_id": 77,
-                "parent_id": 56,
+                "span_id": 61,
+                "parent_id": 46,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT term_id, meta_key, meta_value FROM wp55_termmeta WHERE term_id IN (1) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 89,
-                   "parent_id": 77,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
            {
              "name": "WP_Widget.display_callback",
              "service": "wordpress_55_test_app",
              "resource": "WP_Widget.display_callback",
              "trace_id": 0,
-             "span_id": 57,
-             "parent_id": 41,
+             "span_id": 47,
+             "parent_id": 32,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -1329,7 +727,7 @@
           "service": "wordpress_55_test_app",
           "resource": "/home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/wp-content/themes/twentytwenty/footer.php",
           "trace_id": 0,
-          "span_id": 42,
+          "span_id": 33,
           "parent_id": 21,
           "type": "web",
           "meta": {
@@ -1341,8 +739,8 @@
              "service": "wordpress_55_test_app",
              "resource": "wp_print_footer_scripts",
              "trace_id": 0,
-             "span_id": 58,
-             "parent_id": 42,
+             "span_id": 48,
+             "parent_id": 33,
              "type": "web",
              "meta": {
                "component": "wordpress"

--- a/tests/snapshots/tests.integrations.word_press.v5_5.common_scenarios_test.test_scenario_get_return_string.json
+++ b/tests/snapshots/tests.integrations.word_press.v5_5.common_scenarios_test.test_scenario_get_return_string.json
@@ -5,16 +5,17 @@
     "resource": "GET /simple",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 9639977890261987175,
+    "parent_id": 16500283725275646794,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e7015000000000",
       "component": "wordpress",
       "http.method": "GET",
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/simple?key=value&<redacted>",
-      "runtime-id": "9244a46d-d13c-4bce-b787-87c52dd20f33",
+      "runtime-id": "f188c752-a672-4955-97f7-e41a31d13fe7",
       "span.kind": "server"
     },
     "metrics": {
@@ -22,108 +23,11 @@
     }
   },
      {
-       "name": "mysqli_real_connect",
-       "service": "mysqli",
-       "resource": "mysqli_real_connect",
-       "trace_id": 0,
-       "span_id": 2,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-       "trace_id": 0,
-       "span_id": 3,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT @@SESSION.sql_mode",
-       "trace_id": 0,
-       "span_id": 4,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 1.0
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-       "trace_id": 0,
-       "span_id": 5,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_name, option_value FROM wp55_options WHERE autoload = 'yes'",
-       "trace_id": 0,
-       "span_id": 6,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 111.0
-       }
-     },
-     {
        "name": "create_initial_taxonomies",
        "service": "wordpress_55_test_app",
        "resource": "create_initial_taxonomies",
        "trace_id": 0,
-       "span_id": 7,
+       "span_id": 2,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -135,7 +39,7 @@
        "service": "wordpress_55_test_app",
        "resource": "create_initial_post_types",
        "trace_id": 0,
-       "span_id": 8,
+       "span_id": 3,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -147,7 +51,7 @@
        "service": "wordpress_55_test_app",
        "resource": "datadog (plugin)",
        "trace_id": 0,
-       "span_id": 9,
+       "span_id": 4,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -160,7 +64,7 @@
        "service": "wordpress_55_test_app",
        "resource": "plugins_loaded (hook)",
        "trace_id": 0,
-       "span_id": 10,
+       "span_id": 5,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -173,8 +77,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_maybe_load_widgets",
           "trace_id": 0,
-          "span_id": 20,
-          "parent_id": 10,
+          "span_id": 14,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -185,8 +89,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_maybe_load_embeds",
           "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 10,
+          "span_id": 15,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -197,8 +101,8 @@
           "service": "wordpress_55_test_app",
           "resource": "_wp_customize_include",
           "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 10,
+          "span_id": 16,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -209,7 +113,7 @@
        "service": "wordpress_55_test_app",
        "resource": "setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 11,
+       "span_id": 6,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -218,33 +122,11 @@
        }
      },
      {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'WPLANG' LIMIT 1",
-       "trace_id": 0,
-       "span_id": 12,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 0.0
-       }
-     },
-     {
        "name": "load_theme",
        "service": "wordpress_55_test_app",
        "resource": "Twentytwenty (theme)",
        "trace_id": 0,
-       "span_id": 13,
+       "span_id": 7,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -257,7 +139,7 @@
        "service": "wordpress_55_test_app",
        "resource": "after_setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 14,
+       "span_id": 8,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -270,7 +152,7 @@
        "service": "wordpress_55_test_app",
        "resource": "WP.init",
        "trace_id": 0,
-       "span_id": 15,
+       "span_id": 9,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -282,7 +164,7 @@
        "service": "wordpress_55_test_app",
        "resource": "init (hook)",
        "trace_id": 0,
-       "span_id": 16,
+       "span_id": 10,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -295,8 +177,8 @@
           "service": "wordpress_55_test_app",
           "resource": "create_initial_post_types",
           "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 16,
+          "span_id": 17,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -307,8 +189,8 @@
           "service": "wordpress_55_test_app",
           "resource": "create_initial_taxonomies",
           "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 16,
+          "span_id": 18,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -319,8 +201,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_widgets_init",
           "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 16,
+          "span_id": 19,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -331,63 +213,19 @@
              "service": "wordpress_55_test_app",
              "resource": "WP_Widget_Factory._register_widgets",
              "trace_id": 0,
-             "span_id": 29,
-             "parent_id": 25,
+             "span_id": 22,
+             "parent_id": 19,
              "type": "web",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-                "trace_id": 0,
-                "span_id": 31,
-                "parent_id": 29,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_55_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'theme_switched' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 16,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "action",
        "service": "wordpress_55_test_app",
        "resource": "wp_loaded (hook)",
        "trace_id": 0,
-       "span_id": 17,
+       "span_id": 11,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -400,7 +238,7 @@
        "service": "wordpress_55_test_app",
        "resource": "WP.main",
        "trace_id": 0,
-       "span_id": 18,
+       "span_id": 12,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -412,8 +250,8 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 18,
+          "span_id": 20,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -424,41 +262,19 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 28,
-          "parent_id": 18,
+          "span_id": 21,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('simple')\n\t\tAND post_type IN ('page','attachment')\n\t",
-             "trace_id": 0,
-             "span_id": 30,
-             "parent_id": 28,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_55_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_55_test_app",
        "resource": "shutdown (hook)",
        "trace_id": 0,
-       "span_id": 19,
+       "span_id": 13,
        "parent_id": 1,
        "type": "web",
        "meta": {

--- a/tests/snapshots/tests.integrations.word_press.v5_5.common_scenarios_test.test_scenario_get_to_missing_route.json
+++ b/tests/snapshots/tests.integrations.word_press.v5_5.common_scenarios_test.test_scenario_get_to_missing_route.json
@@ -5,15 +5,16 @@
     "resource": "GET /does_not_exist",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 4536844318343104219,
+    "parent_id": 6063775393296416580,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e7016500000000",
       "component": "wordpress",
       "http.method": "GET",
       "http.status_code": "404",
       "http.url": "http://localhost:9999/does_not_exist?key=value&<redacted>",
-      "runtime-id": "b5e7ee20-5ea1-486f-a770-c17a3b60636e",
+      "runtime-id": "f188c752-a672-4955-97f7-e41a31d13fe7",
       "span.kind": "server"
     },
     "metrics": {
@@ -21,108 +22,11 @@
     }
   },
      {
-       "name": "mysqli_real_connect",
-       "service": "mysqli",
-       "resource": "mysqli_real_connect",
-       "trace_id": 0,
-       "span_id": 2,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-       "trace_id": 0,
-       "span_id": 3,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT @@SESSION.sql_mode",
-       "trace_id": 0,
-       "span_id": 4,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 1.0
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-       "trace_id": 0,
-       "span_id": 5,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_name, option_value FROM wp55_options WHERE autoload = 'yes'",
-       "trace_id": 0,
-       "span_id": 6,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 111.0
-       }
-     },
-     {
        "name": "create_initial_taxonomies",
        "service": "wordpress_55_test_app",
        "resource": "create_initial_taxonomies",
        "trace_id": 0,
-       "span_id": 7,
+       "span_id": 2,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -134,7 +38,7 @@
        "service": "wordpress_55_test_app",
        "resource": "create_initial_post_types",
        "trace_id": 0,
-       "span_id": 8,
+       "span_id": 3,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -146,7 +50,7 @@
        "service": "wordpress_55_test_app",
        "resource": "datadog (plugin)",
        "trace_id": 0,
-       "span_id": 9,
+       "span_id": 4,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -159,7 +63,7 @@
        "service": "wordpress_55_test_app",
        "resource": "plugins_loaded (hook)",
        "trace_id": 0,
-       "span_id": 10,
+       "span_id": 5,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -172,8 +76,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_maybe_load_widgets",
           "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 10,
+          "span_id": 15,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -184,8 +88,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_maybe_load_embeds",
           "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 10,
+          "span_id": 16,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -196,8 +100,8 @@
           "service": "wordpress_55_test_app",
           "resource": "_wp_customize_include",
           "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 10,
+          "span_id": 17,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -208,7 +112,7 @@
        "service": "wordpress_55_test_app",
        "resource": "setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 11,
+       "span_id": 6,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -217,33 +121,11 @@
        }
      },
      {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'WPLANG' LIMIT 1",
-       "trace_id": 0,
-       "span_id": 12,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 0.0
-       }
-     },
-     {
        "name": "load_theme",
        "service": "wordpress_55_test_app",
        "resource": "Twentytwenty (theme)",
        "trace_id": 0,
-       "span_id": 13,
+       "span_id": 7,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -256,7 +138,7 @@
        "service": "wordpress_55_test_app",
        "resource": "after_setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 14,
+       "span_id": 8,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -269,7 +151,7 @@
        "service": "wordpress_55_test_app",
        "resource": "WP.init",
        "trace_id": 0,
-       "span_id": 15,
+       "span_id": 9,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -281,7 +163,7 @@
        "service": "wordpress_55_test_app",
        "resource": "init (hook)",
        "trace_id": 0,
-       "span_id": 16,
+       "span_id": 10,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -294,8 +176,8 @@
           "service": "wordpress_55_test_app",
           "resource": "create_initial_post_types",
           "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 16,
+          "span_id": 18,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -306,8 +188,8 @@
           "service": "wordpress_55_test_app",
           "resource": "create_initial_taxonomies",
           "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 16,
+          "span_id": 19,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -318,8 +200,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_widgets_init",
           "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 16,
+          "span_id": 20,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -330,63 +212,19 @@
              "service": "wordpress_55_test_app",
              "resource": "WP_Widget_Factory._register_widgets",
              "trace_id": 0,
-             "span_id": 40,
-             "parent_id": 26,
+             "span_id": 33,
+             "parent_id": 20,
              "type": "web",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-                "trace_id": 0,
-                "span_id": 49,
-                "parent_id": 40,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_55_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'theme_switched' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 16,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "action",
        "service": "wordpress_55_test_app",
        "resource": "wp_loaded (hook)",
        "trace_id": 0,
-       "span_id": 17,
+       "span_id": 11,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -399,7 +237,7 @@
        "service": "wordpress_55_test_app",
        "resource": "WP.main",
        "trace_id": 0,
-       "span_id": 18,
+       "span_id": 12,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -411,8 +249,8 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 28,
-          "parent_id": 18,
+          "span_id": 21,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -423,42 +261,20 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 29,
-          "parent_id": 18,
+          "span_id": 22,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('does_not_exist')\n\t\tAND post_type IN ('page','attachment')\n\t",
-             "trace_id": 0,
-             "span_id": 41,
-             "parent_id": 29,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_55_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
         {
           "name": "WP.send_headers",
           "service": "wordpress_55_test_app",
           "resource": "WP.send_headers",
           "trace_id": 0,
-          "span_id": 30,
-          "parent_id": 18,
+          "span_id": 23,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -469,42 +285,20 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.query_posts",
           "trace_id": 0,
-          "span_id": 31,
-          "parent_id": 18,
+          "span_id": 24,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT   wp55_posts.* FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_name = 'does_not_exist' AND wp55_posts.post_type = 'post'  ORDER BY wp55_posts.post_date DESC ",
-             "trace_id": 0,
-             "span_id": 42,
-             "parent_id": 31,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_55_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
         {
           "name": "WP.handle_404",
           "service": "wordpress_55_test_app",
           "resource": "WP.handle_404",
           "trace_id": 0,
-          "span_id": 32,
-          "parent_id": 18,
+          "span_id": 25,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -515,8 +309,8 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.register_globals",
           "trace_id": 0,
-          "span_id": 33,
-          "parent_id": 18,
+          "span_id": 26,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -527,8 +321,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp (hook)",
           "trace_id": 0,
-          "span_id": 34,
-          "parent_id": 18,
+          "span_id": 27,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -540,7 +334,7 @@
        "service": "wordpress_55_test_app",
        "resource": "load_template_loader",
        "trace_id": 0,
-       "span_id": 19,
+       "span_id": 13,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -552,65 +346,21 @@
           "service": "wordpress_55_test_app",
           "resource": "template_redirect (hook)",
           "trace_id": 0,
-          "span_id": 35,
-          "parent_id": 19,
+          "span_id": 28,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
             "wordpress.hook": "template_redirect"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT post_id FROM wp55_postmeta, wp55_posts WHERE ID = post_id AND post_type = 'post' AND meta_key = '_wp_old_slug' AND meta_value = 'does_not_exist'",
-             "trace_id": 0,
-             "span_id": 43,
-             "parent_id": 35,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_55_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT ID FROM wp55_posts WHERE post_name LIKE 'does\\\\_not\\\\_exist%' AND post_type IN ('post', 'page', 'attachment') AND post_status = 'publish'",
-             "trace_id": 0,
-             "span_id": 44,
-             "parent_id": 35,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_55_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
         {
           "name": "template",
           "service": "wordpress_55_test_app",
           "resource": "404 (type)",
           "trace_id": 0,
-          "span_id": 36,
-          "parent_id": 19,
+          "span_id": 29,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -623,8 +373,8 @@
           "service": "wordpress_55_test_app",
           "resource": "get_header",
           "trace_id": 0,
-          "span_id": 37,
-          "parent_id": 19,
+          "span_id": 30,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -635,8 +385,8 @@
              "service": "wordpress_55_test_app",
              "resource": "header (template)",
              "trace_id": 0,
-             "span_id": 45,
-             "parent_id": 37,
+             "span_id": 34,
+             "parent_id": 30,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -649,8 +399,8 @@
                 "service": "wordpress_55_test_app",
                 "resource": "wp_head (hook)",
                 "trace_id": 0,
-                "span_id": 50,
-                "parent_id": 45,
+                "span_id": 38,
+                "parent_id": 34,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -662,8 +412,8 @@
                    "service": "wordpress_55_test_app",
                    "resource": "wp_print_head_scripts",
                    "trace_id": 0,
-                   "span_id": 60,
-                   "parent_id": 50,
+                   "span_id": 47,
+                   "parent_id": 38,
                    "type": "web",
                    "meta": {
                      "component": "wordpress"
@@ -674,33 +424,11 @@
                 "service": "wordpress_55_test_app",
                 "resource": "body_class",
                 "trace_id": 0,
-                "span_id": 51,
-                "parent_id": 45,
+                "span_id": 39,
+                "parent_id": 34,
                 "type": "web",
                 "meta": {
                   "component": "wordpress"
-                }
-              },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT * FROM wp55_posts  WHERE (post_type = 'page' AND post_status = 'publish')     ORDER BY menu_order,wp55_posts.post_title ASC",
-                "trace_id": 0,
-                "span_id": 52,
-                "parent_id": 45,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_55_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
                 }
               },
         {
@@ -708,8 +436,8 @@
           "service": "wordpress_55_test_app",
           "resource": "footer-menus-widgets (template)",
           "trace_id": 0,
-          "span_id": 38,
-          "parent_id": 19,
+          "span_id": 31,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -722,8 +450,8 @@
              "service": "wordpress_55_test_app",
              "resource": "sidebar-1",
              "trace_id": 0,
-             "span_id": 46,
-             "parent_id": 38,
+             "span_id": 35,
+             "parent_id": 31,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -734,8 +462,8 @@
                 "service": "wordpress_55_test_app",
                 "resource": "Search (widget)",
                 "trace_id": 0,
-                "span_id": 53,
-                "parent_id": 46,
+                "span_id": 40,
+                "parent_id": 35,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -747,188 +475,34 @@
                 "service": "wordpress_55_test_app",
                 "resource": "Recent Posts (widget)",
                 "trace_id": 0,
-                "span_id": 54,
-                "parent_id": 46,
+                "span_id": 41,
+                "parent_id": 35,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Recent Posts"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT   wp55_posts.ID FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_type = 'post' AND ((wp55_posts.post_status = 'publish'))  ORDER BY wp55_posts.post_date DESC LIMIT 0, 5",
-                   "trace_id": 0,
-                   "span_id": 61,
-                   "parent_id": 54,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 2.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT wp55_posts.* FROM wp55_posts WHERE ID IN (5,1)",
-                   "trace_id": 0,
-                   "span_id": 62,
-                   "parent_id": 54,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 2.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  t.*, tt.*, tr.object_id FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id INNER JOIN wp55_term_relationships AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy IN ('category', 'post_tag', 'post_format') AND tr.object_id IN (1, 5) ORDER BY t.name ASC ",
-                   "trace_id": 0,
-                   "span_id": 63,
-                   "parent_id": 54,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 2.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT post_id, meta_key, meta_value FROM wp55_postmeta WHERE post_id IN (1,5) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 64,
-                   "parent_id": 54,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 3.0
-                   }
-                 },
               {
                 "name": "widget",
                 "service": "wordpress_55_test_app",
                 "resource": "Recent Comments (widget)",
                 "trace_id": 0,
-                "span_id": 55,
-                "parent_id": 46,
+                "span_id": 42,
+                "parent_id": 35,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Recent Comments"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  wp55_comments.comment_ID FROM wp55_comments JOIN wp55_posts ON wp55_posts.ID = wp55_comments.comment_post_ID WHERE ( comment_approved = '1' ) AND  wp55_posts.post_status IN ('publish')  ORDER BY wp55_comments.comment_date_gmt DESC LIMIT 0,5",
-                   "trace_id": 0,
-                   "span_id": 65,
-                   "parent_id": 55,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT wp55_comments.* FROM wp55_comments WHERE comment_ID IN (1)",
-                   "trace_id": 0,
-                   "span_id": 66,
-                   "parent_id": 55,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT comment_id, meta_key, meta_value FROM wp55_commentmeta WHERE comment_id IN (1) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 67,
-                   "parent_id": 55,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
            {
              "name": "dynamic_sidebar",
              "service": "wordpress_55_test_app",
              "resource": "sidebar-2",
              "trace_id": 0,
-             "span_id": 47,
-             "parent_id": 38,
+             "span_id": 36,
+             "parent_id": 31,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -939,100 +513,34 @@
                 "service": "wordpress_55_test_app",
                 "resource": "Archives (widget)",
                 "trace_id": 0,
-                "span_id": 56,
-                "parent_id": 47,
+                "span_id": 43,
+                "parent_id": 36,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Archives"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT YEAR(post_date) AS `year`, MONTH(post_date) AS `month`, count(ID) as posts FROM wp55_posts  WHERE post_type = 'post' AND post_status = 'publish' GROUP BY YEAR(post_date), MONTH(post_date) ORDER BY post_date DESC ",
-                   "trace_id": 0,
-                   "span_id": 68,
-                   "parent_id": 56,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
               {
                 "name": "widget",
                 "service": "wordpress_55_test_app",
                 "resource": "Categories (widget)",
                 "trace_id": 0,
-                "span_id": 57,
-                "parent_id": 47,
+                "span_id": 44,
+                "parent_id": 36,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Categories"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  t.*, tt.* FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id WHERE tt.taxonomy IN ('category') AND tt.count > 0 ORDER BY t.name ASC ",
-                   "trace_id": 0,
-                   "span_id": 69,
-                   "parent_id": 57,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT term_id, meta_key, meta_value FROM wp55_termmeta WHERE term_id IN (1) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 70,
-                   "parent_id": 57,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
               {
                 "name": "widget",
                 "service": "wordpress_55_test_app",
                 "resource": "Meta (widget)",
                 "trace_id": 0,
-                "span_id": 58,
-                "parent_id": 47,
+                "span_id": 45,
+                "parent_id": 36,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -1044,8 +552,8 @@
           "service": "wordpress_55_test_app",
           "resource": "get_footer",
           "trace_id": 0,
-          "span_id": 39,
-          "parent_id": 19,
+          "span_id": 32,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -1056,8 +564,8 @@
              "service": "wordpress_55_test_app",
              "resource": "footer (template)",
              "trace_id": 0,
-             "span_id": 48,
-             "parent_id": 39,
+             "span_id": 37,
+             "parent_id": 32,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1070,8 +578,8 @@
                 "service": "wordpress_55_test_app",
                 "resource": "wp_footer (hook)",
                 "trace_id": 0,
-                "span_id": 59,
-                "parent_id": 48,
+                "span_id": 46,
+                "parent_id": 37,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -1083,7 +591,7 @@
        "service": "wordpress_55_test_app",
        "resource": "shutdown (hook)",
        "trace_id": 0,
-       "span_id": 20,
+       "span_id": 14,
        "parent_id": 1,
        "type": "web",
        "meta": {

--- a/tests/snapshots/tests.integrations.word_press.v5_5.common_scenarios_test.test_scenario_get_with_exception.json
+++ b/tests/snapshots/tests.integrations.word_press.v5_5.common_scenarios_test.test_scenario_get_with_exception.json
@@ -5,11 +5,12 @@
     "resource": "GET /error",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 9914475240121656994,
+    "parent_id": 10716415254926069522,
     "type": "web",
     "error": 1,
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e7016000000000",
       "component": "wordpress",
       "error.message": "Uncaught Exception: Oops! in /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/wp-content/plugins/datadog/datadog.php:23",
       "error.stack": "#0 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/wp-includes/class-wp-hook.php(287): datadog_parse_request()\n#1 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/wp-includes/class-wp-hook.php(311): WP_Hook->apply_filters()\n#2 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/wp-includes/plugin.php(544): WP_Hook->do_action()\n#3 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/wp-includes/class-wp.php(388): do_action_ref_array()\n#4 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/wp-includes/class-wp.php(745): WP->parse_request()\n#5 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/wp-includes/functions.php(1285): WP->main()\n#6 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/wp-blog-header.php(16): wp()\n#7 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_5/index.php(17): require()\n#8 {main}",
@@ -18,7 +19,7 @@
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/error?key=value&<redacted>",
-      "runtime-id": "7a9eb703-4857-4061-adce-a45e58093b65",
+      "runtime-id": "f188c752-a672-4955-97f7-e41a31d13fe7",
       "span.kind": "server"
     },
     "metrics": {
@@ -26,108 +27,11 @@
     }
   },
      {
-       "name": "mysqli_real_connect",
-       "service": "mysqli",
-       "resource": "mysqli_real_connect",
-       "trace_id": 0,
-       "span_id": 2,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-       "trace_id": 0,
-       "span_id": 3,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT @@SESSION.sql_mode",
-       "trace_id": 0,
-       "span_id": 4,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 1.0
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-       "trace_id": 0,
-       "span_id": 5,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_name, option_value FROM wp55_options WHERE autoload = 'yes'",
-       "trace_id": 0,
-       "span_id": 6,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 111.0
-       }
-     },
-     {
        "name": "create_initial_taxonomies",
        "service": "wordpress_55_test_app",
        "resource": "create_initial_taxonomies",
        "trace_id": 0,
-       "span_id": 7,
+       "span_id": 2,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -139,7 +43,7 @@
        "service": "wordpress_55_test_app",
        "resource": "create_initial_post_types",
        "trace_id": 0,
-       "span_id": 8,
+       "span_id": 3,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -151,7 +55,7 @@
        "service": "wordpress_55_test_app",
        "resource": "datadog (plugin)",
        "trace_id": 0,
-       "span_id": 9,
+       "span_id": 4,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -164,7 +68,7 @@
        "service": "wordpress_55_test_app",
        "resource": "plugins_loaded (hook)",
        "trace_id": 0,
-       "span_id": 10,
+       "span_id": 5,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -177,8 +81,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_maybe_load_widgets",
           "trace_id": 0,
-          "span_id": 20,
-          "parent_id": 10,
+          "span_id": 14,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -189,8 +93,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_maybe_load_embeds",
           "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 10,
+          "span_id": 15,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -201,8 +105,8 @@
           "service": "wordpress_55_test_app",
           "resource": "_wp_customize_include",
           "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 10,
+          "span_id": 16,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -213,7 +117,7 @@
        "service": "wordpress_55_test_app",
        "resource": "setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 11,
+       "span_id": 6,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -222,33 +126,11 @@
        }
      },
      {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'WPLANG' LIMIT 1",
-       "trace_id": 0,
-       "span_id": 12,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 0.0
-       }
-     },
-     {
        "name": "load_theme",
        "service": "wordpress_55_test_app",
        "resource": "Twentytwenty (theme)",
        "trace_id": 0,
-       "span_id": 13,
+       "span_id": 7,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -261,7 +143,7 @@
        "service": "wordpress_55_test_app",
        "resource": "after_setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 14,
+       "span_id": 8,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -274,7 +156,7 @@
        "service": "wordpress_55_test_app",
        "resource": "WP.init",
        "trace_id": 0,
-       "span_id": 15,
+       "span_id": 9,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -286,7 +168,7 @@
        "service": "wordpress_55_test_app",
        "resource": "init (hook)",
        "trace_id": 0,
-       "span_id": 16,
+       "span_id": 10,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -299,8 +181,8 @@
           "service": "wordpress_55_test_app",
           "resource": "create_initial_post_types",
           "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 16,
+          "span_id": 17,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -311,8 +193,8 @@
           "service": "wordpress_55_test_app",
           "resource": "create_initial_taxonomies",
           "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 16,
+          "span_id": 18,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -323,8 +205,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_widgets_init",
           "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 16,
+          "span_id": 19,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -335,63 +217,19 @@
              "service": "wordpress_55_test_app",
              "resource": "WP_Widget_Factory._register_widgets",
              "trace_id": 0,
-             "span_id": 29,
-             "parent_id": 25,
+             "span_id": 22,
+             "parent_id": 19,
              "type": "web",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-                "trace_id": 0,
-                "span_id": 31,
-                "parent_id": 29,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_55_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'theme_switched' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 16,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "action",
        "service": "wordpress_55_test_app",
        "resource": "wp_loaded (hook)",
        "trace_id": 0,
-       "span_id": 17,
+       "span_id": 11,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -404,7 +242,7 @@
        "service": "wordpress_55_test_app",
        "resource": "WP.main",
        "trace_id": 0,
-       "span_id": 18,
+       "span_id": 12,
        "parent_id": 1,
        "type": "web",
        "error": 1,
@@ -420,8 +258,8 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 18,
+          "span_id": 20,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -432,8 +270,8 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 28,
-          "parent_id": 18,
+          "span_id": 21,
+          "parent_id": 12,
           "type": "web",
           "error": 1,
           "meta": {
@@ -443,34 +281,12 @@
             "error.type": "Exception"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('error')\n\t\tAND post_type IN ('page','attachment')\n\t",
-             "trace_id": 0,
-             "span_id": 30,
-             "parent_id": 28,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_55_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_55_test_app",
        "resource": "shutdown (hook)",
        "trace_id": 0,
-       "span_id": 19,
+       "span_id": 13,
        "parent_id": 1,
        "type": "web",
        "meta": {

--- a/tests/snapshots/tests.integrations.word_press.v5_5.common_scenarios_test.test_scenario_get_with_view.json
+++ b/tests/snapshots/tests.integrations.word_press.v5_5.common_scenarios_test.test_scenario_get_with_view.json
@@ -5,16 +5,17 @@
     "resource": "GET /simple_view",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 1914478145394293009,
+    "parent_id": 9737943469842154724,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e7015a00000000",
       "component": "wordpress",
       "http.method": "GET",
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/simple_view?key=value&<redacted>",
-      "runtime-id": "b5e7ee20-5ea1-486f-a770-c17a3b60636e",
+      "runtime-id": "f188c752-a672-4955-97f7-e41a31d13fe7",
       "span.kind": "server"
     },
     "metrics": {
@@ -22,108 +23,11 @@
     }
   },
      {
-       "name": "mysqli_real_connect",
-       "service": "mysqli",
-       "resource": "mysqli_real_connect",
-       "trace_id": 0,
-       "span_id": 2,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-       "trace_id": 0,
-       "span_id": 3,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT @@SESSION.sql_mode",
-       "trace_id": 0,
-       "span_id": 4,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 1.0
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-       "trace_id": 0,
-       "span_id": 5,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_name, option_value FROM wp55_options WHERE autoload = 'yes'",
-       "trace_id": 0,
-       "span_id": 6,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 111.0
-       }
-     },
-     {
        "name": "create_initial_taxonomies",
        "service": "wordpress_55_test_app",
        "resource": "create_initial_taxonomies",
        "trace_id": 0,
-       "span_id": 7,
+       "span_id": 2,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -135,7 +39,7 @@
        "service": "wordpress_55_test_app",
        "resource": "create_initial_post_types",
        "trace_id": 0,
-       "span_id": 8,
+       "span_id": 3,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -147,7 +51,7 @@
        "service": "wordpress_55_test_app",
        "resource": "datadog (plugin)",
        "trace_id": 0,
-       "span_id": 9,
+       "span_id": 4,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -160,7 +64,7 @@
        "service": "wordpress_55_test_app",
        "resource": "plugins_loaded (hook)",
        "trace_id": 0,
-       "span_id": 10,
+       "span_id": 5,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -173,8 +77,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_maybe_load_widgets",
           "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 10,
+          "span_id": 15,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -185,8 +89,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_maybe_load_embeds",
           "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 10,
+          "span_id": 16,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -197,8 +101,8 @@
           "service": "wordpress_55_test_app",
           "resource": "_wp_customize_include",
           "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 10,
+          "span_id": 17,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -209,7 +113,7 @@
        "service": "wordpress_55_test_app",
        "resource": "setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 11,
+       "span_id": 6,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -218,33 +122,11 @@
        }
      },
      {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'WPLANG' LIMIT 1",
-       "trace_id": 0,
-       "span_id": 12,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_55_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 0.0
-       }
-     },
-     {
        "name": "load_theme",
        "service": "wordpress_55_test_app",
        "resource": "Twentytwenty (theme)",
        "trace_id": 0,
-       "span_id": 13,
+       "span_id": 7,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -257,7 +139,7 @@
        "service": "wordpress_55_test_app",
        "resource": "after_setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 14,
+       "span_id": 8,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -270,7 +152,7 @@
        "service": "wordpress_55_test_app",
        "resource": "WP.init",
        "trace_id": 0,
-       "span_id": 15,
+       "span_id": 9,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -282,7 +164,7 @@
        "service": "wordpress_55_test_app",
        "resource": "init (hook)",
        "trace_id": 0,
-       "span_id": 16,
+       "span_id": 10,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -295,8 +177,8 @@
           "service": "wordpress_55_test_app",
           "resource": "create_initial_post_types",
           "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 16,
+          "span_id": 18,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -307,8 +189,8 @@
           "service": "wordpress_55_test_app",
           "resource": "create_initial_taxonomies",
           "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 16,
+          "span_id": 19,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -319,8 +201,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp_widgets_init",
           "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 16,
+          "span_id": 20,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -331,63 +213,19 @@
              "service": "wordpress_55_test_app",
              "resource": "WP_Widget_Factory._register_widgets",
              "trace_id": 0,
-             "span_id": 43,
-             "parent_id": 26,
+             "span_id": 36,
+             "parent_id": 20,
              "type": "web",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-                "trace_id": 0,
-                "span_id": 56,
-                "parent_id": 43,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_55_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'theme_switched' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 16,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_55_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "action",
        "service": "wordpress_55_test_app",
        "resource": "wp_loaded (hook)",
        "trace_id": 0,
-       "span_id": 17,
+       "span_id": 11,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -400,7 +238,7 @@
        "service": "wordpress_55_test_app",
        "resource": "WP.main",
        "trace_id": 0,
-       "span_id": 18,
+       "span_id": 12,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -412,8 +250,8 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 28,
-          "parent_id": 18,
+          "span_id": 21,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -424,42 +262,20 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 29,
-          "parent_id": 18,
+          "span_id": 22,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('simple_view')\n\t\tAND post_type IN ('page','attachment')\n\t",
-             "trace_id": 0,
-             "span_id": 44,
-             "parent_id": 29,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_55_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
         {
           "name": "WP.send_headers",
           "service": "wordpress_55_test_app",
           "resource": "WP.send_headers",
           "trace_id": 0,
-          "span_id": 30,
-          "parent_id": 18,
+          "span_id": 23,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -470,86 +286,20 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.query_posts",
           "trace_id": 0,
-          "span_id": 31,
-          "parent_id": 18,
+          "span_id": 24,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT   wp55_posts.* FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_name = 'simple_view' AND wp55_posts.post_type = 'post'  ORDER BY wp55_posts.post_date DESC ",
-             "trace_id": 0,
-             "span_id": 45,
-             "parent_id": 31,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_55_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT  t.*, tt.*, tr.object_id FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id INNER JOIN wp55_term_relationships AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy IN ('category', 'post_tag', 'post_format') AND tr.object_id IN (5) ORDER BY t.name ASC ",
-             "trace_id": 0,
-             "span_id": 46,
-             "parent_id": 31,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_55_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT post_id, meta_key, meta_value FROM wp55_postmeta WHERE post_id IN (5) ORDER BY meta_id ASC",
-             "trace_id": 0,
-             "span_id": 47,
-             "parent_id": 31,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_55_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 3.0
-             }
-           },
         {
           "name": "WP.handle_404",
           "service": "wordpress_55_test_app",
           "resource": "WP.handle_404",
           "trace_id": 0,
-          "span_id": 32,
-          "parent_id": 18,
+          "span_id": 25,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -560,8 +310,8 @@
           "service": "wordpress_55_test_app",
           "resource": "WP.register_globals",
           "trace_id": 0,
-          "span_id": 33,
-          "parent_id": 18,
+          "span_id": 26,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -572,8 +322,8 @@
           "service": "wordpress_55_test_app",
           "resource": "wp (hook)",
           "trace_id": 0,
-          "span_id": 34,
-          "parent_id": 18,
+          "span_id": 27,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -585,7 +335,7 @@
        "service": "wordpress_55_test_app",
        "resource": "load_template_loader",
        "trace_id": 0,
-       "span_id": 19,
+       "span_id": 13,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -597,8 +347,8 @@
           "service": "wordpress_55_test_app",
           "resource": "template_redirect (hook)",
           "trace_id": 0,
-          "span_id": 35,
-          "parent_id": 19,
+          "span_id": 28,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -610,8 +360,8 @@
           "service": "wordpress_55_test_app",
           "resource": "single (type)",
           "trace_id": 0,
-          "span_id": 36,
-          "parent_id": 19,
+          "span_id": 29,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -623,8 +373,8 @@
           "service": "wordpress_55_test_app",
           "resource": "singular (type)",
           "trace_id": 0,
-          "span_id": 37,
-          "parent_id": 19,
+          "span_id": 30,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -637,8 +387,8 @@
           "service": "wordpress_55_test_app",
           "resource": "get_header",
           "trace_id": 0,
-          "span_id": 38,
-          "parent_id": 19,
+          "span_id": 31,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -649,8 +399,8 @@
              "service": "wordpress_55_test_app",
              "resource": "header (template)",
              "trace_id": 0,
-             "span_id": 48,
-             "parent_id": 38,
+             "span_id": 37,
+             "parent_id": 31,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -663,8 +413,8 @@
                 "service": "wordpress_55_test_app",
                 "resource": "wp_head (hook)",
                 "trace_id": 0,
-                "span_id": 57,
-                "parent_id": 48,
+                "span_id": 43,
+                "parent_id": 37,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -676,77 +426,11 @@
                    "service": "wordpress_55_test_app",
                    "resource": "wp_print_head_scripts",
                    "trace_id": 0,
-                   "span_id": 69,
-                   "parent_id": 57,
+                   "span_id": 53,
+                   "parent_id": 43,
                    "type": "web",
                    "meta": {
                      "component": "wordpress"
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT p.ID FROM wp55_posts AS p  WHERE p.post_date < '2020-10-22 16:32:26' AND p.post_type = 'post'  AND p.post_status = 'publish' ORDER BY p.post_date DESC LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 70,
-                   "parent_id": 57,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT * FROM wp55_posts WHERE ID = 1 LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 71,
-                   "parent_id": 57,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT p.ID FROM wp55_posts AS p  WHERE p.post_date > '2020-10-22 16:32:26' AND p.post_type = 'post'  AND p.post_status = 'publish' ORDER BY p.post_date ASC LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 72,
-                   "parent_id": 57,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
                    }
                  },
               {
@@ -754,33 +438,11 @@
                 "service": "wordpress_55_test_app",
                 "resource": "body_class",
                 "trace_id": 0,
-                "span_id": 58,
-                "parent_id": 48,
+                "span_id": 44,
+                "parent_id": 37,
                 "type": "web",
                 "meta": {
                   "component": "wordpress"
-                }
-              },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT * FROM wp55_posts  WHERE (post_type = 'page' AND post_status = 'publish')     ORDER BY menu_order,wp55_posts.post_title ASC",
-                "trace_id": 0,
-                "span_id": 59,
-                "parent_id": 48,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_55_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
                 }
               },
         {
@@ -788,64 +450,20 @@
           "service": "wordpress_55_test_app",
           "resource": "the_post",
           "trace_id": 0,
-          "span_id": 39,
-          "parent_id": 19,
+          "span_id": 32,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT * FROM wp55_users WHERE ID = '1' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 49,
-             "parent_id": 39,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_55_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT user_id, meta_key, meta_value FROM wp55_usermeta WHERE user_id IN (1) ORDER BY umeta_id ASC",
-             "trace_id": 0,
-             "span_id": 50,
-             "parent_id": 39,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_55_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 18.0
-             }
-           },
         {
           "name": "load_template",
           "service": "wordpress_55_test_app",
           "resource": "content (template)",
           "trace_id": 0,
-          "span_id": 40,
-          "parent_id": 19,
+          "span_id": 33,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -858,8 +476,8 @@
              "service": "wordpress_55_test_app",
              "resource": "the_content",
              "trace_id": 0,
-             "span_id": 51,
-             "parent_id": 40,
+             "span_id": 38,
+             "parent_id": 33,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -871,8 +489,8 @@
                 "service": "wordpress_55_test_app",
                 "resource": "core/paragraph (block)",
                 "trace_id": 0,
-                "span_id": 60,
-                "parent_id": 51,
+                "span_id": 45,
+                "parent_id": 38,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -884,42 +502,20 @@
              "service": "wordpress_55_test_app",
              "resource": "comments_template",
              "trace_id": 0,
-             "span_id": 52,
-             "parent_id": 40,
+             "span_id": 39,
+             "parent_id": 33,
              "type": "web",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT SQL_CALC_FOUND_ROWS wp55_comments.comment_ID FROM wp55_comments  WHERE ( comment_approved = '1' ) AND comment_post_ID = 5 AND comment_parent = 0  ORDER BY wp55_comments.comment_date_gmt ASC, wp55_comments.comment_ID ASC ",
-                "trace_id": 0,
-                "span_id": 61,
-                "parent_id": 52,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_55_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              },
         {
           "name": "load_template",
           "service": "wordpress_55_test_app",
           "resource": "footer-menus-widgets (template)",
           "trace_id": 0,
-          "span_id": 41,
-          "parent_id": 19,
+          "span_id": 34,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -932,8 +528,8 @@
              "service": "wordpress_55_test_app",
              "resource": "sidebar-1",
              "trace_id": 0,
-             "span_id": 53,
-             "parent_id": 41,
+             "span_id": 40,
+             "parent_id": 34,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -944,8 +540,8 @@
                 "service": "wordpress_55_test_app",
                 "resource": "Search (widget)",
                 "trace_id": 0,
-                "span_id": 62,
-                "parent_id": 53,
+                "span_id": 46,
+                "parent_id": 40,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -957,166 +553,34 @@
                 "service": "wordpress_55_test_app",
                 "resource": "Recent Posts (widget)",
                 "trace_id": 0,
-                "span_id": 63,
-                "parent_id": 53,
+                "span_id": 47,
+                "parent_id": 40,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Recent Posts"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT   wp55_posts.ID FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_type = 'post' AND ((wp55_posts.post_status = 'publish'))  ORDER BY wp55_posts.post_date DESC LIMIT 0, 5",
-                   "trace_id": 0,
-                   "span_id": 73,
-                   "parent_id": 63,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 2.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  t.*, tt.*, tr.object_id FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id INNER JOIN wp55_term_relationships AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy IN ('category', 'post_tag', 'post_format') AND tr.object_id IN (1) ORDER BY t.name ASC ",
-                   "trace_id": 0,
-                   "span_id": 74,
-                   "parent_id": 63,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT post_id, meta_key, meta_value FROM wp55_postmeta WHERE post_id IN (1) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 75,
-                   "parent_id": 63,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
               {
                 "name": "widget",
                 "service": "wordpress_55_test_app",
                 "resource": "Recent Comments (widget)",
                 "trace_id": 0,
-                "span_id": 64,
-                "parent_id": 53,
+                "span_id": 48,
+                "parent_id": 40,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Recent Comments"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  wp55_comments.comment_ID FROM wp55_comments JOIN wp55_posts ON wp55_posts.ID = wp55_comments.comment_post_ID WHERE ( comment_approved = '1' ) AND  wp55_posts.post_status IN ('publish')  ORDER BY wp55_comments.comment_date_gmt DESC LIMIT 0,5",
-                   "trace_id": 0,
-                   "span_id": 76,
-                   "parent_id": 64,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT wp55_comments.* FROM wp55_comments WHERE comment_ID IN (1)",
-                   "trace_id": 0,
-                   "span_id": 77,
-                   "parent_id": 64,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT comment_id, meta_key, meta_value FROM wp55_commentmeta WHERE comment_id IN (1) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 78,
-                   "parent_id": 64,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
            {
              "name": "dynamic_sidebar",
              "service": "wordpress_55_test_app",
              "resource": "sidebar-2",
              "trace_id": 0,
-             "span_id": 54,
-             "parent_id": 41,
+             "span_id": 41,
+             "parent_id": 34,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -1127,100 +591,34 @@
                 "service": "wordpress_55_test_app",
                 "resource": "Archives (widget)",
                 "trace_id": 0,
-                "span_id": 65,
-                "parent_id": 54,
+                "span_id": 49,
+                "parent_id": 41,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Archives"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT YEAR(post_date) AS `year`, MONTH(post_date) AS `month`, count(ID) as posts FROM wp55_posts  WHERE post_type = 'post' AND post_status = 'publish' GROUP BY YEAR(post_date), MONTH(post_date) ORDER BY post_date DESC ",
-                   "trace_id": 0,
-                   "span_id": 79,
-                   "parent_id": 65,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
               {
                 "name": "widget",
                 "service": "wordpress_55_test_app",
                 "resource": "Categories (widget)",
                 "trace_id": 0,
-                "span_id": 66,
-                "parent_id": 54,
+                "span_id": 50,
+                "parent_id": 41,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Categories"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  t.*, tt.* FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id WHERE tt.taxonomy IN ('category') AND tt.count > 0 ORDER BY t.name ASC ",
-                   "trace_id": 0,
-                   "span_id": 80,
-                   "parent_id": 66,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT term_id, meta_key, meta_value FROM wp55_termmeta WHERE term_id IN (1) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 81,
-                   "parent_id": 66,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_55_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
               {
                 "name": "widget",
                 "service": "wordpress_55_test_app",
                 "resource": "Meta (widget)",
                 "trace_id": 0,
-                "span_id": 67,
-                "parent_id": 54,
+                "span_id": 51,
+                "parent_id": 41,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -1232,8 +630,8 @@
           "service": "wordpress_55_test_app",
           "resource": "get_footer",
           "trace_id": 0,
-          "span_id": 42,
-          "parent_id": 19,
+          "span_id": 35,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -1244,8 +642,8 @@
              "service": "wordpress_55_test_app",
              "resource": "footer (template)",
              "trace_id": 0,
-             "span_id": 55,
-             "parent_id": 42,
+             "span_id": 42,
+             "parent_id": 35,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1258,8 +656,8 @@
                 "service": "wordpress_55_test_app",
                 "resource": "wp_footer (hook)",
                 "trace_id": 0,
-                "span_id": 68,
-                "parent_id": 55,
+                "span_id": 52,
+                "parent_id": 42,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -1271,7 +669,7 @@
        "service": "wordpress_55_test_app",
        "resource": "shutdown (hook)",
        "trace_id": 0,
-       "span_id": 20,
+       "span_id": 14,
        "parent_id": 1,
        "type": "web",
        "meta": {

--- a/tests/snapshots/tests.integrations.word_press.v5_9.common_scenarios_callbacks_test.test_scenario_get_return_string.json
+++ b/tests/snapshots/tests.integrations.word_press.v5_9.common_scenarios_callbacks_test.test_scenario_get_return_string.json
@@ -5,16 +5,17 @@
     "resource": "GET /simple",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 10231339834288839009,
+    "parent_id": 308357991195215464,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e6fff800000000",
       "component": "wordpress",
       "http.method": "GET",
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/simple?key=value&<redacted>",
-      "runtime-id": "95e244b4-fc3a-4566-8940-d2badc3e99b5",
+      "runtime-id": "896f86bc-7139-44f3-a99f-ed35e643f726",
       "span.kind": "server"
     },
     "metrics": {
@@ -22,108 +23,11 @@
     }
   },
      {
-       "name": "mysqli_real_connect",
-       "service": "mysqli",
-       "resource": "mysqli_real_connect",
-       "trace_id": 0,
-       "span_id": 2,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-       "trace_id": 0,
-       "span_id": 3,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT @@SESSION.sql_mode",
-       "trace_id": 0,
-       "span_id": 4,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 1.0
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-       "trace_id": 0,
-       "span_id": 5,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_name, option_value FROM wp55_options WHERE autoload = 'yes'",
-       "trace_id": 0,
-       "span_id": 6,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 111.0
-       }
-     },
-     {
        "name": "create_initial_taxonomies",
        "service": "wordpress_59_test_app",
        "resource": "create_initial_taxonomies",
        "trace_id": 0,
-       "span_id": 7,
+       "span_id": 2,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -137,7 +41,7 @@
        "service": "wordpress_59_test_app",
        "resource": "create_initial_post_types",
        "trace_id": 0,
-       "span_id": 8,
+       "span_id": 3,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -151,7 +55,7 @@
        "service": "wordpress_59_test_app",
        "resource": "datadog (plugin)",
        "trace_id": 0,
-       "span_id": 9,
+       "span_id": 4,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -164,7 +68,7 @@
        "service": "wordpress_59_test_app",
        "resource": "plugins_loaded (hook)",
        "trace_id": 0,
-       "span_id": 10,
+       "span_id": 5,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -177,8 +81,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_maybe_load_widgets",
           "trace_id": 0,
-          "span_id": 20,
-          "parent_id": 10,
+          "span_id": 14,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -191,8 +95,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_maybe_load_embeds",
           "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 10,
+          "span_id": 15,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -205,8 +109,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_wp_add_additional_image_sizes (callback)",
           "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 10,
+          "span_id": 16,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -219,8 +123,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_wp_customize_include",
           "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 10,
+          "span_id": 17,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -233,7 +137,7 @@
        "service": "wordpress_59_test_app",
        "resource": "setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 11,
+       "span_id": 6,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -246,8 +150,8 @@
           "service": "wordpress_59_test_app",
           "resource": "create_initial_theme_features (callback)",
           "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 11,
+          "span_id": 18,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -260,8 +164,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_add_default_theme_supports (callback)",
           "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 11,
+          "span_id": 19,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -274,8 +178,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_enable_block_templates (callback)",
           "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 11,
+          "span_id": 20,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -288,8 +192,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_delete_site_logo_on_remove_custom_logo_on_setup_theme (callback)",
           "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 11,
+          "span_id": 21,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -298,33 +202,11 @@
           }
         },
      {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'WPLANG' LIMIT 1",
-       "trace_id": 0,
-       "span_id": 12,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 0.0
-       }
-     },
-     {
        "name": "load_theme",
        "service": "wordpress_59_test_app",
        "resource": "Twentytwenty (theme)",
        "trace_id": 0,
-       "span_id": 13,
+       "span_id": 7,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -337,7 +219,7 @@
        "service": "wordpress_59_test_app",
        "resource": "after_setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 14,
+       "span_id": 8,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -350,8 +232,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_setup_widgets_block_editor (callback)",
           "trace_id": 0,
-          "span_id": 28,
-          "parent_id": 14,
+          "span_id": 22,
+          "parent_id": 8,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -364,8 +246,8 @@
           "service": "wordpress_59_test_app",
           "resource": "twentytwenty_theme_support (callback)",
           "trace_id": 0,
-          "span_id": 29,
-          "parent_id": 14,
+          "span_id": 23,
+          "parent_id": 8,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -378,8 +260,8 @@
           "service": "wordpress_59_test_app",
           "resource": "twentytwenty_block_editor_settings (callback)",
           "trace_id": 0,
-          "span_id": 30,
-          "parent_id": 14,
+          "span_id": 24,
+          "parent_id": 8,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -392,7 +274,7 @@
        "service": "wordpress_59_test_app",
        "resource": "WP.init",
        "trace_id": 0,
-       "span_id": 15,
+       "span_id": 9,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -404,8 +286,8 @@
           "service": "wordpress_59_test_app",
           "resource": "kses_init (callback)",
           "trace_id": 0,
-          "span_id": 31,
-          "parent_id": 15,
+          "span_id": 25,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -418,7 +300,7 @@
        "service": "wordpress_59_test_app",
        "resource": "init (hook)",
        "trace_id": 0,
-       "span_id": 16,
+       "span_id": 10,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -431,8 +313,8 @@
           "service": "wordpress_59_test_app",
           "resource": "create_initial_post_types",
           "trace_id": 0,
-          "span_id": 32,
-          "parent_id": 16,
+          "span_id": 26,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -443,8 +325,8 @@
           "service": "wordpress_59_test_app",
           "resource": "create_initial_taxonomies",
           "trace_id": 0,
-          "span_id": 33,
-          "parent_id": 16,
+          "span_id": 27,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -455,8 +337,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_widgets_init",
           "trace_id": 0,
-          "span_id": 34,
-          "parent_id": 16,
+          "span_id": 28,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -469,83 +351,20 @@
              "service": "wordpress_59_test_app",
              "resource": "WP_Widget_Factory._register_widgets",
              "trace_id": 0,
-             "span_id": 98,
-             "parent_id": 34,
+             "span_id": 92,
+             "parent_id": 28,
              "type": "web",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-                "trace_id": 0,
-                "span_id": 101,
-                "parent_id": 98,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'widget_block' LIMIT 1",
-                "trace_id": 0,
-                "span_id": 102,
-                "parent_id": 98,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "INSERT INTO `wp55_options` (`option_name`, `option_value`, `autoload`) VALUES ('widget_block', 'a:1:{s:12:\\\"_multiwidget\\\";i:1;}', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)",
-                "trace_id": 0,
-                "span_id": 103,
-                "parent_id": 98,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                }
-              },
         {
           "name": "callback",
           "service": "wordpress_59_test_app",
           "resource": "smilies_init (callback)",
           "trace_id": 0,
-          "span_id": 35,
-          "parent_id": 16,
+          "span_id": 29,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -558,8 +377,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_init_targeted_link_rel_filters (callback)",
           "trace_id": 0,
-          "span_id": 36,
-          "parent_id": 16,
+          "span_id": 30,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -572,8 +391,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_register_core_block_patterns_and_categories (callback)",
           "trace_id": 0,
-          "span_id": 37,
-          "parent_id": 16,
+          "span_id": 31,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -586,8 +405,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_cron (callback)",
           "trace_id": 0,
-          "span_id": 38,
-          "parent_id": 16,
+          "span_id": 32,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -600,8 +419,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_schedule_https_detection (callback)",
           "trace_id": 0,
-          "span_id": 39,
-          "parent_id": 16,
+          "span_id": 33,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -614,8 +433,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_schedule_delete_old_privacy_export_files (callback)",
           "trace_id": 0,
-          "span_id": 40,
-          "parent_id": 16,
+          "span_id": 34,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -628,8 +447,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_show_post_preview (callback)",
           "trace_id": 0,
-          "span_id": 41,
-          "parent_id": 16,
+          "span_id": 35,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -642,8 +461,8 @@
           "service": "wordpress_59_test_app",
           "resource": "rest_api_init (callback)",
           "trace_id": 0,
-          "span_id": 42,
-          "parent_id": 16,
+          "span_id": 36,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -656,8 +475,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_sitemaps_get_server (callback)",
           "trace_id": 0,
-          "span_id": 43,
-          "parent_id": 16,
+          "span_id": 37,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -670,8 +489,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_schedule_update_checks (callback)",
           "trace_id": 0,
-          "span_id": 44,
-          "parent_id": 16,
+          "span_id": 38,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -684,8 +503,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_archives (callback)",
           "trace_id": 0,
-          "span_id": 45,
-          "parent_id": 16,
+          "span_id": 39,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -698,8 +517,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_block (callback)",
           "trace_id": 0,
-          "span_id": 46,
-          "parent_id": 16,
+          "span_id": 40,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -712,8 +531,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_calendar (callback)",
           "trace_id": 0,
-          "span_id": 47,
-          "parent_id": 16,
+          "span_id": 41,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -726,8 +545,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_categories (callback)",
           "trace_id": 0,
-          "span_id": 48,
-          "parent_id": 16,
+          "span_id": 42,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -740,8 +559,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_file (callback)",
           "trace_id": 0,
-          "span_id": 49,
-          "parent_id": 16,
+          "span_id": 43,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -754,8 +573,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_gallery (callback)",
           "trace_id": 0,
-          "span_id": 50,
-          "parent_id": 16,
+          "span_id": 44,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -768,8 +587,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_image (callback)",
           "trace_id": 0,
-          "span_id": 51,
-          "parent_id": 16,
+          "span_id": 45,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -782,8 +601,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_latest_comments (callback)",
           "trace_id": 0,
-          "span_id": 52,
-          "parent_id": 16,
+          "span_id": 46,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -796,8 +615,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_latest_posts (callback)",
           "trace_id": 0,
-          "span_id": 53,
-          "parent_id": 16,
+          "span_id": 47,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -810,8 +629,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_legacy_widget (callback)",
           "trace_id": 0,
-          "span_id": 54,
-          "parent_id": 16,
+          "span_id": 48,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -824,8 +643,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_loginout (callback)",
           "trace_id": 0,
-          "span_id": 55,
-          "parent_id": 16,
+          "span_id": 49,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -838,8 +657,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_navigation_link (callback)",
           "trace_id": 0,
-          "span_id": 56,
-          "parent_id": 16,
+          "span_id": 50,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -852,8 +671,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_navigation_submenu (callback)",
           "trace_id": 0,
-          "span_id": 57,
-          "parent_id": 16,
+          "span_id": 51,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -866,8 +685,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_navigation (callback)",
           "trace_id": 0,
-          "span_id": 58,
-          "parent_id": 16,
+          "span_id": 52,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -880,8 +699,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_page_list (callback)",
           "trace_id": 0,
-          "span_id": 59,
-          "parent_id": 16,
+          "span_id": 53,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -894,8 +713,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_pattern (callback)",
           "trace_id": 0,
-          "span_id": 60,
-          "parent_id": 16,
+          "span_id": 54,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -908,8 +727,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_author (callback)",
           "trace_id": 0,
-          "span_id": 61,
-          "parent_id": 16,
+          "span_id": 55,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -922,8 +741,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_comments (callback)",
           "trace_id": 0,
-          "span_id": 62,
-          "parent_id": 16,
+          "span_id": 56,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -936,8 +755,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_content (callback)",
           "trace_id": 0,
-          "span_id": 63,
-          "parent_id": 16,
+          "span_id": 57,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -950,8 +769,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_date (callback)",
           "trace_id": 0,
-          "span_id": 64,
-          "parent_id": 16,
+          "span_id": 58,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -964,8 +783,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_excerpt (callback)",
           "trace_id": 0,
-          "span_id": 65,
-          "parent_id": 16,
+          "span_id": 59,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -978,8 +797,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_featured_image (callback)",
           "trace_id": 0,
-          "span_id": 66,
-          "parent_id": 16,
+          "span_id": 60,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -992,8 +811,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_navigation_link (callback)",
           "trace_id": 0,
-          "span_id": 67,
-          "parent_id": 16,
+          "span_id": 61,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1006,8 +825,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_template (callback)",
           "trace_id": 0,
-          "span_id": 68,
-          "parent_id": 16,
+          "span_id": 62,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1020,8 +839,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_terms (callback)",
           "trace_id": 0,
-          "span_id": 69,
-          "parent_id": 16,
+          "span_id": 63,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1034,8 +853,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_title (callback)",
           "trace_id": 0,
-          "span_id": 70,
-          "parent_id": 16,
+          "span_id": 64,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1048,8 +867,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_query_pagination_next (callback)",
           "trace_id": 0,
-          "span_id": 71,
-          "parent_id": 16,
+          "span_id": 65,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1062,8 +881,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_query_pagination_numbers (callback)",
           "trace_id": 0,
-          "span_id": 72,
-          "parent_id": 16,
+          "span_id": 66,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1076,8 +895,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_query_pagination_previous (callback)",
           "trace_id": 0,
-          "span_id": 73,
-          "parent_id": 16,
+          "span_id": 67,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1090,8 +909,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_query_pagination (callback)",
           "trace_id": 0,
-          "span_id": 74,
-          "parent_id": 16,
+          "span_id": 68,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1104,8 +923,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_query_title (callback)",
           "trace_id": 0,
-          "span_id": 75,
-          "parent_id": 16,
+          "span_id": 69,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1118,8 +937,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_query (callback)",
           "trace_id": 0,
-          "span_id": 76,
-          "parent_id": 16,
+          "span_id": 70,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1132,8 +951,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_rss (callback)",
           "trace_id": 0,
-          "span_id": 77,
-          "parent_id": 16,
+          "span_id": 71,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1146,8 +965,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_search (callback)",
           "trace_id": 0,
-          "span_id": 78,
-          "parent_id": 16,
+          "span_id": 72,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1160,8 +979,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_shortcode (callback)",
           "trace_id": 0,
-          "span_id": 79,
-          "parent_id": 16,
+          "span_id": 73,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1174,8 +993,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_site_logo (callback)",
           "trace_id": 0,
-          "span_id": 80,
-          "parent_id": 16,
+          "span_id": 74,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1188,8 +1007,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_site_tagline (callback)",
           "trace_id": 0,
-          "span_id": 81,
-          "parent_id": 16,
+          "span_id": 75,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1202,8 +1021,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_site_title (callback)",
           "trace_id": 0,
-          "span_id": 82,
-          "parent_id": 16,
+          "span_id": 76,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1216,8 +1035,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_social_link (callback)",
           "trace_id": 0,
-          "span_id": 83,
-          "parent_id": 16,
+          "span_id": 77,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1230,8 +1049,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_tag_cloud (callback)",
           "trace_id": 0,
-          "span_id": 84,
-          "parent_id": 16,
+          "span_id": 78,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1244,8 +1063,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_template_part (callback)",
           "trace_id": 0,
-          "span_id": 85,
-          "parent_id": 16,
+          "span_id": 79,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1258,8 +1077,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_term_description (callback)",
           "trace_id": 0,
-          "span_id": 86,
-          "parent_id": 16,
+          "span_id": 80,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1272,8 +1091,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_core_block_types_from_metadata (callback)",
           "trace_id": 0,
-          "span_id": 87,
-          "parent_id": 16,
+          "span_id": 81,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1286,8 +1105,8 @@
           "service": "wordpress_59_test_app",
           "resource": "twentytwenty_menus (callback)",
           "trace_id": 0,
-          "span_id": 88,
-          "parent_id": 16,
+          "span_id": 82,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1300,8 +1119,8 @@
           "service": "wordpress_59_test_app",
           "resource": "twentytwenty_classic_editor_styles (callback)",
           "trace_id": 0,
-          "span_id": 89,
-          "parent_id": 16,
+          "span_id": 83,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1314,8 +1133,8 @@
           "service": "wordpress_59_test_app",
           "resource": "WP_Block_Supports::init (callback)",
           "trace_id": 0,
-          "span_id": 90,
-          "parent_id": 16,
+          "span_id": 84,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1328,8 +1147,8 @@
           "service": "wordpress_59_test_app",
           "resource": "check_theme_switched (callback)",
           "trace_id": 0,
-          "span_id": 91,
-          "parent_id": 16,
+          "span_id": 85,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1337,34 +1156,12 @@
             "wordpress.hook": "init"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'theme_switched' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 99,
-             "parent_id": 91,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_59_test_app",
        "resource": "wp_loaded (hook)",
        "trace_id": 0,
-       "span_id": 17,
+       "span_id": 11,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -1377,8 +1174,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_custom_header_background_just_in_time (callback)",
           "trace_id": 0,
-          "span_id": 92,
-          "parent_id": 17,
+          "span_id": 86,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1391,8 +1188,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_add_template_loader_filters (callback)",
           "trace_id": 0,
-          "span_id": 93,
-          "parent_id": 17,
+          "span_id": 87,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1405,8 +1202,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_wp_cron (callback)",
           "trace_id": 0,
-          "span_id": 94,
-          "parent_id": 17,
+          "span_id": 88,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1419,7 +1216,7 @@
        "service": "wordpress_59_test_app",
        "resource": "WP.main",
        "trace_id": 0,
-       "span_id": 18,
+       "span_id": 12,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -1431,8 +1228,8 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 95,
-          "parent_id": 18,
+          "span_id": 89,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -1443,41 +1240,19 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 96,
-          "parent_id": 18,
+          "span_id": 90,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('simple')\n\t\tAND post_type IN ('page','attachment')\n\t",
-             "trace_id": 0,
-             "span_id": 100,
-             "parent_id": 96,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_59_test_app",
        "resource": "shutdown (hook)",
        "trace_id": 0,
-       "span_id": 19,
+       "span_id": 13,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -1490,8 +1265,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_ob_end_flush_all (callback)",
           "trace_id": 0,
-          "span_id": 97,
-          "parent_id": 19,
+          "span_id": 91,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",

--- a/tests/snapshots/tests.integrations.word_press.v5_9.common_scenarios_callbacks_test.test_scenario_get_to_missing_route.json
+++ b/tests/snapshots/tests.integrations.word_press.v5_9.common_scenarios_callbacks_test.test_scenario_get_to_missing_route.json
@@ -5,15 +5,16 @@
     "resource": "GET /does_not_exist",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 7217153423167374317,
+    "parent_id": 821520816598726870,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e7001f00000000",
       "component": "wordpress",
       "http.method": "GET",
       "http.status_code": "404",
       "http.url": "http://localhost:9999/does_not_exist?key=value&<redacted>",
-      "runtime-id": "95e244b4-fc3a-4566-8940-d2badc3e99b5",
+      "runtime-id": "896f86bc-7139-44f3-a99f-ed35e643f726",
       "span.kind": "server"
     },
     "metrics": {
@@ -21,108 +22,11 @@
     }
   },
      {
-       "name": "mysqli_real_connect",
-       "service": "mysqli",
-       "resource": "mysqli_real_connect",
-       "trace_id": 0,
-       "span_id": 2,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-       "trace_id": 0,
-       "span_id": 3,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT @@SESSION.sql_mode",
-       "trace_id": 0,
-       "span_id": 4,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 1.0
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-       "trace_id": 0,
-       "span_id": 5,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_name, option_value FROM wp55_options WHERE autoload = 'yes'",
-       "trace_id": 0,
-       "span_id": 6,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 111.0
-       }
-     },
-     {
        "name": "create_initial_taxonomies",
        "service": "wordpress_59_test_app",
        "resource": "create_initial_taxonomies",
        "trace_id": 0,
-       "span_id": 7,
+       "span_id": 2,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -136,7 +40,7 @@
        "service": "wordpress_59_test_app",
        "resource": "create_initial_post_types",
        "trace_id": 0,
-       "span_id": 8,
+       "span_id": 3,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -150,7 +54,7 @@
        "service": "wordpress_59_test_app",
        "resource": "datadog (plugin)",
        "trace_id": 0,
-       "span_id": 9,
+       "span_id": 4,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -163,7 +67,7 @@
        "service": "wordpress_59_test_app",
        "resource": "plugins_loaded (hook)",
        "trace_id": 0,
-       "span_id": 10,
+       "span_id": 5,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -176,8 +80,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_maybe_load_widgets",
           "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 10,
+          "span_id": 15,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -190,8 +94,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_maybe_load_embeds",
           "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 10,
+          "span_id": 16,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -204,8 +108,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_wp_add_additional_image_sizes (callback)",
           "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 10,
+          "span_id": 17,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -218,8 +122,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_wp_customize_include",
           "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 10,
+          "span_id": 18,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -232,7 +136,7 @@
        "service": "wordpress_59_test_app",
        "resource": "setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 11,
+       "span_id": 6,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -245,8 +149,8 @@
           "service": "wordpress_59_test_app",
           "resource": "create_initial_theme_features (callback)",
           "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 11,
+          "span_id": 19,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -259,8 +163,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_add_default_theme_supports (callback)",
           "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 11,
+          "span_id": 20,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -273,8 +177,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_enable_block_templates (callback)",
           "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 11,
+          "span_id": 21,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -287,8 +191,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_delete_site_logo_on_remove_custom_logo_on_setup_theme (callback)",
           "trace_id": 0,
-          "span_id": 28,
-          "parent_id": 11,
+          "span_id": 22,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -297,33 +201,11 @@
           }
         },
      {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'WPLANG' LIMIT 1",
-       "trace_id": 0,
-       "span_id": 12,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 0.0
-       }
-     },
-     {
        "name": "load_theme",
        "service": "wordpress_59_test_app",
        "resource": "Twentytwenty (theme)",
        "trace_id": 0,
-       "span_id": 13,
+       "span_id": 7,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -336,7 +218,7 @@
        "service": "wordpress_59_test_app",
        "resource": "after_setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 14,
+       "span_id": 8,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -349,8 +231,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_setup_widgets_block_editor (callback)",
           "trace_id": 0,
-          "span_id": 29,
-          "parent_id": 14,
+          "span_id": 23,
+          "parent_id": 8,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -363,8 +245,8 @@
           "service": "wordpress_59_test_app",
           "resource": "twentytwenty_theme_support (callback)",
           "trace_id": 0,
-          "span_id": 30,
-          "parent_id": 14,
+          "span_id": 24,
+          "parent_id": 8,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -377,8 +259,8 @@
           "service": "wordpress_59_test_app",
           "resource": "twentytwenty_block_editor_settings (callback)",
           "trace_id": 0,
-          "span_id": 31,
-          "parent_id": 14,
+          "span_id": 25,
+          "parent_id": 8,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -391,7 +273,7 @@
        "service": "wordpress_59_test_app",
        "resource": "WP.init",
        "trace_id": 0,
-       "span_id": 15,
+       "span_id": 9,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -403,8 +285,8 @@
           "service": "wordpress_59_test_app",
           "resource": "kses_init (callback)",
           "trace_id": 0,
-          "span_id": 32,
-          "parent_id": 15,
+          "span_id": 26,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -417,7 +299,7 @@
        "service": "wordpress_59_test_app",
        "resource": "init (hook)",
        "trace_id": 0,
-       "span_id": 16,
+       "span_id": 10,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -430,8 +312,8 @@
           "service": "wordpress_59_test_app",
           "resource": "create_initial_post_types",
           "trace_id": 0,
-          "span_id": 33,
-          "parent_id": 16,
+          "span_id": 27,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -442,8 +324,8 @@
           "service": "wordpress_59_test_app",
           "resource": "create_initial_taxonomies",
           "trace_id": 0,
-          "span_id": 34,
-          "parent_id": 16,
+          "span_id": 28,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -454,8 +336,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_widgets_init",
           "trace_id": 0,
-          "span_id": 35,
-          "parent_id": 16,
+          "span_id": 29,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -468,83 +350,20 @@
              "service": "wordpress_59_test_app",
              "resource": "WP_Widget_Factory._register_widgets",
              "trace_id": 0,
-             "span_id": 109,
-             "parent_id": 35,
+             "span_id": 103,
+             "parent_id": 29,
              "type": "web",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-                "trace_id": 0,
-                "span_id": 126,
-                "parent_id": 109,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'widget_block' LIMIT 1",
-                "trace_id": 0,
-                "span_id": 127,
-                "parent_id": 109,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "INSERT INTO `wp55_options` (`option_name`, `option_value`, `autoload`) VALUES ('widget_block', 'a:1:{s:12:\\\"_multiwidget\\\";i:1;}', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)",
-                "trace_id": 0,
-                "span_id": 128,
-                "parent_id": 109,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                }
-              },
         {
           "name": "callback",
           "service": "wordpress_59_test_app",
           "resource": "smilies_init (callback)",
           "trace_id": 0,
-          "span_id": 36,
-          "parent_id": 16,
+          "span_id": 30,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -557,8 +376,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_init_targeted_link_rel_filters (callback)",
           "trace_id": 0,
-          "span_id": 37,
-          "parent_id": 16,
+          "span_id": 31,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -571,8 +390,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_register_core_block_patterns_and_categories (callback)",
           "trace_id": 0,
-          "span_id": 38,
-          "parent_id": 16,
+          "span_id": 32,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -585,8 +404,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_cron (callback)",
           "trace_id": 0,
-          "span_id": 39,
-          "parent_id": 16,
+          "span_id": 33,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -599,8 +418,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_schedule_https_detection (callback)",
           "trace_id": 0,
-          "span_id": 40,
-          "parent_id": 16,
+          "span_id": 34,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -613,8 +432,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_schedule_delete_old_privacy_export_files (callback)",
           "trace_id": 0,
-          "span_id": 41,
-          "parent_id": 16,
+          "span_id": 35,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -627,8 +446,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_show_post_preview (callback)",
           "trace_id": 0,
-          "span_id": 42,
-          "parent_id": 16,
+          "span_id": 36,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -641,8 +460,8 @@
           "service": "wordpress_59_test_app",
           "resource": "rest_api_init (callback)",
           "trace_id": 0,
-          "span_id": 43,
-          "parent_id": 16,
+          "span_id": 37,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -655,8 +474,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_sitemaps_get_server (callback)",
           "trace_id": 0,
-          "span_id": 44,
-          "parent_id": 16,
+          "span_id": 38,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -669,8 +488,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_schedule_update_checks (callback)",
           "trace_id": 0,
-          "span_id": 45,
-          "parent_id": 16,
+          "span_id": 39,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -683,8 +502,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_archives (callback)",
           "trace_id": 0,
-          "span_id": 46,
-          "parent_id": 16,
+          "span_id": 40,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -697,8 +516,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_block (callback)",
           "trace_id": 0,
-          "span_id": 47,
-          "parent_id": 16,
+          "span_id": 41,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -711,8 +530,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_calendar (callback)",
           "trace_id": 0,
-          "span_id": 48,
-          "parent_id": 16,
+          "span_id": 42,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -725,8 +544,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_categories (callback)",
           "trace_id": 0,
-          "span_id": 49,
-          "parent_id": 16,
+          "span_id": 43,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -739,8 +558,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_file (callback)",
           "trace_id": 0,
-          "span_id": 50,
-          "parent_id": 16,
+          "span_id": 44,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -753,8 +572,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_gallery (callback)",
           "trace_id": 0,
-          "span_id": 51,
-          "parent_id": 16,
+          "span_id": 45,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -767,8 +586,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_image (callback)",
           "trace_id": 0,
-          "span_id": 52,
-          "parent_id": 16,
+          "span_id": 46,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -781,8 +600,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_latest_comments (callback)",
           "trace_id": 0,
-          "span_id": 53,
-          "parent_id": 16,
+          "span_id": 47,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -795,8 +614,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_latest_posts (callback)",
           "trace_id": 0,
-          "span_id": 54,
-          "parent_id": 16,
+          "span_id": 48,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -809,8 +628,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_legacy_widget (callback)",
           "trace_id": 0,
-          "span_id": 55,
-          "parent_id": 16,
+          "span_id": 49,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -823,8 +642,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_loginout (callback)",
           "trace_id": 0,
-          "span_id": 56,
-          "parent_id": 16,
+          "span_id": 50,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -837,8 +656,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_navigation_link (callback)",
           "trace_id": 0,
-          "span_id": 57,
-          "parent_id": 16,
+          "span_id": 51,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -851,8 +670,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_navigation_submenu (callback)",
           "trace_id": 0,
-          "span_id": 58,
-          "parent_id": 16,
+          "span_id": 52,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -865,8 +684,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_navigation (callback)",
           "trace_id": 0,
-          "span_id": 59,
-          "parent_id": 16,
+          "span_id": 53,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -879,8 +698,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_page_list (callback)",
           "trace_id": 0,
-          "span_id": 60,
-          "parent_id": 16,
+          "span_id": 54,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -893,8 +712,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_pattern (callback)",
           "trace_id": 0,
-          "span_id": 61,
-          "parent_id": 16,
+          "span_id": 55,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -907,8 +726,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_author (callback)",
           "trace_id": 0,
-          "span_id": 62,
-          "parent_id": 16,
+          "span_id": 56,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -921,8 +740,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_comments (callback)",
           "trace_id": 0,
-          "span_id": 63,
-          "parent_id": 16,
+          "span_id": 57,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -935,8 +754,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_content (callback)",
           "trace_id": 0,
-          "span_id": 64,
-          "parent_id": 16,
+          "span_id": 58,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -949,8 +768,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_date (callback)",
           "trace_id": 0,
-          "span_id": 65,
-          "parent_id": 16,
+          "span_id": 59,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -963,8 +782,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_excerpt (callback)",
           "trace_id": 0,
-          "span_id": 66,
-          "parent_id": 16,
+          "span_id": 60,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -977,8 +796,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_featured_image (callback)",
           "trace_id": 0,
-          "span_id": 67,
-          "parent_id": 16,
+          "span_id": 61,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -991,8 +810,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_navigation_link (callback)",
           "trace_id": 0,
-          "span_id": 68,
-          "parent_id": 16,
+          "span_id": 62,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1005,8 +824,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_template (callback)",
           "trace_id": 0,
-          "span_id": 69,
-          "parent_id": 16,
+          "span_id": 63,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1019,8 +838,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_terms (callback)",
           "trace_id": 0,
-          "span_id": 70,
-          "parent_id": 16,
+          "span_id": 64,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1033,8 +852,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_title (callback)",
           "trace_id": 0,
-          "span_id": 71,
-          "parent_id": 16,
+          "span_id": 65,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1047,8 +866,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_query_pagination_next (callback)",
           "trace_id": 0,
-          "span_id": 72,
-          "parent_id": 16,
+          "span_id": 66,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1061,8 +880,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_query_pagination_numbers (callback)",
           "trace_id": 0,
-          "span_id": 73,
-          "parent_id": 16,
+          "span_id": 67,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1075,8 +894,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_query_pagination_previous (callback)",
           "trace_id": 0,
-          "span_id": 74,
-          "parent_id": 16,
+          "span_id": 68,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1089,8 +908,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_query_pagination (callback)",
           "trace_id": 0,
-          "span_id": 75,
-          "parent_id": 16,
+          "span_id": 69,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1103,8 +922,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_query_title (callback)",
           "trace_id": 0,
-          "span_id": 76,
-          "parent_id": 16,
+          "span_id": 70,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1117,8 +936,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_query (callback)",
           "trace_id": 0,
-          "span_id": 77,
-          "parent_id": 16,
+          "span_id": 71,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1131,8 +950,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_rss (callback)",
           "trace_id": 0,
-          "span_id": 78,
-          "parent_id": 16,
+          "span_id": 72,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1145,8 +964,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_search (callback)",
           "trace_id": 0,
-          "span_id": 79,
-          "parent_id": 16,
+          "span_id": 73,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1159,8 +978,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_shortcode (callback)",
           "trace_id": 0,
-          "span_id": 80,
-          "parent_id": 16,
+          "span_id": 74,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1173,8 +992,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_site_logo (callback)",
           "trace_id": 0,
-          "span_id": 81,
-          "parent_id": 16,
+          "span_id": 75,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1187,8 +1006,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_site_tagline (callback)",
           "trace_id": 0,
-          "span_id": 82,
-          "parent_id": 16,
+          "span_id": 76,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1201,8 +1020,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_site_title (callback)",
           "trace_id": 0,
-          "span_id": 83,
-          "parent_id": 16,
+          "span_id": 77,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1215,8 +1034,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_social_link (callback)",
           "trace_id": 0,
-          "span_id": 84,
-          "parent_id": 16,
+          "span_id": 78,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1229,8 +1048,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_tag_cloud (callback)",
           "trace_id": 0,
-          "span_id": 85,
-          "parent_id": 16,
+          "span_id": 79,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1243,8 +1062,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_template_part (callback)",
           "trace_id": 0,
-          "span_id": 86,
-          "parent_id": 16,
+          "span_id": 80,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1257,8 +1076,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_term_description (callback)",
           "trace_id": 0,
-          "span_id": 87,
-          "parent_id": 16,
+          "span_id": 81,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1271,8 +1090,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_core_block_types_from_metadata (callback)",
           "trace_id": 0,
-          "span_id": 88,
-          "parent_id": 16,
+          "span_id": 82,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1285,8 +1104,8 @@
           "service": "wordpress_59_test_app",
           "resource": "twentytwenty_menus (callback)",
           "trace_id": 0,
-          "span_id": 89,
-          "parent_id": 16,
+          "span_id": 83,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1299,8 +1118,8 @@
           "service": "wordpress_59_test_app",
           "resource": "twentytwenty_classic_editor_styles (callback)",
           "trace_id": 0,
-          "span_id": 90,
-          "parent_id": 16,
+          "span_id": 84,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1313,8 +1132,8 @@
           "service": "wordpress_59_test_app",
           "resource": "WP_Block_Supports::init (callback)",
           "trace_id": 0,
-          "span_id": 91,
-          "parent_id": 16,
+          "span_id": 85,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1327,8 +1146,8 @@
           "service": "wordpress_59_test_app",
           "resource": "check_theme_switched (callback)",
           "trace_id": 0,
-          "span_id": 92,
-          "parent_id": 16,
+          "span_id": 86,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1336,34 +1155,12 @@
             "wordpress.hook": "init"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'theme_switched' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 110,
-             "parent_id": 92,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_59_test_app",
        "resource": "wp_loaded (hook)",
        "trace_id": 0,
-       "span_id": 17,
+       "span_id": 11,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -1376,8 +1173,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_custom_header_background_just_in_time (callback)",
           "trace_id": 0,
-          "span_id": 93,
-          "parent_id": 17,
+          "span_id": 87,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1390,8 +1187,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_add_template_loader_filters (callback)",
           "trace_id": 0,
-          "span_id": 94,
-          "parent_id": 17,
+          "span_id": 88,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1404,8 +1201,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_wp_cron (callback)",
           "trace_id": 0,
-          "span_id": 95,
-          "parent_id": 17,
+          "span_id": 89,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1418,7 +1215,7 @@
        "service": "wordpress_59_test_app",
        "resource": "WP.main",
        "trace_id": 0,
-       "span_id": 18,
+       "span_id": 12,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -1430,8 +1227,8 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 96,
-          "parent_id": 18,
+          "span_id": 90,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -1442,42 +1239,20 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 97,
-          "parent_id": 18,
+          "span_id": 91,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('does_not_exist')\n\t\tAND post_type IN ('page','attachment')\n\t",
-             "trace_id": 0,
-             "span_id": 111,
-             "parent_id": 97,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
         {
           "name": "WP.send_headers",
           "service": "wordpress_59_test_app",
           "resource": "WP.send_headers",
           "trace_id": 0,
-          "span_id": 98,
-          "parent_id": 18,
+          "span_id": 92,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -1488,42 +1263,20 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.query_posts",
           "trace_id": 0,
-          "span_id": 99,
-          "parent_id": 18,
+          "span_id": 93,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT   wp55_posts.* FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_name = 'does_not_exist' AND wp55_posts.post_type = 'post'  ORDER BY wp55_posts.post_date DESC ",
-             "trace_id": 0,
-             "span_id": 112,
-             "parent_id": 99,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
         {
           "name": "WP.handle_404",
           "service": "wordpress_59_test_app",
           "resource": "WP.handle_404",
           "trace_id": 0,
-          "span_id": 100,
-          "parent_id": 18,
+          "span_id": 94,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -1534,8 +1287,8 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.register_globals",
           "trace_id": 0,
-          "span_id": 101,
-          "parent_id": 18,
+          "span_id": 95,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -1546,8 +1299,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp (hook)",
           "trace_id": 0,
-          "span_id": 102,
-          "parent_id": 18,
+          "span_id": 96,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1559,7 +1312,7 @@
        "service": "wordpress_59_test_app",
        "resource": "load_template_loader",
        "trace_id": 0,
-       "span_id": 19,
+       "span_id": 13,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -1571,8 +1324,8 @@
           "service": "wordpress_59_test_app",
           "resource": "template_redirect (hook)",
           "trace_id": 0,
-          "span_id": 103,
-          "parent_id": 19,
+          "span_id": 97,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1584,8 +1337,8 @@
              "service": "wordpress_59_test_app",
              "resource": "_wp_admin_bar_init (callback)",
              "trace_id": 0,
-             "span_id": 113,
-             "parent_id": 103,
+             "span_id": 104,
+             "parent_id": 97,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1598,8 +1351,8 @@
              "service": "wordpress_59_test_app",
              "resource": "wp_old_slug_redirect (callback)",
              "trace_id": 0,
-             "span_id": 114,
-             "parent_id": 103,
+             "span_id": 105,
+             "parent_id": 97,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1607,35 +1360,13 @@
                "wordpress.hook": "template_redirect"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT post_id FROM wp55_postmeta, wp55_posts WHERE ID = post_id AND post_type = 'post' AND meta_key = '_wp_old_slug' AND meta_value = 'does_not_exist'",
-                "trace_id": 0,
-                "span_id": 129,
-                "parent_id": 114,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              },
            {
              "name": "callback",
              "service": "wordpress_59_test_app",
              "resource": "redirect_canonical (callback)",
              "trace_id": 0,
-             "span_id": 115,
-             "parent_id": 103,
+             "span_id": 106,
+             "parent_id": 97,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1643,35 +1374,13 @@
                "wordpress.hook": "template_redirect"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT ID FROM wp55_posts WHERE post_name LIKE 'does\\\\_not\\\\_exist%' AND post_type IN ('post', 'page', 'attachment') AND post_status = 'publish'",
-                "trace_id": 0,
-                "span_id": 130,
-                "parent_id": 115,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              },
            {
              "name": "callback",
              "service": "wordpress_59_test_app",
              "resource": "WP_Sitemaps::render_sitemaps (callback)",
              "trace_id": 0,
-             "span_id": 116,
-             "parent_id": 103,
+             "span_id": 107,
+             "parent_id": 97,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1684,8 +1393,8 @@
              "service": "wordpress_59_test_app",
              "resource": "rest_output_link_header (callback)",
              "trace_id": 0,
-             "span_id": 117,
-             "parent_id": 103,
+             "span_id": 108,
+             "parent_id": 97,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1698,8 +1407,8 @@
              "service": "wordpress_59_test_app",
              "resource": "wp_shortlink_header (callback)",
              "trace_id": 0,
-             "span_id": 118,
-             "parent_id": 103,
+             "span_id": 109,
+             "parent_id": 97,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1712,8 +1421,8 @@
              "service": "wordpress_59_test_app",
              "resource": "wp_redirect_admin_locations (callback)",
              "trace_id": 0,
-             "span_id": 119,
-             "parent_id": 103,
+             "span_id": 110,
+             "parent_id": 97,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1726,8 +1435,8 @@
           "service": "wordpress_59_test_app",
           "resource": "404 (type)",
           "trace_id": 0,
-          "span_id": 104,
-          "parent_id": 19,
+          "span_id": 98,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1735,57 +1444,13 @@
             "wordpress.theme": "Twenty Twenty"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT  t.*, tt.* FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id WHERE tt.taxonomy IN ('wp_theme') AND t.name IN ('twentytwenty')  ",
-             "trace_id": 0,
-             "span_id": 120,
-             "parent_id": 104,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT   wp55_posts.* FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_name IN ('404') AND ( \n  0 = 1\n) AND wp55_posts.post_type = 'wp_template' AND ((wp55_posts.post_status = 'publish')) GROUP BY wp55_posts.ID ORDER BY wp55_posts.post_date DESC ",
-             "trace_id": 0,
-             "span_id": 121,
-             "parent_id": 104,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
         {
           "name": "get_header",
           "service": "wordpress_59_test_app",
           "resource": "get_header",
           "trace_id": 0,
-          "span_id": 105,
-          "parent_id": 19,
+          "span_id": 99,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -1796,8 +1461,8 @@
              "service": "wordpress_59_test_app",
              "resource": "header (template)",
              "trace_id": 0,
-             "span_id": 122,
-             "parent_id": 105,
+             "span_id": 111,
+             "parent_id": 99,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1810,8 +1475,8 @@
                 "service": "wordpress_59_test_app",
                 "resource": "wp_head (hook)",
                 "trace_id": 0,
-                "span_id": 131,
-                "parent_id": 122,
+                "span_id": 115,
+                "parent_id": 111,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -1823,8 +1488,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "_wp_render_title_tag (callback)",
                    "trace_id": 0,
-                   "span_id": 143,
-                   "parent_id": 131,
+                   "span_id": 125,
+                   "parent_id": 115,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1837,8 +1502,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "wp_enqueue_scripts (callback)",
                    "trace_id": 0,
-                   "span_id": 144,
-                   "parent_id": 131,
+                   "span_id": 126,
+                   "parent_id": 115,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1851,8 +1516,8 @@
                       "service": "wordpress_59_test_app",
                       "resource": "wp_enqueue_global_styles (callback)",
                       "trace_id": 0,
-                      "span_id": 183,
-                      "parent_id": 144,
+                      "span_id": 154,
+                      "parent_id": 126,
                       "type": "web",
                       "meta": {
                         "component": "wordpress",
@@ -1860,101 +1525,13 @@
                         "wordpress.hook": "wp_footer"
                       }
                     },
-                       {
-                         "name": "mysqli_query",
-                         "service": "mysqli",
-                         "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'medium_crop' LIMIT 1",
-                         "trace_id": 0,
-                         "span_id": 184,
-                         "parent_id": 183,
-                         "type": "sql",
-                         "meta": {
-                           "_dd.base_service": "wordpress_59_test_app",
-                           "component": "mysqli",
-                           "db.name": "test",
-                           "db.system": "mysql",
-                           "db.type": "mysql",
-                           "out.host": "mysql_integration",
-                           "out.port": "3306",
-                           "span.kind": "client"
-                         },
-                         "metrics": {
-                           "db.row_count": 0.0
-                         }
-                       },
-                       {
-                         "name": "mysqli_query",
-                         "service": "mysqli",
-                         "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'medium_large_crop' LIMIT 1",
-                         "trace_id": 0,
-                         "span_id": 185,
-                         "parent_id": 183,
-                         "type": "sql",
-                         "meta": {
-                           "_dd.base_service": "wordpress_59_test_app",
-                           "component": "mysqli",
-                           "db.name": "test",
-                           "db.system": "mysql",
-                           "db.type": "mysql",
-                           "out.host": "mysql_integration",
-                           "out.port": "3306",
-                           "span.kind": "client"
-                         },
-                         "metrics": {
-                           "db.row_count": 0.0
-                         }
-                       },
-                       {
-                         "name": "mysqli_query",
-                         "service": "mysqli",
-                         "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'large_crop' LIMIT 1",
-                         "trace_id": 0,
-                         "span_id": 186,
-                         "parent_id": 183,
-                         "type": "sql",
-                         "meta": {
-                           "_dd.base_service": "wordpress_59_test_app",
-                           "component": "mysqli",
-                           "db.name": "test",
-                           "db.system": "mysql",
-                           "db.type": "mysql",
-                           "out.host": "mysql_integration",
-                           "out.port": "3306",
-                           "span.kind": "client"
-                         },
-                         "metrics": {
-                           "db.row_count": 0.0
-                         }
-                       },
-                       {
-                         "name": "mysqli_query",
-                         "service": "mysqli",
-                         "resource": "SELECT   wp55_posts.ID FROM wp55_posts  WHERE 1=1  AND ( \n  0 = 1\n) AND wp55_posts.post_type = 'wp_global_styles' AND ((wp55_posts.post_status = 'publish')) GROUP BY wp55_posts.ID ORDER BY wp55_posts.post_date DESC LIMIT 0, 1",
-                         "trace_id": 0,
-                         "span_id": 187,
-                         "parent_id": 183,
-                         "type": "sql",
-                         "meta": {
-                           "_dd.base_service": "wordpress_59_test_app",
-                           "component": "mysqli",
-                           "db.name": "test",
-                           "db.system": "mysql",
-                           "db.type": "mysql",
-                           "out.host": "mysql_integration",
-                           "out.port": "3306",
-                           "span.kind": "client"
-                         },
-                         "metrics": {
-                           "db.row_count": 0.0
-                         }
-                       },
                  {
                    "name": "callback",
                    "service": "wordpress_59_test_app",
                    "resource": "wp_robots (callback)",
                    "trace_id": 0,
-                   "span_id": 145,
-                   "parent_id": 131,
+                   "span_id": 127,
+                   "parent_id": 115,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1967,8 +1544,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "wp_post_preview_js (callback)",
                    "trace_id": 0,
-                   "span_id": 146,
-                   "parent_id": 131,
+                   "span_id": 128,
+                   "parent_id": 115,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1981,8 +1558,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "wp_maybe_inline_styles (callback)",
                    "trace_id": 0,
-                   "span_id": 147,
-                   "parent_id": 131,
+                   "span_id": 129,
+                   "parent_id": 115,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1995,8 +1572,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "wp_resource_hints (callback)",
                    "trace_id": 0,
-                   "span_id": 148,
-                   "parent_id": 131,
+                   "span_id": 130,
+                   "parent_id": 115,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2009,8 +1586,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "feed_links (callback)",
                    "trace_id": 0,
-                   "span_id": 149,
-                   "parent_id": 131,
+                   "span_id": 131,
+                   "parent_id": 115,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2023,8 +1600,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "feed_links_extra (callback)",
                    "trace_id": 0,
-                   "span_id": 150,
-                   "parent_id": 131,
+                   "span_id": 132,
+                   "parent_id": 115,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2037,8 +1614,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "print_emoji_detection_script (callback)",
                    "trace_id": 0,
-                   "span_id": 151,
-                   "parent_id": 131,
+                   "span_id": 133,
+                   "parent_id": 115,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2051,8 +1628,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "wp_print_styles (callback)",
                    "trace_id": 0,
-                   "span_id": 152,
-                   "parent_id": 131,
+                   "span_id": 134,
+                   "parent_id": 115,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2065,8 +1642,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "wp_print_head_scripts",
                    "trace_id": 0,
-                   "span_id": 153,
-                   "parent_id": 131,
+                   "span_id": 135,
+                   "parent_id": 115,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2079,8 +1656,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "rest_output_link_wp_head (callback)",
                    "trace_id": 0,
-                   "span_id": 154,
-                   "parent_id": 131,
+                   "span_id": 136,
+                   "parent_id": 115,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2093,8 +1670,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "rsd_link (callback)",
                    "trace_id": 0,
-                   "span_id": 155,
-                   "parent_id": 131,
+                   "span_id": 137,
+                   "parent_id": 115,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2107,8 +1684,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "wlwmanifest_link (callback)",
                    "trace_id": 0,
-                   "span_id": 156,
-                   "parent_id": 131,
+                   "span_id": 138,
+                   "parent_id": 115,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2121,8 +1698,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "locale_stylesheet (callback)",
                    "trace_id": 0,
-                   "span_id": 157,
-                   "parent_id": 131,
+                   "span_id": 139,
+                   "parent_id": 115,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2135,8 +1712,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "wp_generator (callback)",
                    "trace_id": 0,
-                   "span_id": 158,
-                   "parent_id": 131,
+                   "span_id": 140,
+                   "parent_id": 115,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2149,8 +1726,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "rel_canonical (callback)",
                    "trace_id": 0,
-                   "span_id": 159,
-                   "parent_id": 131,
+                   "span_id": 141,
+                   "parent_id": 115,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2163,8 +1740,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "wp_shortlink_wp_head (callback)",
                    "trace_id": 0,
-                   "span_id": 160,
-                   "parent_id": 131,
+                   "span_id": 142,
+                   "parent_id": 115,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2177,8 +1754,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "_custom_logo_header_styles (callback)",
                    "trace_id": 0,
-                   "span_id": 161,
-                   "parent_id": 131,
+                   "span_id": 143,
+                   "parent_id": 115,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2191,8 +1768,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "wp_oembed_add_discovery_links (callback)",
                    "trace_id": 0,
-                   "span_id": 162,
-                   "parent_id": 131,
+                   "span_id": 144,
+                   "parent_id": 115,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2205,8 +1782,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "wp_oembed_add_host_js (callback)",
                    "trace_id": 0,
-                   "span_id": 163,
-                   "parent_id": 131,
+                   "span_id": 145,
+                   "parent_id": 115,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2219,8 +1796,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "twentytwenty_no_js_class (callback)",
                    "trace_id": 0,
-                   "span_id": 164,
-                   "parent_id": 131,
+                   "span_id": 146,
+                   "parent_id": 115,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2233,8 +1810,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "WP_Widget_Recent_Comments::recent_comments_style (callback)",
                    "trace_id": 0,
-                   "span_id": 165,
-                   "parent_id": 131,
+                   "span_id": 147,
+                   "parent_id": 115,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2247,8 +1824,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "_custom_background_cb (callback)",
                    "trace_id": 0,
-                   "span_id": 166,
-                   "parent_id": 131,
+                   "span_id": 148,
+                   "parent_id": 115,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2261,8 +1838,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "wp_site_icon (callback)",
                    "trace_id": 0,
-                   "span_id": 167,
-                   "parent_id": 131,
+                   "span_id": 149,
+                   "parent_id": 115,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2275,8 +1852,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "wp_custom_css_cb (callback)",
                    "trace_id": 0,
-                   "span_id": 168,
-                   "parent_id": 131,
+                   "span_id": 150,
+                   "parent_id": 115,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2289,42 +1866,20 @@
                 "service": "wordpress_59_test_app",
                 "resource": "body_class",
                 "trace_id": 0,
-                "span_id": 132,
-                "parent_id": 122,
+                "span_id": 116,
+                "parent_id": 111,
                 "type": "web",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'site_logo' LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 169,
-                   "parent_id": 132,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
               {
                 "name": "callback",
                 "service": "wordpress_59_test_app",
                 "resource": "wp_admin_bar_render (callback)",
                 "trace_id": 0,
-                "span_id": 133,
-                "parent_id": 122,
+                "span_id": 117,
+                "parent_id": 111,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -2332,35 +1887,13 @@
                   "wordpress.hook": "wp_footer"
                 }
               },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT * FROM wp55_posts  WHERE (post_type = 'page' AND post_status = 'publish')     ORDER BY menu_order,wp55_posts.post_title ASC",
-                "trace_id": 0,
-                "span_id": 134,
-                "parent_id": 122,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
         {
           "name": "load_template",
           "service": "wordpress_59_test_app",
           "resource": "footer-menus-widgets (template)",
           "trace_id": 0,
-          "span_id": 106,
-          "parent_id": 19,
+          "span_id": 100,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -2373,8 +1906,8 @@
              "service": "wordpress_59_test_app",
              "resource": "sidebar-1",
              "trace_id": 0,
-             "span_id": 123,
-             "parent_id": 106,
+             "span_id": 112,
+             "parent_id": 100,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -2385,8 +1918,8 @@
                 "service": "wordpress_59_test_app",
                 "resource": "Search (widget)",
                 "trace_id": 0,
-                "span_id": 135,
-                "parent_id": 123,
+                "span_id": 118,
+                "parent_id": 112,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -2398,188 +1931,34 @@
                 "service": "wordpress_59_test_app",
                 "resource": "Recent Posts (widget)",
                 "trace_id": 0,
-                "span_id": 136,
-                "parent_id": 123,
+                "span_id": 119,
+                "parent_id": 112,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Recent Posts"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT   wp55_posts.ID FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_type = 'post' AND ((wp55_posts.post_status = 'publish'))  ORDER BY wp55_posts.post_date DESC LIMIT 0, 5",
-                   "trace_id": 0,
-                   "span_id": 170,
-                   "parent_id": 136,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 2.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT wp55_posts.* FROM wp55_posts WHERE ID IN (5,1)",
-                   "trace_id": 0,
-                   "span_id": 171,
-                   "parent_id": 136,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 2.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  t.*, tt.*, tr.object_id FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id INNER JOIN wp55_term_relationships AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy IN ('category', 'post_tag', 'post_format') AND tr.object_id IN (1, 5) ORDER BY t.name ASC ",
-                   "trace_id": 0,
-                   "span_id": 172,
-                   "parent_id": 136,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 2.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT post_id, meta_key, meta_value FROM wp55_postmeta WHERE post_id IN (1,5) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 173,
-                   "parent_id": 136,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 3.0
-                   }
-                 },
               {
                 "name": "widget",
                 "service": "wordpress_59_test_app",
                 "resource": "Recent Comments (widget)",
                 "trace_id": 0,
-                "span_id": 137,
-                "parent_id": 123,
+                "span_id": 120,
+                "parent_id": 112,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Recent Comments"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  wp55_comments.comment_ID FROM wp55_comments JOIN wp55_posts ON wp55_posts.ID = wp55_comments.comment_post_ID WHERE ( comment_approved = '1' ) AND  wp55_posts.post_status IN ('publish')  ORDER BY wp55_comments.comment_date_gmt DESC LIMIT 0,5",
-                   "trace_id": 0,
-                   "span_id": 174,
-                   "parent_id": 137,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT wp55_comments.* FROM wp55_comments WHERE comment_ID IN (1)",
-                   "trace_id": 0,
-                   "span_id": 175,
-                   "parent_id": 137,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT comment_id, meta_key, meta_value FROM wp55_commentmeta WHERE comment_id IN (1) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 176,
-                   "parent_id": 137,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
            {
              "name": "dynamic_sidebar",
              "service": "wordpress_59_test_app",
              "resource": "sidebar-2",
              "trace_id": 0,
-             "span_id": 124,
-             "parent_id": 106,
+             "span_id": 113,
+             "parent_id": 100,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -2590,100 +1969,34 @@
                 "service": "wordpress_59_test_app",
                 "resource": "Archives (widget)",
                 "trace_id": 0,
-                "span_id": 138,
-                "parent_id": 124,
+                "span_id": 121,
+                "parent_id": 113,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Archives"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT YEAR(post_date) AS `year`, MONTH(post_date) AS `month`, count(ID) as posts FROM wp55_posts  WHERE post_type = 'post' AND post_status = 'publish' GROUP BY YEAR(post_date), MONTH(post_date) ORDER BY post_date DESC ",
-                   "trace_id": 0,
-                   "span_id": 177,
-                   "parent_id": 138,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
               {
                 "name": "widget",
                 "service": "wordpress_59_test_app",
                 "resource": "Categories (widget)",
                 "trace_id": 0,
-                "span_id": 139,
-                "parent_id": 124,
+                "span_id": 122,
+                "parent_id": 113,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Categories"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  t.*, tt.* FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id WHERE tt.taxonomy IN ('category') AND tt.count > 0 ORDER BY t.name ASC ",
-                   "trace_id": 0,
-                   "span_id": 178,
-                   "parent_id": 139,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT term_id, meta_key, meta_value FROM wp55_termmeta WHERE term_id IN (1) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 179,
-                   "parent_id": 139,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
               {
                 "name": "widget",
                 "service": "wordpress_59_test_app",
                 "resource": "Meta (widget)",
                 "trace_id": 0,
-                "span_id": 140,
-                "parent_id": 124,
+                "span_id": 123,
+                "parent_id": 113,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -2695,8 +2008,8 @@
           "service": "wordpress_59_test_app",
           "resource": "get_footer",
           "trace_id": 0,
-          "span_id": 107,
-          "parent_id": 19,
+          "span_id": 101,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -2707,8 +2020,8 @@
              "service": "wordpress_59_test_app",
              "resource": "footer (template)",
              "trace_id": 0,
-             "span_id": 125,
-             "parent_id": 107,
+             "span_id": 114,
+             "parent_id": 101,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -2717,34 +2030,12 @@
              }
            },
               {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT * FROM wp55_posts WHERE ID = 3 LIMIT 1",
-                "trace_id": 0,
-                "span_id": 141,
-                "parent_id": 125,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
-              {
                 "name": "action",
                 "service": "wordpress_59_test_app",
                 "resource": "wp_footer (hook)",
                 "trace_id": 0,
-                "span_id": 142,
-                "parent_id": 125,
+                "span_id": 124,
+                "parent_id": 114,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -2756,8 +2047,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "the_block_template_skip_link (callback)",
                    "trace_id": 0,
-                   "span_id": 180,
-                   "parent_id": 142,
+                   "span_id": 151,
+                   "parent_id": 124,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2770,8 +2061,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "Closure (callback)",
                    "trace_id": 0,
-                   "span_id": 181,
-                   "parent_id": 142,
+                   "span_id": 152,
+                   "parent_id": 124,
                    "type": "web",
                    "meta": {
                      "closure.declaration": "/home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/wp-includes/block-supports/duotone.php:464",
@@ -2785,8 +2076,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "wp_print_footer_scripts (callback)",
                    "trace_id": 0,
-                   "span_id": 182,
-                   "parent_id": 142,
+                   "span_id": 153,
+                   "parent_id": 124,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2799,7 +2090,7 @@
        "service": "wordpress_59_test_app",
        "resource": "shutdown (hook)",
        "trace_id": 0,
-       "span_id": 20,
+       "span_id": 14,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -2812,8 +2103,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_ob_end_flush_all (callback)",
           "trace_id": 0,
-          "span_id": 108,
-          "parent_id": 20,
+          "span_id": 102,
+          "parent_id": 14,
           "type": "web",
           "meta": {
             "component": "wordpress",

--- a/tests/snapshots/tests.integrations.word_press.v5_9.common_scenarios_callbacks_test.test_scenario_get_with_exception.json
+++ b/tests/snapshots/tests.integrations.word_press.v5_9.common_scenarios_callbacks_test.test_scenario_get_with_exception.json
@@ -5,11 +5,12 @@
     "resource": "GET /error",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 8533551302326625189,
+    "parent_id": 1348561331787252532,
     "type": "web",
     "error": 1,
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e7000f00000000",
       "component": "wordpress",
       "error.message": "Uncaught Exception: Oops! in /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/wp-content/plugins/datadog/datadog.php:23",
       "error.stack": "#0 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/wp-includes/class-wp-hook.php(307): datadog_parse_request()\n#1 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/wp-includes/class-wp-hook.php(331): WP_Hook->apply_filters()\n#2 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/wp-includes/plugin.php(522): WP_Hook->do_action()\n#3 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/wp-includes/class-wp.php(396): do_action_ref_array()\n#4 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/wp-includes/class-wp.php(758): WP->parse_request()\n#5 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/wp-includes/functions.php(1310): WP->main()\n#6 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/wp-blog-header.php(16): wp()\n#7 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/index.php(17): require()\n#8 {main}",
@@ -18,7 +19,7 @@
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/error?key=value&<redacted>",
-      "runtime-id": "eae4f3b0-bd58-46e8-ac81-96149959e17a",
+      "runtime-id": "896f86bc-7139-44f3-a99f-ed35e643f726",
       "span.kind": "server"
     },
     "metrics": {
@@ -26,108 +27,11 @@
     }
   },
      {
-       "name": "mysqli_real_connect",
-       "service": "mysqli",
-       "resource": "mysqli_real_connect",
-       "trace_id": 0,
-       "span_id": 2,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-       "trace_id": 0,
-       "span_id": 3,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT @@SESSION.sql_mode",
-       "trace_id": 0,
-       "span_id": 4,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 1.0
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-       "trace_id": 0,
-       "span_id": 5,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_name, option_value FROM wp55_options WHERE autoload = 'yes'",
-       "trace_id": 0,
-       "span_id": 6,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 111.0
-       }
-     },
-     {
        "name": "create_initial_taxonomies",
        "service": "wordpress_59_test_app",
        "resource": "create_initial_taxonomies",
        "trace_id": 0,
-       "span_id": 7,
+       "span_id": 2,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -141,7 +45,7 @@
        "service": "wordpress_59_test_app",
        "resource": "create_initial_post_types",
        "trace_id": 0,
-       "span_id": 8,
+       "span_id": 3,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -155,7 +59,7 @@
        "service": "wordpress_59_test_app",
        "resource": "datadog (plugin)",
        "trace_id": 0,
-       "span_id": 9,
+       "span_id": 4,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -168,7 +72,7 @@
        "service": "wordpress_59_test_app",
        "resource": "plugins_loaded (hook)",
        "trace_id": 0,
-       "span_id": 10,
+       "span_id": 5,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -181,8 +85,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_maybe_load_widgets",
           "trace_id": 0,
-          "span_id": 20,
-          "parent_id": 10,
+          "span_id": 14,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -195,8 +99,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_maybe_load_embeds",
           "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 10,
+          "span_id": 15,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -209,8 +113,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_wp_add_additional_image_sizes (callback)",
           "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 10,
+          "span_id": 16,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -223,8 +127,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_wp_customize_include",
           "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 10,
+          "span_id": 17,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -237,7 +141,7 @@
        "service": "wordpress_59_test_app",
        "resource": "setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 11,
+       "span_id": 6,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -250,8 +154,8 @@
           "service": "wordpress_59_test_app",
           "resource": "create_initial_theme_features (callback)",
           "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 11,
+          "span_id": 18,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -264,8 +168,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_add_default_theme_supports (callback)",
           "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 11,
+          "span_id": 19,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -278,8 +182,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_enable_block_templates (callback)",
           "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 11,
+          "span_id": 20,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -292,8 +196,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_delete_site_logo_on_remove_custom_logo_on_setup_theme (callback)",
           "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 11,
+          "span_id": 21,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -302,33 +206,11 @@
           }
         },
      {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'WPLANG' LIMIT 1",
-       "trace_id": 0,
-       "span_id": 12,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 0.0
-       }
-     },
-     {
        "name": "load_theme",
        "service": "wordpress_59_test_app",
        "resource": "Twentytwenty (theme)",
        "trace_id": 0,
-       "span_id": 13,
+       "span_id": 7,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -341,7 +223,7 @@
        "service": "wordpress_59_test_app",
        "resource": "after_setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 14,
+       "span_id": 8,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -354,8 +236,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_setup_widgets_block_editor (callback)",
           "trace_id": 0,
-          "span_id": 28,
-          "parent_id": 14,
+          "span_id": 22,
+          "parent_id": 8,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -368,8 +250,8 @@
           "service": "wordpress_59_test_app",
           "resource": "twentytwenty_theme_support (callback)",
           "trace_id": 0,
-          "span_id": 29,
-          "parent_id": 14,
+          "span_id": 23,
+          "parent_id": 8,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -382,8 +264,8 @@
           "service": "wordpress_59_test_app",
           "resource": "twentytwenty_block_editor_settings (callback)",
           "trace_id": 0,
-          "span_id": 30,
-          "parent_id": 14,
+          "span_id": 24,
+          "parent_id": 8,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -396,7 +278,7 @@
        "service": "wordpress_59_test_app",
        "resource": "WP.init",
        "trace_id": 0,
-       "span_id": 15,
+       "span_id": 9,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -408,8 +290,8 @@
           "service": "wordpress_59_test_app",
           "resource": "kses_init (callback)",
           "trace_id": 0,
-          "span_id": 31,
-          "parent_id": 15,
+          "span_id": 25,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -422,7 +304,7 @@
        "service": "wordpress_59_test_app",
        "resource": "init (hook)",
        "trace_id": 0,
-       "span_id": 16,
+       "span_id": 10,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -435,8 +317,8 @@
           "service": "wordpress_59_test_app",
           "resource": "create_initial_post_types",
           "trace_id": 0,
-          "span_id": 32,
-          "parent_id": 16,
+          "span_id": 26,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -447,8 +329,8 @@
           "service": "wordpress_59_test_app",
           "resource": "create_initial_taxonomies",
           "trace_id": 0,
-          "span_id": 33,
-          "parent_id": 16,
+          "span_id": 27,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -459,8 +341,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_widgets_init",
           "trace_id": 0,
-          "span_id": 34,
-          "parent_id": 16,
+          "span_id": 28,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -473,83 +355,20 @@
              "service": "wordpress_59_test_app",
              "resource": "WP_Widget_Factory._register_widgets",
              "trace_id": 0,
-             "span_id": 98,
-             "parent_id": 34,
+             "span_id": 92,
+             "parent_id": 28,
              "type": "web",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-                "trace_id": 0,
-                "span_id": 101,
-                "parent_id": 98,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'widget_block' LIMIT 1",
-                "trace_id": 0,
-                "span_id": 102,
-                "parent_id": 98,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "INSERT INTO `wp55_options` (`option_name`, `option_value`, `autoload`) VALUES ('widget_block', 'a:1:{s:12:\\\"_multiwidget\\\";i:1;}', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)",
-                "trace_id": 0,
-                "span_id": 103,
-                "parent_id": 98,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                }
-              },
         {
           "name": "callback",
           "service": "wordpress_59_test_app",
           "resource": "smilies_init (callback)",
           "trace_id": 0,
-          "span_id": 35,
-          "parent_id": 16,
+          "span_id": 29,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -562,8 +381,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_init_targeted_link_rel_filters (callback)",
           "trace_id": 0,
-          "span_id": 36,
-          "parent_id": 16,
+          "span_id": 30,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -576,8 +395,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_register_core_block_patterns_and_categories (callback)",
           "trace_id": 0,
-          "span_id": 37,
-          "parent_id": 16,
+          "span_id": 31,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -590,8 +409,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_cron (callback)",
           "trace_id": 0,
-          "span_id": 38,
-          "parent_id": 16,
+          "span_id": 32,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -604,8 +423,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_schedule_https_detection (callback)",
           "trace_id": 0,
-          "span_id": 39,
-          "parent_id": 16,
+          "span_id": 33,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -618,8 +437,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_schedule_delete_old_privacy_export_files (callback)",
           "trace_id": 0,
-          "span_id": 40,
-          "parent_id": 16,
+          "span_id": 34,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -632,8 +451,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_show_post_preview (callback)",
           "trace_id": 0,
-          "span_id": 41,
-          "parent_id": 16,
+          "span_id": 35,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -646,8 +465,8 @@
           "service": "wordpress_59_test_app",
           "resource": "rest_api_init (callback)",
           "trace_id": 0,
-          "span_id": 42,
-          "parent_id": 16,
+          "span_id": 36,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -660,8 +479,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_sitemaps_get_server (callback)",
           "trace_id": 0,
-          "span_id": 43,
-          "parent_id": 16,
+          "span_id": 37,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -674,8 +493,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_schedule_update_checks (callback)",
           "trace_id": 0,
-          "span_id": 44,
-          "parent_id": 16,
+          "span_id": 38,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -688,8 +507,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_archives (callback)",
           "trace_id": 0,
-          "span_id": 45,
-          "parent_id": 16,
+          "span_id": 39,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -702,8 +521,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_block (callback)",
           "trace_id": 0,
-          "span_id": 46,
-          "parent_id": 16,
+          "span_id": 40,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -716,8 +535,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_calendar (callback)",
           "trace_id": 0,
-          "span_id": 47,
-          "parent_id": 16,
+          "span_id": 41,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -730,8 +549,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_categories (callback)",
           "trace_id": 0,
-          "span_id": 48,
-          "parent_id": 16,
+          "span_id": 42,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -744,8 +563,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_file (callback)",
           "trace_id": 0,
-          "span_id": 49,
-          "parent_id": 16,
+          "span_id": 43,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -758,8 +577,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_gallery (callback)",
           "trace_id": 0,
-          "span_id": 50,
-          "parent_id": 16,
+          "span_id": 44,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -772,8 +591,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_image (callback)",
           "trace_id": 0,
-          "span_id": 51,
-          "parent_id": 16,
+          "span_id": 45,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -786,8 +605,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_latest_comments (callback)",
           "trace_id": 0,
-          "span_id": 52,
-          "parent_id": 16,
+          "span_id": 46,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -800,8 +619,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_latest_posts (callback)",
           "trace_id": 0,
-          "span_id": 53,
-          "parent_id": 16,
+          "span_id": 47,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -814,8 +633,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_legacy_widget (callback)",
           "trace_id": 0,
-          "span_id": 54,
-          "parent_id": 16,
+          "span_id": 48,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -828,8 +647,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_loginout (callback)",
           "trace_id": 0,
-          "span_id": 55,
-          "parent_id": 16,
+          "span_id": 49,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -842,8 +661,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_navigation_link (callback)",
           "trace_id": 0,
-          "span_id": 56,
-          "parent_id": 16,
+          "span_id": 50,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -856,8 +675,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_navigation_submenu (callback)",
           "trace_id": 0,
-          "span_id": 57,
-          "parent_id": 16,
+          "span_id": 51,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -870,8 +689,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_navigation (callback)",
           "trace_id": 0,
-          "span_id": 58,
-          "parent_id": 16,
+          "span_id": 52,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -884,8 +703,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_page_list (callback)",
           "trace_id": 0,
-          "span_id": 59,
-          "parent_id": 16,
+          "span_id": 53,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -898,8 +717,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_pattern (callback)",
           "trace_id": 0,
-          "span_id": 60,
-          "parent_id": 16,
+          "span_id": 54,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -912,8 +731,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_author (callback)",
           "trace_id": 0,
-          "span_id": 61,
-          "parent_id": 16,
+          "span_id": 55,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -926,8 +745,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_comments (callback)",
           "trace_id": 0,
-          "span_id": 62,
-          "parent_id": 16,
+          "span_id": 56,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -940,8 +759,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_content (callback)",
           "trace_id": 0,
-          "span_id": 63,
-          "parent_id": 16,
+          "span_id": 57,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -954,8 +773,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_date (callback)",
           "trace_id": 0,
-          "span_id": 64,
-          "parent_id": 16,
+          "span_id": 58,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -968,8 +787,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_excerpt (callback)",
           "trace_id": 0,
-          "span_id": 65,
-          "parent_id": 16,
+          "span_id": 59,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -982,8 +801,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_featured_image (callback)",
           "trace_id": 0,
-          "span_id": 66,
-          "parent_id": 16,
+          "span_id": 60,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -996,8 +815,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_navigation_link (callback)",
           "trace_id": 0,
-          "span_id": 67,
-          "parent_id": 16,
+          "span_id": 61,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1010,8 +829,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_template (callback)",
           "trace_id": 0,
-          "span_id": 68,
-          "parent_id": 16,
+          "span_id": 62,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1024,8 +843,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_terms (callback)",
           "trace_id": 0,
-          "span_id": 69,
-          "parent_id": 16,
+          "span_id": 63,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1038,8 +857,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_title (callback)",
           "trace_id": 0,
-          "span_id": 70,
-          "parent_id": 16,
+          "span_id": 64,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1052,8 +871,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_query_pagination_next (callback)",
           "trace_id": 0,
-          "span_id": 71,
-          "parent_id": 16,
+          "span_id": 65,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1066,8 +885,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_query_pagination_numbers (callback)",
           "trace_id": 0,
-          "span_id": 72,
-          "parent_id": 16,
+          "span_id": 66,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1080,8 +899,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_query_pagination_previous (callback)",
           "trace_id": 0,
-          "span_id": 73,
-          "parent_id": 16,
+          "span_id": 67,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1094,8 +913,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_query_pagination (callback)",
           "trace_id": 0,
-          "span_id": 74,
-          "parent_id": 16,
+          "span_id": 68,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1108,8 +927,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_query_title (callback)",
           "trace_id": 0,
-          "span_id": 75,
-          "parent_id": 16,
+          "span_id": 69,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1122,8 +941,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_query (callback)",
           "trace_id": 0,
-          "span_id": 76,
-          "parent_id": 16,
+          "span_id": 70,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1136,8 +955,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_rss (callback)",
           "trace_id": 0,
-          "span_id": 77,
-          "parent_id": 16,
+          "span_id": 71,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1150,8 +969,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_search (callback)",
           "trace_id": 0,
-          "span_id": 78,
-          "parent_id": 16,
+          "span_id": 72,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1164,8 +983,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_shortcode (callback)",
           "trace_id": 0,
-          "span_id": 79,
-          "parent_id": 16,
+          "span_id": 73,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1178,8 +997,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_site_logo (callback)",
           "trace_id": 0,
-          "span_id": 80,
-          "parent_id": 16,
+          "span_id": 74,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1192,8 +1011,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_site_tagline (callback)",
           "trace_id": 0,
-          "span_id": 81,
-          "parent_id": 16,
+          "span_id": 75,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1206,8 +1025,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_site_title (callback)",
           "trace_id": 0,
-          "span_id": 82,
-          "parent_id": 16,
+          "span_id": 76,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1220,8 +1039,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_social_link (callback)",
           "trace_id": 0,
-          "span_id": 83,
-          "parent_id": 16,
+          "span_id": 77,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1234,8 +1053,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_tag_cloud (callback)",
           "trace_id": 0,
-          "span_id": 84,
-          "parent_id": 16,
+          "span_id": 78,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1248,8 +1067,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_template_part (callback)",
           "trace_id": 0,
-          "span_id": 85,
-          "parent_id": 16,
+          "span_id": 79,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1262,8 +1081,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_term_description (callback)",
           "trace_id": 0,
-          "span_id": 86,
-          "parent_id": 16,
+          "span_id": 80,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1276,8 +1095,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_core_block_types_from_metadata (callback)",
           "trace_id": 0,
-          "span_id": 87,
-          "parent_id": 16,
+          "span_id": 81,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1290,8 +1109,8 @@
           "service": "wordpress_59_test_app",
           "resource": "twentytwenty_menus (callback)",
           "trace_id": 0,
-          "span_id": 88,
-          "parent_id": 16,
+          "span_id": 82,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1304,8 +1123,8 @@
           "service": "wordpress_59_test_app",
           "resource": "twentytwenty_classic_editor_styles (callback)",
           "trace_id": 0,
-          "span_id": 89,
-          "parent_id": 16,
+          "span_id": 83,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1318,8 +1137,8 @@
           "service": "wordpress_59_test_app",
           "resource": "WP_Block_Supports::init (callback)",
           "trace_id": 0,
-          "span_id": 90,
-          "parent_id": 16,
+          "span_id": 84,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1332,8 +1151,8 @@
           "service": "wordpress_59_test_app",
           "resource": "check_theme_switched (callback)",
           "trace_id": 0,
-          "span_id": 91,
-          "parent_id": 16,
+          "span_id": 85,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1341,34 +1160,12 @@
             "wordpress.hook": "init"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'theme_switched' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 99,
-             "parent_id": 91,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_59_test_app",
        "resource": "wp_loaded (hook)",
        "trace_id": 0,
-       "span_id": 17,
+       "span_id": 11,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -1381,8 +1178,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_custom_header_background_just_in_time (callback)",
           "trace_id": 0,
-          "span_id": 92,
-          "parent_id": 17,
+          "span_id": 86,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1395,8 +1192,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_add_template_loader_filters (callback)",
           "trace_id": 0,
-          "span_id": 93,
-          "parent_id": 17,
+          "span_id": 87,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1409,8 +1206,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_wp_cron (callback)",
           "trace_id": 0,
-          "span_id": 94,
-          "parent_id": 17,
+          "span_id": 88,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1423,7 +1220,7 @@
        "service": "wordpress_59_test_app",
        "resource": "WP.main",
        "trace_id": 0,
-       "span_id": 18,
+       "span_id": 12,
        "parent_id": 1,
        "type": "web",
        "error": 1,
@@ -1439,8 +1236,8 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 95,
-          "parent_id": 18,
+          "span_id": 89,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -1451,8 +1248,8 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 96,
-          "parent_id": 18,
+          "span_id": 90,
+          "parent_id": 12,
           "type": "web",
           "error": 1,
           "meta": {
@@ -1462,34 +1259,12 @@
             "error.type": "Exception"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('error')\n\t\tAND post_type IN ('page','attachment')\n\t",
-             "trace_id": 0,
-             "span_id": 100,
-             "parent_id": 96,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_59_test_app",
        "resource": "shutdown (hook)",
        "trace_id": 0,
-       "span_id": 19,
+       "span_id": 13,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -1502,8 +1277,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_ob_end_flush_all (callback)",
           "trace_id": 0,
-          "span_id": 97,
-          "parent_id": 19,
+          "span_id": 91,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",

--- a/tests/snapshots/tests.integrations.word_press.v5_9.common_scenarios_callbacks_test.test_scenario_get_with_view.json
+++ b/tests/snapshots/tests.integrations.word_press.v5_9.common_scenarios_callbacks_test.test_scenario_get_with_view.json
@@ -5,16 +5,17 @@
     "resource": "GET /simple_view",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 11672833717113024137,
+    "parent_id": 6543666624596584279,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e7000400000000",
       "component": "wordpress",
       "http.method": "GET",
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/simple_view?key=value&<redacted>",
-      "runtime-id": "95e244b4-fc3a-4566-8940-d2badc3e99b5",
+      "runtime-id": "896f86bc-7139-44f3-a99f-ed35e643f726",
       "span.kind": "server"
     },
     "metrics": {
@@ -22,108 +23,11 @@
     }
   },
      {
-       "name": "mysqli_real_connect",
-       "service": "mysqli",
-       "resource": "mysqli_real_connect",
-       "trace_id": 0,
-       "span_id": 2,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-       "trace_id": 0,
-       "span_id": 3,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT @@SESSION.sql_mode",
-       "trace_id": 0,
-       "span_id": 4,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 1.0
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-       "trace_id": 0,
-       "span_id": 5,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_name, option_value FROM wp55_options WHERE autoload = 'yes'",
-       "trace_id": 0,
-       "span_id": 6,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 111.0
-       }
-     },
-     {
        "name": "create_initial_taxonomies",
        "service": "wordpress_59_test_app",
        "resource": "create_initial_taxonomies",
        "trace_id": 0,
-       "span_id": 7,
+       "span_id": 2,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -137,7 +41,7 @@
        "service": "wordpress_59_test_app",
        "resource": "create_initial_post_types",
        "trace_id": 0,
-       "span_id": 8,
+       "span_id": 3,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -151,7 +55,7 @@
        "service": "wordpress_59_test_app",
        "resource": "datadog (plugin)",
        "trace_id": 0,
-       "span_id": 9,
+       "span_id": 4,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -164,7 +68,7 @@
        "service": "wordpress_59_test_app",
        "resource": "plugins_loaded (hook)",
        "trace_id": 0,
-       "span_id": 10,
+       "span_id": 5,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -177,8 +81,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_maybe_load_widgets",
           "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 10,
+          "span_id": 15,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -191,8 +95,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_maybe_load_embeds",
           "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 10,
+          "span_id": 16,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -205,8 +109,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_wp_add_additional_image_sizes (callback)",
           "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 10,
+          "span_id": 17,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -219,8 +123,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_wp_customize_include",
           "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 10,
+          "span_id": 18,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -233,7 +137,7 @@
        "service": "wordpress_59_test_app",
        "resource": "setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 11,
+       "span_id": 6,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -246,8 +150,8 @@
           "service": "wordpress_59_test_app",
           "resource": "create_initial_theme_features (callback)",
           "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 11,
+          "span_id": 19,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -260,8 +164,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_add_default_theme_supports (callback)",
           "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 11,
+          "span_id": 20,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -274,8 +178,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_enable_block_templates (callback)",
           "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 11,
+          "span_id": 21,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -288,8 +192,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_delete_site_logo_on_remove_custom_logo_on_setup_theme (callback)",
           "trace_id": 0,
-          "span_id": 28,
-          "parent_id": 11,
+          "span_id": 22,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -298,33 +202,11 @@
           }
         },
      {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'WPLANG' LIMIT 1",
-       "trace_id": 0,
-       "span_id": 12,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 0.0
-       }
-     },
-     {
        "name": "load_theme",
        "service": "wordpress_59_test_app",
        "resource": "Twentytwenty (theme)",
        "trace_id": 0,
-       "span_id": 13,
+       "span_id": 7,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -337,7 +219,7 @@
        "service": "wordpress_59_test_app",
        "resource": "after_setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 14,
+       "span_id": 8,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -350,8 +232,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_setup_widgets_block_editor (callback)",
           "trace_id": 0,
-          "span_id": 29,
-          "parent_id": 14,
+          "span_id": 23,
+          "parent_id": 8,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -364,8 +246,8 @@
           "service": "wordpress_59_test_app",
           "resource": "twentytwenty_theme_support (callback)",
           "trace_id": 0,
-          "span_id": 30,
-          "parent_id": 14,
+          "span_id": 24,
+          "parent_id": 8,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -378,8 +260,8 @@
           "service": "wordpress_59_test_app",
           "resource": "twentytwenty_block_editor_settings (callback)",
           "trace_id": 0,
-          "span_id": 31,
-          "parent_id": 14,
+          "span_id": 25,
+          "parent_id": 8,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -392,7 +274,7 @@
        "service": "wordpress_59_test_app",
        "resource": "WP.init",
        "trace_id": 0,
-       "span_id": 15,
+       "span_id": 9,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -404,8 +286,8 @@
           "service": "wordpress_59_test_app",
           "resource": "kses_init (callback)",
           "trace_id": 0,
-          "span_id": 32,
-          "parent_id": 15,
+          "span_id": 26,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -418,7 +300,7 @@
        "service": "wordpress_59_test_app",
        "resource": "init (hook)",
        "trace_id": 0,
-       "span_id": 16,
+       "span_id": 10,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -431,8 +313,8 @@
           "service": "wordpress_59_test_app",
           "resource": "create_initial_post_types",
           "trace_id": 0,
-          "span_id": 33,
-          "parent_id": 16,
+          "span_id": 27,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -443,8 +325,8 @@
           "service": "wordpress_59_test_app",
           "resource": "create_initial_taxonomies",
           "trace_id": 0,
-          "span_id": 34,
-          "parent_id": 16,
+          "span_id": 28,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -455,8 +337,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_widgets_init",
           "trace_id": 0,
-          "span_id": 35,
-          "parent_id": 16,
+          "span_id": 29,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -469,83 +351,20 @@
              "service": "wordpress_59_test_app",
              "resource": "WP_Widget_Factory._register_widgets",
              "trace_id": 0,
-             "span_id": 112,
-             "parent_id": 35,
+             "span_id": 106,
+             "parent_id": 29,
              "type": "web",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-                "trace_id": 0,
-                "span_id": 136,
-                "parent_id": 112,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'widget_block' LIMIT 1",
-                "trace_id": 0,
-                "span_id": 137,
-                "parent_id": 112,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "INSERT INTO `wp55_options` (`option_name`, `option_value`, `autoload`) VALUES ('widget_block', 'a:1:{s:12:\\\"_multiwidget\\\";i:1;}', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)",
-                "trace_id": 0,
-                "span_id": 138,
-                "parent_id": 112,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                }
-              },
         {
           "name": "callback",
           "service": "wordpress_59_test_app",
           "resource": "smilies_init (callback)",
           "trace_id": 0,
-          "span_id": 36,
-          "parent_id": 16,
+          "span_id": 30,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -558,8 +377,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_init_targeted_link_rel_filters (callback)",
           "trace_id": 0,
-          "span_id": 37,
-          "parent_id": 16,
+          "span_id": 31,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -572,8 +391,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_register_core_block_patterns_and_categories (callback)",
           "trace_id": 0,
-          "span_id": 38,
-          "parent_id": 16,
+          "span_id": 32,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -586,8 +405,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_cron (callback)",
           "trace_id": 0,
-          "span_id": 39,
-          "parent_id": 16,
+          "span_id": 33,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -600,8 +419,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_schedule_https_detection (callback)",
           "trace_id": 0,
-          "span_id": 40,
-          "parent_id": 16,
+          "span_id": 34,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -614,8 +433,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_schedule_delete_old_privacy_export_files (callback)",
           "trace_id": 0,
-          "span_id": 41,
-          "parent_id": 16,
+          "span_id": 35,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -628,8 +447,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_show_post_preview (callback)",
           "trace_id": 0,
-          "span_id": 42,
-          "parent_id": 16,
+          "span_id": 36,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -642,8 +461,8 @@
           "service": "wordpress_59_test_app",
           "resource": "rest_api_init (callback)",
           "trace_id": 0,
-          "span_id": 43,
-          "parent_id": 16,
+          "span_id": 37,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -656,8 +475,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_sitemaps_get_server (callback)",
           "trace_id": 0,
-          "span_id": 44,
-          "parent_id": 16,
+          "span_id": 38,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -670,8 +489,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_schedule_update_checks (callback)",
           "trace_id": 0,
-          "span_id": 45,
-          "parent_id": 16,
+          "span_id": 39,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -684,8 +503,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_archives (callback)",
           "trace_id": 0,
-          "span_id": 46,
-          "parent_id": 16,
+          "span_id": 40,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -698,8 +517,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_block (callback)",
           "trace_id": 0,
-          "span_id": 47,
-          "parent_id": 16,
+          "span_id": 41,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -712,8 +531,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_calendar (callback)",
           "trace_id": 0,
-          "span_id": 48,
-          "parent_id": 16,
+          "span_id": 42,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -726,8 +545,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_categories (callback)",
           "trace_id": 0,
-          "span_id": 49,
-          "parent_id": 16,
+          "span_id": 43,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -740,8 +559,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_file (callback)",
           "trace_id": 0,
-          "span_id": 50,
-          "parent_id": 16,
+          "span_id": 44,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -754,8 +573,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_gallery (callback)",
           "trace_id": 0,
-          "span_id": 51,
-          "parent_id": 16,
+          "span_id": 45,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -768,8 +587,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_image (callback)",
           "trace_id": 0,
-          "span_id": 52,
-          "parent_id": 16,
+          "span_id": 46,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -782,8 +601,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_latest_comments (callback)",
           "trace_id": 0,
-          "span_id": 53,
-          "parent_id": 16,
+          "span_id": 47,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -796,8 +615,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_latest_posts (callback)",
           "trace_id": 0,
-          "span_id": 54,
-          "parent_id": 16,
+          "span_id": 48,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -810,8 +629,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_legacy_widget (callback)",
           "trace_id": 0,
-          "span_id": 55,
-          "parent_id": 16,
+          "span_id": 49,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -824,8 +643,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_loginout (callback)",
           "trace_id": 0,
-          "span_id": 56,
-          "parent_id": 16,
+          "span_id": 50,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -838,8 +657,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_navigation_link (callback)",
           "trace_id": 0,
-          "span_id": 57,
-          "parent_id": 16,
+          "span_id": 51,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -852,8 +671,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_navigation_submenu (callback)",
           "trace_id": 0,
-          "span_id": 58,
-          "parent_id": 16,
+          "span_id": 52,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -866,8 +685,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_navigation (callback)",
           "trace_id": 0,
-          "span_id": 59,
-          "parent_id": 16,
+          "span_id": 53,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -880,8 +699,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_page_list (callback)",
           "trace_id": 0,
-          "span_id": 60,
-          "parent_id": 16,
+          "span_id": 54,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -894,8 +713,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_pattern (callback)",
           "trace_id": 0,
-          "span_id": 61,
-          "parent_id": 16,
+          "span_id": 55,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -908,8 +727,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_author (callback)",
           "trace_id": 0,
-          "span_id": 62,
-          "parent_id": 16,
+          "span_id": 56,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -922,8 +741,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_comments (callback)",
           "trace_id": 0,
-          "span_id": 63,
-          "parent_id": 16,
+          "span_id": 57,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -936,8 +755,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_content (callback)",
           "trace_id": 0,
-          "span_id": 64,
-          "parent_id": 16,
+          "span_id": 58,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -950,8 +769,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_date (callback)",
           "trace_id": 0,
-          "span_id": 65,
-          "parent_id": 16,
+          "span_id": 59,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -964,8 +783,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_excerpt (callback)",
           "trace_id": 0,
-          "span_id": 66,
-          "parent_id": 16,
+          "span_id": 60,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -978,8 +797,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_featured_image (callback)",
           "trace_id": 0,
-          "span_id": 67,
-          "parent_id": 16,
+          "span_id": 61,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -992,8 +811,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_navigation_link (callback)",
           "trace_id": 0,
-          "span_id": 68,
-          "parent_id": 16,
+          "span_id": 62,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1006,8 +825,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_template (callback)",
           "trace_id": 0,
-          "span_id": 69,
-          "parent_id": 16,
+          "span_id": 63,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1020,8 +839,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_terms (callback)",
           "trace_id": 0,
-          "span_id": 70,
-          "parent_id": 16,
+          "span_id": 64,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1034,8 +853,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_post_title (callback)",
           "trace_id": 0,
-          "span_id": 71,
-          "parent_id": 16,
+          "span_id": 65,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1048,8 +867,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_query_pagination_next (callback)",
           "trace_id": 0,
-          "span_id": 72,
-          "parent_id": 16,
+          "span_id": 66,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1062,8 +881,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_query_pagination_numbers (callback)",
           "trace_id": 0,
-          "span_id": 73,
-          "parent_id": 16,
+          "span_id": 67,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1076,8 +895,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_query_pagination_previous (callback)",
           "trace_id": 0,
-          "span_id": 74,
-          "parent_id": 16,
+          "span_id": 68,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1090,8 +909,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_query_pagination (callback)",
           "trace_id": 0,
-          "span_id": 75,
-          "parent_id": 16,
+          "span_id": 69,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1104,8 +923,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_query_title (callback)",
           "trace_id": 0,
-          "span_id": 76,
-          "parent_id": 16,
+          "span_id": 70,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1118,8 +937,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_query (callback)",
           "trace_id": 0,
-          "span_id": 77,
-          "parent_id": 16,
+          "span_id": 71,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1132,8 +951,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_rss (callback)",
           "trace_id": 0,
-          "span_id": 78,
-          "parent_id": 16,
+          "span_id": 72,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1146,8 +965,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_search (callback)",
           "trace_id": 0,
-          "span_id": 79,
-          "parent_id": 16,
+          "span_id": 73,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1160,8 +979,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_shortcode (callback)",
           "trace_id": 0,
-          "span_id": 80,
-          "parent_id": 16,
+          "span_id": 74,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1174,8 +993,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_site_logo (callback)",
           "trace_id": 0,
-          "span_id": 81,
-          "parent_id": 16,
+          "span_id": 75,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1188,8 +1007,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_site_tagline (callback)",
           "trace_id": 0,
-          "span_id": 82,
-          "parent_id": 16,
+          "span_id": 76,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1202,8 +1021,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_site_title (callback)",
           "trace_id": 0,
-          "span_id": 83,
-          "parent_id": 16,
+          "span_id": 77,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1216,8 +1035,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_social_link (callback)",
           "trace_id": 0,
-          "span_id": 84,
-          "parent_id": 16,
+          "span_id": 78,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1230,8 +1049,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_tag_cloud (callback)",
           "trace_id": 0,
-          "span_id": 85,
-          "parent_id": 16,
+          "span_id": 79,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1244,8 +1063,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_template_part (callback)",
           "trace_id": 0,
-          "span_id": 86,
-          "parent_id": 16,
+          "span_id": 80,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1258,8 +1077,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_block_core_term_description (callback)",
           "trace_id": 0,
-          "span_id": 87,
-          "parent_id": 16,
+          "span_id": 81,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1272,8 +1091,8 @@
           "service": "wordpress_59_test_app",
           "resource": "register_core_block_types_from_metadata (callback)",
           "trace_id": 0,
-          "span_id": 88,
-          "parent_id": 16,
+          "span_id": 82,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1286,8 +1105,8 @@
           "service": "wordpress_59_test_app",
           "resource": "twentytwenty_menus (callback)",
           "trace_id": 0,
-          "span_id": 89,
-          "parent_id": 16,
+          "span_id": 83,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1300,8 +1119,8 @@
           "service": "wordpress_59_test_app",
           "resource": "twentytwenty_classic_editor_styles (callback)",
           "trace_id": 0,
-          "span_id": 90,
-          "parent_id": 16,
+          "span_id": 84,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1314,8 +1133,8 @@
           "service": "wordpress_59_test_app",
           "resource": "WP_Block_Supports::init (callback)",
           "trace_id": 0,
-          "span_id": 91,
-          "parent_id": 16,
+          "span_id": 85,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1328,8 +1147,8 @@
           "service": "wordpress_59_test_app",
           "resource": "check_theme_switched (callback)",
           "trace_id": 0,
-          "span_id": 92,
-          "parent_id": 16,
+          "span_id": 86,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1337,34 +1156,12 @@
             "wordpress.hook": "init"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'theme_switched' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 113,
-             "parent_id": 92,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_59_test_app",
        "resource": "wp_loaded (hook)",
        "trace_id": 0,
-       "span_id": 17,
+       "span_id": 11,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -1377,8 +1174,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_custom_header_background_just_in_time (callback)",
           "trace_id": 0,
-          "span_id": 93,
-          "parent_id": 17,
+          "span_id": 87,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1391,8 +1188,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_add_template_loader_filters (callback)",
           "trace_id": 0,
-          "span_id": 94,
-          "parent_id": 17,
+          "span_id": 88,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1405,8 +1202,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_wp_cron (callback)",
           "trace_id": 0,
-          "span_id": 95,
-          "parent_id": 17,
+          "span_id": 89,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1419,7 +1216,7 @@
        "service": "wordpress_59_test_app",
        "resource": "WP.main",
        "trace_id": 0,
-       "span_id": 18,
+       "span_id": 12,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -1431,8 +1228,8 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 96,
-          "parent_id": 18,
+          "span_id": 90,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -1443,42 +1240,20 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 97,
-          "parent_id": 18,
+          "span_id": 91,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('simple_view')\n\t\tAND post_type IN ('page','attachment')\n\t",
-             "trace_id": 0,
-             "span_id": 114,
-             "parent_id": 97,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
         {
           "name": "WP.send_headers",
           "service": "wordpress_59_test_app",
           "resource": "WP.send_headers",
           "trace_id": 0,
-          "span_id": 98,
-          "parent_id": 18,
+          "span_id": 92,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -1489,86 +1264,20 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.query_posts",
           "trace_id": 0,
-          "span_id": 99,
-          "parent_id": 18,
+          "span_id": 93,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT   wp55_posts.* FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_name = 'simple_view' AND wp55_posts.post_type = 'post'  ORDER BY wp55_posts.post_date DESC ",
-             "trace_id": 0,
-             "span_id": 115,
-             "parent_id": 99,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT  t.*, tt.*, tr.object_id FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id INNER JOIN wp55_term_relationships AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy IN ('category', 'post_tag', 'post_format') AND tr.object_id IN (5) ORDER BY t.name ASC ",
-             "trace_id": 0,
-             "span_id": 116,
-             "parent_id": 99,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT post_id, meta_key, meta_value FROM wp55_postmeta WHERE post_id IN (5) ORDER BY meta_id ASC",
-             "trace_id": 0,
-             "span_id": 117,
-             "parent_id": 99,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 3.0
-             }
-           },
         {
           "name": "WP.handle_404",
           "service": "wordpress_59_test_app",
           "resource": "WP.handle_404",
           "trace_id": 0,
-          "span_id": 100,
-          "parent_id": 18,
+          "span_id": 94,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -1579,8 +1288,8 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.register_globals",
           "trace_id": 0,
-          "span_id": 101,
-          "parent_id": 18,
+          "span_id": 95,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -1591,8 +1300,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp (hook)",
           "trace_id": 0,
-          "span_id": 102,
-          "parent_id": 18,
+          "span_id": 96,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1604,7 +1313,7 @@
        "service": "wordpress_59_test_app",
        "resource": "load_template_loader",
        "trace_id": 0,
-       "span_id": 19,
+       "span_id": 13,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -1616,8 +1325,8 @@
           "service": "wordpress_59_test_app",
           "resource": "template_redirect (hook)",
           "trace_id": 0,
-          "span_id": 103,
-          "parent_id": 19,
+          "span_id": 97,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1629,8 +1338,8 @@
              "service": "wordpress_59_test_app",
              "resource": "_wp_admin_bar_init (callback)",
              "trace_id": 0,
-             "span_id": 118,
-             "parent_id": 103,
+             "span_id": 107,
+             "parent_id": 97,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1643,8 +1352,8 @@
              "service": "wordpress_59_test_app",
              "resource": "wp_old_slug_redirect (callback)",
              "trace_id": 0,
-             "span_id": 119,
-             "parent_id": 103,
+             "span_id": 108,
+             "parent_id": 97,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1657,8 +1366,8 @@
              "service": "wordpress_59_test_app",
              "resource": "redirect_canonical (callback)",
              "trace_id": 0,
-             "span_id": 120,
-             "parent_id": 103,
+             "span_id": 109,
+             "parent_id": 97,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1671,8 +1380,8 @@
              "service": "wordpress_59_test_app",
              "resource": "WP_Sitemaps::render_sitemaps (callback)",
              "trace_id": 0,
-             "span_id": 121,
-             "parent_id": 103,
+             "span_id": 110,
+             "parent_id": 97,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1685,8 +1394,8 @@
              "service": "wordpress_59_test_app",
              "resource": "rest_output_link_header (callback)",
              "trace_id": 0,
-             "span_id": 122,
-             "parent_id": 103,
+             "span_id": 111,
+             "parent_id": 97,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1699,8 +1408,8 @@
              "service": "wordpress_59_test_app",
              "resource": "wp_shortlink_header (callback)",
              "trace_id": 0,
-             "span_id": 123,
-             "parent_id": 103,
+             "span_id": 112,
+             "parent_id": 97,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1713,8 +1422,8 @@
              "service": "wordpress_59_test_app",
              "resource": "wp_redirect_admin_locations (callback)",
              "trace_id": 0,
-             "span_id": 124,
-             "parent_id": 103,
+             "span_id": 113,
+             "parent_id": 97,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1727,65 +1436,21 @@
           "service": "wordpress_59_test_app",
           "resource": "single (type)",
           "trace_id": 0,
-          "span_id": 104,
-          "parent_id": 19,
+          "span_id": 98,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
             "wordpress.template_type": "single"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT  t.*, tt.* FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id WHERE tt.taxonomy IN ('wp_theme') AND t.name IN ('twentytwenty')  ",
-             "trace_id": 0,
-             "span_id": 125,
-             "parent_id": 104,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT   wp55_posts.* FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_name IN ('single-post-simple_view','single-post','single') AND ( \n  0 = 1\n) AND wp55_posts.post_type = 'wp_template' AND ((wp55_posts.post_status = 'publish')) GROUP BY wp55_posts.ID ORDER BY wp55_posts.post_date DESC ",
-             "trace_id": 0,
-             "span_id": 126,
-             "parent_id": 104,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
         {
           "name": "template",
           "service": "wordpress_59_test_app",
           "resource": "singular (type)",
           "trace_id": 0,
-          "span_id": 105,
-          "parent_id": 19,
+          "span_id": 99,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1793,35 +1458,13 @@
             "wordpress.theme": "Twenty Twenty"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT   wp55_posts.* FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_name IN ('singular') AND ( \n  0 = 1\n) AND wp55_posts.post_type = 'wp_template' AND ((wp55_posts.post_status = 'publish')) GROUP BY wp55_posts.ID ORDER BY wp55_posts.post_date DESC ",
-             "trace_id": 0,
-             "span_id": 127,
-             "parent_id": 105,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
         {
           "name": "get_header",
           "service": "wordpress_59_test_app",
           "resource": "get_header",
           "trace_id": 0,
-          "span_id": 106,
-          "parent_id": 19,
+          "span_id": 100,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -1832,8 +1475,8 @@
              "service": "wordpress_59_test_app",
              "resource": "header (template)",
              "trace_id": 0,
-             "span_id": 128,
-             "parent_id": 106,
+             "span_id": 114,
+             "parent_id": 100,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1846,8 +1489,8 @@
                 "service": "wordpress_59_test_app",
                 "resource": "wp_head (hook)",
                 "trace_id": 0,
-                "span_id": 139,
-                "parent_id": 128,
+                "span_id": 120,
+                "parent_id": 114,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -1859,8 +1502,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "_wp_render_title_tag (callback)",
                    "trace_id": 0,
-                   "span_id": 153,
-                   "parent_id": 139,
+                   "span_id": 131,
+                   "parent_id": 120,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1873,8 +1516,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "wp_enqueue_scripts (callback)",
                    "trace_id": 0,
-                   "span_id": 154,
-                   "parent_id": 139,
+                   "span_id": 132,
+                   "parent_id": 120,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -1887,8 +1530,8 @@
                       "service": "wordpress_59_test_app",
                       "resource": "wp_enqueue_global_styles (callback)",
                       "trace_id": 0,
-                      "span_id": 195,
-                      "parent_id": 154,
+                      "span_id": 160,
+                      "parent_id": 132,
                       "type": "web",
                       "meta": {
                         "component": "wordpress",
@@ -1896,101 +1539,13 @@
                         "wordpress.hook": "wp_footer"
                       }
                     },
-                       {
-                         "name": "mysqli_query",
-                         "service": "mysqli",
-                         "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'medium_crop' LIMIT 1",
-                         "trace_id": 0,
-                         "span_id": 196,
-                         "parent_id": 195,
-                         "type": "sql",
-                         "meta": {
-                           "_dd.base_service": "wordpress_59_test_app",
-                           "component": "mysqli",
-                           "db.name": "test",
-                           "db.system": "mysql",
-                           "db.type": "mysql",
-                           "out.host": "mysql_integration",
-                           "out.port": "3306",
-                           "span.kind": "client"
-                         },
-                         "metrics": {
-                           "db.row_count": 0.0
-                         }
-                       },
-                       {
-                         "name": "mysqli_query",
-                         "service": "mysqli",
-                         "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'medium_large_crop' LIMIT 1",
-                         "trace_id": 0,
-                         "span_id": 197,
-                         "parent_id": 195,
-                         "type": "sql",
-                         "meta": {
-                           "_dd.base_service": "wordpress_59_test_app",
-                           "component": "mysqli",
-                           "db.name": "test",
-                           "db.system": "mysql",
-                           "db.type": "mysql",
-                           "out.host": "mysql_integration",
-                           "out.port": "3306",
-                           "span.kind": "client"
-                         },
-                         "metrics": {
-                           "db.row_count": 0.0
-                         }
-                       },
-                       {
-                         "name": "mysqli_query",
-                         "service": "mysqli",
-                         "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'large_crop' LIMIT 1",
-                         "trace_id": 0,
-                         "span_id": 198,
-                         "parent_id": 195,
-                         "type": "sql",
-                         "meta": {
-                           "_dd.base_service": "wordpress_59_test_app",
-                           "component": "mysqli",
-                           "db.name": "test",
-                           "db.system": "mysql",
-                           "db.type": "mysql",
-                           "out.host": "mysql_integration",
-                           "out.port": "3306",
-                           "span.kind": "client"
-                         },
-                         "metrics": {
-                           "db.row_count": 0.0
-                         }
-                       },
-                       {
-                         "name": "mysqli_query",
-                         "service": "mysqli",
-                         "resource": "SELECT   wp55_posts.ID FROM wp55_posts  WHERE 1=1  AND ( \n  0 = 1\n) AND wp55_posts.post_type = 'wp_global_styles' AND ((wp55_posts.post_status = 'publish')) GROUP BY wp55_posts.ID ORDER BY wp55_posts.post_date DESC LIMIT 0, 1",
-                         "trace_id": 0,
-                         "span_id": 199,
-                         "parent_id": 195,
-                         "type": "sql",
-                         "meta": {
-                           "_dd.base_service": "wordpress_59_test_app",
-                           "component": "mysqli",
-                           "db.name": "test",
-                           "db.system": "mysql",
-                           "db.type": "mysql",
-                           "out.host": "mysql_integration",
-                           "out.port": "3306",
-                           "span.kind": "client"
-                         },
-                         "metrics": {
-                           "db.row_count": 0.0
-                         }
-                       },
                  {
                    "name": "callback",
                    "service": "wordpress_59_test_app",
                    "resource": "wp_robots (callback)",
                    "trace_id": 0,
-                   "span_id": 155,
-                   "parent_id": 139,
+                   "span_id": 133,
+                   "parent_id": 120,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2003,8 +1558,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "wp_post_preview_js (callback)",
                    "trace_id": 0,
-                   "span_id": 156,
-                   "parent_id": 139,
+                   "span_id": 134,
+                   "parent_id": 120,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2017,8 +1572,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "wp_maybe_inline_styles (callback)",
                    "trace_id": 0,
-                   "span_id": 157,
-                   "parent_id": 139,
+                   "span_id": 135,
+                   "parent_id": 120,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2031,8 +1586,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "wp_resource_hints (callback)",
                    "trace_id": 0,
-                   "span_id": 158,
-                   "parent_id": 139,
+                   "span_id": 136,
+                   "parent_id": 120,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2045,8 +1600,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "feed_links (callback)",
                    "trace_id": 0,
-                   "span_id": 159,
-                   "parent_id": 139,
+                   "span_id": 137,
+                   "parent_id": 120,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2059,8 +1614,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "feed_links_extra (callback)",
                    "trace_id": 0,
-                   "span_id": 160,
-                   "parent_id": 139,
+                   "span_id": 138,
+                   "parent_id": 120,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2073,8 +1628,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "print_emoji_detection_script (callback)",
                    "trace_id": 0,
-                   "span_id": 161,
-                   "parent_id": 139,
+                   "span_id": 139,
+                   "parent_id": 120,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2087,8 +1642,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "wp_print_styles (callback)",
                    "trace_id": 0,
-                   "span_id": 162,
-                   "parent_id": 139,
+                   "span_id": 140,
+                   "parent_id": 120,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2101,8 +1656,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "wp_print_head_scripts",
                    "trace_id": 0,
-                   "span_id": 163,
-                   "parent_id": 139,
+                   "span_id": 141,
+                   "parent_id": 120,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2115,8 +1670,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "rest_output_link_wp_head (callback)",
                    "trace_id": 0,
-                   "span_id": 164,
-                   "parent_id": 139,
+                   "span_id": 142,
+                   "parent_id": 120,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2129,8 +1684,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "rsd_link (callback)",
                    "trace_id": 0,
-                   "span_id": 165,
-                   "parent_id": 139,
+                   "span_id": 143,
+                   "parent_id": 120,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2143,8 +1698,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "wlwmanifest_link (callback)",
                    "trace_id": 0,
-                   "span_id": 166,
-                   "parent_id": 139,
+                   "span_id": 144,
+                   "parent_id": 120,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2157,8 +1712,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "locale_stylesheet (callback)",
                    "trace_id": 0,
-                   "span_id": 167,
-                   "parent_id": 139,
+                   "span_id": 145,
+                   "parent_id": 120,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2171,8 +1726,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "wp_generator (callback)",
                    "trace_id": 0,
-                   "span_id": 168,
-                   "parent_id": 139,
+                   "span_id": 146,
+                   "parent_id": 120,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2185,8 +1740,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "rel_canonical (callback)",
                    "trace_id": 0,
-                   "span_id": 169,
-                   "parent_id": 139,
+                   "span_id": 147,
+                   "parent_id": 120,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2199,8 +1754,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "wp_shortlink_wp_head (callback)",
                    "trace_id": 0,
-                   "span_id": 170,
-                   "parent_id": 139,
+                   "span_id": 148,
+                   "parent_id": 120,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2213,8 +1768,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "_custom_logo_header_styles (callback)",
                    "trace_id": 0,
-                   "span_id": 171,
-                   "parent_id": 139,
+                   "span_id": 149,
+                   "parent_id": 120,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2227,8 +1782,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "wp_oembed_add_discovery_links (callback)",
                    "trace_id": 0,
-                   "span_id": 172,
-                   "parent_id": 139,
+                   "span_id": 150,
+                   "parent_id": 120,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2241,8 +1796,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "wp_oembed_add_host_js (callback)",
                    "trace_id": 0,
-                   "span_id": 173,
-                   "parent_id": 139,
+                   "span_id": 151,
+                   "parent_id": 120,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2255,8 +1810,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "twentytwenty_no_js_class (callback)",
                    "trace_id": 0,
-                   "span_id": 174,
-                   "parent_id": 139,
+                   "span_id": 152,
+                   "parent_id": 120,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2269,8 +1824,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "WP_Widget_Recent_Comments::recent_comments_style (callback)",
                    "trace_id": 0,
-                   "span_id": 175,
-                   "parent_id": 139,
+                   "span_id": 153,
+                   "parent_id": 120,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2283,8 +1838,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "_custom_background_cb (callback)",
                    "trace_id": 0,
-                   "span_id": 176,
-                   "parent_id": 139,
+                   "span_id": 154,
+                   "parent_id": 120,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2297,8 +1852,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "wp_site_icon (callback)",
                    "trace_id": 0,
-                   "span_id": 177,
-                   "parent_id": 139,
+                   "span_id": 155,
+                   "parent_id": 120,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2311,8 +1866,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "wp_custom_css_cb (callback)",
                    "trace_id": 0,
-                   "span_id": 178,
-                   "parent_id": 139,
+                   "span_id": 156,
+                   "parent_id": 120,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2325,108 +1880,20 @@
                 "service": "wordpress_59_test_app",
                 "resource": "body_class",
                 "trace_id": 0,
-                "span_id": 140,
-                "parent_id": 128,
+                "span_id": 121,
+                "parent_id": 114,
                 "type": "web",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'site_logo' LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 179,
-                   "parent_id": 140,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT p.ID FROM wp55_posts AS p  WHERE p.post_date > '2020-10-22 16:32:26' AND p.post_type = 'post'  AND p.post_status = 'publish' ORDER BY p.post_date ASC LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 180,
-                   "parent_id": 140,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT p.ID FROM wp55_posts AS p  WHERE p.post_date < '2020-10-22 16:32:26' AND p.post_type = 'post'  AND p.post_status = 'publish' ORDER BY p.post_date DESC LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 181,
-                   "parent_id": 140,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT * FROM wp55_posts WHERE ID = 1 LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 182,
-                   "parent_id": 140,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
               {
                 "name": "callback",
                 "service": "wordpress_59_test_app",
                 "resource": "wp_admin_bar_render (callback)",
                 "trace_id": 0,
-                "span_id": 141,
-                "parent_id": 128,
+                "span_id": 122,
+                "parent_id": 114,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -2434,91 +1901,25 @@
                   "wordpress.hook": "wp_footer"
                 }
               },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT * FROM wp55_posts  WHERE (post_type = 'page' AND post_status = 'publish')     ORDER BY menu_order,wp55_posts.post_title ASC",
-                "trace_id": 0,
-                "span_id": 142,
-                "parent_id": 128,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
         {
           "name": "the_post",
           "service": "wordpress_59_test_app",
           "resource": "the_post",
           "trace_id": 0,
-          "span_id": 107,
-          "parent_id": 19,
+          "span_id": 101,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT * FROM wp55_users WHERE ID = '1' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 129,
-             "parent_id": 107,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT user_id, meta_key, meta_value FROM wp55_usermeta WHERE user_id IN (1) ORDER BY umeta_id ASC",
-             "trace_id": 0,
-             "span_id": 130,
-             "parent_id": 107,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 18.0
-             }
-           },
         {
           "name": "load_template",
           "service": "wordpress_59_test_app",
           "resource": "content (template)",
           "trace_id": 0,
-          "span_id": 108,
-          "parent_id": 19,
+          "span_id": 102,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -2531,8 +1932,8 @@
              "service": "wordpress_59_test_app",
              "resource": "the_content",
              "trace_id": 0,
-             "span_id": 131,
-             "parent_id": 108,
+             "span_id": 115,
+             "parent_id": 102,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -2544,8 +1945,8 @@
                 "service": "wordpress_59_test_app",
                 "resource": "core/paragraph (block)",
                 "trace_id": 0,
-                "span_id": 143,
-                "parent_id": 131,
+                "span_id": 123,
+                "parent_id": 115,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -2557,42 +1958,20 @@
              "service": "wordpress_59_test_app",
              "resource": "comments_template",
              "trace_id": 0,
-             "span_id": 132,
-             "parent_id": 108,
+             "span_id": 116,
+             "parent_id": 102,
              "type": "web",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT SQL_CALC_FOUND_ROWS wp55_comments.comment_ID FROM wp55_comments  WHERE ( comment_approved = '1' ) AND comment_post_ID = 5 AND comment_parent = 0  ORDER BY wp55_comments.comment_date_gmt ASC, wp55_comments.comment_ID ASC ",
-                "trace_id": 0,
-                "span_id": 144,
-                "parent_id": 132,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              },
         {
           "name": "load_template",
           "service": "wordpress_59_test_app",
           "resource": "footer-menus-widgets (template)",
           "trace_id": 0,
-          "span_id": 109,
-          "parent_id": 19,
+          "span_id": 103,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -2605,8 +1984,8 @@
              "service": "wordpress_59_test_app",
              "resource": "sidebar-1",
              "trace_id": 0,
-             "span_id": 133,
-             "parent_id": 109,
+             "span_id": 117,
+             "parent_id": 103,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -2617,8 +1996,8 @@
                 "service": "wordpress_59_test_app",
                 "resource": "Search (widget)",
                 "trace_id": 0,
-                "span_id": 145,
-                "parent_id": 133,
+                "span_id": 124,
+                "parent_id": 117,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -2630,166 +2009,34 @@
                 "service": "wordpress_59_test_app",
                 "resource": "Recent Posts (widget)",
                 "trace_id": 0,
-                "span_id": 146,
-                "parent_id": 133,
+                "span_id": 125,
+                "parent_id": 117,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Recent Posts"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT   wp55_posts.ID FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_type = 'post' AND ((wp55_posts.post_status = 'publish'))  ORDER BY wp55_posts.post_date DESC LIMIT 0, 5",
-                   "trace_id": 0,
-                   "span_id": 183,
-                   "parent_id": 146,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 2.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  t.*, tt.*, tr.object_id FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id INNER JOIN wp55_term_relationships AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy IN ('category', 'post_tag', 'post_format') AND tr.object_id IN (1) ORDER BY t.name ASC ",
-                   "trace_id": 0,
-                   "span_id": 184,
-                   "parent_id": 146,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT post_id, meta_key, meta_value FROM wp55_postmeta WHERE post_id IN (1) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 185,
-                   "parent_id": 146,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
               {
                 "name": "widget",
                 "service": "wordpress_59_test_app",
                 "resource": "Recent Comments (widget)",
                 "trace_id": 0,
-                "span_id": 147,
-                "parent_id": 133,
+                "span_id": 126,
+                "parent_id": 117,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Recent Comments"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  wp55_comments.comment_ID FROM wp55_comments JOIN wp55_posts ON wp55_posts.ID = wp55_comments.comment_post_ID WHERE ( comment_approved = '1' ) AND  wp55_posts.post_status IN ('publish')  ORDER BY wp55_comments.comment_date_gmt DESC LIMIT 0,5",
-                   "trace_id": 0,
-                   "span_id": 186,
-                   "parent_id": 147,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT wp55_comments.* FROM wp55_comments WHERE comment_ID IN (1)",
-                   "trace_id": 0,
-                   "span_id": 187,
-                   "parent_id": 147,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT comment_id, meta_key, meta_value FROM wp55_commentmeta WHERE comment_id IN (1) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 188,
-                   "parent_id": 147,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
            {
              "name": "dynamic_sidebar",
              "service": "wordpress_59_test_app",
              "resource": "sidebar-2",
              "trace_id": 0,
-             "span_id": 134,
-             "parent_id": 109,
+             "span_id": 118,
+             "parent_id": 103,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -2800,100 +2047,34 @@
                 "service": "wordpress_59_test_app",
                 "resource": "Archives (widget)",
                 "trace_id": 0,
-                "span_id": 148,
-                "parent_id": 134,
+                "span_id": 127,
+                "parent_id": 118,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Archives"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT YEAR(post_date) AS `year`, MONTH(post_date) AS `month`, count(ID) as posts FROM wp55_posts  WHERE post_type = 'post' AND post_status = 'publish' GROUP BY YEAR(post_date), MONTH(post_date) ORDER BY post_date DESC ",
-                   "trace_id": 0,
-                   "span_id": 189,
-                   "parent_id": 148,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
               {
                 "name": "widget",
                 "service": "wordpress_59_test_app",
                 "resource": "Categories (widget)",
                 "trace_id": 0,
-                "span_id": 149,
-                "parent_id": 134,
+                "span_id": 128,
+                "parent_id": 118,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Categories"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  t.*, tt.* FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id WHERE tt.taxonomy IN ('category') AND tt.count > 0 ORDER BY t.name ASC ",
-                   "trace_id": 0,
-                   "span_id": 190,
-                   "parent_id": 149,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT term_id, meta_key, meta_value FROM wp55_termmeta WHERE term_id IN (1) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 191,
-                   "parent_id": 149,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
               {
                 "name": "widget",
                 "service": "wordpress_59_test_app",
                 "resource": "Meta (widget)",
                 "trace_id": 0,
-                "span_id": 150,
-                "parent_id": 134,
+                "span_id": 129,
+                "parent_id": 118,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -2905,8 +2086,8 @@
           "service": "wordpress_59_test_app",
           "resource": "get_footer",
           "trace_id": 0,
-          "span_id": 110,
-          "parent_id": 19,
+          "span_id": 104,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -2917,8 +2098,8 @@
              "service": "wordpress_59_test_app",
              "resource": "footer (template)",
              "trace_id": 0,
-             "span_id": 135,
-             "parent_id": 110,
+             "span_id": 119,
+             "parent_id": 104,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -2927,34 +2108,12 @@
              }
            },
               {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT * FROM wp55_posts WHERE ID = 3 LIMIT 1",
-                "trace_id": 0,
-                "span_id": 151,
-                "parent_id": 135,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
-              {
                 "name": "action",
                 "service": "wordpress_59_test_app",
                 "resource": "wp_footer (hook)",
                 "trace_id": 0,
-                "span_id": 152,
-                "parent_id": 135,
+                "span_id": 130,
+                "parent_id": 119,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -2966,8 +2125,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "the_block_template_skip_link (callback)",
                    "trace_id": 0,
-                   "span_id": 192,
-                   "parent_id": 152,
+                   "span_id": 157,
+                   "parent_id": 130,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -2980,8 +2139,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "Closure (callback)",
                    "trace_id": 0,
-                   "span_id": 193,
-                   "parent_id": 152,
+                   "span_id": 158,
+                   "parent_id": 130,
                    "type": "web",
                    "meta": {
                      "closure.declaration": "/home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/wp-includes/block-supports/duotone.php:464",
@@ -2995,8 +2154,8 @@
                    "service": "wordpress_59_test_app",
                    "resource": "wp_print_footer_scripts (callback)",
                    "trace_id": 0,
-                   "span_id": 194,
-                   "parent_id": 152,
+                   "span_id": 159,
+                   "parent_id": 130,
                    "type": "web",
                    "meta": {
                      "component": "wordpress",
@@ -3009,7 +2168,7 @@
        "service": "wordpress_59_test_app",
        "resource": "shutdown (hook)",
        "trace_id": 0,
-       "span_id": 20,
+       "span_id": 14,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -3022,8 +2181,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_ob_end_flush_all (callback)",
           "trace_id": 0,
-          "span_id": 111,
-          "parent_id": 20,
+          "span_id": 105,
+          "parent_id": 14,
           "type": "web",
           "meta": {
             "component": "wordpress",

--- a/tests/snapshots/tests.integrations.word_press.v5_9.common_scenarios_legacy_test.test_scenario_get_return_string.json
+++ b/tests/snapshots/tests.integrations.word_press.v5_9.common_scenarios_legacy_test.test_scenario_get_return_string.json
@@ -5,16 +5,17 @@
     "resource": "GET /simple",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 15360509330838616158,
+    "parent_id": 11710245789344707145,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e7002600000000",
       "component": "wordpress",
       "http.method": "GET",
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/simple?key=value&<redacted>",
-      "runtime-id": "37ac3b3a-349e-47b8-91b6-924b1abbbd25",
+      "runtime-id": "14bffb6f-c982-47fa-af57-3e92c0774391",
       "span.kind": "server"
     },
     "metrics": {
@@ -37,81 +38,6 @@
          "db.user": "test"
        }
      },
-        {
-          "name": "mysqli_real_connect",
-          "service": "mysqli",
-          "resource": "mysqli_real_connect",
-          "trace_id": 0,
-          "span_id": 16,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-          "trace_id": 0,
-          "span_id": 17,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT @@SESSION.sql_mode",
-          "trace_id": 0,
-          "span_id": 18,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 1.0
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-          "trace_id": 0,
-          "span_id": 19,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_59_test_app",
@@ -124,28 +50,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_name, option_value FROM wp55_options WHERE autoload = 'yes'",
-          "trace_id": 0,
-          "span_id": 20,
-          "parent_id": 3,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 111.0
-          }
-        },
      {
        "name": "create_initial_taxonomies",
        "service": "wordpress_59_test_app",
@@ -218,28 +122,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'WPLANG' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 9,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.init",
        "service": "wordpress_59_test_app",
@@ -293,100 +175,37 @@
           "service": "wordpress_59_test_app",
           "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
           "trace_id": 0,
-          "span_id": 22,
+          "span_id": 16,
           "parent_id": 13,
           "type": "sql",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 28,
-             "parent_id": 22,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
         {
           "name": "wpdb.query",
           "service": "wordpress_59_test_app",
           "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'widget_block' LIMIT 1",
           "trace_id": 0,
-          "span_id": 23,
+          "span_id": 17,
           "parent_id": 13,
           "type": "sql",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'widget_block' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 29,
-             "parent_id": 23,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
         {
           "name": "wpdb.query",
           "service": "wordpress_59_test_app",
           "resource": "INSERT INTO `wp55_options` (`option_name`, `option_value`, `autoload`) VALUES ('widget_block', 'a:1:{s:12:\\\"_multiwidget\\\";i:1;}', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)",
           "trace_id": 0,
-          "span_id": 24,
+          "span_id": 18,
           "parent_id": 13,
           "type": "sql",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "INSERT INTO `wp55_options` (`option_name`, `option_value`, `autoload`) VALUES ('widget_block', 'a:1:{s:12:\\\"_multiwidget\\\";i:1;}', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)",
-             "trace_id": 0,
-             "span_id": 30,
-             "parent_id": 24,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             }
-           },
      {
        "name": "wpdb.query",
        "service": "wordpress_59_test_app",
@@ -399,28 +218,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'theme_switched' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 14,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.main",
        "service": "wordpress_59_test_app",
@@ -438,7 +235,7 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 26,
+          "span_id": 19,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -450,7 +247,7 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 27,
+          "span_id": 20,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -462,32 +259,10 @@
              "service": "wordpress_59_test_app",
              "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('simple')\n\t\tAND post_type IN ('page','attachment')\n\t",
              "trace_id": 0,
-             "span_id": 31,
-             "parent_id": 27,
+             "span_id": 21,
+             "parent_id": 20,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
-           },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('simple')\n\t\tAND post_type IN ('page','attachment')\n\t",
-                "trace_id": 0,
-                "span_id": 32,
-                "parent_id": 31,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              }]]
+           }]]

--- a/tests/snapshots/tests.integrations.word_press.v5_9.common_scenarios_legacy_test.test_scenario_get_to_missing_route.json
+++ b/tests/snapshots/tests.integrations.word_press.v5_9.common_scenarios_legacy_test.test_scenario_get_to_missing_route.json
@@ -5,15 +5,16 @@
     "resource": "GET /does_not_exist",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 2082656520519468046,
+    "parent_id": 14355554945037285044,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e7004900000000",
       "component": "wordpress",
       "http.method": "GET",
       "http.status_code": "404",
       "http.url": "http://localhost:9999/does_not_exist?key=value&<redacted>",
-      "runtime-id": "744319d8-1655-48fa-90de-6f64743672f4",
+      "runtime-id": "14bffb6f-c982-47fa-af57-3e92c0774391",
       "span.kind": "server"
     },
     "metrics": {
@@ -36,81 +37,6 @@
          "db.user": "test"
        }
      },
-        {
-          "name": "mysqli_real_connect",
-          "service": "mysqli",
-          "resource": "mysqli_real_connect",
-          "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-          "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT @@SESSION.sql_mode",
-          "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 1.0
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-          "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_59_test_app",
@@ -123,28 +49,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_name, option_value FROM wp55_options WHERE autoload = 'yes'",
-          "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 3,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 111.0
-          }
-        },
      {
        "name": "create_initial_taxonomies",
        "service": "wordpress_59_test_app",
@@ -217,28 +121,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'WPLANG' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 28,
-          "parent_id": 9,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.init",
        "service": "wordpress_59_test_app",
@@ -292,100 +174,37 @@
           "service": "wordpress_59_test_app",
           "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
           "trace_id": 0,
-          "span_id": 29,
+          "span_id": 23,
           "parent_id": 13,
           "type": "sql",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 47,
-             "parent_id": 29,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
         {
           "name": "wpdb.query",
           "service": "wordpress_59_test_app",
           "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'widget_block' LIMIT 1",
           "trace_id": 0,
-          "span_id": 30,
+          "span_id": 24,
           "parent_id": 13,
           "type": "sql",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'widget_block' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 48,
-             "parent_id": 30,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
         {
           "name": "wpdb.query",
           "service": "wordpress_59_test_app",
           "resource": "INSERT INTO `wp55_options` (`option_name`, `option_value`, `autoload`) VALUES ('widget_block', 'a:1:{s:12:\\\"_multiwidget\\\";i:1;}', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)",
           "trace_id": 0,
-          "span_id": 31,
+          "span_id": 25,
           "parent_id": 13,
           "type": "sql",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "INSERT INTO `wp55_options` (`option_name`, `option_value`, `autoload`) VALUES ('widget_block', 'a:1:{s:12:\\\"_multiwidget\\\";i:1;}', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)",
-             "trace_id": 0,
-             "span_id": 49,
-             "parent_id": 31,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             }
-           },
      {
        "name": "wpdb.query",
        "service": "wordpress_59_test_app",
@@ -398,28 +217,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'theme_switched' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 32,
-          "parent_id": 14,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.main",
        "service": "wordpress_59_test_app",
@@ -437,7 +234,7 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 33,
+          "span_id": 26,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -449,7 +246,7 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 34,
+          "span_id": 27,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -461,41 +258,19 @@
              "service": "wordpress_59_test_app",
              "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('does_not_exist')\n\t\tAND post_type IN ('page','attachment')\n\t",
              "trace_id": 0,
-             "span_id": 50,
-             "parent_id": 34,
+             "span_id": 36,
+             "parent_id": 27,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('does_not_exist')\n\t\tAND post_type IN ('page','attachment')\n\t",
-                "trace_id": 0,
-                "span_id": 63,
-                "parent_id": 50,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              },
         {
           "name": "WP.send_headers",
           "service": "wordpress_59_test_app",
           "resource": "WP.send_headers",
           "trace_id": 0,
-          "span_id": 35,
+          "span_id": 28,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -507,7 +282,7 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.query_posts",
           "trace_id": 0,
-          "span_id": 36,
+          "span_id": 29,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -519,41 +294,19 @@
              "service": "wordpress_59_test_app",
              "resource": "SELECT   wp55_posts.* FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_name = 'does_not_exist' AND wp55_posts.post_type = 'post'  ORDER BY wp55_posts.post_date DESC ",
              "trace_id": 0,
-             "span_id": 51,
-             "parent_id": 36,
+             "span_id": 37,
+             "parent_id": 29,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT   wp55_posts.* FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_name = 'does_not_exist' AND wp55_posts.post_type = 'post'  ORDER BY wp55_posts.post_date DESC ",
-                "trace_id": 0,
-                "span_id": 64,
-                "parent_id": 51,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              },
         {
           "name": "WP.handle_404",
           "service": "wordpress_59_test_app",
           "resource": "WP.handle_404",
           "trace_id": 0,
-          "span_id": 37,
+          "span_id": 30,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -565,7 +318,7 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.register_globals",
           "trace_id": 0,
-          "span_id": 38,
+          "span_id": 31,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -584,28 +337,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT post_id FROM wp55_postmeta, wp55_posts WHERE ID = post_id AND post_type = 'post' AND meta_key = '_wp_old_slug' AND meta_value = 'does_not_exist'",
-          "trace_id": 0,
-          "span_id": 39,
-          "parent_id": 16,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_59_test_app",
@@ -618,28 +349,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT ID FROM wp55_posts WHERE post_name LIKE 'does\\\\_not\\\\_exist%' AND post_type IN ('post', 'page', 'attachment') AND post_status = 'publish'",
-          "trace_id": 0,
-          "span_id": 40,
-          "parent_id": 17,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_59_test_app",
@@ -652,28 +361,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT  t.*, tt.* FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id WHERE tt.taxonomy IN ('wp_theme') AND t.name IN ('twentytwenty')  ",
-          "trace_id": 0,
-          "span_id": 41,
-          "parent_id": 18,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_59_test_app",
@@ -686,28 +373,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT   wp55_posts.* FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_name IN ('404') AND ( \n  0 = 1\n) AND wp55_posts.post_type = 'wp_template' AND ((wp55_posts.post_status = 'publish')) GROUP BY wp55_posts.ID ORDER BY wp55_posts.post_date DESC ",
-          "trace_id": 0,
-          "span_id": 42,
-          "parent_id": 19,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "get_header",
        "service": "wordpress_59_test_app",
@@ -725,7 +390,7 @@
           "service": "wordpress_59_test_app",
           "resource": "/home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/wp-content/themes/twentytwenty/header.php",
           "trace_id": 0,
-          "span_id": 43,
+          "span_id": 32,
           "parent_id": 20,
           "type": "web",
           "meta": {
@@ -737,8 +402,8 @@
              "service": "wordpress_59_test_app",
              "resource": "wp_head",
              "trace_id": 0,
-             "span_id": 52,
-             "parent_id": 43,
+             "span_id": 38,
+             "parent_id": 32,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -749,144 +414,56 @@
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'medium_crop' LIMIT 1",
                 "trace_id": 0,
-                "span_id": 65,
-                "parent_id": 52,
+                "span_id": 49,
+                "parent_id": 38,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'medium_crop' LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 83,
-                   "parent_id": 65,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'medium_large_crop' LIMIT 1",
                 "trace_id": 0,
-                "span_id": 66,
-                "parent_id": 52,
+                "span_id": 50,
+                "parent_id": 38,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'medium_large_crop' LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 84,
-                   "parent_id": 66,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'large_crop' LIMIT 1",
                 "trace_id": 0,
-                "span_id": 67,
-                "parent_id": 52,
+                "span_id": 51,
+                "parent_id": 38,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'large_crop' LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 85,
-                   "parent_id": 67,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT   wp55_posts.ID FROM wp55_posts  WHERE 1=1  AND ( \n  0 = 1\n) AND wp55_posts.post_type = 'wp_global_styles' AND ((wp55_posts.post_status = 'publish')) GROUP BY wp55_posts.ID ORDER BY wp55_posts.post_date DESC LIMIT 0, 1",
                 "trace_id": 0,
-                "span_id": 68,
-                "parent_id": 52,
+                "span_id": 52,
+                "parent_id": 38,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT   wp55_posts.ID FROM wp55_posts  WHERE 1=1  AND ( \n  0 = 1\n) AND wp55_posts.post_type = 'wp_global_styles' AND ((wp55_posts.post_status = 'publish')) GROUP BY wp55_posts.ID ORDER BY wp55_posts.post_date DESC LIMIT 0, 1",
-                   "trace_id": 0,
-                   "span_id": 86,
-                   "parent_id": 68,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
               {
                 "name": "wp_print_head_scripts",
                 "service": "wordpress_59_test_app",
                 "resource": "wp_print_head_scripts",
                 "trace_id": 0,
-                "span_id": 69,
-                "parent_id": 52,
+                "span_id": 53,
+                "parent_id": 38,
                 "type": "web",
                 "meta": {
                   "component": "wordpress"
@@ -897,8 +474,8 @@
              "service": "wordpress_59_test_app",
              "resource": "body_class",
              "trace_id": 0,
-             "span_id": 53,
-             "parent_id": 43,
+             "span_id": 39,
+             "parent_id": 32,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -909,69 +486,25 @@
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'site_logo' LIMIT 1",
                 "trace_id": 0,
-                "span_id": 70,
-                "parent_id": 53,
+                "span_id": 54,
+                "parent_id": 39,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'site_logo' LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 87,
-                   "parent_id": 70,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
            {
              "name": "wpdb.query",
              "service": "wordpress_59_test_app",
              "resource": "SELECT * FROM wp55_posts  WHERE (post_type = 'page' AND post_status = 'publish')     ORDER BY menu_order,wp55_posts.post_title ASC",
              "trace_id": 0,
-             "span_id": 54,
-             "parent_id": 43,
+             "span_id": 40,
+             "parent_id": 32,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT * FROM wp55_posts  WHERE (post_type = 'page' AND post_status = 'publish')     ORDER BY menu_order,wp55_posts.post_title ASC",
-                "trace_id": 0,
-                "span_id": 71,
-                "parent_id": 54,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
      {
        "name": "load_template",
        "service": "wordpress_59_test_app",
@@ -989,7 +522,7 @@
           "service": "wordpress_59_test_app",
           "resource": "sidebar-1",
           "trace_id": 0,
-          "span_id": 44,
+          "span_id": 33,
           "parent_id": 21,
           "type": "web",
           "meta": {
@@ -1001,8 +534,8 @@
              "service": "wordpress_59_test_app",
              "resource": "WP_Widget.display_callback",
              "trace_id": 0,
-             "span_id": 55,
-             "parent_id": 44,
+             "span_id": 41,
+             "parent_id": 33,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -1013,8 +546,8 @@
              "service": "wordpress_59_test_app",
              "resource": "WP_Widget.display_callback",
              "trace_id": 0,
-             "span_id": 56,
-             "parent_id": 44,
+             "span_id": 42,
+             "parent_id": 33,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -1025,144 +558,56 @@
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT   wp55_posts.ID FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_type = 'post' AND ((wp55_posts.post_status = 'publish'))  ORDER BY wp55_posts.post_date DESC LIMIT 0, 5",
                 "trace_id": 0,
-                "span_id": 72,
-                "parent_id": 56,
+                "span_id": 55,
+                "parent_id": 42,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT   wp55_posts.ID FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_type = 'post' AND ((wp55_posts.post_status = 'publish'))  ORDER BY wp55_posts.post_date DESC LIMIT 0, 5",
-                   "trace_id": 0,
-                   "span_id": 88,
-                   "parent_id": 72,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 2.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT wp55_posts.* FROM wp55_posts WHERE ID IN (5,1)",
                 "trace_id": 0,
-                "span_id": 73,
-                "parent_id": 56,
+                "span_id": 56,
+                "parent_id": 42,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT wp55_posts.* FROM wp55_posts WHERE ID IN (5,1)",
-                   "trace_id": 0,
-                   "span_id": 89,
-                   "parent_id": 73,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 2.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT  t.*, tt.*, tr.object_id FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id INNER JOIN wp55_term_relationships AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy IN ('category', 'post_tag', 'post_format') AND tr.object_id IN (1, 5) ORDER BY t.name ASC ",
                 "trace_id": 0,
-                "span_id": 74,
-                "parent_id": 56,
+                "span_id": 57,
+                "parent_id": 42,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  t.*, tt.*, tr.object_id FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id INNER JOIN wp55_term_relationships AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy IN ('category', 'post_tag', 'post_format') AND tr.object_id IN (1, 5) ORDER BY t.name ASC ",
-                   "trace_id": 0,
-                   "span_id": 90,
-                   "parent_id": 74,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 2.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT post_id, meta_key, meta_value FROM wp55_postmeta WHERE post_id IN (1,5) ORDER BY meta_id ASC",
                 "trace_id": 0,
-                "span_id": 75,
-                "parent_id": 56,
+                "span_id": 58,
+                "parent_id": 42,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT post_id, meta_key, meta_value FROM wp55_postmeta WHERE post_id IN (1,5) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 91,
-                   "parent_id": 75,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 3.0
-                   }
-                 },
            {
              "name": "WP_Widget.display_callback",
              "service": "wordpress_59_test_app",
              "resource": "WP_Widget.display_callback",
              "trace_id": 0,
-             "span_id": 57,
-             "parent_id": 44,
+             "span_id": 43,
+             "parent_id": 33,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -1173,109 +618,43 @@
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT  wp55_comments.comment_ID FROM wp55_comments JOIN wp55_posts ON wp55_posts.ID = wp55_comments.comment_post_ID WHERE ( comment_approved = '1' ) AND  wp55_posts.post_status IN ('publish')  ORDER BY wp55_comments.comment_date_gmt DESC LIMIT 0,5",
                 "trace_id": 0,
-                "span_id": 76,
-                "parent_id": 57,
+                "span_id": 59,
+                "parent_id": 43,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  wp55_comments.comment_ID FROM wp55_comments JOIN wp55_posts ON wp55_posts.ID = wp55_comments.comment_post_ID WHERE ( comment_approved = '1' ) AND  wp55_posts.post_status IN ('publish')  ORDER BY wp55_comments.comment_date_gmt DESC LIMIT 0,5",
-                   "trace_id": 0,
-                   "span_id": 92,
-                   "parent_id": 76,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT wp55_comments.* FROM wp55_comments WHERE comment_ID IN (1)",
                 "trace_id": 0,
-                "span_id": 77,
-                "parent_id": 57,
+                "span_id": 60,
+                "parent_id": 43,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT wp55_comments.* FROM wp55_comments WHERE comment_ID IN (1)",
-                   "trace_id": 0,
-                   "span_id": 93,
-                   "parent_id": 77,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT comment_id, meta_key, meta_value FROM wp55_commentmeta WHERE comment_id IN (1) ORDER BY meta_id ASC",
                 "trace_id": 0,
-                "span_id": 78,
-                "parent_id": 57,
+                "span_id": 61,
+                "parent_id": 43,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT comment_id, meta_key, meta_value FROM wp55_commentmeta WHERE comment_id IN (1) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 94,
-                   "parent_id": 78,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
         {
           "name": "dynamic_sidebar",
           "service": "wordpress_59_test_app",
           "resource": "sidebar-2",
           "trace_id": 0,
-          "span_id": 45,
+          "span_id": 34,
           "parent_id": 21,
           "type": "web",
           "meta": {
@@ -1287,8 +666,8 @@
              "service": "wordpress_59_test_app",
              "resource": "WP_Widget.display_callback",
              "trace_id": 0,
-             "span_id": 58,
-             "parent_id": 45,
+             "span_id": 44,
+             "parent_id": 34,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -1299,42 +678,20 @@
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT YEAR(post_date) AS `year`, MONTH(post_date) AS `month`, count(ID) as posts FROM wp55_posts  WHERE post_type = 'post' AND post_status = 'publish' GROUP BY YEAR(post_date), MONTH(post_date) ORDER BY post_date DESC ",
                 "trace_id": 0,
-                "span_id": 79,
-                "parent_id": 58,
+                "span_id": 62,
+                "parent_id": 44,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT YEAR(post_date) AS `year`, MONTH(post_date) AS `month`, count(ID) as posts FROM wp55_posts  WHERE post_type = 'post' AND post_status = 'publish' GROUP BY YEAR(post_date), MONTH(post_date) ORDER BY post_date DESC ",
-                   "trace_id": 0,
-                   "span_id": 95,
-                   "parent_id": 79,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
            {
              "name": "WP_Widget.display_callback",
              "service": "wordpress_59_test_app",
              "resource": "WP_Widget.display_callback",
              "trace_id": 0,
-             "span_id": 59,
-             "parent_id": 45,
+             "span_id": 45,
+             "parent_id": 34,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -1345,76 +702,32 @@
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT  t.*, tt.* FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id WHERE tt.taxonomy IN ('category') AND tt.count > 0 ORDER BY t.name ASC ",
                 "trace_id": 0,
-                "span_id": 80,
-                "parent_id": 59,
+                "span_id": 63,
+                "parent_id": 45,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  t.*, tt.* FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id WHERE tt.taxonomy IN ('category') AND tt.count > 0 ORDER BY t.name ASC ",
-                   "trace_id": 0,
-                   "span_id": 96,
-                   "parent_id": 80,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT term_id, meta_key, meta_value FROM wp55_termmeta WHERE term_id IN (1) ORDER BY meta_id ASC",
                 "trace_id": 0,
-                "span_id": 81,
-                "parent_id": 59,
+                "span_id": 64,
+                "parent_id": 45,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT term_id, meta_key, meta_value FROM wp55_termmeta WHERE term_id IN (1) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 97,
-                   "parent_id": 81,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
            {
              "name": "WP_Widget.display_callback",
              "service": "wordpress_59_test_app",
              "resource": "WP_Widget.display_callback",
              "trace_id": 0,
-             "span_id": 60,
-             "parent_id": 45,
+             "span_id": 46,
+             "parent_id": 34,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -1437,7 +750,7 @@
           "service": "wordpress_59_test_app",
           "resource": "/home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/wp-content/themes/twentytwenty/footer.php",
           "trace_id": 0,
-          "span_id": 46,
+          "span_id": 35,
           "parent_id": 22,
           "type": "web",
           "meta": {
@@ -1449,42 +762,20 @@
              "service": "wordpress_59_test_app",
              "resource": "SELECT * FROM wp55_posts WHERE ID = 3 LIMIT 1",
              "trace_id": 0,
-             "span_id": 61,
-             "parent_id": 46,
+             "span_id": 47,
+             "parent_id": 35,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT * FROM wp55_posts WHERE ID = 3 LIMIT 1",
-                "trace_id": 0,
-                "span_id": 82,
-                "parent_id": 61,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
            {
              "name": "wp_print_footer_scripts",
              "service": "wordpress_59_test_app",
              "resource": "wp_print_footer_scripts",
              "trace_id": 0,
-             "span_id": 62,
-             "parent_id": 46,
+             "span_id": 48,
+             "parent_id": 35,
              "type": "web",
              "meta": {
                "component": "wordpress"

--- a/tests/snapshots/tests.integrations.word_press.v5_9.common_scenarios_legacy_test.test_scenario_get_with_exception.json
+++ b/tests/snapshots/tests.integrations.word_press.v5_9.common_scenarios_legacy_test.test_scenario_get_with_exception.json
@@ -5,11 +5,12 @@
     "resource": "GET /error",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 13239102393275368025,
+    "parent_id": 16169029165905344015,
     "type": "web",
     "error": 1,
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e7003700000000",
       "component": "wordpress",
       "error.message": "Uncaught Exception: Oops! in /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/wp-content/plugins/datadog/datadog.php:23",
       "error.stack": "#0 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/wp-includes/class-wp-hook.php(307): datadog_parse_request()\n#1 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/wp-includes/class-wp-hook.php(331): WP_Hook->apply_filters()\n#2 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/wp-includes/plugin.php(522): WP_Hook->do_action()\n#3 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/wp-includes/class-wp.php(396): do_action_ref_array()\n#4 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/wp-includes/class-wp.php(758): WP->parse_request()\n#5 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/wp-includes/functions.php(1310): WP->main()\n#6 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/wp-blog-header.php(16): wp()\n#7 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/index.php(17): require()\n#8 {main}",
@@ -18,7 +19,7 @@
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/error?key=value&<redacted>",
-      "runtime-id": "37ac3b3a-349e-47b8-91b6-924b1abbbd25",
+      "runtime-id": "14bffb6f-c982-47fa-af57-3e92c0774391",
       "span.kind": "server"
     },
     "metrics": {
@@ -41,81 +42,6 @@
          "db.user": "test"
        }
      },
-        {
-          "name": "mysqli_real_connect",
-          "service": "mysqli",
-          "resource": "mysqli_real_connect",
-          "trace_id": 0,
-          "span_id": 16,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-          "trace_id": 0,
-          "span_id": 17,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT @@SESSION.sql_mode",
-          "trace_id": 0,
-          "span_id": 18,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 1.0
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-          "trace_id": 0,
-          "span_id": 19,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_59_test_app",
@@ -128,28 +54,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_name, option_value FROM wp55_options WHERE autoload = 'yes'",
-          "trace_id": 0,
-          "span_id": 20,
-          "parent_id": 3,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 111.0
-          }
-        },
      {
        "name": "create_initial_taxonomies",
        "service": "wordpress_59_test_app",
@@ -222,28 +126,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'WPLANG' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 9,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.init",
        "service": "wordpress_59_test_app",
@@ -297,100 +179,37 @@
           "service": "wordpress_59_test_app",
           "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
           "trace_id": 0,
-          "span_id": 22,
+          "span_id": 16,
           "parent_id": 13,
           "type": "sql",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 28,
-             "parent_id": 22,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
         {
           "name": "wpdb.query",
           "service": "wordpress_59_test_app",
           "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'widget_block' LIMIT 1",
           "trace_id": 0,
-          "span_id": 23,
+          "span_id": 17,
           "parent_id": 13,
           "type": "sql",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'widget_block' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 29,
-             "parent_id": 23,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
         {
           "name": "wpdb.query",
           "service": "wordpress_59_test_app",
           "resource": "INSERT INTO `wp55_options` (`option_name`, `option_value`, `autoload`) VALUES ('widget_block', 'a:1:{s:12:\\\"_multiwidget\\\";i:1;}', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)",
           "trace_id": 0,
-          "span_id": 24,
+          "span_id": 18,
           "parent_id": 13,
           "type": "sql",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "INSERT INTO `wp55_options` (`option_name`, `option_value`, `autoload`) VALUES ('widget_block', 'a:1:{s:12:\\\"_multiwidget\\\";i:1;}', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)",
-             "trace_id": 0,
-             "span_id": 30,
-             "parent_id": 24,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             }
-           },
      {
        "name": "wpdb.query",
        "service": "wordpress_59_test_app",
@@ -403,28 +222,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'theme_switched' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 14,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.main",
        "service": "wordpress_59_test_app",
@@ -446,7 +243,7 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 26,
+          "span_id": 19,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -458,7 +255,7 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 27,
+          "span_id": 20,
           "parent_id": 15,
           "type": "web",
           "error": 1,
@@ -474,32 +271,10 @@
              "service": "wordpress_59_test_app",
              "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('error')\n\t\tAND post_type IN ('page','attachment')\n\t",
              "trace_id": 0,
-             "span_id": 31,
-             "parent_id": 27,
+             "span_id": 21,
+             "parent_id": 20,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
-           },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('error')\n\t\tAND post_type IN ('page','attachment')\n\t",
-                "trace_id": 0,
-                "span_id": 32,
-                "parent_id": 31,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              }]]
+           }]]

--- a/tests/snapshots/tests.integrations.word_press.v5_9.common_scenarios_legacy_test.test_scenario_get_with_view.json
+++ b/tests/snapshots/tests.integrations.word_press.v5_9.common_scenarios_legacy_test.test_scenario_get_with_view.json
@@ -5,16 +5,17 @@
     "resource": "GET /simple_view",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 5760996200555978682,
+    "parent_id": 4387670627450098101,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e7003100000000",
       "component": "wordpress",
       "http.method": "GET",
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/simple_view?key=value&<redacted>",
-      "runtime-id": "37ac3b3a-349e-47b8-91b6-924b1abbbd25",
+      "runtime-id": "14bffb6f-c982-47fa-af57-3e92c0774391",
       "span.kind": "server"
     },
     "metrics": {
@@ -37,81 +38,6 @@
          "db.user": "test"
        }
      },
-        {
-          "name": "mysqli_real_connect",
-          "service": "mysqli",
-          "resource": "mysqli_real_connect",
-          "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-          "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT @@SESSION.sql_mode",
-          "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 1.0
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-          "trace_id": 0,
-          "span_id": 28,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_59_test_app",
@@ -124,28 +50,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_name, option_value FROM wp55_options WHERE autoload = 'yes'",
-          "trace_id": 0,
-          "span_id": 29,
-          "parent_id": 3,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 111.0
-          }
-        },
      {
        "name": "create_initial_taxonomies",
        "service": "wordpress_59_test_app",
@@ -218,28 +122,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'WPLANG' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 30,
-          "parent_id": 9,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.init",
        "service": "wordpress_59_test_app",
@@ -293,100 +175,37 @@
           "service": "wordpress_59_test_app",
           "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
           "trace_id": 0,
-          "span_id": 31,
+          "span_id": 25,
           "parent_id": 13,
           "type": "sql",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 51,
-             "parent_id": 31,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
         {
           "name": "wpdb.query",
           "service": "wordpress_59_test_app",
           "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'widget_block' LIMIT 1",
           "trace_id": 0,
-          "span_id": 32,
+          "span_id": 26,
           "parent_id": 13,
           "type": "sql",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'widget_block' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 52,
-             "parent_id": 32,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
         {
           "name": "wpdb.query",
           "service": "wordpress_59_test_app",
           "resource": "INSERT INTO `wp55_options` (`option_name`, `option_value`, `autoload`) VALUES ('widget_block', 'a:1:{s:12:\\\"_multiwidget\\\";i:1;}', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)",
           "trace_id": 0,
-          "span_id": 33,
+          "span_id": 27,
           "parent_id": 13,
           "type": "sql",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "INSERT INTO `wp55_options` (`option_name`, `option_value`, `autoload`) VALUES ('widget_block', 'a:1:{s:12:\\\"_multiwidget\\\";i:1;}', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)",
-             "trace_id": 0,
-             "span_id": 53,
-             "parent_id": 33,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             }
-           },
      {
        "name": "wpdb.query",
        "service": "wordpress_59_test_app",
@@ -399,28 +218,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'theme_switched' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 34,
-          "parent_id": 14,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.main",
        "service": "wordpress_59_test_app",
@@ -438,7 +235,7 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 35,
+          "span_id": 28,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -450,7 +247,7 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 36,
+          "span_id": 29,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -462,41 +259,19 @@
              "service": "wordpress_59_test_app",
              "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('simple_view')\n\t\tAND post_type IN ('page','attachment')\n\t",
              "trace_id": 0,
-             "span_id": 54,
-             "parent_id": 36,
+             "span_id": 39,
+             "parent_id": 29,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('simple_view')\n\t\tAND post_type IN ('page','attachment')\n\t",
-                "trace_id": 0,
-                "span_id": 70,
-                "parent_id": 54,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              },
         {
           "name": "WP.send_headers",
           "service": "wordpress_59_test_app",
           "resource": "WP.send_headers",
           "trace_id": 0,
-          "span_id": 37,
+          "span_id": 30,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -508,7 +283,7 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.query_posts",
           "trace_id": 0,
-          "span_id": 38,
+          "span_id": 31,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -520,109 +295,43 @@
              "service": "wordpress_59_test_app",
              "resource": "SELECT   wp55_posts.* FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_name = 'simple_view' AND wp55_posts.post_type = 'post'  ORDER BY wp55_posts.post_date DESC ",
              "trace_id": 0,
-             "span_id": 55,
-             "parent_id": 38,
+             "span_id": 40,
+             "parent_id": 31,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT   wp55_posts.* FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_name = 'simple_view' AND wp55_posts.post_type = 'post'  ORDER BY wp55_posts.post_date DESC ",
-                "trace_id": 0,
-                "span_id": 71,
-                "parent_id": 55,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
            {
              "name": "wpdb.query",
              "service": "wordpress_59_test_app",
              "resource": "SELECT  t.*, tt.*, tr.object_id FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id INNER JOIN wp55_term_relationships AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy IN ('category', 'post_tag', 'post_format') AND tr.object_id IN (5) ORDER BY t.name ASC ",
              "trace_id": 0,
-             "span_id": 56,
-             "parent_id": 38,
+             "span_id": 41,
+             "parent_id": 31,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT  t.*, tt.*, tr.object_id FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id INNER JOIN wp55_term_relationships AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy IN ('category', 'post_tag', 'post_format') AND tr.object_id IN (5) ORDER BY t.name ASC ",
-                "trace_id": 0,
-                "span_id": 72,
-                "parent_id": 56,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
            {
              "name": "wpdb.query",
              "service": "wordpress_59_test_app",
              "resource": "SELECT post_id, meta_key, meta_value FROM wp55_postmeta WHERE post_id IN (5) ORDER BY meta_id ASC",
              "trace_id": 0,
-             "span_id": 57,
-             "parent_id": 38,
+             "span_id": 42,
+             "parent_id": 31,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT post_id, meta_key, meta_value FROM wp55_postmeta WHERE post_id IN (5) ORDER BY meta_id ASC",
-                "trace_id": 0,
-                "span_id": 73,
-                "parent_id": 57,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 3.0
-                }
-              },
         {
           "name": "WP.handle_404",
           "service": "wordpress_59_test_app",
           "resource": "WP.handle_404",
           "trace_id": 0,
-          "span_id": 39,
+          "span_id": 32,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -634,7 +343,7 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.register_globals",
           "trace_id": 0,
-          "span_id": 40,
+          "span_id": 33,
           "parent_id": 15,
           "type": "web",
           "meta": {
@@ -653,28 +362,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT  t.*, tt.* FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id WHERE tt.taxonomy IN ('wp_theme') AND t.name IN ('twentytwenty')  ",
-          "trace_id": 0,
-          "span_id": 41,
-          "parent_id": 16,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_59_test_app",
@@ -687,28 +374,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT   wp55_posts.* FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_name IN ('single-post-simple_view','single-post','single') AND ( \n  0 = 1\n) AND wp55_posts.post_type = 'wp_template' AND ((wp55_posts.post_status = 'publish')) GROUP BY wp55_posts.ID ORDER BY wp55_posts.post_date DESC ",
-          "trace_id": 0,
-          "span_id": 42,
-          "parent_id": 17,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_59_test_app",
@@ -721,28 +386,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT   wp55_posts.* FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_name IN ('singular') AND ( \n  0 = 1\n) AND wp55_posts.post_type = 'wp_template' AND ((wp55_posts.post_status = 'publish')) GROUP BY wp55_posts.ID ORDER BY wp55_posts.post_date DESC ",
-          "trace_id": 0,
-          "span_id": 43,
-          "parent_id": 18,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "get_header",
        "service": "wordpress_59_test_app",
@@ -760,7 +403,7 @@
           "service": "wordpress_59_test_app",
           "resource": "/home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/wp-content/themes/twentytwenty/header.php",
           "trace_id": 0,
-          "span_id": 44,
+          "span_id": 34,
           "parent_id": 19,
           "type": "web",
           "meta": {
@@ -772,8 +415,8 @@
              "service": "wordpress_59_test_app",
              "resource": "wp_head",
              "trace_id": 0,
-             "span_id": 58,
-             "parent_id": 44,
+             "span_id": 43,
+             "parent_id": 34,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -784,144 +427,56 @@
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'medium_crop' LIMIT 1",
                 "trace_id": 0,
-                "span_id": 74,
-                "parent_id": 58,
+                "span_id": 55,
+                "parent_id": 43,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'medium_crop' LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 95,
-                   "parent_id": 74,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'medium_large_crop' LIMIT 1",
                 "trace_id": 0,
-                "span_id": 75,
-                "parent_id": 58,
+                "span_id": 56,
+                "parent_id": 43,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'medium_large_crop' LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 96,
-                   "parent_id": 75,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'large_crop' LIMIT 1",
                 "trace_id": 0,
-                "span_id": 76,
-                "parent_id": 58,
+                "span_id": 57,
+                "parent_id": 43,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'large_crop' LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 97,
-                   "parent_id": 76,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT   wp55_posts.ID FROM wp55_posts  WHERE 1=1  AND ( \n  0 = 1\n) AND wp55_posts.post_type = 'wp_global_styles' AND ((wp55_posts.post_status = 'publish')) GROUP BY wp55_posts.ID ORDER BY wp55_posts.post_date DESC LIMIT 0, 1",
                 "trace_id": 0,
-                "span_id": 77,
-                "parent_id": 58,
+                "span_id": 58,
+                "parent_id": 43,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT   wp55_posts.ID FROM wp55_posts  WHERE 1=1  AND ( \n  0 = 1\n) AND wp55_posts.post_type = 'wp_global_styles' AND ((wp55_posts.post_status = 'publish')) GROUP BY wp55_posts.ID ORDER BY wp55_posts.post_date DESC LIMIT 0, 1",
-                   "trace_id": 0,
-                   "span_id": 98,
-                   "parent_id": 77,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
               {
                 "name": "wp_print_head_scripts",
                 "service": "wordpress_59_test_app",
                 "resource": "wp_print_head_scripts",
                 "trace_id": 0,
-                "span_id": 78,
-                "parent_id": 58,
+                "span_id": 59,
+                "parent_id": 43,
                 "type": "web",
                 "meta": {
                   "component": "wordpress"
@@ -932,8 +487,8 @@
              "service": "wordpress_59_test_app",
              "resource": "body_class",
              "trace_id": 0,
-             "span_id": 59,
-             "parent_id": 44,
+             "span_id": 44,
+             "parent_id": 34,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -944,171 +499,61 @@
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'site_logo' LIMIT 1",
                 "trace_id": 0,
-                "span_id": 79,
-                "parent_id": 59,
+                "span_id": 60,
+                "parent_id": 44,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'site_logo' LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 99,
-                   "parent_id": 79,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT p.ID FROM wp55_posts AS p  WHERE p.post_date > '2020-10-22 16:32:26' AND p.post_type = 'post'  AND p.post_status = 'publish' ORDER BY p.post_date ASC LIMIT 1",
                 "trace_id": 0,
-                "span_id": 80,
-                "parent_id": 59,
+                "span_id": 61,
+                "parent_id": 44,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT p.ID FROM wp55_posts AS p  WHERE p.post_date > '2020-10-22 16:32:26' AND p.post_type = 'post'  AND p.post_status = 'publish' ORDER BY p.post_date ASC LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 100,
-                   "parent_id": 80,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT p.ID FROM wp55_posts AS p  WHERE p.post_date < '2020-10-22 16:32:26' AND p.post_type = 'post'  AND p.post_status = 'publish' ORDER BY p.post_date DESC LIMIT 1",
                 "trace_id": 0,
-                "span_id": 81,
-                "parent_id": 59,
+                "span_id": 62,
+                "parent_id": 44,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT p.ID FROM wp55_posts AS p  WHERE p.post_date < '2020-10-22 16:32:26' AND p.post_type = 'post'  AND p.post_status = 'publish' ORDER BY p.post_date DESC LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 101,
-                   "parent_id": 81,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT * FROM wp55_posts WHERE ID = 1 LIMIT 1",
                 "trace_id": 0,
-                "span_id": 82,
-                "parent_id": 59,
+                "span_id": 63,
+                "parent_id": 44,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT * FROM wp55_posts WHERE ID = 1 LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 102,
-                   "parent_id": 82,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
            {
              "name": "wpdb.query",
              "service": "wordpress_59_test_app",
              "resource": "SELECT * FROM wp55_posts  WHERE (post_type = 'page' AND post_status = 'publish')     ORDER BY menu_order,wp55_posts.post_title ASC",
              "trace_id": 0,
-             "span_id": 60,
-             "parent_id": 44,
+             "span_id": 45,
+             "parent_id": 34,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT * FROM wp55_posts  WHERE (post_type = 'page' AND post_status = 'publish')     ORDER BY menu_order,wp55_posts.post_title ASC",
-                "trace_id": 0,
-                "span_id": 83,
-                "parent_id": 60,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
      {
        "name": "wpdb.query",
        "service": "wordpress_59_test_app",
@@ -1121,28 +566,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT * FROM wp55_users WHERE ID = '1' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 45,
-          "parent_id": 20,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 1.0
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_59_test_app",
@@ -1155,28 +578,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT user_id, meta_key, meta_value FROM wp55_usermeta WHERE user_id IN (1) ORDER BY umeta_id ASC",
-          "trace_id": 0,
-          "span_id": 46,
-          "parent_id": 21,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 18.0
-          }
-        },
      {
        "name": "load_template",
        "service": "wordpress_59_test_app",
@@ -1194,7 +595,7 @@
           "service": "wordpress_59_test_app",
           "resource": "comments_template",
           "trace_id": 0,
-          "span_id": 47,
+          "span_id": 35,
           "parent_id": 22,
           "type": "web",
           "meta": {
@@ -1206,35 +607,13 @@
              "service": "wordpress_59_test_app",
              "resource": "SELECT SQL_CALC_FOUND_ROWS wp55_comments.comment_ID FROM wp55_comments  WHERE ( comment_approved = '1' ) AND comment_post_ID = 5 AND comment_parent = 0  ORDER BY wp55_comments.comment_date_gmt ASC, wp55_comments.comment_ID ASC ",
              "trace_id": 0,
-             "span_id": 61,
-             "parent_id": 47,
+             "span_id": 46,
+             "parent_id": 35,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT SQL_CALC_FOUND_ROWS wp55_comments.comment_ID FROM wp55_comments  WHERE ( comment_approved = '1' ) AND comment_post_ID = 5 AND comment_parent = 0  ORDER BY wp55_comments.comment_date_gmt ASC, wp55_comments.comment_ID ASC ",
-                "trace_id": 0,
-                "span_id": 84,
-                "parent_id": 61,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              },
      {
        "name": "load_template",
        "service": "wordpress_59_test_app",
@@ -1252,7 +631,7 @@
           "service": "wordpress_59_test_app",
           "resource": "sidebar-1",
           "trace_id": 0,
-          "span_id": 48,
+          "span_id": 36,
           "parent_id": 23,
           "type": "web",
           "meta": {
@@ -1264,8 +643,8 @@
              "service": "wordpress_59_test_app",
              "resource": "WP_Widget.display_callback",
              "trace_id": 0,
-             "span_id": 62,
-             "parent_id": 48,
+             "span_id": 47,
+             "parent_id": 36,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -1276,8 +655,8 @@
              "service": "wordpress_59_test_app",
              "resource": "WP_Widget.display_callback",
              "trace_id": 0,
-             "span_id": 63,
-             "parent_id": 48,
+             "span_id": 48,
+             "parent_id": 36,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -1288,110 +667,44 @@
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT   wp55_posts.ID FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_type = 'post' AND ((wp55_posts.post_status = 'publish'))  ORDER BY wp55_posts.post_date DESC LIMIT 0, 5",
                 "trace_id": 0,
-                "span_id": 85,
-                "parent_id": 63,
+                "span_id": 64,
+                "parent_id": 48,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT   wp55_posts.ID FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_type = 'post' AND ((wp55_posts.post_status = 'publish'))  ORDER BY wp55_posts.post_date DESC LIMIT 0, 5",
-                   "trace_id": 0,
-                   "span_id": 103,
-                   "parent_id": 85,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 2.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT  t.*, tt.*, tr.object_id FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id INNER JOIN wp55_term_relationships AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy IN ('category', 'post_tag', 'post_format') AND tr.object_id IN (1) ORDER BY t.name ASC ",
                 "trace_id": 0,
-                "span_id": 86,
-                "parent_id": 63,
+                "span_id": 65,
+                "parent_id": 48,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  t.*, tt.*, tr.object_id FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id INNER JOIN wp55_term_relationships AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy IN ('category', 'post_tag', 'post_format') AND tr.object_id IN (1) ORDER BY t.name ASC ",
-                   "trace_id": 0,
-                   "span_id": 104,
-                   "parent_id": 86,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT post_id, meta_key, meta_value FROM wp55_postmeta WHERE post_id IN (1) ORDER BY meta_id ASC",
                 "trace_id": 0,
-                "span_id": 87,
-                "parent_id": 63,
+                "span_id": 66,
+                "parent_id": 48,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT post_id, meta_key, meta_value FROM wp55_postmeta WHERE post_id IN (1) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 105,
-                   "parent_id": 87,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
            {
              "name": "WP_Widget.display_callback",
              "service": "wordpress_59_test_app",
              "resource": "WP_Widget.display_callback",
              "trace_id": 0,
-             "span_id": 64,
-             "parent_id": 48,
+             "span_id": 49,
+             "parent_id": 36,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -1402,109 +715,43 @@
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT  wp55_comments.comment_ID FROM wp55_comments JOIN wp55_posts ON wp55_posts.ID = wp55_comments.comment_post_ID WHERE ( comment_approved = '1' ) AND  wp55_posts.post_status IN ('publish')  ORDER BY wp55_comments.comment_date_gmt DESC LIMIT 0,5",
                 "trace_id": 0,
-                "span_id": 88,
-                "parent_id": 64,
+                "span_id": 67,
+                "parent_id": 49,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  wp55_comments.comment_ID FROM wp55_comments JOIN wp55_posts ON wp55_posts.ID = wp55_comments.comment_post_ID WHERE ( comment_approved = '1' ) AND  wp55_posts.post_status IN ('publish')  ORDER BY wp55_comments.comment_date_gmt DESC LIMIT 0,5",
-                   "trace_id": 0,
-                   "span_id": 106,
-                   "parent_id": 88,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT wp55_comments.* FROM wp55_comments WHERE comment_ID IN (1)",
                 "trace_id": 0,
-                "span_id": 89,
-                "parent_id": 64,
+                "span_id": 68,
+                "parent_id": 49,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT wp55_comments.* FROM wp55_comments WHERE comment_ID IN (1)",
-                   "trace_id": 0,
-                   "span_id": 107,
-                   "parent_id": 89,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT comment_id, meta_key, meta_value FROM wp55_commentmeta WHERE comment_id IN (1) ORDER BY meta_id ASC",
                 "trace_id": 0,
-                "span_id": 90,
-                "parent_id": 64,
+                "span_id": 69,
+                "parent_id": 49,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT comment_id, meta_key, meta_value FROM wp55_commentmeta WHERE comment_id IN (1) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 108,
-                   "parent_id": 90,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
         {
           "name": "dynamic_sidebar",
           "service": "wordpress_59_test_app",
           "resource": "sidebar-2",
           "trace_id": 0,
-          "span_id": 49,
+          "span_id": 37,
           "parent_id": 23,
           "type": "web",
           "meta": {
@@ -1516,8 +763,8 @@
              "service": "wordpress_59_test_app",
              "resource": "WP_Widget.display_callback",
              "trace_id": 0,
-             "span_id": 65,
-             "parent_id": 49,
+             "span_id": 50,
+             "parent_id": 37,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -1528,42 +775,20 @@
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT YEAR(post_date) AS `year`, MONTH(post_date) AS `month`, count(ID) as posts FROM wp55_posts  WHERE post_type = 'post' AND post_status = 'publish' GROUP BY YEAR(post_date), MONTH(post_date) ORDER BY post_date DESC ",
                 "trace_id": 0,
-                "span_id": 91,
-                "parent_id": 65,
+                "span_id": 70,
+                "parent_id": 50,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT YEAR(post_date) AS `year`, MONTH(post_date) AS `month`, count(ID) as posts FROM wp55_posts  WHERE post_type = 'post' AND post_status = 'publish' GROUP BY YEAR(post_date), MONTH(post_date) ORDER BY post_date DESC ",
-                   "trace_id": 0,
-                   "span_id": 109,
-                   "parent_id": 91,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
            {
              "name": "WP_Widget.display_callback",
              "service": "wordpress_59_test_app",
              "resource": "WP_Widget.display_callback",
              "trace_id": 0,
-             "span_id": 66,
-             "parent_id": 49,
+             "span_id": 51,
+             "parent_id": 37,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -1574,76 +799,32 @@
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT  t.*, tt.* FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id WHERE tt.taxonomy IN ('category') AND tt.count > 0 ORDER BY t.name ASC ",
                 "trace_id": 0,
-                "span_id": 92,
-                "parent_id": 66,
+                "span_id": 71,
+                "parent_id": 51,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  t.*, tt.* FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id WHERE tt.taxonomy IN ('category') AND tt.count > 0 ORDER BY t.name ASC ",
-                   "trace_id": 0,
-                   "span_id": 110,
-                   "parent_id": 92,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
               {
                 "name": "wpdb.query",
                 "service": "wordpress_59_test_app",
                 "resource": "SELECT term_id, meta_key, meta_value FROM wp55_termmeta WHERE term_id IN (1) ORDER BY meta_id ASC",
                 "trace_id": 0,
-                "span_id": 93,
-                "parent_id": 66,
+                "span_id": 72,
+                "parent_id": 51,
                 "type": "sql",
                 "meta": {
                   "component": "wordpress"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT term_id, meta_key, meta_value FROM wp55_termmeta WHERE term_id IN (1) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 111,
-                   "parent_id": 93,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
            {
              "name": "WP_Widget.display_callback",
              "service": "wordpress_59_test_app",
              "resource": "WP_Widget.display_callback",
              "trace_id": 0,
-             "span_id": 67,
-             "parent_id": 49,
+             "span_id": 52,
+             "parent_id": 37,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -1666,7 +847,7 @@
           "service": "wordpress_59_test_app",
           "resource": "/home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/wp-content/themes/twentytwenty/footer.php",
           "trace_id": 0,
-          "span_id": 50,
+          "span_id": 38,
           "parent_id": 24,
           "type": "web",
           "meta": {
@@ -1678,42 +859,20 @@
              "service": "wordpress_59_test_app",
              "resource": "SELECT * FROM wp55_posts WHERE ID = 3 LIMIT 1",
              "trace_id": 0,
-             "span_id": 68,
-             "parent_id": 50,
+             "span_id": 53,
+             "parent_id": 38,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT * FROM wp55_posts WHERE ID = 3 LIMIT 1",
-                "trace_id": 0,
-                "span_id": 94,
-                "parent_id": 68,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
            {
              "name": "wp_print_footer_scripts",
              "service": "wordpress_59_test_app",
              "resource": "wp_print_footer_scripts",
              "trace_id": 0,
-             "span_id": 69,
-             "parent_id": 50,
+             "span_id": 54,
+             "parent_id": 38,
              "type": "web",
              "meta": {
                "component": "wordpress"

--- a/tests/snapshots/tests.integrations.word_press.v5_9.common_scenarios_test.test_scenario_get_return_string.json
+++ b/tests/snapshots/tests.integrations.word_press.v5_9.common_scenarios_test.test_scenario_get_return_string.json
@@ -5,16 +5,17 @@
     "resource": "GET /simple",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 8699478024760093354,
+    "parent_id": 7368348772295178372,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e7005000000000",
       "component": "wordpress",
       "http.method": "GET",
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/simple?key=value&<redacted>",
-      "runtime-id": "500b19ab-e36c-4cbc-a9dd-f15015a52ccf",
+      "runtime-id": "4c46007f-c934-41aa-bcbe-c48ecee2d4cc",
       "span.kind": "server"
     },
     "metrics": {
@@ -22,108 +23,11 @@
     }
   },
      {
-       "name": "mysqli_real_connect",
-       "service": "mysqli",
-       "resource": "mysqli_real_connect",
-       "trace_id": 0,
-       "span_id": 2,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-       "trace_id": 0,
-       "span_id": 3,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT @@SESSION.sql_mode",
-       "trace_id": 0,
-       "span_id": 4,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 1.0
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-       "trace_id": 0,
-       "span_id": 5,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_name, option_value FROM wp55_options WHERE autoload = 'yes'",
-       "trace_id": 0,
-       "span_id": 6,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 111.0
-       }
-     },
-     {
        "name": "create_initial_taxonomies",
        "service": "wordpress_59_test_app",
        "resource": "create_initial_taxonomies",
        "trace_id": 0,
-       "span_id": 7,
+       "span_id": 2,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -135,7 +39,7 @@
        "service": "wordpress_59_test_app",
        "resource": "create_initial_post_types",
        "trace_id": 0,
-       "span_id": 8,
+       "span_id": 3,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -147,7 +51,7 @@
        "service": "wordpress_59_test_app",
        "resource": "datadog (plugin)",
        "trace_id": 0,
-       "span_id": 9,
+       "span_id": 4,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -160,7 +64,7 @@
        "service": "wordpress_59_test_app",
        "resource": "plugins_loaded (hook)",
        "trace_id": 0,
-       "span_id": 10,
+       "span_id": 5,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -173,8 +77,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_maybe_load_widgets",
           "trace_id": 0,
-          "span_id": 20,
-          "parent_id": 10,
+          "span_id": 14,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -185,8 +89,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_maybe_load_embeds",
           "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 10,
+          "span_id": 15,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -197,8 +101,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_wp_customize_include",
           "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 10,
+          "span_id": 16,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -209,7 +113,7 @@
        "service": "wordpress_59_test_app",
        "resource": "setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 11,
+       "span_id": 6,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -218,33 +122,11 @@
        }
      },
      {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'WPLANG' LIMIT 1",
-       "trace_id": 0,
-       "span_id": 12,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 0.0
-       }
-     },
-     {
        "name": "load_theme",
        "service": "wordpress_59_test_app",
        "resource": "Twentytwenty (theme)",
        "trace_id": 0,
-       "span_id": 13,
+       "span_id": 7,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -257,7 +139,7 @@
        "service": "wordpress_59_test_app",
        "resource": "after_setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 14,
+       "span_id": 8,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -270,7 +152,7 @@
        "service": "wordpress_59_test_app",
        "resource": "WP.init",
        "trace_id": 0,
-       "span_id": 15,
+       "span_id": 9,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -282,7 +164,7 @@
        "service": "wordpress_59_test_app",
        "resource": "init (hook)",
        "trace_id": 0,
-       "span_id": 16,
+       "span_id": 10,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -295,8 +177,8 @@
           "service": "wordpress_59_test_app",
           "resource": "create_initial_post_types",
           "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 16,
+          "span_id": 17,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -307,8 +189,8 @@
           "service": "wordpress_59_test_app",
           "resource": "create_initial_taxonomies",
           "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 16,
+          "span_id": 18,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -319,8 +201,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_widgets_init",
           "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 16,
+          "span_id": 19,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -331,104 +213,19 @@
              "service": "wordpress_59_test_app",
              "resource": "WP_Widget_Factory._register_widgets",
              "trace_id": 0,
-             "span_id": 29,
-             "parent_id": 25,
+             "span_id": 22,
+             "parent_id": 19,
              "type": "web",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-                "trace_id": 0,
-                "span_id": 31,
-                "parent_id": 29,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'widget_block' LIMIT 1",
-                "trace_id": 0,
-                "span_id": 32,
-                "parent_id": 29,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "INSERT INTO `wp55_options` (`option_name`, `option_value`, `autoload`) VALUES ('widget_block', 'a:1:{s:12:\\\"_multiwidget\\\";i:1;}', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)",
-                "trace_id": 0,
-                "span_id": 33,
-                "parent_id": 29,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                }
-              },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'theme_switched' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 16,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "action",
        "service": "wordpress_59_test_app",
        "resource": "wp_loaded (hook)",
        "trace_id": 0,
-       "span_id": 17,
+       "span_id": 11,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -441,7 +238,7 @@
        "service": "wordpress_59_test_app",
        "resource": "WP.main",
        "trace_id": 0,
-       "span_id": 18,
+       "span_id": 12,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -453,8 +250,8 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 18,
+          "span_id": 20,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -465,41 +262,19 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 28,
-          "parent_id": 18,
+          "span_id": 21,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('simple')\n\t\tAND post_type IN ('page','attachment')\n\t",
-             "trace_id": 0,
-             "span_id": 30,
-             "parent_id": 28,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_59_test_app",
        "resource": "shutdown (hook)",
        "trace_id": 0,
-       "span_id": 19,
+       "span_id": 13,
        "parent_id": 1,
        "type": "web",
        "meta": {

--- a/tests/snapshots/tests.integrations.word_press.v5_9.common_scenarios_test.test_scenario_get_to_missing_route.json
+++ b/tests/snapshots/tests.integrations.word_press.v5_9.common_scenarios_test.test_scenario_get_to_missing_route.json
@@ -5,15 +5,16 @@
     "resource": "GET /does_not_exist",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 929880556876491322,
+    "parent_id": 15038554303071755467,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e7006c00000000",
       "component": "wordpress",
       "http.method": "GET",
       "http.status_code": "404",
       "http.url": "http://localhost:9999/does_not_exist?key=value&<redacted>",
-      "runtime-id": "c1971c1f-c171-4612-ba42-df98413a59df",
+      "runtime-id": "4c46007f-c934-41aa-bcbe-c48ecee2d4cc",
       "span.kind": "server"
     },
     "metrics": {
@@ -21,108 +22,11 @@
     }
   },
      {
-       "name": "mysqli_real_connect",
-       "service": "mysqli",
-       "resource": "mysqli_real_connect",
-       "trace_id": 0,
-       "span_id": 2,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-       "trace_id": 0,
-       "span_id": 3,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT @@SESSION.sql_mode",
-       "trace_id": 0,
-       "span_id": 4,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 1.0
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-       "trace_id": 0,
-       "span_id": 5,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_name, option_value FROM wp55_options WHERE autoload = 'yes'",
-       "trace_id": 0,
-       "span_id": 6,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 111.0
-       }
-     },
-     {
        "name": "create_initial_taxonomies",
        "service": "wordpress_59_test_app",
        "resource": "create_initial_taxonomies",
        "trace_id": 0,
-       "span_id": 7,
+       "span_id": 2,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -134,7 +38,7 @@
        "service": "wordpress_59_test_app",
        "resource": "create_initial_post_types",
        "trace_id": 0,
-       "span_id": 8,
+       "span_id": 3,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -146,7 +50,7 @@
        "service": "wordpress_59_test_app",
        "resource": "datadog (plugin)",
        "trace_id": 0,
-       "span_id": 9,
+       "span_id": 4,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -159,7 +63,7 @@
        "service": "wordpress_59_test_app",
        "resource": "plugins_loaded (hook)",
        "trace_id": 0,
-       "span_id": 10,
+       "span_id": 5,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -172,8 +76,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_maybe_load_widgets",
           "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 10,
+          "span_id": 15,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -184,8 +88,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_maybe_load_embeds",
           "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 10,
+          "span_id": 16,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -196,8 +100,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_wp_customize_include",
           "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 10,
+          "span_id": 17,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -208,7 +112,7 @@
        "service": "wordpress_59_test_app",
        "resource": "setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 11,
+       "span_id": 6,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -217,33 +121,11 @@
        }
      },
      {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'WPLANG' LIMIT 1",
-       "trace_id": 0,
-       "span_id": 12,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 0.0
-       }
-     },
-     {
        "name": "load_theme",
        "service": "wordpress_59_test_app",
        "resource": "Twentytwenty (theme)",
        "trace_id": 0,
-       "span_id": 13,
+       "span_id": 7,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -256,7 +138,7 @@
        "service": "wordpress_59_test_app",
        "resource": "after_setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 14,
+       "span_id": 8,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -269,7 +151,7 @@
        "service": "wordpress_59_test_app",
        "resource": "WP.init",
        "trace_id": 0,
-       "span_id": 15,
+       "span_id": 9,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -281,7 +163,7 @@
        "service": "wordpress_59_test_app",
        "resource": "init (hook)",
        "trace_id": 0,
-       "span_id": 16,
+       "span_id": 10,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -294,8 +176,8 @@
           "service": "wordpress_59_test_app",
           "resource": "create_initial_post_types",
           "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 16,
+          "span_id": 18,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -306,8 +188,8 @@
           "service": "wordpress_59_test_app",
           "resource": "create_initial_taxonomies",
           "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 16,
+          "span_id": 19,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -318,8 +200,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_widgets_init",
           "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 16,
+          "span_id": 20,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -330,104 +212,19 @@
              "service": "wordpress_59_test_app",
              "resource": "WP_Widget_Factory._register_widgets",
              "trace_id": 0,
-             "span_id": 40,
-             "parent_id": 26,
+             "span_id": 33,
+             "parent_id": 20,
              "type": "web",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-                "trace_id": 0,
-                "span_id": 51,
-                "parent_id": 40,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'widget_block' LIMIT 1",
-                "trace_id": 0,
-                "span_id": 52,
-                "parent_id": 40,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "INSERT INTO `wp55_options` (`option_name`, `option_value`, `autoload`) VALUES ('widget_block', 'a:1:{s:12:\\\"_multiwidget\\\";i:1;}', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)",
-                "trace_id": 0,
-                "span_id": 53,
-                "parent_id": 40,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                }
-              },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'theme_switched' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 16,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "action",
        "service": "wordpress_59_test_app",
        "resource": "wp_loaded (hook)",
        "trace_id": 0,
-       "span_id": 17,
+       "span_id": 11,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -440,7 +237,7 @@
        "service": "wordpress_59_test_app",
        "resource": "WP.main",
        "trace_id": 0,
-       "span_id": 18,
+       "span_id": 12,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -452,8 +249,8 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 28,
-          "parent_id": 18,
+          "span_id": 21,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -464,42 +261,20 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 29,
-          "parent_id": 18,
+          "span_id": 22,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('does_not_exist')\n\t\tAND post_type IN ('page','attachment')\n\t",
-             "trace_id": 0,
-             "span_id": 41,
-             "parent_id": 29,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
         {
           "name": "WP.send_headers",
           "service": "wordpress_59_test_app",
           "resource": "WP.send_headers",
           "trace_id": 0,
-          "span_id": 30,
-          "parent_id": 18,
+          "span_id": 23,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -510,42 +285,20 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.query_posts",
           "trace_id": 0,
-          "span_id": 31,
-          "parent_id": 18,
+          "span_id": 24,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT   wp55_posts.* FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_name = 'does_not_exist' AND wp55_posts.post_type = 'post'  ORDER BY wp55_posts.post_date DESC ",
-             "trace_id": 0,
-             "span_id": 42,
-             "parent_id": 31,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
         {
           "name": "WP.handle_404",
           "service": "wordpress_59_test_app",
           "resource": "WP.handle_404",
           "trace_id": 0,
-          "span_id": 32,
-          "parent_id": 18,
+          "span_id": 25,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -556,8 +309,8 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.register_globals",
           "trace_id": 0,
-          "span_id": 33,
-          "parent_id": 18,
+          "span_id": 26,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -568,8 +321,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp (hook)",
           "trace_id": 0,
-          "span_id": 34,
-          "parent_id": 18,
+          "span_id": 27,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -581,7 +334,7 @@
        "service": "wordpress_59_test_app",
        "resource": "load_template_loader",
        "trace_id": 0,
-       "span_id": 19,
+       "span_id": 13,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -593,65 +346,21 @@
           "service": "wordpress_59_test_app",
           "resource": "template_redirect (hook)",
           "trace_id": 0,
-          "span_id": 35,
-          "parent_id": 19,
+          "span_id": 28,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
             "wordpress.hook": "template_redirect"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT post_id FROM wp55_postmeta, wp55_posts WHERE ID = post_id AND post_type = 'post' AND meta_key = '_wp_old_slug' AND meta_value = 'does_not_exist'",
-             "trace_id": 0,
-             "span_id": 43,
-             "parent_id": 35,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT ID FROM wp55_posts WHERE post_name LIKE 'does\\\\_not\\\\_exist%' AND post_type IN ('post', 'page', 'attachment') AND post_status = 'publish'",
-             "trace_id": 0,
-             "span_id": 44,
-             "parent_id": 35,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
         {
           "name": "template",
           "service": "wordpress_59_test_app",
           "resource": "404 (type)",
           "trace_id": 0,
-          "span_id": 36,
-          "parent_id": 19,
+          "span_id": 29,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -659,57 +368,13 @@
             "wordpress.theme": "Twenty Twenty"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT  t.*, tt.* FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id WHERE tt.taxonomy IN ('wp_theme') AND t.name IN ('twentytwenty')  ",
-             "trace_id": 0,
-             "span_id": 45,
-             "parent_id": 36,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT   wp55_posts.* FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_name IN ('404') AND ( \n  0 = 1\n) AND wp55_posts.post_type = 'wp_template' AND ((wp55_posts.post_status = 'publish')) GROUP BY wp55_posts.ID ORDER BY wp55_posts.post_date DESC ",
-             "trace_id": 0,
-             "span_id": 46,
-             "parent_id": 36,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
         {
           "name": "get_header",
           "service": "wordpress_59_test_app",
           "resource": "get_header",
           "trace_id": 0,
-          "span_id": 37,
-          "parent_id": 19,
+          "span_id": 30,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -720,8 +385,8 @@
              "service": "wordpress_59_test_app",
              "resource": "header (template)",
              "trace_id": 0,
-             "span_id": 47,
-             "parent_id": 37,
+             "span_id": 34,
+             "parent_id": 30,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -734,8 +399,8 @@
                 "service": "wordpress_59_test_app",
                 "resource": "wp_head (hook)",
                 "trace_id": 0,
-                "span_id": 54,
-                "parent_id": 47,
+                "span_id": 38,
+                "parent_id": 34,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -743,100 +408,12 @@
                 }
               },
                  {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'medium_crop' LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 65,
-                   "parent_id": 54,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'medium_large_crop' LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 66,
-                   "parent_id": 54,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'large_crop' LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 67,
-                   "parent_id": 54,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT   wp55_posts.ID FROM wp55_posts  WHERE 1=1  AND ( \n  0 = 1\n) AND wp55_posts.post_type = 'wp_global_styles' AND ((wp55_posts.post_status = 'publish')) GROUP BY wp55_posts.ID ORDER BY wp55_posts.post_date DESC LIMIT 0, 1",
-                   "trace_id": 0,
-                   "span_id": 68,
-                   "parent_id": 54,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
-                 {
                    "name": "wp_print_head_scripts",
                    "service": "wordpress_59_test_app",
                    "resource": "wp_print_head_scripts",
                    "trace_id": 0,
-                   "span_id": 69,
-                   "parent_id": 54,
+                   "span_id": 47,
+                   "parent_id": 38,
                    "type": "web",
                    "meta": {
                      "component": "wordpress"
@@ -847,55 +424,11 @@
                 "service": "wordpress_59_test_app",
                 "resource": "body_class",
                 "trace_id": 0,
-                "span_id": 55,
-                "parent_id": 47,
+                "span_id": 39,
+                "parent_id": 34,
                 "type": "web",
                 "meta": {
                   "component": "wordpress"
-                }
-              },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'site_logo' LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 70,
-                   "parent_id": 55,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT * FROM wp55_posts  WHERE (post_type = 'page' AND post_status = 'publish')     ORDER BY menu_order,wp55_posts.post_title ASC",
-                "trace_id": 0,
-                "span_id": 56,
-                "parent_id": 47,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
                 }
               },
         {
@@ -903,8 +436,8 @@
           "service": "wordpress_59_test_app",
           "resource": "footer-menus-widgets (template)",
           "trace_id": 0,
-          "span_id": 38,
-          "parent_id": 19,
+          "span_id": 31,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -917,8 +450,8 @@
              "service": "wordpress_59_test_app",
              "resource": "sidebar-1",
              "trace_id": 0,
-             "span_id": 48,
-             "parent_id": 38,
+             "span_id": 35,
+             "parent_id": 31,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -929,8 +462,8 @@
                 "service": "wordpress_59_test_app",
                 "resource": "Search (widget)",
                 "trace_id": 0,
-                "span_id": 57,
-                "parent_id": 48,
+                "span_id": 40,
+                "parent_id": 35,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -942,188 +475,34 @@
                 "service": "wordpress_59_test_app",
                 "resource": "Recent Posts (widget)",
                 "trace_id": 0,
-                "span_id": 58,
-                "parent_id": 48,
+                "span_id": 41,
+                "parent_id": 35,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Recent Posts"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT   wp55_posts.ID FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_type = 'post' AND ((wp55_posts.post_status = 'publish'))  ORDER BY wp55_posts.post_date DESC LIMIT 0, 5",
-                   "trace_id": 0,
-                   "span_id": 71,
-                   "parent_id": 58,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 2.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT wp55_posts.* FROM wp55_posts WHERE ID IN (5,1)",
-                   "trace_id": 0,
-                   "span_id": 72,
-                   "parent_id": 58,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 2.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  t.*, tt.*, tr.object_id FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id INNER JOIN wp55_term_relationships AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy IN ('category', 'post_tag', 'post_format') AND tr.object_id IN (1, 5) ORDER BY t.name ASC ",
-                   "trace_id": 0,
-                   "span_id": 73,
-                   "parent_id": 58,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 2.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT post_id, meta_key, meta_value FROM wp55_postmeta WHERE post_id IN (1,5) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 74,
-                   "parent_id": 58,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 3.0
-                   }
-                 },
               {
                 "name": "widget",
                 "service": "wordpress_59_test_app",
                 "resource": "Recent Comments (widget)",
                 "trace_id": 0,
-                "span_id": 59,
-                "parent_id": 48,
+                "span_id": 42,
+                "parent_id": 35,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Recent Comments"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  wp55_comments.comment_ID FROM wp55_comments JOIN wp55_posts ON wp55_posts.ID = wp55_comments.comment_post_ID WHERE ( comment_approved = '1' ) AND  wp55_posts.post_status IN ('publish')  ORDER BY wp55_comments.comment_date_gmt DESC LIMIT 0,5",
-                   "trace_id": 0,
-                   "span_id": 75,
-                   "parent_id": 59,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT wp55_comments.* FROM wp55_comments WHERE comment_ID IN (1)",
-                   "trace_id": 0,
-                   "span_id": 76,
-                   "parent_id": 59,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT comment_id, meta_key, meta_value FROM wp55_commentmeta WHERE comment_id IN (1) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 77,
-                   "parent_id": 59,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
            {
              "name": "dynamic_sidebar",
              "service": "wordpress_59_test_app",
              "resource": "sidebar-2",
              "trace_id": 0,
-             "span_id": 49,
-             "parent_id": 38,
+             "span_id": 36,
+             "parent_id": 31,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -1134,100 +513,34 @@
                 "service": "wordpress_59_test_app",
                 "resource": "Archives (widget)",
                 "trace_id": 0,
-                "span_id": 60,
-                "parent_id": 49,
+                "span_id": 43,
+                "parent_id": 36,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Archives"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT YEAR(post_date) AS `year`, MONTH(post_date) AS `month`, count(ID) as posts FROM wp55_posts  WHERE post_type = 'post' AND post_status = 'publish' GROUP BY YEAR(post_date), MONTH(post_date) ORDER BY post_date DESC ",
-                   "trace_id": 0,
-                   "span_id": 78,
-                   "parent_id": 60,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
               {
                 "name": "widget",
                 "service": "wordpress_59_test_app",
                 "resource": "Categories (widget)",
                 "trace_id": 0,
-                "span_id": 61,
-                "parent_id": 49,
+                "span_id": 44,
+                "parent_id": 36,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Categories"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  t.*, tt.* FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id WHERE tt.taxonomy IN ('category') AND tt.count > 0 ORDER BY t.name ASC ",
-                   "trace_id": 0,
-                   "span_id": 79,
-                   "parent_id": 61,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT term_id, meta_key, meta_value FROM wp55_termmeta WHERE term_id IN (1) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 80,
-                   "parent_id": 61,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
               {
                 "name": "widget",
                 "service": "wordpress_59_test_app",
                 "resource": "Meta (widget)",
                 "trace_id": 0,
-                "span_id": 62,
-                "parent_id": 49,
+                "span_id": 45,
+                "parent_id": 36,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -1239,8 +552,8 @@
           "service": "wordpress_59_test_app",
           "resource": "get_footer",
           "trace_id": 0,
-          "span_id": 39,
-          "parent_id": 19,
+          "span_id": 32,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -1251,8 +564,8 @@
              "service": "wordpress_59_test_app",
              "resource": "footer (template)",
              "trace_id": 0,
-             "span_id": 50,
-             "parent_id": 39,
+             "span_id": 37,
+             "parent_id": 32,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1261,34 +574,12 @@
              }
            },
               {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT * FROM wp55_posts WHERE ID = 3 LIMIT 1",
-                "trace_id": 0,
-                "span_id": 63,
-                "parent_id": 50,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
-              {
                 "name": "action",
                 "service": "wordpress_59_test_app",
                 "resource": "wp_footer (hook)",
                 "trace_id": 0,
-                "span_id": 64,
-                "parent_id": 50,
+                "span_id": 46,
+                "parent_id": 37,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -1300,7 +591,7 @@
        "service": "wordpress_59_test_app",
        "resource": "shutdown (hook)",
        "trace_id": 0,
-       "span_id": 20,
+       "span_id": 14,
        "parent_id": 1,
        "type": "web",
        "meta": {

--- a/tests/snapshots/tests.integrations.word_press.v5_9.common_scenarios_test.test_scenario_get_with_exception.json
+++ b/tests/snapshots/tests.integrations.word_press.v5_9.common_scenarios_test.test_scenario_get_with_exception.json
@@ -5,11 +5,12 @@
     "resource": "GET /error",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 5903754045475109089,
+    "parent_id": 16833302661627952540,
     "type": "web",
     "error": 1,
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e7005c00000000",
       "component": "wordpress",
       "error.message": "Uncaught Exception: Oops! in /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/wp-content/plugins/datadog/datadog.php:23",
       "error.stack": "#0 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/wp-includes/class-wp-hook.php(307): datadog_parse_request()\n#1 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/wp-includes/class-wp-hook.php(331): WP_Hook->apply_filters()\n#2 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/wp-includes/plugin.php(522): WP_Hook->do_action()\n#3 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/wp-includes/class-wp.php(396): do_action_ref_array()\n#4 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/wp-includes/class-wp.php(758): WP->parse_request()\n#5 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/wp-includes/functions.php(1310): WP->main()\n#6 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/wp-blog-header.php(16): wp()\n#7 /home/circleci/datadog/tests/Frameworks/WordPress/Version_5_9/index.php(17): require()\n#8 {main}",
@@ -18,7 +19,7 @@
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/error?key=value&<redacted>",
-      "runtime-id": "500b19ab-e36c-4cbc-a9dd-f15015a52ccf",
+      "runtime-id": "4c46007f-c934-41aa-bcbe-c48ecee2d4cc",
       "span.kind": "server"
     },
     "metrics": {
@@ -26,108 +27,11 @@
     }
   },
      {
-       "name": "mysqli_real_connect",
-       "service": "mysqli",
-       "resource": "mysqli_real_connect",
-       "trace_id": 0,
-       "span_id": 2,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-       "trace_id": 0,
-       "span_id": 3,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT @@SESSION.sql_mode",
-       "trace_id": 0,
-       "span_id": 4,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 1.0
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-       "trace_id": 0,
-       "span_id": 5,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_name, option_value FROM wp55_options WHERE autoload = 'yes'",
-       "trace_id": 0,
-       "span_id": 6,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 111.0
-       }
-     },
-     {
        "name": "create_initial_taxonomies",
        "service": "wordpress_59_test_app",
        "resource": "create_initial_taxonomies",
        "trace_id": 0,
-       "span_id": 7,
+       "span_id": 2,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -139,7 +43,7 @@
        "service": "wordpress_59_test_app",
        "resource": "create_initial_post_types",
        "trace_id": 0,
-       "span_id": 8,
+       "span_id": 3,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -151,7 +55,7 @@
        "service": "wordpress_59_test_app",
        "resource": "datadog (plugin)",
        "trace_id": 0,
-       "span_id": 9,
+       "span_id": 4,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -164,7 +68,7 @@
        "service": "wordpress_59_test_app",
        "resource": "plugins_loaded (hook)",
        "trace_id": 0,
-       "span_id": 10,
+       "span_id": 5,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -177,8 +81,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_maybe_load_widgets",
           "trace_id": 0,
-          "span_id": 20,
-          "parent_id": 10,
+          "span_id": 14,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -189,8 +93,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_maybe_load_embeds",
           "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 10,
+          "span_id": 15,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -201,8 +105,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_wp_customize_include",
           "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 10,
+          "span_id": 16,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -213,7 +117,7 @@
        "service": "wordpress_59_test_app",
        "resource": "setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 11,
+       "span_id": 6,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -222,33 +126,11 @@
        }
      },
      {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'WPLANG' LIMIT 1",
-       "trace_id": 0,
-       "span_id": 12,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 0.0
-       }
-     },
-     {
        "name": "load_theme",
        "service": "wordpress_59_test_app",
        "resource": "Twentytwenty (theme)",
        "trace_id": 0,
-       "span_id": 13,
+       "span_id": 7,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -261,7 +143,7 @@
        "service": "wordpress_59_test_app",
        "resource": "after_setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 14,
+       "span_id": 8,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -274,7 +156,7 @@
        "service": "wordpress_59_test_app",
        "resource": "WP.init",
        "trace_id": 0,
-       "span_id": 15,
+       "span_id": 9,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -286,7 +168,7 @@
        "service": "wordpress_59_test_app",
        "resource": "init (hook)",
        "trace_id": 0,
-       "span_id": 16,
+       "span_id": 10,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -299,8 +181,8 @@
           "service": "wordpress_59_test_app",
           "resource": "create_initial_post_types",
           "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 16,
+          "span_id": 17,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -311,8 +193,8 @@
           "service": "wordpress_59_test_app",
           "resource": "create_initial_taxonomies",
           "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 16,
+          "span_id": 18,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -323,8 +205,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_widgets_init",
           "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 16,
+          "span_id": 19,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -335,104 +217,19 @@
              "service": "wordpress_59_test_app",
              "resource": "WP_Widget_Factory._register_widgets",
              "trace_id": 0,
-             "span_id": 29,
-             "parent_id": 25,
+             "span_id": 22,
+             "parent_id": 19,
              "type": "web",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-                "trace_id": 0,
-                "span_id": 31,
-                "parent_id": 29,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'widget_block' LIMIT 1",
-                "trace_id": 0,
-                "span_id": 32,
-                "parent_id": 29,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "INSERT INTO `wp55_options` (`option_name`, `option_value`, `autoload`) VALUES ('widget_block', 'a:1:{s:12:\\\"_multiwidget\\\";i:1;}', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)",
-                "trace_id": 0,
-                "span_id": 33,
-                "parent_id": 29,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                }
-              },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'theme_switched' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 16,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "action",
        "service": "wordpress_59_test_app",
        "resource": "wp_loaded (hook)",
        "trace_id": 0,
-       "span_id": 17,
+       "span_id": 11,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -445,7 +242,7 @@
        "service": "wordpress_59_test_app",
        "resource": "WP.main",
        "trace_id": 0,
-       "span_id": 18,
+       "span_id": 12,
        "parent_id": 1,
        "type": "web",
        "error": 1,
@@ -461,8 +258,8 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 18,
+          "span_id": 20,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -473,8 +270,8 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 28,
-          "parent_id": 18,
+          "span_id": 21,
+          "parent_id": 12,
           "type": "web",
           "error": 1,
           "meta": {
@@ -484,34 +281,12 @@
             "error.type": "Exception"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('error')\n\t\tAND post_type IN ('page','attachment')\n\t",
-             "trace_id": 0,
-             "span_id": 30,
-             "parent_id": 28,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_59_test_app",
        "resource": "shutdown (hook)",
        "trace_id": 0,
-       "span_id": 19,
+       "span_id": 13,
        "parent_id": 1,
        "type": "web",
        "meta": {

--- a/tests/snapshots/tests.integrations.word_press.v5_9.common_scenarios_test.test_scenario_get_with_view.json
+++ b/tests/snapshots/tests.integrations.word_press.v5_9.common_scenarios_test.test_scenario_get_with_view.json
@@ -5,16 +5,17 @@
     "resource": "GET /simple_view",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 8549288142567688443,
+    "parent_id": 14707770386545716536,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
+      "_dd.p.tid": "65e7005100000000",
       "component": "wordpress",
       "http.method": "GET",
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/simple_view?key=value&<redacted>",
-      "runtime-id": "c1971c1f-c171-4612-ba42-df98413a59df",
+      "runtime-id": "4c46007f-c934-41aa-bcbe-c48ecee2d4cc",
       "span.kind": "server"
     },
     "metrics": {
@@ -22,108 +23,11 @@
     }
   },
      {
-       "name": "mysqli_real_connect",
-       "service": "mysqli",
-       "resource": "mysqli_real_connect",
-       "trace_id": 0,
-       "span_id": 2,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-       "trace_id": 0,
-       "span_id": 3,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT @@SESSION.sql_mode",
-       "trace_id": 0,
-       "span_id": 4,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 1.0
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-       "trace_id": 0,
-       "span_id": 5,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_name, option_value FROM wp55_options WHERE autoload = 'yes'",
-       "trace_id": 0,
-       "span_id": 6,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 111.0
-       }
-     },
-     {
        "name": "create_initial_taxonomies",
        "service": "wordpress_59_test_app",
        "resource": "create_initial_taxonomies",
        "trace_id": 0,
-       "span_id": 7,
+       "span_id": 2,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -135,7 +39,7 @@
        "service": "wordpress_59_test_app",
        "resource": "create_initial_post_types",
        "trace_id": 0,
-       "span_id": 8,
+       "span_id": 3,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -147,7 +51,7 @@
        "service": "wordpress_59_test_app",
        "resource": "datadog (plugin)",
        "trace_id": 0,
-       "span_id": 9,
+       "span_id": 4,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -160,7 +64,7 @@
        "service": "wordpress_59_test_app",
        "resource": "plugins_loaded (hook)",
        "trace_id": 0,
-       "span_id": 10,
+       "span_id": 5,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -173,8 +77,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_maybe_load_widgets",
           "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 10,
+          "span_id": 15,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -185,8 +89,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_maybe_load_embeds",
           "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 10,
+          "span_id": 16,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -197,8 +101,8 @@
           "service": "wordpress_59_test_app",
           "resource": "_wp_customize_include",
           "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 10,
+          "span_id": 17,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -209,7 +113,7 @@
        "service": "wordpress_59_test_app",
        "resource": "setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 11,
+       "span_id": 6,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -218,33 +122,11 @@
        }
      },
      {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'WPLANG' LIMIT 1",
-       "trace_id": 0,
-       "span_id": 12,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_59_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 0.0
-       }
-     },
-     {
        "name": "load_theme",
        "service": "wordpress_59_test_app",
        "resource": "Twentytwenty (theme)",
        "trace_id": 0,
-       "span_id": 13,
+       "span_id": 7,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -257,7 +139,7 @@
        "service": "wordpress_59_test_app",
        "resource": "after_setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 14,
+       "span_id": 8,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -270,7 +152,7 @@
        "service": "wordpress_59_test_app",
        "resource": "WP.init",
        "trace_id": 0,
-       "span_id": 15,
+       "span_id": 9,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -282,7 +164,7 @@
        "service": "wordpress_59_test_app",
        "resource": "init (hook)",
        "trace_id": 0,
-       "span_id": 16,
+       "span_id": 10,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -295,8 +177,8 @@
           "service": "wordpress_59_test_app",
           "resource": "create_initial_post_types",
           "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 16,
+          "span_id": 18,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -307,8 +189,8 @@
           "service": "wordpress_59_test_app",
           "resource": "create_initial_taxonomies",
           "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 16,
+          "span_id": 19,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -319,8 +201,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp_widgets_init",
           "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 16,
+          "span_id": 20,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -331,104 +213,19 @@
              "service": "wordpress_59_test_app",
              "resource": "WP_Widget_Factory._register_widgets",
              "trace_id": 0,
-             "span_id": 43,
-             "parent_id": 26,
+             "span_id": 36,
+             "parent_id": 20,
              "type": "web",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-                "trace_id": 0,
-                "span_id": 59,
-                "parent_id": 43,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'widget_block' LIMIT 1",
-                "trace_id": 0,
-                "span_id": 60,
-                "parent_id": 43,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "INSERT INTO `wp55_options` (`option_name`, `option_value`, `autoload`) VALUES ('widget_block', 'a:1:{s:12:\\\"_multiwidget\\\";i:1;}', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)",
-                "trace_id": 0,
-                "span_id": 61,
-                "parent_id": 43,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                }
-              },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'theme_switched' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 16,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_59_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "action",
        "service": "wordpress_59_test_app",
        "resource": "wp_loaded (hook)",
        "trace_id": 0,
-       "span_id": 17,
+       "span_id": 11,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -441,7 +238,7 @@
        "service": "wordpress_59_test_app",
        "resource": "WP.main",
        "trace_id": 0,
-       "span_id": 18,
+       "span_id": 12,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -453,8 +250,8 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 28,
-          "parent_id": 18,
+          "span_id": 21,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -465,42 +262,20 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 29,
-          "parent_id": 18,
+          "span_id": 22,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp55_posts\n\t\tWHERE post_name IN ('simple_view')\n\t\tAND post_type IN ('page','attachment')\n\t",
-             "trace_id": 0,
-             "span_id": 44,
-             "parent_id": 29,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
         {
           "name": "WP.send_headers",
           "service": "wordpress_59_test_app",
           "resource": "WP.send_headers",
           "trace_id": 0,
-          "span_id": 30,
-          "parent_id": 18,
+          "span_id": 23,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -511,86 +286,20 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.query_posts",
           "trace_id": 0,
-          "span_id": 31,
-          "parent_id": 18,
+          "span_id": 24,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT   wp55_posts.* FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_name = 'simple_view' AND wp55_posts.post_type = 'post'  ORDER BY wp55_posts.post_date DESC ",
-             "trace_id": 0,
-             "span_id": 45,
-             "parent_id": 31,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT  t.*, tt.*, tr.object_id FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id INNER JOIN wp55_term_relationships AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy IN ('category', 'post_tag', 'post_format') AND tr.object_id IN (5) ORDER BY t.name ASC ",
-             "trace_id": 0,
-             "span_id": 46,
-             "parent_id": 31,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT post_id, meta_key, meta_value FROM wp55_postmeta WHERE post_id IN (5) ORDER BY meta_id ASC",
-             "trace_id": 0,
-             "span_id": 47,
-             "parent_id": 31,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 3.0
-             }
-           },
         {
           "name": "WP.handle_404",
           "service": "wordpress_59_test_app",
           "resource": "WP.handle_404",
           "trace_id": 0,
-          "span_id": 32,
-          "parent_id": 18,
+          "span_id": 25,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -601,8 +310,8 @@
           "service": "wordpress_59_test_app",
           "resource": "WP.register_globals",
           "trace_id": 0,
-          "span_id": 33,
-          "parent_id": 18,
+          "span_id": 26,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -613,8 +322,8 @@
           "service": "wordpress_59_test_app",
           "resource": "wp (hook)",
           "trace_id": 0,
-          "span_id": 34,
-          "parent_id": 18,
+          "span_id": 27,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -626,7 +335,7 @@
        "service": "wordpress_59_test_app",
        "resource": "load_template_loader",
        "trace_id": 0,
-       "span_id": 19,
+       "span_id": 13,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -638,8 +347,8 @@
           "service": "wordpress_59_test_app",
           "resource": "template_redirect (hook)",
           "trace_id": 0,
-          "span_id": 35,
-          "parent_id": 19,
+          "span_id": 28,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -651,65 +360,21 @@
           "service": "wordpress_59_test_app",
           "resource": "single (type)",
           "trace_id": 0,
-          "span_id": 36,
-          "parent_id": 19,
+          "span_id": 29,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
             "wordpress.template_type": "single"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT  t.*, tt.* FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id WHERE tt.taxonomy IN ('wp_theme') AND t.name IN ('twentytwenty')  ",
-             "trace_id": 0,
-             "span_id": 48,
-             "parent_id": 36,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT   wp55_posts.* FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_name IN ('single-post-simple_view','single-post','single') AND ( \n  0 = 1\n) AND wp55_posts.post_type = 'wp_template' AND ((wp55_posts.post_status = 'publish')) GROUP BY wp55_posts.ID ORDER BY wp55_posts.post_date DESC ",
-             "trace_id": 0,
-             "span_id": 49,
-             "parent_id": 36,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
         {
           "name": "template",
           "service": "wordpress_59_test_app",
           "resource": "singular (type)",
           "trace_id": 0,
-          "span_id": 37,
-          "parent_id": 19,
+          "span_id": 30,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -717,35 +382,13 @@
             "wordpress.theme": "Twenty Twenty"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT   wp55_posts.* FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_name IN ('singular') AND ( \n  0 = 1\n) AND wp55_posts.post_type = 'wp_template' AND ((wp55_posts.post_status = 'publish')) GROUP BY wp55_posts.ID ORDER BY wp55_posts.post_date DESC ",
-             "trace_id": 0,
-             "span_id": 50,
-             "parent_id": 37,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
         {
           "name": "get_header",
           "service": "wordpress_59_test_app",
           "resource": "get_header",
           "trace_id": 0,
-          "span_id": 38,
-          "parent_id": 19,
+          "span_id": 31,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -756,8 +399,8 @@
              "service": "wordpress_59_test_app",
              "resource": "header (template)",
              "trace_id": 0,
-             "span_id": 51,
-             "parent_id": 38,
+             "span_id": 37,
+             "parent_id": 31,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -770,8 +413,8 @@
                 "service": "wordpress_59_test_app",
                 "resource": "wp_head (hook)",
                 "trace_id": 0,
-                "span_id": 62,
-                "parent_id": 51,
+                "span_id": 43,
+                "parent_id": 37,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -779,100 +422,12 @@
                 }
               },
                  {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'medium_crop' LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 75,
-                   "parent_id": 62,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'medium_large_crop' LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 76,
-                   "parent_id": 62,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'large_crop' LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 77,
-                   "parent_id": 62,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT   wp55_posts.ID FROM wp55_posts  WHERE 1=1  AND ( \n  0 = 1\n) AND wp55_posts.post_type = 'wp_global_styles' AND ((wp55_posts.post_status = 'publish')) GROUP BY wp55_posts.ID ORDER BY wp55_posts.post_date DESC LIMIT 0, 1",
-                   "trace_id": 0,
-                   "span_id": 78,
-                   "parent_id": 62,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
-                 {
                    "name": "wp_print_head_scripts",
                    "service": "wordpress_59_test_app",
                    "resource": "wp_print_head_scripts",
                    "trace_id": 0,
-                   "span_id": 79,
-                   "parent_id": 62,
+                   "span_id": 53,
+                   "parent_id": 43,
                    "type": "web",
                    "meta": {
                      "component": "wordpress"
@@ -883,121 +438,11 @@
                 "service": "wordpress_59_test_app",
                 "resource": "body_class",
                 "trace_id": 0,
-                "span_id": 63,
-                "parent_id": 51,
+                "span_id": 44,
+                "parent_id": 37,
                 "type": "web",
                 "meta": {
                   "component": "wordpress"
-                }
-              },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT option_value FROM wp55_options WHERE option_name = 'site_logo' LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 80,
-                   "parent_id": 63,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT p.ID FROM wp55_posts AS p  WHERE p.post_date > '2020-10-22 16:32:26' AND p.post_type = 'post'  AND p.post_status = 'publish' ORDER BY p.post_date ASC LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 81,
-                   "parent_id": 63,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT p.ID FROM wp55_posts AS p  WHERE p.post_date < '2020-10-22 16:32:26' AND p.post_type = 'post'  AND p.post_status = 'publish' ORDER BY p.post_date DESC LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 82,
-                   "parent_id": 63,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT * FROM wp55_posts WHERE ID = 1 LIMIT 1",
-                   "trace_id": 0,
-                   "span_id": 83,
-                   "parent_id": 63,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT * FROM wp55_posts  WHERE (post_type = 'page' AND post_status = 'publish')     ORDER BY menu_order,wp55_posts.post_title ASC",
-                "trace_id": 0,
-                "span_id": 64,
-                "parent_id": 51,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
                 }
               },
         {
@@ -1005,64 +450,20 @@
           "service": "wordpress_59_test_app",
           "resource": "the_post",
           "trace_id": 0,
-          "span_id": 39,
-          "parent_id": 19,
+          "span_id": 32,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT * FROM wp55_users WHERE ID = '1' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 52,
-             "parent_id": 39,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT user_id, meta_key, meta_value FROM wp55_usermeta WHERE user_id IN (1) ORDER BY umeta_id ASC",
-             "trace_id": 0,
-             "span_id": 53,
-             "parent_id": 39,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_59_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 18.0
-             }
-           },
         {
           "name": "load_template",
           "service": "wordpress_59_test_app",
           "resource": "content (template)",
           "trace_id": 0,
-          "span_id": 40,
-          "parent_id": 19,
+          "span_id": 33,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1075,8 +476,8 @@
              "service": "wordpress_59_test_app",
              "resource": "the_content",
              "trace_id": 0,
-             "span_id": 54,
-             "parent_id": 40,
+             "span_id": 38,
+             "parent_id": 33,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1088,8 +489,8 @@
                 "service": "wordpress_59_test_app",
                 "resource": "core/paragraph (block)",
                 "trace_id": 0,
-                "span_id": 65,
-                "parent_id": 54,
+                "span_id": 45,
+                "parent_id": 38,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -1101,42 +502,20 @@
              "service": "wordpress_59_test_app",
              "resource": "comments_template",
              "trace_id": 0,
-             "span_id": 55,
-             "parent_id": 40,
+             "span_id": 39,
+             "parent_id": 33,
              "type": "web",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT SQL_CALC_FOUND_ROWS wp55_comments.comment_ID FROM wp55_comments  WHERE ( comment_approved = '1' ) AND comment_post_ID = 5 AND comment_parent = 0  ORDER BY wp55_comments.comment_date_gmt ASC, wp55_comments.comment_ID ASC ",
-                "trace_id": 0,
-                "span_id": 66,
-                "parent_id": 55,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              },
         {
           "name": "load_template",
           "service": "wordpress_59_test_app",
           "resource": "footer-menus-widgets (template)",
           "trace_id": 0,
-          "span_id": 41,
-          "parent_id": 19,
+          "span_id": 34,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1149,8 +528,8 @@
              "service": "wordpress_59_test_app",
              "resource": "sidebar-1",
              "trace_id": 0,
-             "span_id": 56,
-             "parent_id": 41,
+             "span_id": 40,
+             "parent_id": 34,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -1161,8 +540,8 @@
                 "service": "wordpress_59_test_app",
                 "resource": "Search (widget)",
                 "trace_id": 0,
-                "span_id": 67,
-                "parent_id": 56,
+                "span_id": 46,
+                "parent_id": 40,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -1174,166 +553,34 @@
                 "service": "wordpress_59_test_app",
                 "resource": "Recent Posts (widget)",
                 "trace_id": 0,
-                "span_id": 68,
-                "parent_id": 56,
+                "span_id": 47,
+                "parent_id": 40,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Recent Posts"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT   wp55_posts.ID FROM wp55_posts  WHERE 1=1  AND wp55_posts.post_type = 'post' AND ((wp55_posts.post_status = 'publish'))  ORDER BY wp55_posts.post_date DESC LIMIT 0, 5",
-                   "trace_id": 0,
-                   "span_id": 84,
-                   "parent_id": 68,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 2.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  t.*, tt.*, tr.object_id FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id INNER JOIN wp55_term_relationships AS tr ON tr.term_taxonomy_id = tt.term_taxonomy_id WHERE tt.taxonomy IN ('category', 'post_tag', 'post_format') AND tr.object_id IN (1) ORDER BY t.name ASC ",
-                   "trace_id": 0,
-                   "span_id": 85,
-                   "parent_id": 68,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT post_id, meta_key, meta_value FROM wp55_postmeta WHERE post_id IN (1) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 86,
-                   "parent_id": 68,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
               {
                 "name": "widget",
                 "service": "wordpress_59_test_app",
                 "resource": "Recent Comments (widget)",
                 "trace_id": 0,
-                "span_id": 69,
-                "parent_id": 56,
+                "span_id": 48,
+                "parent_id": 40,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Recent Comments"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  wp55_comments.comment_ID FROM wp55_comments JOIN wp55_posts ON wp55_posts.ID = wp55_comments.comment_post_ID WHERE ( comment_approved = '1' ) AND  wp55_posts.post_status IN ('publish')  ORDER BY wp55_comments.comment_date_gmt DESC LIMIT 0,5",
-                   "trace_id": 0,
-                   "span_id": 87,
-                   "parent_id": 69,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT wp55_comments.* FROM wp55_comments WHERE comment_ID IN (1)",
-                   "trace_id": 0,
-                   "span_id": 88,
-                   "parent_id": 69,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT comment_id, meta_key, meta_value FROM wp55_commentmeta WHERE comment_id IN (1) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 89,
-                   "parent_id": 69,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
            {
              "name": "dynamic_sidebar",
              "service": "wordpress_59_test_app",
              "resource": "sidebar-2",
              "trace_id": 0,
-             "span_id": 57,
-             "parent_id": 41,
+             "span_id": 41,
+             "parent_id": 34,
              "type": "web",
              "meta": {
                "component": "wordpress"
@@ -1344,100 +591,34 @@
                 "service": "wordpress_59_test_app",
                 "resource": "Archives (widget)",
                 "trace_id": 0,
-                "span_id": 70,
-                "parent_id": 57,
+                "span_id": 49,
+                "parent_id": 41,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Archives"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT YEAR(post_date) AS `year`, MONTH(post_date) AS `month`, count(ID) as posts FROM wp55_posts  WHERE post_type = 'post' AND post_status = 'publish' GROUP BY YEAR(post_date), MONTH(post_date) ORDER BY post_date DESC ",
-                   "trace_id": 0,
-                   "span_id": 90,
-                   "parent_id": 70,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
               {
                 "name": "widget",
                 "service": "wordpress_59_test_app",
                 "resource": "Categories (widget)",
                 "trace_id": 0,
-                "span_id": 71,
-                "parent_id": 57,
+                "span_id": 50,
+                "parent_id": 41,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
                   "wordpress.widget": "Categories"
                 }
               },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT  t.*, tt.* FROM wp55_terms AS t  INNER JOIN wp55_term_taxonomy AS tt ON t.term_id = tt.term_id WHERE tt.taxonomy IN ('category') AND tt.count > 0 ORDER BY t.name ASC ",
-                   "trace_id": 0,
-                   "span_id": 91,
-                   "parent_id": 71,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 1.0
-                   }
-                 },
-                 {
-                   "name": "mysqli_query",
-                   "service": "mysqli",
-                   "resource": "SELECT term_id, meta_key, meta_value FROM wp55_termmeta WHERE term_id IN (1) ORDER BY meta_id ASC",
-                   "trace_id": 0,
-                   "span_id": 92,
-                   "parent_id": 71,
-                   "type": "sql",
-                   "meta": {
-                     "_dd.base_service": "wordpress_59_test_app",
-                     "component": "mysqli",
-                     "db.name": "test",
-                     "db.system": "mysql",
-                     "db.type": "mysql",
-                     "out.host": "mysql_integration",
-                     "out.port": "3306",
-                     "span.kind": "client"
-                   },
-                   "metrics": {
-                     "db.row_count": 0.0
-                   }
-                 },
               {
                 "name": "widget",
                 "service": "wordpress_59_test_app",
                 "resource": "Meta (widget)",
                 "trace_id": 0,
-                "span_id": 72,
-                "parent_id": 57,
+                "span_id": 51,
+                "parent_id": 41,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -1449,8 +630,8 @@
           "service": "wordpress_59_test_app",
           "resource": "get_footer",
           "trace_id": 0,
-          "span_id": 42,
-          "parent_id": 19,
+          "span_id": 35,
+          "parent_id": 13,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -1461,8 +642,8 @@
              "service": "wordpress_59_test_app",
              "resource": "footer (template)",
              "trace_id": 0,
-             "span_id": 58,
-             "parent_id": 42,
+             "span_id": 42,
+             "parent_id": 35,
              "type": "web",
              "meta": {
                "component": "wordpress",
@@ -1471,34 +652,12 @@
              }
            },
               {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT * FROM wp55_posts WHERE ID = 3 LIMIT 1",
-                "trace_id": 0,
-                "span_id": 73,
-                "parent_id": 58,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_59_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
-              {
                 "name": "action",
                 "service": "wordpress_59_test_app",
                 "resource": "wp_footer (hook)",
                 "trace_id": 0,
-                "span_id": 74,
-                "parent_id": 58,
+                "span_id": 52,
+                "parent_id": 42,
                 "type": "web",
                 "meta": {
                   "component": "wordpress",
@@ -1510,7 +669,7 @@
        "service": "wordpress_59_test_app",
        "resource": "shutdown (hook)",
        "trace_id": 0,
-       "span_id": 20,
+       "span_id": 14,
        "parent_id": 1,
        "type": "web",
        "meta": {

--- a/tests/snapshots/tests.integrations.word_press.v6_1.common_scenarios_callbacks_test.test_scenario_get_return_string.json
+++ b/tests/snapshots/tests.integrations.word_press.v6_1.common_scenarios_callbacks_test.test_scenario_get_return_string.json
@@ -5,17 +5,17 @@
     "resource": "GET /simple",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 4094591049531586713,
+    "parent_id": 16094858704330228281,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "65ba300d00000000",
+      "_dd.p.tid": "65e6fe9900000000",
       "component": "wordpress",
       "http.method": "GET",
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/simple?key=value&<redacted>",
-      "runtime-id": "a4e954f4-642e-4091-995b-793d3df555ca",
+      "runtime-id": "333590aa-cf9b-4804-9dde-1ac7b59c09ab",
       "span.kind": "server"
     },
     "metrics": {
@@ -23,108 +23,11 @@
     }
   },
      {
-       "name": "mysqli_real_connect",
-       "service": "mysqli",
-       "resource": "mysqli_real_connect",
-       "trace_id": 0,
-       "span_id": 2,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-       "trace_id": 0,
-       "span_id": 3,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT @@SESSION.sql_mode",
-       "trace_id": 0,
-       "span_id": 4,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 1.0
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-       "trace_id": 0,
-       "span_id": 5,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_name, option_value FROM wp_options WHERE autoload = 'yes'",
-       "trace_id": 0,
-       "span_id": 6,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 118.0
-       }
-     },
-     {
        "name": "create_initial_taxonomies",
        "service": "wordpress_61_test_app",
        "resource": "create_initial_taxonomies",
        "trace_id": 0,
-       "span_id": 7,
+       "span_id": 2,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -138,7 +41,7 @@
        "service": "wordpress_61_test_app",
        "resource": "create_initial_post_types",
        "trace_id": 0,
-       "span_id": 8,
+       "span_id": 3,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -152,7 +55,7 @@
        "service": "wordpress_61_test_app",
        "resource": "datadog (plugin)",
        "trace_id": 0,
-       "span_id": 9,
+       "span_id": 4,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -165,7 +68,7 @@
        "service": "wordpress_61_test_app",
        "resource": "plugins_loaded (hook)",
        "trace_id": 0,
-       "span_id": 10,
+       "span_id": 5,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -178,8 +81,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_maybe_load_widgets",
           "trace_id": 0,
-          "span_id": 19,
-          "parent_id": 10,
+          "span_id": 13,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -192,8 +95,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_maybe_load_embeds",
           "trace_id": 0,
-          "span_id": 20,
-          "parent_id": 10,
+          "span_id": 14,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -206,8 +109,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_wp_add_additional_image_sizes (callback)",
           "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 10,
+          "span_id": 15,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -220,8 +123,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_wp_theme_json_webfonts_handler (callback)",
           "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 10,
+          "span_id": 16,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -234,8 +137,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_wp_customize_include",
           "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 10,
+          "span_id": 17,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -248,7 +151,7 @@
        "service": "wordpress_61_test_app",
        "resource": "setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 11,
+       "span_id": 6,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -261,8 +164,8 @@
           "service": "wordpress_61_test_app",
           "resource": "create_initial_theme_features (callback)",
           "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 11,
+          "span_id": 18,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -275,8 +178,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_add_default_theme_supports (callback)",
           "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 11,
+          "span_id": 19,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -289,8 +192,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_enable_block_templates (callback)",
           "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 11,
+          "span_id": 20,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -303,8 +206,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_delete_site_logo_on_remove_custom_logo_on_setup_theme (callback)",
           "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 11,
+          "span_id": 21,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -313,33 +216,11 @@
           }
         },
      {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_value FROM wp_options WHERE option_name = 'WPLANG' LIMIT 1",
-       "trace_id": 0,
-       "span_id": 12,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 0.0
-       }
-     },
-     {
        "name": "action",
        "service": "wordpress_61_test_app",
        "resource": "after_setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 13,
+       "span_id": 7,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -352,8 +233,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_setup_widgets_block_editor (callback)",
           "trace_id": 0,
-          "span_id": 28,
-          "parent_id": 13,
+          "span_id": 22,
+          "parent_id": 7,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -366,7 +247,7 @@
        "service": "wordpress_61_test_app",
        "resource": "WP.init",
        "trace_id": 0,
-       "span_id": 14,
+       "span_id": 8,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -378,8 +259,8 @@
           "service": "wordpress_61_test_app",
           "resource": "kses_init (callback)",
           "trace_id": 0,
-          "span_id": 29,
-          "parent_id": 14,
+          "span_id": 23,
+          "parent_id": 8,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -392,7 +273,7 @@
        "service": "wordpress_61_test_app",
        "resource": "init (hook)",
        "trace_id": 0,
-       "span_id": 15,
+       "span_id": 9,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -405,8 +286,8 @@
           "service": "wordpress_61_test_app",
           "resource": "create_initial_post_types",
           "trace_id": 0,
-          "span_id": 30,
-          "parent_id": 15,
+          "span_id": 24,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -417,8 +298,8 @@
           "service": "wordpress_61_test_app",
           "resource": "create_initial_taxonomies",
           "trace_id": 0,
-          "span_id": 31,
-          "parent_id": 15,
+          "span_id": 25,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -429,8 +310,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_widgets_init",
           "trace_id": 0,
-          "span_id": 32,
-          "parent_id": 15,
+          "span_id": 26,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -443,42 +324,20 @@
              "service": "wordpress_61_test_app",
              "resource": "WP_Widget_Factory._register_widgets",
              "trace_id": 0,
-             "span_id": 117,
-             "parent_id": 32,
+             "span_id": 111,
+             "parent_id": 26,
              "type": "web",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT option_value FROM wp_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-                "trace_id": 0,
-                "span_id": 127,
-                "parent_id": 117,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_61_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
         {
           "name": "callback",
           "service": "wordpress_61_test_app",
           "resource": "smilies_init (callback)",
           "trace_id": 0,
-          "span_id": 33,
-          "parent_id": 15,
+          "span_id": 27,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -491,8 +350,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_init_targeted_link_rel_filters (callback)",
           "trace_id": 0,
-          "span_id": 34,
-          "parent_id": 15,
+          "span_id": 28,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -505,8 +364,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_register_core_block_patterns_and_categories (callback)",
           "trace_id": 0,
-          "span_id": 35,
-          "parent_id": 15,
+          "span_id": 29,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -519,8 +378,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_cron (callback)",
           "trace_id": 0,
-          "span_id": 36,
-          "parent_id": 15,
+          "span_id": 30,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -533,8 +392,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_schedule_https_detection (callback)",
           "trace_id": 0,
-          "span_id": 37,
-          "parent_id": 15,
+          "span_id": 31,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -547,8 +406,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_schedule_delete_old_privacy_export_files (callback)",
           "trace_id": 0,
-          "span_id": 38,
-          "parent_id": 15,
+          "span_id": 32,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -561,8 +420,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_show_post_preview (callback)",
           "trace_id": 0,
-          "span_id": 39,
-          "parent_id": 15,
+          "span_id": 33,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -575,8 +434,8 @@
           "service": "wordpress_61_test_app",
           "resource": "rest_api_init (callback)",
           "trace_id": 0,
-          "span_id": 40,
-          "parent_id": 15,
+          "span_id": 34,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -589,8 +448,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_sitemaps_get_server (callback)",
           "trace_id": 0,
-          "span_id": 41,
-          "parent_id": 15,
+          "span_id": 35,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -603,8 +462,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_register_persisted_preferences_meta (callback)",
           "trace_id": 0,
-          "span_id": 42,
-          "parent_id": 15,
+          "span_id": 36,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -617,8 +476,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_schedule_update_checks (callback)",
           "trace_id": 0,
-          "span_id": 43,
-          "parent_id": 15,
+          "span_id": 37,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -631,8 +490,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_legacy_widget (callback)",
           "trace_id": 0,
-          "span_id": 44,
-          "parent_id": 15,
+          "span_id": 38,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -645,8 +504,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_widget_group (callback)",
           "trace_id": 0,
-          "span_id": 45,
-          "parent_id": 15,
+          "span_id": 39,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -659,8 +518,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_archives (callback)",
           "trace_id": 0,
-          "span_id": 46,
-          "parent_id": 15,
+          "span_id": 40,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -673,8 +532,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_avatar (callback)",
           "trace_id": 0,
-          "span_id": 47,
-          "parent_id": 15,
+          "span_id": 41,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -687,8 +546,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_block (callback)",
           "trace_id": 0,
-          "span_id": 48,
-          "parent_id": 15,
+          "span_id": 42,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -701,8 +560,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_calendar (callback)",
           "trace_id": 0,
-          "span_id": 49,
-          "parent_id": 15,
+          "span_id": 43,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -715,8 +574,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_categories (callback)",
           "trace_id": 0,
-          "span_id": 50,
-          "parent_id": 15,
+          "span_id": 44,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -729,8 +588,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comment_author_name (callback)",
           "trace_id": 0,
-          "span_id": 51,
-          "parent_id": 15,
+          "span_id": 45,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -743,8 +602,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comment_content (callback)",
           "trace_id": 0,
-          "span_id": 52,
-          "parent_id": 15,
+          "span_id": 46,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -757,8 +616,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comment_date (callback)",
           "trace_id": 0,
-          "span_id": 53,
-          "parent_id": 15,
+          "span_id": 47,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -771,8 +630,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comment_edit_link (callback)",
           "trace_id": 0,
-          "span_id": 54,
-          "parent_id": 15,
+          "span_id": 48,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -785,8 +644,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comment_reply_link (callback)",
           "trace_id": 0,
-          "span_id": 55,
-          "parent_id": 15,
+          "span_id": 49,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -799,8 +658,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comment_template (callback)",
           "trace_id": 0,
-          "span_id": 56,
-          "parent_id": 15,
+          "span_id": 50,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -813,8 +672,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comments (callback)",
           "trace_id": 0,
-          "span_id": 57,
-          "parent_id": 15,
+          "span_id": 51,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -827,8 +686,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comments_pagination (callback)",
           "trace_id": 0,
-          "span_id": 58,
-          "parent_id": 15,
+          "span_id": 52,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -841,8 +700,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comments_pagination_next (callback)",
           "trace_id": 0,
-          "span_id": 59,
-          "parent_id": 15,
+          "span_id": 53,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -855,8 +714,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comments_pagination_numbers (callback)",
           "trace_id": 0,
-          "span_id": 60,
-          "parent_id": 15,
+          "span_id": 54,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -869,8 +728,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comments_pagination_previous (callback)",
           "trace_id": 0,
-          "span_id": 61,
-          "parent_id": 15,
+          "span_id": 55,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -883,8 +742,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comments_title (callback)",
           "trace_id": 0,
-          "span_id": 62,
-          "parent_id": 15,
+          "span_id": 56,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -897,8 +756,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_cover (callback)",
           "trace_id": 0,
-          "span_id": 63,
-          "parent_id": 15,
+          "span_id": 57,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -911,8 +770,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_file (callback)",
           "trace_id": 0,
-          "span_id": 64,
-          "parent_id": 15,
+          "span_id": 58,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -925,8 +784,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_gallery (callback)",
           "trace_id": 0,
-          "span_id": 65,
-          "parent_id": 15,
+          "span_id": 59,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -939,8 +798,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_home_link (callback)",
           "trace_id": 0,
-          "span_id": 66,
-          "parent_id": 15,
+          "span_id": 60,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -953,8 +812,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_image (callback)",
           "trace_id": 0,
-          "span_id": 67,
-          "parent_id": 15,
+          "span_id": 61,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -967,8 +826,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_latest_comments (callback)",
           "trace_id": 0,
-          "span_id": 68,
-          "parent_id": 15,
+          "span_id": 62,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -981,8 +840,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_latest_posts (callback)",
           "trace_id": 0,
-          "span_id": 69,
-          "parent_id": 15,
+          "span_id": 63,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -995,8 +854,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_loginout (callback)",
           "trace_id": 0,
-          "span_id": 70,
-          "parent_id": 15,
+          "span_id": 64,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1009,8 +868,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_navigation (callback)",
           "trace_id": 0,
-          "span_id": 71,
-          "parent_id": 15,
+          "span_id": 65,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1023,8 +882,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_navigation_link (callback)",
           "trace_id": 0,
-          "span_id": 72,
-          "parent_id": 15,
+          "span_id": 66,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1037,8 +896,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_navigation_submenu (callback)",
           "trace_id": 0,
-          "span_id": 73,
-          "parent_id": 15,
+          "span_id": 67,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1051,8 +910,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_page_list (callback)",
           "trace_id": 0,
-          "span_id": 74,
-          "parent_id": 15,
+          "span_id": 68,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1065,8 +924,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_pattern (callback)",
           "trace_id": 0,
-          "span_id": 75,
-          "parent_id": 15,
+          "span_id": 69,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1079,8 +938,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_author (callback)",
           "trace_id": 0,
-          "span_id": 76,
-          "parent_id": 15,
+          "span_id": 70,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1093,8 +952,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_author_biography (callback)",
           "trace_id": 0,
-          "span_id": 77,
-          "parent_id": 15,
+          "span_id": 71,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1107,8 +966,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_comments_form (callback)",
           "trace_id": 0,
-          "span_id": 78,
-          "parent_id": 15,
+          "span_id": 72,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1121,8 +980,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_content (callback)",
           "trace_id": 0,
-          "span_id": 79,
-          "parent_id": 15,
+          "span_id": 73,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1135,8 +994,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_date (callback)",
           "trace_id": 0,
-          "span_id": 80,
-          "parent_id": 15,
+          "span_id": 74,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1149,8 +1008,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_excerpt (callback)",
           "trace_id": 0,
-          "span_id": 81,
-          "parent_id": 15,
+          "span_id": 75,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1163,8 +1022,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_featured_image (callback)",
           "trace_id": 0,
-          "span_id": 82,
-          "parent_id": 15,
+          "span_id": 76,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1177,8 +1036,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_navigation_link (callback)",
           "trace_id": 0,
-          "span_id": 83,
-          "parent_id": 15,
+          "span_id": 77,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1191,8 +1050,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_template (callback)",
           "trace_id": 0,
-          "span_id": 84,
-          "parent_id": 15,
+          "span_id": 78,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1205,8 +1064,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_terms (callback)",
           "trace_id": 0,
-          "span_id": 85,
-          "parent_id": 15,
+          "span_id": 79,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1219,8 +1078,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_title (callback)",
           "trace_id": 0,
-          "span_id": 86,
-          "parent_id": 15,
+          "span_id": 80,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1233,8 +1092,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_query (callback)",
           "trace_id": 0,
-          "span_id": 87,
-          "parent_id": 15,
+          "span_id": 81,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1247,8 +1106,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_query_no_results (callback)",
           "trace_id": 0,
-          "span_id": 88,
-          "parent_id": 15,
+          "span_id": 82,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1261,8 +1120,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_query_pagination (callback)",
           "trace_id": 0,
-          "span_id": 89,
-          "parent_id": 15,
+          "span_id": 83,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1275,8 +1134,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_query_pagination_next (callback)",
           "trace_id": 0,
-          "span_id": 90,
-          "parent_id": 15,
+          "span_id": 84,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1289,8 +1148,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_query_pagination_numbers (callback)",
           "trace_id": 0,
-          "span_id": 91,
-          "parent_id": 15,
+          "span_id": 85,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1303,8 +1162,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_query_pagination_previous (callback)",
           "trace_id": 0,
-          "span_id": 92,
-          "parent_id": 15,
+          "span_id": 86,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1317,8 +1176,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_query_title (callback)",
           "trace_id": 0,
-          "span_id": 93,
-          "parent_id": 15,
+          "span_id": 87,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1331,8 +1190,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_read_more (callback)",
           "trace_id": 0,
-          "span_id": 94,
-          "parent_id": 15,
+          "span_id": 88,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1345,8 +1204,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_rss (callback)",
           "trace_id": 0,
-          "span_id": 95,
-          "parent_id": 15,
+          "span_id": 89,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1359,8 +1218,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_search (callback)",
           "trace_id": 0,
-          "span_id": 96,
-          "parent_id": 15,
+          "span_id": 90,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1373,8 +1232,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_shortcode (callback)",
           "trace_id": 0,
-          "span_id": 97,
-          "parent_id": 15,
+          "span_id": 91,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1387,8 +1246,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_site_logo (callback)",
           "trace_id": 0,
-          "span_id": 98,
-          "parent_id": 15,
+          "span_id": 92,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1401,8 +1260,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_site_tagline (callback)",
           "trace_id": 0,
-          "span_id": 99,
-          "parent_id": 15,
+          "span_id": 93,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1415,8 +1274,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_site_title (callback)",
           "trace_id": 0,
-          "span_id": 100,
-          "parent_id": 15,
+          "span_id": 94,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1429,8 +1288,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_social_link (callback)",
           "trace_id": 0,
-          "span_id": 101,
-          "parent_id": 15,
+          "span_id": 95,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1443,8 +1302,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_tag_cloud (callback)",
           "trace_id": 0,
-          "span_id": 102,
-          "parent_id": 15,
+          "span_id": 96,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1457,8 +1316,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_template_part (callback)",
           "trace_id": 0,
-          "span_id": 103,
-          "parent_id": 15,
+          "span_id": 97,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1466,123 +1325,13 @@
             "wordpress.hook": "init"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\t\tSELECT  t.term_id\n\t\t\tFROM wp_terms AS t  INNER JOIN wp_term_taxonomy AS tt ON t.term_id = tt.term_id\n\t\t\tWHERE tt.taxonomy IN ('wp_theme') AND t.name IN ('twentytwentythree')\n\t\t\t\n\t\t\tLIMIT 1\n\t\t",
-             "trace_id": 0,
-             "span_id": 118,
-             "parent_id": 103,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\t\tSELECT   wp_posts.*\n\t\t\tFROM wp_posts \n\t\t\tWHERE 1=1  AND ( \n  0 = 1\n) AND wp_posts.post_type = 'wp_template_part' AND ((wp_posts.post_status = 'publish'))\n\t\t\tGROUP BY wp_posts.ID\n\t\t\tORDER BY wp_posts.post_date DESC\n\t\t\t\n\t\t",
-             "trace_id": 0,
-             "span_id": 119,
-             "parent_id": 103,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp_options WHERE option_name = 'medium_crop' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 120,
-             "parent_id": 103,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp_options WHERE option_name = 'medium_large_crop' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 121,
-             "parent_id": 103,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp_options WHERE option_name = 'large_crop' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 122,
-             "parent_id": 103,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
         {
           "name": "callback",
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_term_description (callback)",
           "trace_id": 0,
-          "span_id": 104,
-          "parent_id": 15,
+          "span_id": 98,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1595,8 +1344,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_core_block_types_from_metadata (callback)",
           "trace_id": 0,
-          "span_id": 105,
-          "parent_id": 15,
+          "span_id": 99,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1609,8 +1358,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_register_theme_block_patterns (callback)",
           "trace_id": 0,
-          "span_id": 106,
-          "parent_id": 15,
+          "span_id": 100,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1623,8 +1372,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_legacy_post_comments_block (callback)",
           "trace_id": 0,
-          "span_id": 107,
-          "parent_id": 15,
+          "span_id": 101,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1637,8 +1386,8 @@
           "service": "wordpress_61_test_app",
           "resource": "WP_Block_Supports::init (callback)",
           "trace_id": 0,
-          "span_id": 108,
-          "parent_id": 15,
+          "span_id": 102,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1651,8 +1400,8 @@
           "service": "wordpress_61_test_app",
           "resource": "check_theme_switched (callback)",
           "trace_id": 0,
-          "span_id": 109,
-          "parent_id": 15,
+          "span_id": 103,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1660,34 +1409,12 @@
             "wordpress.hook": "init"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp_options WHERE option_name = 'theme_switched' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 123,
-             "parent_id": 109,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_61_test_app",
        "resource": "wp_loaded (hook)",
        "trace_id": 0,
-       "span_id": 16,
+       "span_id": 10,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -1700,8 +1427,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_custom_header_background_just_in_time (callback)",
           "trace_id": 0,
-          "span_id": 110,
-          "parent_id": 16,
+          "span_id": 104,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1714,8 +1441,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_add_template_loader_filters (callback)",
           "trace_id": 0,
-          "span_id": 111,
-          "parent_id": 16,
+          "span_id": 105,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1728,8 +1455,8 @@
           "service": "wordpress_61_test_app",
           "resource": "Closure (callback)",
           "trace_id": 0,
-          "span_id": 112,
-          "parent_id": 16,
+          "span_id": 106,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "closure.declaration": "/home/circleci/datadog/tests/Frameworks/WordPress/Version_6_1/wp-includes/script-loader.php:3398",
@@ -1738,35 +1465,13 @@
             "wordpress.hook": "wp_loaded"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\t\t\t\tSELECT   wp_posts.ID\n\t\t\t\t\tFROM wp_posts \n\t\t\t\t\tWHERE 1=1  AND ( \n  0 = 1\n) AND wp_posts.post_type = 'wp_global_styles' AND ((wp_posts.post_status = 'publish'))\n\t\t\t\t\tGROUP BY wp_posts.ID\n\t\t\t\t\tORDER BY wp_posts.post_date DESC\n\t\t\t\t\tLIMIT 0, 1\n\t\t\t\t",
-             "trace_id": 0,
-             "span_id": 124,
-             "parent_id": 112,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
         {
           "name": "callback",
           "service": "wordpress_61_test_app",
           "resource": "_wp_cron (callback)",
           "trace_id": 0,
-          "span_id": 113,
-          "parent_id": 16,
+          "span_id": 107,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1779,7 +1484,7 @@
        "service": "wordpress_61_test_app",
        "resource": "WP.main",
        "trace_id": 0,
-       "span_id": 17,
+       "span_id": 11,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -1791,8 +1496,8 @@
           "service": "wordpress_61_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 114,
-          "parent_id": 17,
+          "span_id": 108,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -1803,60 +1508,19 @@
           "service": "wordpress_61_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 115,
-          "parent_id": 17,
+          "span_id": 109,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('rewrite_rules', 'a:93:{s:11:\\\"^wp-json/?$\\\";s:22:\\\"index.php?rest_route=/\\\";s:14:\\\"^wp-json/(.*)?\\\";s:33:\\\"index.php?rest_route=/$matches[1]\\\";s:21:\\\"^index.php/wp-json/?$\\\";s:22:\\\"index.php?rest_route=/\\\";s:24:\\\"^index.php/wp-json/(.*)?\\\";s:33:\\\"index.php?rest_route=/$matches[1]\\\";s:17:\\\"^wp-sitemap\\\\.xml$\\\";s:23:\\\"index.php?sitemap=index\\\";s:17:\\\"^wp-sitemap\\\\.xsl$\\\";s:36:\\\"index.php?sitemap-stylesheet=sitemap\\\";s:23:\\\"^wp-sitemap-index\\\\.xsl$\\\";s:34:\\\"index.php?sitemap-stylesheet=index\\\";s:48:\\\"^wp-sitemap-([a-z]+?)-([a-z\\\\d_-]+?)-(\\\\d+?)\\\\.xml$\\\";s:75:\\\"index.php?sitemap=$matches[1]&sitemap-subtype=$matches[2]&paged=$matches[3]\\\";s:34:\\\"^wp-sitemap-([a-z]+?)-(\\\\d+?)\\\\.xml$\\\";s:47:\\\"index.php?sitemap=$matches[1]&paged=$matches[2]\\\";s:47:\\\"category/(.+?)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:52:\\\"index.php?category_name=$matches[1]&feed=$matches[2]\\\";s:42:\\\"category/(.+?)/(feed|rdf|rss|rss2|atom)/?$\\\";s:52:\\\"index.php?category_name=$matches[1]&feed=$matches[2]\\\";s:23:\\\"category/(.+?)/embed/?$\\\";s:46:\\\"index.php?category_name=$matches[1]&embed=true\\\";s:35:\\\"category/(.+?)/page/?([0-9]{1,})/?$\\\";s:53:\\\"index.php?category_name=$matches[1]&paged=$matches[2]\\\";s:17:\\\"category/(.+?)/?$\\\";s:35:\\\"index.php?category_name=$matches[1]\\\";s:44:\\\"tag/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?tag=$matches[1]&feed=$matches[2]\\\";s:39:\\\"tag/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?tag=$matches[1]&feed=$matches[2]\\\";s:20:\\\"tag/([^/]+)/embed/?$\\\";s:36:\\\"index.php?tag=$matches[1]&embed=true\\\";s:32:\\\"tag/([^/]+)/page/?([0-9]{1,})/?$\\\";s:43:\\\"index.php?tag=$matches[1]&paged=$matches[2]\\\";s:14:\\\"tag/([^/]+)/?$\\\";s:25:\\\"index.php?tag=$matches[1]\\\";s:45:\\\"type/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?post_format=$matches[1]&feed=$matches[2]\\\";s:40:\\\"type/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?post_format=$matches[1]&feed=$matches[2]\\\";s:21:\\\"type/([^/]+)/embed/?$\\\";s:44:\\\"index.php?post_format=$matches[1]&embed=true\\\";s:33:\\\"type/([^/]+)/page/?([0-9]{1,})/?$\\\";s:51:\\\"index.php?post_format=$matches[1]&paged=$matches[2]\\\";s:15:\\\"type/([^/]+)/?$\\\";s:33:\\\"index.php?post_format=$matches[1]\\\";s:12:\\\"robots\\\\.txt$\\\";s:18:\\\"index.php?robots=1\\\";s:13:\\\"favicon\\\\.ico$\\\";s:19:\\\"index.php?favicon=1\\\";s:48:\\\".*wp-(atom|rdf|rss|rss2|feed|commentsrss2)\\\\.php$\\\";s:18:\\\"index.php?feed=old\\\";s:20:\\\".*wp-app\\\\.php(/.*)?$\\\";s:19:\\\"index.php?error=403\\\";s:18:\\\".*wp-register.php$\\\";s:23:\\\"index.php?register=true\\\";s:32:\\\"feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:27:\\\"index.php?&feed=$matches[1]\\\";s:27:\\\"(feed|rdf|rss|rss2|atom)/?$\\\";s:27:\\\"index.php?&feed=$matches[1]\\\";s:8:\\\"embed/?$\\\";s:21:\\\"index.php?&embed=true\\\";s:20:\\\"page/?([0-9]{1,})/?$\\\";s:28:\\\"index.php?&paged=$matches[1]\\\";s:41:\\\"comments/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?&feed=$matches[1]&withcomments=1\\\";s:36:\\\"comments/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?&feed=$matches[1]&withcomments=1\\\";s:17:\\\"comments/embed/?$\\\";s:21:\\\"index.php?&embed=true\\\";s:44:\\\"search/(.+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:40:\\\"index.php?s=$matches[1]&feed=$matches[2]\\\";s:39:\\\"search/(.+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:40:\\\"index.php?s=$matches[1]&feed=$matches[2]\\\";s:20:\\\"search/(.+)/embed/?$\\\";s:34:\\\"index.php?s=$matches[1]&embed=true\\\";s:32:\\\"search/(.+)/page/?([0-9]{1,})/?$\\\";s:41:\\\"index.php?s=$matches[1]&paged=$matches[2]\\\";s:14:\\\"search/(.+)/?$\\\";s:23:\\\"index.php?s=$matches[1]\\\";s:47:\\\"author/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?author_name=$matches[1]&feed=$matches[2]\\\";s:42:\\\"author/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?author_name=$matches[1]&feed=$matches[2]\\\";s:23:\\\"author/([^/]+)/embed/?$\\\";s:44:\\\"index.php?author_name=$matches[1]&embed=true\\\";s:35:\\\"author/([^/]+)/page/?([0-9]{1,})/?$\\\";s:51:\\\"index.php?author_name=$matches[1]&paged=$matches[2]\\\";s:17:\\\"author/([^/]+)/?$\\\";s:33:\\\"index.php?author_name=$matches[1]\\\";s:69:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:80:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&feed=$matches[4]\\\";s:64:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/(feed|rdf|rss|rss2|atom)/?$\\\";s:80:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&feed=$matches[4]\\\";s:45:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/embed/?$\\\";s:74:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&embed=true\\\";s:57:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/page/?([0-9]{1,})/?$\\\";s:81:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&paged=$matches[4]\\\";s:39:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/?$\\\";s:63:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]\\\";s:56:\\\"([0-9]{4})/([0-9]{1,2})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:64:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&feed=$matches[3]\\\";s:51:\\\"([0-9]{4})/([0-9]{1,2})/(feed|rdf|rss|rss2|atom)/?$\\\";s:64:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&feed=$matches[3]\\\";s:32:\\\"([0-9]{4})/([0-9]{1,2})/embed/?$\\\";s:58:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&embed=true\\\";s:44:\\\"([0-9]{4})/([0-9]{1,2})/page/?([0-9]{1,})/?$\\\";s:65:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&paged=$matches[3]\\\";s:26:\\\"([0-9]{4})/([0-9]{1,2})/?$\\\";s:47:\\\"index.php?year=$matches[1]&monthnum=$matches[2]\\\";s:43:\\\"([0-9]{4})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?year=$matches[1]&feed=$matches[2]\\\";s:38:\\\"([0-9]{4})/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?year=$matches[1]&feed=$matches[2]\\\";s:19:\\\"([0-9]{4})/embed/?$\\\";s:37:\\\"index.php?year=$matches[1]&embed=true\\\";s:31:\\\"([0-9]{4})/page/?([0-9]{1,})/?$\\\";s:44:\\\"index.php?year=$matches[1]&paged=$matches[2]\\\";s:13:\\\"([0-9]{4})/?$\\\";s:26:\\\"index.php?year=$matches[1]\\\";s:27:\\\".?.+?/attachment/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:37:\\\".?.+?/attachment/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:57:\\\".?.+?/attachment/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\".?.+?/attachment/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\".?.+?/attachment/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:33:\\\".?.+?/attachment/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";s:16:\\\"(.?.+?)/embed/?$\\\";s:41:\\\"index.php?pagename=$matches[1]&embed=true\\\";s:20:\\\"(.?.+?)/trackback/?$\\\";s:35:\\\"index.php?pagename=$matches[1]&tb=1\\\";s:40:\\\"(.?.+?)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&feed=$matches[2]\\\";s:35:\\\"(.?.+?)/(feed|rdf|rss|rss2|atom)/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&feed=$matches[2]\\\";s:28:\\\"(.?.+?)/page/?([0-9]{1,})/?$\\\";s:48:\\\"index.php?pagename=$matches[1]&paged=$matches[2]\\\";s:35:\\\"(.?.+?)/comment-page-([0-9]{1,})/?$\\\";s:48:\\\"index.php?pagename=$matches[1]&cpage=$matches[2]\\\";s:24:\\\"(.?.+?)(?:/([0-9]+))?/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&page=$matches[2]\\\";s:27:\\\"[^/]+/attachment/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:37:\\\"[^/]+/attachment/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:57:\\\"[^/]+/attachment/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\"[^/]+/attachment/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\"[^/]+/attachment/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:33:\\\"[^/]+/attachment/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";s:16:\\\"([^/]+)/embed/?$\\\";s:37:\\\"index.php?name=$matches[1]&embed=true\\\";s:20:\\\"([^/]+)/trackback/?$\\\";s:31:\\\"index.php?name=$matches[1]&tb=1\\\";s:40:\\\"([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?name=$matches[1]&feed=$matches[2]\\\";s:35:\\\"([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?name=$matches[1]&feed=$matches[2]\\\";s:28:\\\"([^/]+)/page/?([0-9]{1,})/?$\\\";s:44:\\\"index.php?name=$matches[1]&paged=$matches[2]\\\";s:35:\\\"([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:44:\\\"index.php?name=$matches[1]&cpage=$matches[2]\\\";s:24:\\\"([^/]+)(?:/([0-9]+))?/?$\\\";s:43:\\\"index.php?name=$matches[1]&page=$matches[2]\\\";s:16:\\\"[^/]+/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:26:\\\"[^/]+/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:46:\\\"[^/]+/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:41:\\\"[^/]+/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:41:\\\"[^/]+/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:22:\\\"[^/]+/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";}', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)",
-             "trace_id": 0,
-             "span_id": 125,
-             "parent_id": 115,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp_posts\n\t\tWHERE post_name IN ('simple')\n\t\tAND post_type IN ('page','attachment')\n\t",
-             "trace_id": 0,
-             "span_id": 126,
-             "parent_id": 115,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_61_test_app",
        "resource": "shutdown (hook)",
        "trace_id": 0,
-       "span_id": 18,
+       "span_id": 12,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -1869,8 +1533,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_ob_end_flush_all (callback)",
           "trace_id": 0,
-          "span_id": 116,
-          "parent_id": 18,
+          "span_id": 110,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress",

--- a/tests/snapshots/tests.integrations.word_press.v6_1.common_scenarios_callbacks_test.test_scenario_get_with_exception.json
+++ b/tests/snapshots/tests.integrations.word_press.v6_1.common_scenarios_callbacks_test.test_scenario_get_with_exception.json
@@ -5,12 +5,12 @@
     "resource": "GET /error",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 8511486485941812640,
+    "parent_id": 13388519595029026482,
     "type": "web",
     "error": 1,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "65ba25e700000000",
+      "_dd.p.tid": "65e6feb000000000",
       "component": "wordpress",
       "error.message": "Uncaught Exception: Oops! in /home/circleci/datadog/tests/Frameworks/WordPress/Version_6_1/wp-content/plugins/datadog/datadog.php:20",
       "error.stack": "#0 /home/circleci/datadog/tests/Frameworks/WordPress/Version_6_1/wp-includes/class-wp-hook.php(308): datadog_parse_request()\n#1 /home/circleci/datadog/tests/Frameworks/WordPress/Version_6_1/wp-includes/class-wp-hook.php(332): WP_Hook->apply_filters()\n#2 /home/circleci/datadog/tests/Frameworks/WordPress/Version_6_1/wp-includes/plugin.php(565): WP_Hook->do_action()\n#3 /home/circleci/datadog/tests/Frameworks/WordPress/Version_6_1/wp-includes/class-wp.php(399): do_action_ref_array()\n#4 /home/circleci/datadog/tests/Frameworks/WordPress/Version_6_1/wp-includes/class-wp.php(780): WP->parse_request()\n#5 /home/circleci/datadog/tests/Frameworks/WordPress/Version_6_1/wp-includes/functions.php(1332): WP->main()\n#6 /home/circleci/datadog/tests/Frameworks/WordPress/Version_6_1/wp-blog-header.php(16): wp()\n#7 /home/circleci/datadog/tests/Frameworks/WordPress/Version_6_1/index.php(17): require()\n#8 {main}",
@@ -19,7 +19,7 @@
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/error?key=value&<redacted>",
-      "runtime-id": "94b95fa0-b274-419b-a1fc-1a76d74fa102",
+      "runtime-id": "333590aa-cf9b-4804-9dde-1ac7b59c09ab",
       "span.kind": "server"
     },
     "metrics": {
@@ -27,108 +27,11 @@
     }
   },
      {
-       "name": "mysqli_real_connect",
-       "service": "mysqli",
-       "resource": "mysqli_real_connect",
-       "trace_id": 0,
-       "span_id": 2,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-       "trace_id": 0,
-       "span_id": 3,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT @@SESSION.sql_mode",
-       "trace_id": 0,
-       "span_id": 4,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 1.0
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-       "trace_id": 0,
-       "span_id": 5,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_name, option_value FROM wp_options WHERE autoload = 'yes'",
-       "trace_id": 0,
-       "span_id": 6,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 118.0
-       }
-     },
-     {
        "name": "create_initial_taxonomies",
        "service": "wordpress_61_test_app",
        "resource": "create_initial_taxonomies",
        "trace_id": 0,
-       "span_id": 7,
+       "span_id": 2,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -142,7 +45,7 @@
        "service": "wordpress_61_test_app",
        "resource": "create_initial_post_types",
        "trace_id": 0,
-       "span_id": 8,
+       "span_id": 3,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -156,7 +59,7 @@
        "service": "wordpress_61_test_app",
        "resource": "datadog (plugin)",
        "trace_id": 0,
-       "span_id": 9,
+       "span_id": 4,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -169,7 +72,7 @@
        "service": "wordpress_61_test_app",
        "resource": "plugins_loaded (hook)",
        "trace_id": 0,
-       "span_id": 10,
+       "span_id": 5,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -182,8 +85,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_maybe_load_widgets",
           "trace_id": 0,
-          "span_id": 19,
-          "parent_id": 10,
+          "span_id": 13,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -196,8 +99,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_maybe_load_embeds",
           "trace_id": 0,
-          "span_id": 20,
-          "parent_id": 10,
+          "span_id": 14,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -210,8 +113,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_wp_add_additional_image_sizes (callback)",
           "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 10,
+          "span_id": 15,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -224,8 +127,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_wp_theme_json_webfonts_handler (callback)",
           "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 10,
+          "span_id": 16,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -238,8 +141,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_wp_customize_include",
           "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 10,
+          "span_id": 17,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -252,7 +155,7 @@
        "service": "wordpress_61_test_app",
        "resource": "setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 11,
+       "span_id": 6,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -265,8 +168,8 @@
           "service": "wordpress_61_test_app",
           "resource": "create_initial_theme_features (callback)",
           "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 11,
+          "span_id": 18,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -279,8 +182,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_add_default_theme_supports (callback)",
           "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 11,
+          "span_id": 19,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -293,8 +196,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_enable_block_templates (callback)",
           "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 11,
+          "span_id": 20,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -307,8 +210,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_delete_site_logo_on_remove_custom_logo_on_setup_theme (callback)",
           "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 11,
+          "span_id": 21,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -317,33 +220,11 @@
           }
         },
      {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_value FROM wp_options WHERE option_name = 'WPLANG' LIMIT 1",
-       "trace_id": 0,
-       "span_id": 12,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 0.0
-       }
-     },
-     {
        "name": "action",
        "service": "wordpress_61_test_app",
        "resource": "after_setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 13,
+       "span_id": 7,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -356,8 +237,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_setup_widgets_block_editor (callback)",
           "trace_id": 0,
-          "span_id": 28,
-          "parent_id": 13,
+          "span_id": 22,
+          "parent_id": 7,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -370,7 +251,7 @@
        "service": "wordpress_61_test_app",
        "resource": "WP.init",
        "trace_id": 0,
-       "span_id": 14,
+       "span_id": 8,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -382,8 +263,8 @@
           "service": "wordpress_61_test_app",
           "resource": "kses_init (callback)",
           "trace_id": 0,
-          "span_id": 29,
-          "parent_id": 14,
+          "span_id": 23,
+          "parent_id": 8,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -396,7 +277,7 @@
        "service": "wordpress_61_test_app",
        "resource": "init (hook)",
        "trace_id": 0,
-       "span_id": 15,
+       "span_id": 9,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -409,8 +290,8 @@
           "service": "wordpress_61_test_app",
           "resource": "create_initial_post_types",
           "trace_id": 0,
-          "span_id": 30,
-          "parent_id": 15,
+          "span_id": 24,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -421,8 +302,8 @@
           "service": "wordpress_61_test_app",
           "resource": "create_initial_taxonomies",
           "trace_id": 0,
-          "span_id": 31,
-          "parent_id": 15,
+          "span_id": 25,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -433,8 +314,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_widgets_init",
           "trace_id": 0,
-          "span_id": 32,
-          "parent_id": 15,
+          "span_id": 26,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -447,42 +328,20 @@
              "service": "wordpress_61_test_app",
              "resource": "WP_Widget_Factory._register_widgets",
              "trace_id": 0,
-             "span_id": 117,
-             "parent_id": 32,
+             "span_id": 111,
+             "parent_id": 26,
              "type": "web",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT option_value FROM wp_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-                "trace_id": 0,
-                "span_id": 127,
-                "parent_id": 117,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_61_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
         {
           "name": "callback",
           "service": "wordpress_61_test_app",
           "resource": "smilies_init (callback)",
           "trace_id": 0,
-          "span_id": 33,
-          "parent_id": 15,
+          "span_id": 27,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -495,8 +354,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_init_targeted_link_rel_filters (callback)",
           "trace_id": 0,
-          "span_id": 34,
-          "parent_id": 15,
+          "span_id": 28,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -509,8 +368,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_register_core_block_patterns_and_categories (callback)",
           "trace_id": 0,
-          "span_id": 35,
-          "parent_id": 15,
+          "span_id": 29,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -523,8 +382,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_cron (callback)",
           "trace_id": 0,
-          "span_id": 36,
-          "parent_id": 15,
+          "span_id": 30,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -537,8 +396,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_schedule_https_detection (callback)",
           "trace_id": 0,
-          "span_id": 37,
-          "parent_id": 15,
+          "span_id": 31,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -551,8 +410,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_schedule_delete_old_privacy_export_files (callback)",
           "trace_id": 0,
-          "span_id": 38,
-          "parent_id": 15,
+          "span_id": 32,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -565,8 +424,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_show_post_preview (callback)",
           "trace_id": 0,
-          "span_id": 39,
-          "parent_id": 15,
+          "span_id": 33,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -579,8 +438,8 @@
           "service": "wordpress_61_test_app",
           "resource": "rest_api_init (callback)",
           "trace_id": 0,
-          "span_id": 40,
-          "parent_id": 15,
+          "span_id": 34,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -593,8 +452,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_sitemaps_get_server (callback)",
           "trace_id": 0,
-          "span_id": 41,
-          "parent_id": 15,
+          "span_id": 35,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -607,8 +466,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_register_persisted_preferences_meta (callback)",
           "trace_id": 0,
-          "span_id": 42,
-          "parent_id": 15,
+          "span_id": 36,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -621,8 +480,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_schedule_update_checks (callback)",
           "trace_id": 0,
-          "span_id": 43,
-          "parent_id": 15,
+          "span_id": 37,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -635,8 +494,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_legacy_widget (callback)",
           "trace_id": 0,
-          "span_id": 44,
-          "parent_id": 15,
+          "span_id": 38,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -649,8 +508,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_widget_group (callback)",
           "trace_id": 0,
-          "span_id": 45,
-          "parent_id": 15,
+          "span_id": 39,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -663,8 +522,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_archives (callback)",
           "trace_id": 0,
-          "span_id": 46,
-          "parent_id": 15,
+          "span_id": 40,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -677,8 +536,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_avatar (callback)",
           "trace_id": 0,
-          "span_id": 47,
-          "parent_id": 15,
+          "span_id": 41,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -691,8 +550,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_block (callback)",
           "trace_id": 0,
-          "span_id": 48,
-          "parent_id": 15,
+          "span_id": 42,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -705,8 +564,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_calendar (callback)",
           "trace_id": 0,
-          "span_id": 49,
-          "parent_id": 15,
+          "span_id": 43,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -719,8 +578,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_categories (callback)",
           "trace_id": 0,
-          "span_id": 50,
-          "parent_id": 15,
+          "span_id": 44,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -733,8 +592,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comment_author_name (callback)",
           "trace_id": 0,
-          "span_id": 51,
-          "parent_id": 15,
+          "span_id": 45,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -747,8 +606,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comment_content (callback)",
           "trace_id": 0,
-          "span_id": 52,
-          "parent_id": 15,
+          "span_id": 46,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -761,8 +620,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comment_date (callback)",
           "trace_id": 0,
-          "span_id": 53,
-          "parent_id": 15,
+          "span_id": 47,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -775,8 +634,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comment_edit_link (callback)",
           "trace_id": 0,
-          "span_id": 54,
-          "parent_id": 15,
+          "span_id": 48,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -789,8 +648,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comment_reply_link (callback)",
           "trace_id": 0,
-          "span_id": 55,
-          "parent_id": 15,
+          "span_id": 49,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -803,8 +662,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comment_template (callback)",
           "trace_id": 0,
-          "span_id": 56,
-          "parent_id": 15,
+          "span_id": 50,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -817,8 +676,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comments (callback)",
           "trace_id": 0,
-          "span_id": 57,
-          "parent_id": 15,
+          "span_id": 51,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -831,8 +690,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comments_pagination (callback)",
           "trace_id": 0,
-          "span_id": 58,
-          "parent_id": 15,
+          "span_id": 52,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -845,8 +704,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comments_pagination_next (callback)",
           "trace_id": 0,
-          "span_id": 59,
-          "parent_id": 15,
+          "span_id": 53,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -859,8 +718,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comments_pagination_numbers (callback)",
           "trace_id": 0,
-          "span_id": 60,
-          "parent_id": 15,
+          "span_id": 54,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -873,8 +732,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comments_pagination_previous (callback)",
           "trace_id": 0,
-          "span_id": 61,
-          "parent_id": 15,
+          "span_id": 55,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -887,8 +746,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comments_title (callback)",
           "trace_id": 0,
-          "span_id": 62,
-          "parent_id": 15,
+          "span_id": 56,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -901,8 +760,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_cover (callback)",
           "trace_id": 0,
-          "span_id": 63,
-          "parent_id": 15,
+          "span_id": 57,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -915,8 +774,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_file (callback)",
           "trace_id": 0,
-          "span_id": 64,
-          "parent_id": 15,
+          "span_id": 58,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -929,8 +788,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_gallery (callback)",
           "trace_id": 0,
-          "span_id": 65,
-          "parent_id": 15,
+          "span_id": 59,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -943,8 +802,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_home_link (callback)",
           "trace_id": 0,
-          "span_id": 66,
-          "parent_id": 15,
+          "span_id": 60,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -957,8 +816,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_image (callback)",
           "trace_id": 0,
-          "span_id": 67,
-          "parent_id": 15,
+          "span_id": 61,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -971,8 +830,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_latest_comments (callback)",
           "trace_id": 0,
-          "span_id": 68,
-          "parent_id": 15,
+          "span_id": 62,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -985,8 +844,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_latest_posts (callback)",
           "trace_id": 0,
-          "span_id": 69,
-          "parent_id": 15,
+          "span_id": 63,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -999,8 +858,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_loginout (callback)",
           "trace_id": 0,
-          "span_id": 70,
-          "parent_id": 15,
+          "span_id": 64,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1013,8 +872,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_navigation (callback)",
           "trace_id": 0,
-          "span_id": 71,
-          "parent_id": 15,
+          "span_id": 65,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1027,8 +886,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_navigation_link (callback)",
           "trace_id": 0,
-          "span_id": 72,
-          "parent_id": 15,
+          "span_id": 66,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1041,8 +900,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_navigation_submenu (callback)",
           "trace_id": 0,
-          "span_id": 73,
-          "parent_id": 15,
+          "span_id": 67,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1055,8 +914,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_page_list (callback)",
           "trace_id": 0,
-          "span_id": 74,
-          "parent_id": 15,
+          "span_id": 68,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1069,8 +928,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_pattern (callback)",
           "trace_id": 0,
-          "span_id": 75,
-          "parent_id": 15,
+          "span_id": 69,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1083,8 +942,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_author (callback)",
           "trace_id": 0,
-          "span_id": 76,
-          "parent_id": 15,
+          "span_id": 70,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1097,8 +956,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_author_biography (callback)",
           "trace_id": 0,
-          "span_id": 77,
-          "parent_id": 15,
+          "span_id": 71,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1111,8 +970,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_comments_form (callback)",
           "trace_id": 0,
-          "span_id": 78,
-          "parent_id": 15,
+          "span_id": 72,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1125,8 +984,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_content (callback)",
           "trace_id": 0,
-          "span_id": 79,
-          "parent_id": 15,
+          "span_id": 73,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1139,8 +998,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_date (callback)",
           "trace_id": 0,
-          "span_id": 80,
-          "parent_id": 15,
+          "span_id": 74,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1153,8 +1012,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_excerpt (callback)",
           "trace_id": 0,
-          "span_id": 81,
-          "parent_id": 15,
+          "span_id": 75,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1167,8 +1026,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_featured_image (callback)",
           "trace_id": 0,
-          "span_id": 82,
-          "parent_id": 15,
+          "span_id": 76,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1181,8 +1040,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_navigation_link (callback)",
           "trace_id": 0,
-          "span_id": 83,
-          "parent_id": 15,
+          "span_id": 77,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1195,8 +1054,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_template (callback)",
           "trace_id": 0,
-          "span_id": 84,
-          "parent_id": 15,
+          "span_id": 78,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1209,8 +1068,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_terms (callback)",
           "trace_id": 0,
-          "span_id": 85,
-          "parent_id": 15,
+          "span_id": 79,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1223,8 +1082,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_title (callback)",
           "trace_id": 0,
-          "span_id": 86,
-          "parent_id": 15,
+          "span_id": 80,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1237,8 +1096,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_query (callback)",
           "trace_id": 0,
-          "span_id": 87,
-          "parent_id": 15,
+          "span_id": 81,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1251,8 +1110,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_query_no_results (callback)",
           "trace_id": 0,
-          "span_id": 88,
-          "parent_id": 15,
+          "span_id": 82,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1265,8 +1124,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_query_pagination (callback)",
           "trace_id": 0,
-          "span_id": 89,
-          "parent_id": 15,
+          "span_id": 83,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1279,8 +1138,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_query_pagination_next (callback)",
           "trace_id": 0,
-          "span_id": 90,
-          "parent_id": 15,
+          "span_id": 84,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1293,8 +1152,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_query_pagination_numbers (callback)",
           "trace_id": 0,
-          "span_id": 91,
-          "parent_id": 15,
+          "span_id": 85,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1307,8 +1166,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_query_pagination_previous (callback)",
           "trace_id": 0,
-          "span_id": 92,
-          "parent_id": 15,
+          "span_id": 86,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1321,8 +1180,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_query_title (callback)",
           "trace_id": 0,
-          "span_id": 93,
-          "parent_id": 15,
+          "span_id": 87,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1335,8 +1194,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_read_more (callback)",
           "trace_id": 0,
-          "span_id": 94,
-          "parent_id": 15,
+          "span_id": 88,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1349,8 +1208,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_rss (callback)",
           "trace_id": 0,
-          "span_id": 95,
-          "parent_id": 15,
+          "span_id": 89,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1363,8 +1222,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_search (callback)",
           "trace_id": 0,
-          "span_id": 96,
-          "parent_id": 15,
+          "span_id": 90,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1377,8 +1236,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_shortcode (callback)",
           "trace_id": 0,
-          "span_id": 97,
-          "parent_id": 15,
+          "span_id": 91,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1391,8 +1250,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_site_logo (callback)",
           "trace_id": 0,
-          "span_id": 98,
-          "parent_id": 15,
+          "span_id": 92,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1405,8 +1264,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_site_tagline (callback)",
           "trace_id": 0,
-          "span_id": 99,
-          "parent_id": 15,
+          "span_id": 93,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1419,8 +1278,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_site_title (callback)",
           "trace_id": 0,
-          "span_id": 100,
-          "parent_id": 15,
+          "span_id": 94,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1433,8 +1292,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_social_link (callback)",
           "trace_id": 0,
-          "span_id": 101,
-          "parent_id": 15,
+          "span_id": 95,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1447,8 +1306,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_tag_cloud (callback)",
           "trace_id": 0,
-          "span_id": 102,
-          "parent_id": 15,
+          "span_id": 96,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1461,8 +1320,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_template_part (callback)",
           "trace_id": 0,
-          "span_id": 103,
-          "parent_id": 15,
+          "span_id": 97,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1470,123 +1329,13 @@
             "wordpress.hook": "init"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\t\tSELECT  t.term_id\n\t\t\tFROM wp_terms AS t  INNER JOIN wp_term_taxonomy AS tt ON t.term_id = tt.term_id\n\t\t\tWHERE tt.taxonomy IN ('wp_theme') AND t.name IN ('twentytwentythree')\n\t\t\t\n\t\t\tLIMIT 1\n\t\t",
-             "trace_id": 0,
-             "span_id": 118,
-             "parent_id": 103,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\t\tSELECT   wp_posts.*\n\t\t\tFROM wp_posts \n\t\t\tWHERE 1=1  AND ( \n  0 = 1\n) AND wp_posts.post_type = 'wp_template_part' AND ((wp_posts.post_status = 'publish'))\n\t\t\tGROUP BY wp_posts.ID\n\t\t\tORDER BY wp_posts.post_date DESC\n\t\t\t\n\t\t",
-             "trace_id": 0,
-             "span_id": 119,
-             "parent_id": 103,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp_options WHERE option_name = 'medium_crop' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 120,
-             "parent_id": 103,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp_options WHERE option_name = 'medium_large_crop' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 121,
-             "parent_id": 103,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp_options WHERE option_name = 'large_crop' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 122,
-             "parent_id": 103,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
         {
           "name": "callback",
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_term_description (callback)",
           "trace_id": 0,
-          "span_id": 104,
-          "parent_id": 15,
+          "span_id": 98,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1599,8 +1348,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_core_block_types_from_metadata (callback)",
           "trace_id": 0,
-          "span_id": 105,
-          "parent_id": 15,
+          "span_id": 99,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1613,8 +1362,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_register_theme_block_patterns (callback)",
           "trace_id": 0,
-          "span_id": 106,
-          "parent_id": 15,
+          "span_id": 100,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1627,8 +1376,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_legacy_post_comments_block (callback)",
           "trace_id": 0,
-          "span_id": 107,
-          "parent_id": 15,
+          "span_id": 101,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1641,8 +1390,8 @@
           "service": "wordpress_61_test_app",
           "resource": "WP_Block_Supports::init (callback)",
           "trace_id": 0,
-          "span_id": 108,
-          "parent_id": 15,
+          "span_id": 102,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1655,8 +1404,8 @@
           "service": "wordpress_61_test_app",
           "resource": "check_theme_switched (callback)",
           "trace_id": 0,
-          "span_id": 109,
-          "parent_id": 15,
+          "span_id": 103,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1664,34 +1413,12 @@
             "wordpress.hook": "init"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp_options WHERE option_name = 'theme_switched' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 123,
-             "parent_id": 109,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_61_test_app",
        "resource": "wp_loaded (hook)",
        "trace_id": 0,
-       "span_id": 16,
+       "span_id": 10,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -1704,8 +1431,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_custom_header_background_just_in_time (callback)",
           "trace_id": 0,
-          "span_id": 110,
-          "parent_id": 16,
+          "span_id": 104,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1718,8 +1445,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_add_template_loader_filters (callback)",
           "trace_id": 0,
-          "span_id": 111,
-          "parent_id": 16,
+          "span_id": 105,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1732,8 +1459,8 @@
           "service": "wordpress_61_test_app",
           "resource": "Closure (callback)",
           "trace_id": 0,
-          "span_id": 112,
-          "parent_id": 16,
+          "span_id": 106,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "closure.declaration": "/home/circleci/datadog/tests/Frameworks/WordPress/Version_6_1/wp-includes/script-loader.php:3398",
@@ -1742,35 +1469,13 @@
             "wordpress.hook": "wp_loaded"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\t\t\t\tSELECT   wp_posts.ID\n\t\t\t\t\tFROM wp_posts \n\t\t\t\t\tWHERE 1=1  AND ( \n  0 = 1\n) AND wp_posts.post_type = 'wp_global_styles' AND ((wp_posts.post_status = 'publish'))\n\t\t\t\t\tGROUP BY wp_posts.ID\n\t\t\t\t\tORDER BY wp_posts.post_date DESC\n\t\t\t\t\tLIMIT 0, 1\n\t\t\t\t",
-             "trace_id": 0,
-             "span_id": 124,
-             "parent_id": 112,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
         {
           "name": "callback",
           "service": "wordpress_61_test_app",
           "resource": "_wp_cron (callback)",
           "trace_id": 0,
-          "span_id": 113,
-          "parent_id": 16,
+          "span_id": 107,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1783,7 +1488,7 @@
        "service": "wordpress_61_test_app",
        "resource": "WP.main",
        "trace_id": 0,
-       "span_id": 17,
+       "span_id": 11,
        "parent_id": 1,
        "type": "web",
        "error": 1,
@@ -1799,8 +1504,8 @@
           "service": "wordpress_61_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 114,
-          "parent_id": 17,
+          "span_id": 108,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -1811,8 +1516,8 @@
           "service": "wordpress_61_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 115,
-          "parent_id": 17,
+          "span_id": 109,
+          "parent_id": 11,
           "type": "web",
           "error": 1,
           "meta": {
@@ -1822,53 +1527,12 @@
             "error.type": "Exception"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('rewrite_rules', 'a:93:{s:11:\\\"^wp-json/?$\\\";s:22:\\\"index.php?rest_route=/\\\";s:14:\\\"^wp-json/(.*)?\\\";s:33:\\\"index.php?rest_route=/$matches[1]\\\";s:21:\\\"^index.php/wp-json/?$\\\";s:22:\\\"index.php?rest_route=/\\\";s:24:\\\"^index.php/wp-json/(.*)?\\\";s:33:\\\"index.php?rest_route=/$matches[1]\\\";s:17:\\\"^wp-sitemap\\\\.xml$\\\";s:23:\\\"index.php?sitemap=index\\\";s:17:\\\"^wp-sitemap\\\\.xsl$\\\";s:36:\\\"index.php?sitemap-stylesheet=sitemap\\\";s:23:\\\"^wp-sitemap-index\\\\.xsl$\\\";s:34:\\\"index.php?sitemap-stylesheet=index\\\";s:48:\\\"^wp-sitemap-([a-z]+?)-([a-z\\\\d_-]+?)-(\\\\d+?)\\\\.xml$\\\";s:75:\\\"index.php?sitemap=$matches[1]&sitemap-subtype=$matches[2]&paged=$matches[3]\\\";s:34:\\\"^wp-sitemap-([a-z]+?)-(\\\\d+?)\\\\.xml$\\\";s:47:\\\"index.php?sitemap=$matches[1]&paged=$matches[2]\\\";s:47:\\\"category/(.+?)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:52:\\\"index.php?category_name=$matches[1]&feed=$matches[2]\\\";s:42:\\\"category/(.+?)/(feed|rdf|rss|rss2|atom)/?$\\\";s:52:\\\"index.php?category_name=$matches[1]&feed=$matches[2]\\\";s:23:\\\"category/(.+?)/embed/?$\\\";s:46:\\\"index.php?category_name=$matches[1]&embed=true\\\";s:35:\\\"category/(.+?)/page/?([0-9]{1,})/?$\\\";s:53:\\\"index.php?category_name=$matches[1]&paged=$matches[2]\\\";s:17:\\\"category/(.+?)/?$\\\";s:35:\\\"index.php?category_name=$matches[1]\\\";s:44:\\\"tag/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?tag=$matches[1]&feed=$matches[2]\\\";s:39:\\\"tag/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?tag=$matches[1]&feed=$matches[2]\\\";s:20:\\\"tag/([^/]+)/embed/?$\\\";s:36:\\\"index.php?tag=$matches[1]&embed=true\\\";s:32:\\\"tag/([^/]+)/page/?([0-9]{1,})/?$\\\";s:43:\\\"index.php?tag=$matches[1]&paged=$matches[2]\\\";s:14:\\\"tag/([^/]+)/?$\\\";s:25:\\\"index.php?tag=$matches[1]\\\";s:45:\\\"type/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?post_format=$matches[1]&feed=$matches[2]\\\";s:40:\\\"type/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?post_format=$matches[1]&feed=$matches[2]\\\";s:21:\\\"type/([^/]+)/embed/?$\\\";s:44:\\\"index.php?post_format=$matches[1]&embed=true\\\";s:33:\\\"type/([^/]+)/page/?([0-9]{1,})/?$\\\";s:51:\\\"index.php?post_format=$matches[1]&paged=$matches[2]\\\";s:15:\\\"type/([^/]+)/?$\\\";s:33:\\\"index.php?post_format=$matches[1]\\\";s:12:\\\"robots\\\\.txt$\\\";s:18:\\\"index.php?robots=1\\\";s:13:\\\"favicon\\\\.ico$\\\";s:19:\\\"index.php?favicon=1\\\";s:48:\\\".*wp-(atom|rdf|rss|rss2|feed|commentsrss2)\\\\.php$\\\";s:18:\\\"index.php?feed=old\\\";s:20:\\\".*wp-app\\\\.php(/.*)?$\\\";s:19:\\\"index.php?error=403\\\";s:18:\\\".*wp-register.php$\\\";s:23:\\\"index.php?register=true\\\";s:32:\\\"feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:27:\\\"index.php?&feed=$matches[1]\\\";s:27:\\\"(feed|rdf|rss|rss2|atom)/?$\\\";s:27:\\\"index.php?&feed=$matches[1]\\\";s:8:\\\"embed/?$\\\";s:21:\\\"index.php?&embed=true\\\";s:20:\\\"page/?([0-9]{1,})/?$\\\";s:28:\\\"index.php?&paged=$matches[1]\\\";s:41:\\\"comments/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?&feed=$matches[1]&withcomments=1\\\";s:36:\\\"comments/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?&feed=$matches[1]&withcomments=1\\\";s:17:\\\"comments/embed/?$\\\";s:21:\\\"index.php?&embed=true\\\";s:44:\\\"search/(.+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:40:\\\"index.php?s=$matches[1]&feed=$matches[2]\\\";s:39:\\\"search/(.+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:40:\\\"index.php?s=$matches[1]&feed=$matches[2]\\\";s:20:\\\"search/(.+)/embed/?$\\\";s:34:\\\"index.php?s=$matches[1]&embed=true\\\";s:32:\\\"search/(.+)/page/?([0-9]{1,})/?$\\\";s:41:\\\"index.php?s=$matches[1]&paged=$matches[2]\\\";s:14:\\\"search/(.+)/?$\\\";s:23:\\\"index.php?s=$matches[1]\\\";s:47:\\\"author/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?author_name=$matches[1]&feed=$matches[2]\\\";s:42:\\\"author/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?author_name=$matches[1]&feed=$matches[2]\\\";s:23:\\\"author/([^/]+)/embed/?$\\\";s:44:\\\"index.php?author_name=$matches[1]&embed=true\\\";s:35:\\\"author/([^/]+)/page/?([0-9]{1,})/?$\\\";s:51:\\\"index.php?author_name=$matches[1]&paged=$matches[2]\\\";s:17:\\\"author/([^/]+)/?$\\\";s:33:\\\"index.php?author_name=$matches[1]\\\";s:69:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:80:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&feed=$matches[4]\\\";s:64:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/(feed|rdf|rss|rss2|atom)/?$\\\";s:80:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&feed=$matches[4]\\\";s:45:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/embed/?$\\\";s:74:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&embed=true\\\";s:57:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/page/?([0-9]{1,})/?$\\\";s:81:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&paged=$matches[4]\\\";s:39:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/?$\\\";s:63:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]\\\";s:56:\\\"([0-9]{4})/([0-9]{1,2})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:64:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&feed=$matches[3]\\\";s:51:\\\"([0-9]{4})/([0-9]{1,2})/(feed|rdf|rss|rss2|atom)/?$\\\";s:64:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&feed=$matches[3]\\\";s:32:\\\"([0-9]{4})/([0-9]{1,2})/embed/?$\\\";s:58:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&embed=true\\\";s:44:\\\"([0-9]{4})/([0-9]{1,2})/page/?([0-9]{1,})/?$\\\";s:65:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&paged=$matches[3]\\\";s:26:\\\"([0-9]{4})/([0-9]{1,2})/?$\\\";s:47:\\\"index.php?year=$matches[1]&monthnum=$matches[2]\\\";s:43:\\\"([0-9]{4})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?year=$matches[1]&feed=$matches[2]\\\";s:38:\\\"([0-9]{4})/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?year=$matches[1]&feed=$matches[2]\\\";s:19:\\\"([0-9]{4})/embed/?$\\\";s:37:\\\"index.php?year=$matches[1]&embed=true\\\";s:31:\\\"([0-9]{4})/page/?([0-9]{1,})/?$\\\";s:44:\\\"index.php?year=$matches[1]&paged=$matches[2]\\\";s:13:\\\"([0-9]{4})/?$\\\";s:26:\\\"index.php?year=$matches[1]\\\";s:27:\\\".?.+?/attachment/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:37:\\\".?.+?/attachment/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:57:\\\".?.+?/attachment/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\".?.+?/attachment/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\".?.+?/attachment/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:33:\\\".?.+?/attachment/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";s:16:\\\"(.?.+?)/embed/?$\\\";s:41:\\\"index.php?pagename=$matches[1]&embed=true\\\";s:20:\\\"(.?.+?)/trackback/?$\\\";s:35:\\\"index.php?pagename=$matches[1]&tb=1\\\";s:40:\\\"(.?.+?)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&feed=$matches[2]\\\";s:35:\\\"(.?.+?)/(feed|rdf|rss|rss2|atom)/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&feed=$matches[2]\\\";s:28:\\\"(.?.+?)/page/?([0-9]{1,})/?$\\\";s:48:\\\"index.php?pagename=$matches[1]&paged=$matches[2]\\\";s:35:\\\"(.?.+?)/comment-page-([0-9]{1,})/?$\\\";s:48:\\\"index.php?pagename=$matches[1]&cpage=$matches[2]\\\";s:24:\\\"(.?.+?)(?:/([0-9]+))?/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&page=$matches[2]\\\";s:27:\\\"[^/]+/attachment/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:37:\\\"[^/]+/attachment/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:57:\\\"[^/]+/attachment/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\"[^/]+/attachment/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\"[^/]+/attachment/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:33:\\\"[^/]+/attachment/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";s:16:\\\"([^/]+)/embed/?$\\\";s:37:\\\"index.php?name=$matches[1]&embed=true\\\";s:20:\\\"([^/]+)/trackback/?$\\\";s:31:\\\"index.php?name=$matches[1]&tb=1\\\";s:40:\\\"([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?name=$matches[1]&feed=$matches[2]\\\";s:35:\\\"([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?name=$matches[1]&feed=$matches[2]\\\";s:28:\\\"([^/]+)/page/?([0-9]{1,})/?$\\\";s:44:\\\"index.php?name=$matches[1]&paged=$matches[2]\\\";s:35:\\\"([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:44:\\\"index.php?name=$matches[1]&cpage=$matches[2]\\\";s:24:\\\"([^/]+)(?:/([0-9]+))?/?$\\\";s:43:\\\"index.php?name=$matches[1]&page=$matches[2]\\\";s:16:\\\"[^/]+/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:26:\\\"[^/]+/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:46:\\\"[^/]+/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:41:\\\"[^/]+/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:41:\\\"[^/]+/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:22:\\\"[^/]+/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";}', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)",
-             "trace_id": 0,
-             "span_id": 125,
-             "parent_id": 115,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp_posts\n\t\tWHERE post_name IN ('error')\n\t\tAND post_type IN ('page','attachment')\n\t",
-             "trace_id": 0,
-             "span_id": 126,
-             "parent_id": 115,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_61_test_app",
        "resource": "shutdown (hook)",
        "trace_id": 0,
-       "span_id": 18,
+       "span_id": 12,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -1881,8 +1545,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_ob_end_flush_all (callback)",
           "trace_id": 0,
-          "span_id": 116,
-          "parent_id": 18,
+          "span_id": 110,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress",

--- a/tests/snapshots/tests.integrations.word_press.v6_1.common_scenarios_callbacks_test.test_scenario_get_with_view.json
+++ b/tests/snapshots/tests.integrations.word_press.v6_1.common_scenarios_callbacks_test.test_scenario_get_with_view.json
@@ -5,17 +5,17 @@
     "resource": "GET /simple_view",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 9759489514894777209,
+    "parent_id": 3068051918405542192,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "65ba30e800000000",
+      "_dd.p.tid": "65e6fea000000000",
       "component": "wordpress",
       "http.method": "GET",
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/simple_view?key=value&<redacted>",
-      "runtime-id": "8e9eb59e-3446-4845-b44c-f5bfa0a7d4ab",
+      "runtime-id": "333590aa-cf9b-4804-9dde-1ac7b59c09ab",
       "span.kind": "server"
     },
     "metrics": {
@@ -23,108 +23,11 @@
     }
   },
      {
-       "name": "mysqli_real_connect",
-       "service": "mysqli",
-       "resource": "mysqli_real_connect",
-       "trace_id": 0,
-       "span_id": 2,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-       "trace_id": 0,
-       "span_id": 3,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT @@SESSION.sql_mode",
-       "trace_id": 0,
-       "span_id": 4,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 1.0
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-       "trace_id": 0,
-       "span_id": 5,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_name, option_value FROM wp_options WHERE autoload = 'yes'",
-       "trace_id": 0,
-       "span_id": 6,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 118.0
-       }
-     },
-     {
        "name": "create_initial_taxonomies",
        "service": "wordpress_61_test_app",
        "resource": "create_initial_taxonomies",
        "trace_id": 0,
-       "span_id": 7,
+       "span_id": 2,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -138,7 +41,7 @@
        "service": "wordpress_61_test_app",
        "resource": "create_initial_post_types",
        "trace_id": 0,
-       "span_id": 8,
+       "span_id": 3,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -152,7 +55,7 @@
        "service": "wordpress_61_test_app",
        "resource": "datadog (plugin)",
        "trace_id": 0,
-       "span_id": 9,
+       "span_id": 4,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -165,7 +68,7 @@
        "service": "wordpress_61_test_app",
        "resource": "plugins_loaded (hook)",
        "trace_id": 0,
-       "span_id": 10,
+       "span_id": 5,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -178,8 +81,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_maybe_load_widgets",
           "trace_id": 0,
-          "span_id": 19,
-          "parent_id": 10,
+          "span_id": 13,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -192,8 +95,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_maybe_load_embeds",
           "trace_id": 0,
-          "span_id": 20,
-          "parent_id": 10,
+          "span_id": 14,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -206,8 +109,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_wp_add_additional_image_sizes (callback)",
           "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 10,
+          "span_id": 15,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -220,8 +123,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_wp_theme_json_webfonts_handler (callback)",
           "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 10,
+          "span_id": 16,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -234,8 +137,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_wp_customize_include",
           "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 10,
+          "span_id": 17,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -248,7 +151,7 @@
        "service": "wordpress_61_test_app",
        "resource": "setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 11,
+       "span_id": 6,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -261,8 +164,8 @@
           "service": "wordpress_61_test_app",
           "resource": "create_initial_theme_features (callback)",
           "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 11,
+          "span_id": 18,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -275,8 +178,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_add_default_theme_supports (callback)",
           "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 11,
+          "span_id": 19,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -289,8 +192,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_enable_block_templates (callback)",
           "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 11,
+          "span_id": 20,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -303,8 +206,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_delete_site_logo_on_remove_custom_logo_on_setup_theme (callback)",
           "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 11,
+          "span_id": 21,
+          "parent_id": 6,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -313,33 +216,11 @@
           }
         },
      {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_value FROM wp_options WHERE option_name = 'WPLANG' LIMIT 1",
-       "trace_id": 0,
-       "span_id": 12,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 0.0
-       }
-     },
-     {
        "name": "action",
        "service": "wordpress_61_test_app",
        "resource": "after_setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 13,
+       "span_id": 7,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -352,8 +233,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_setup_widgets_block_editor (callback)",
           "trace_id": 0,
-          "span_id": 28,
-          "parent_id": 13,
+          "span_id": 22,
+          "parent_id": 7,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -366,7 +247,7 @@
        "service": "wordpress_61_test_app",
        "resource": "WP.init",
        "trace_id": 0,
-       "span_id": 14,
+       "span_id": 8,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -378,8 +259,8 @@
           "service": "wordpress_61_test_app",
           "resource": "kses_init (callback)",
           "trace_id": 0,
-          "span_id": 29,
-          "parent_id": 14,
+          "span_id": 23,
+          "parent_id": 8,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -392,7 +273,7 @@
        "service": "wordpress_61_test_app",
        "resource": "init (hook)",
        "trace_id": 0,
-       "span_id": 15,
+       "span_id": 9,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -405,8 +286,8 @@
           "service": "wordpress_61_test_app",
           "resource": "create_initial_post_types",
           "trace_id": 0,
-          "span_id": 30,
-          "parent_id": 15,
+          "span_id": 24,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -417,8 +298,8 @@
           "service": "wordpress_61_test_app",
           "resource": "create_initial_taxonomies",
           "trace_id": 0,
-          "span_id": 31,
-          "parent_id": 15,
+          "span_id": 25,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -429,8 +310,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_widgets_init",
           "trace_id": 0,
-          "span_id": 32,
-          "parent_id": 15,
+          "span_id": 26,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -443,42 +324,20 @@
              "service": "wordpress_61_test_app",
              "resource": "WP_Widget_Factory._register_widgets",
              "trace_id": 0,
-             "span_id": 117,
-             "parent_id": 32,
+             "span_id": 111,
+             "parent_id": 26,
              "type": "web",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT option_value FROM wp_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-                "trace_id": 0,
-                "span_id": 127,
-                "parent_id": 117,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_61_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
         {
           "name": "callback",
           "service": "wordpress_61_test_app",
           "resource": "smilies_init (callback)",
           "trace_id": 0,
-          "span_id": 33,
-          "parent_id": 15,
+          "span_id": 27,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -491,8 +350,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_init_targeted_link_rel_filters (callback)",
           "trace_id": 0,
-          "span_id": 34,
-          "parent_id": 15,
+          "span_id": 28,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -505,8 +364,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_register_core_block_patterns_and_categories (callback)",
           "trace_id": 0,
-          "span_id": 35,
-          "parent_id": 15,
+          "span_id": 29,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -519,8 +378,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_cron (callback)",
           "trace_id": 0,
-          "span_id": 36,
-          "parent_id": 15,
+          "span_id": 30,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -533,8 +392,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_schedule_https_detection (callback)",
           "trace_id": 0,
-          "span_id": 37,
-          "parent_id": 15,
+          "span_id": 31,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -547,8 +406,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_schedule_delete_old_privacy_export_files (callback)",
           "trace_id": 0,
-          "span_id": 38,
-          "parent_id": 15,
+          "span_id": 32,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -561,8 +420,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_show_post_preview (callback)",
           "trace_id": 0,
-          "span_id": 39,
-          "parent_id": 15,
+          "span_id": 33,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -575,8 +434,8 @@
           "service": "wordpress_61_test_app",
           "resource": "rest_api_init (callback)",
           "trace_id": 0,
-          "span_id": 40,
-          "parent_id": 15,
+          "span_id": 34,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -589,8 +448,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_sitemaps_get_server (callback)",
           "trace_id": 0,
-          "span_id": 41,
-          "parent_id": 15,
+          "span_id": 35,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -603,8 +462,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_register_persisted_preferences_meta (callback)",
           "trace_id": 0,
-          "span_id": 42,
-          "parent_id": 15,
+          "span_id": 36,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -617,8 +476,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_schedule_update_checks (callback)",
           "trace_id": 0,
-          "span_id": 43,
-          "parent_id": 15,
+          "span_id": 37,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -631,8 +490,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_legacy_widget (callback)",
           "trace_id": 0,
-          "span_id": 44,
-          "parent_id": 15,
+          "span_id": 38,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -645,8 +504,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_widget_group (callback)",
           "trace_id": 0,
-          "span_id": 45,
-          "parent_id": 15,
+          "span_id": 39,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -659,8 +518,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_archives (callback)",
           "trace_id": 0,
-          "span_id": 46,
-          "parent_id": 15,
+          "span_id": 40,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -673,8 +532,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_avatar (callback)",
           "trace_id": 0,
-          "span_id": 47,
-          "parent_id": 15,
+          "span_id": 41,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -687,8 +546,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_block (callback)",
           "trace_id": 0,
-          "span_id": 48,
-          "parent_id": 15,
+          "span_id": 42,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -701,8 +560,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_calendar (callback)",
           "trace_id": 0,
-          "span_id": 49,
-          "parent_id": 15,
+          "span_id": 43,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -715,8 +574,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_categories (callback)",
           "trace_id": 0,
-          "span_id": 50,
-          "parent_id": 15,
+          "span_id": 44,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -729,8 +588,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comment_author_name (callback)",
           "trace_id": 0,
-          "span_id": 51,
-          "parent_id": 15,
+          "span_id": 45,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -743,8 +602,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comment_content (callback)",
           "trace_id": 0,
-          "span_id": 52,
-          "parent_id": 15,
+          "span_id": 46,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -757,8 +616,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comment_date (callback)",
           "trace_id": 0,
-          "span_id": 53,
-          "parent_id": 15,
+          "span_id": 47,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -771,8 +630,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comment_edit_link (callback)",
           "trace_id": 0,
-          "span_id": 54,
-          "parent_id": 15,
+          "span_id": 48,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -785,8 +644,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comment_reply_link (callback)",
           "trace_id": 0,
-          "span_id": 55,
-          "parent_id": 15,
+          "span_id": 49,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -799,8 +658,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comment_template (callback)",
           "trace_id": 0,
-          "span_id": 56,
-          "parent_id": 15,
+          "span_id": 50,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -813,8 +672,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comments (callback)",
           "trace_id": 0,
-          "span_id": 57,
-          "parent_id": 15,
+          "span_id": 51,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -827,8 +686,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comments_pagination (callback)",
           "trace_id": 0,
-          "span_id": 58,
-          "parent_id": 15,
+          "span_id": 52,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -841,8 +700,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comments_pagination_next (callback)",
           "trace_id": 0,
-          "span_id": 59,
-          "parent_id": 15,
+          "span_id": 53,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -855,8 +714,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comments_pagination_numbers (callback)",
           "trace_id": 0,
-          "span_id": 60,
-          "parent_id": 15,
+          "span_id": 54,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -869,8 +728,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comments_pagination_previous (callback)",
           "trace_id": 0,
-          "span_id": 61,
-          "parent_id": 15,
+          "span_id": 55,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -883,8 +742,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_comments_title (callback)",
           "trace_id": 0,
-          "span_id": 62,
-          "parent_id": 15,
+          "span_id": 56,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -897,8 +756,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_cover (callback)",
           "trace_id": 0,
-          "span_id": 63,
-          "parent_id": 15,
+          "span_id": 57,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -911,8 +770,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_file (callback)",
           "trace_id": 0,
-          "span_id": 64,
-          "parent_id": 15,
+          "span_id": 58,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -925,8 +784,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_gallery (callback)",
           "trace_id": 0,
-          "span_id": 65,
-          "parent_id": 15,
+          "span_id": 59,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -939,8 +798,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_home_link (callback)",
           "trace_id": 0,
-          "span_id": 66,
-          "parent_id": 15,
+          "span_id": 60,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -953,8 +812,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_image (callback)",
           "trace_id": 0,
-          "span_id": 67,
-          "parent_id": 15,
+          "span_id": 61,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -967,8 +826,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_latest_comments (callback)",
           "trace_id": 0,
-          "span_id": 68,
-          "parent_id": 15,
+          "span_id": 62,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -981,8 +840,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_latest_posts (callback)",
           "trace_id": 0,
-          "span_id": 69,
-          "parent_id": 15,
+          "span_id": 63,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -995,8 +854,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_loginout (callback)",
           "trace_id": 0,
-          "span_id": 70,
-          "parent_id": 15,
+          "span_id": 64,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1009,8 +868,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_navigation (callback)",
           "trace_id": 0,
-          "span_id": 71,
-          "parent_id": 15,
+          "span_id": 65,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1023,8 +882,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_navigation_link (callback)",
           "trace_id": 0,
-          "span_id": 72,
-          "parent_id": 15,
+          "span_id": 66,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1037,8 +896,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_navigation_submenu (callback)",
           "trace_id": 0,
-          "span_id": 73,
-          "parent_id": 15,
+          "span_id": 67,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1051,8 +910,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_page_list (callback)",
           "trace_id": 0,
-          "span_id": 74,
-          "parent_id": 15,
+          "span_id": 68,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1065,8 +924,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_pattern (callback)",
           "trace_id": 0,
-          "span_id": 75,
-          "parent_id": 15,
+          "span_id": 69,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1079,8 +938,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_author (callback)",
           "trace_id": 0,
-          "span_id": 76,
-          "parent_id": 15,
+          "span_id": 70,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1093,8 +952,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_author_biography (callback)",
           "trace_id": 0,
-          "span_id": 77,
-          "parent_id": 15,
+          "span_id": 71,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1107,8 +966,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_comments_form (callback)",
           "trace_id": 0,
-          "span_id": 78,
-          "parent_id": 15,
+          "span_id": 72,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1121,8 +980,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_content (callback)",
           "trace_id": 0,
-          "span_id": 79,
-          "parent_id": 15,
+          "span_id": 73,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1135,8 +994,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_date (callback)",
           "trace_id": 0,
-          "span_id": 80,
-          "parent_id": 15,
+          "span_id": 74,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1149,8 +1008,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_excerpt (callback)",
           "trace_id": 0,
-          "span_id": 81,
-          "parent_id": 15,
+          "span_id": 75,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1163,8 +1022,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_featured_image (callback)",
           "trace_id": 0,
-          "span_id": 82,
-          "parent_id": 15,
+          "span_id": 76,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1177,8 +1036,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_navigation_link (callback)",
           "trace_id": 0,
-          "span_id": 83,
-          "parent_id": 15,
+          "span_id": 77,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1191,8 +1050,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_template (callback)",
           "trace_id": 0,
-          "span_id": 84,
-          "parent_id": 15,
+          "span_id": 78,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1205,8 +1064,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_terms (callback)",
           "trace_id": 0,
-          "span_id": 85,
-          "parent_id": 15,
+          "span_id": 79,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1219,8 +1078,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_post_title (callback)",
           "trace_id": 0,
-          "span_id": 86,
-          "parent_id": 15,
+          "span_id": 80,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1233,8 +1092,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_query (callback)",
           "trace_id": 0,
-          "span_id": 87,
-          "parent_id": 15,
+          "span_id": 81,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1247,8 +1106,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_query_no_results (callback)",
           "trace_id": 0,
-          "span_id": 88,
-          "parent_id": 15,
+          "span_id": 82,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1261,8 +1120,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_query_pagination (callback)",
           "trace_id": 0,
-          "span_id": 89,
-          "parent_id": 15,
+          "span_id": 83,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1275,8 +1134,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_query_pagination_next (callback)",
           "trace_id": 0,
-          "span_id": 90,
-          "parent_id": 15,
+          "span_id": 84,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1289,8 +1148,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_query_pagination_numbers (callback)",
           "trace_id": 0,
-          "span_id": 91,
-          "parent_id": 15,
+          "span_id": 85,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1303,8 +1162,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_query_pagination_previous (callback)",
           "trace_id": 0,
-          "span_id": 92,
-          "parent_id": 15,
+          "span_id": 86,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1317,8 +1176,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_query_title (callback)",
           "trace_id": 0,
-          "span_id": 93,
-          "parent_id": 15,
+          "span_id": 87,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1331,8 +1190,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_read_more (callback)",
           "trace_id": 0,
-          "span_id": 94,
-          "parent_id": 15,
+          "span_id": 88,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1345,8 +1204,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_rss (callback)",
           "trace_id": 0,
-          "span_id": 95,
-          "parent_id": 15,
+          "span_id": 89,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1359,8 +1218,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_search (callback)",
           "trace_id": 0,
-          "span_id": 96,
-          "parent_id": 15,
+          "span_id": 90,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1373,8 +1232,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_shortcode (callback)",
           "trace_id": 0,
-          "span_id": 97,
-          "parent_id": 15,
+          "span_id": 91,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1387,8 +1246,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_site_logo (callback)",
           "trace_id": 0,
-          "span_id": 98,
-          "parent_id": 15,
+          "span_id": 92,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1401,8 +1260,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_site_tagline (callback)",
           "trace_id": 0,
-          "span_id": 99,
-          "parent_id": 15,
+          "span_id": 93,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1415,8 +1274,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_site_title (callback)",
           "trace_id": 0,
-          "span_id": 100,
-          "parent_id": 15,
+          "span_id": 94,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1429,8 +1288,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_social_link (callback)",
           "trace_id": 0,
-          "span_id": 101,
-          "parent_id": 15,
+          "span_id": 95,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1443,8 +1302,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_tag_cloud (callback)",
           "trace_id": 0,
-          "span_id": 102,
-          "parent_id": 15,
+          "span_id": 96,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1457,8 +1316,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_template_part (callback)",
           "trace_id": 0,
-          "span_id": 103,
-          "parent_id": 15,
+          "span_id": 97,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1466,123 +1325,13 @@
             "wordpress.hook": "init"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\t\tSELECT  t.term_id\n\t\t\tFROM wp_terms AS t  INNER JOIN wp_term_taxonomy AS tt ON t.term_id = tt.term_id\n\t\t\tWHERE tt.taxonomy IN ('wp_theme') AND t.name IN ('twentytwentythree')\n\t\t\t\n\t\t\tLIMIT 1\n\t\t",
-             "trace_id": 0,
-             "span_id": 118,
-             "parent_id": 103,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\t\tSELECT   wp_posts.*\n\t\t\tFROM wp_posts \n\t\t\tWHERE 1=1  AND ( \n  0 = 1\n) AND wp_posts.post_type = 'wp_template_part' AND ((wp_posts.post_status = 'publish'))\n\t\t\tGROUP BY wp_posts.ID\n\t\t\tORDER BY wp_posts.post_date DESC\n\t\t\t\n\t\t",
-             "trace_id": 0,
-             "span_id": 119,
-             "parent_id": 103,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp_options WHERE option_name = 'medium_crop' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 120,
-             "parent_id": 103,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp_options WHERE option_name = 'medium_large_crop' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 121,
-             "parent_id": 103,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp_options WHERE option_name = 'large_crop' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 122,
-             "parent_id": 103,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
         {
           "name": "callback",
           "service": "wordpress_61_test_app",
           "resource": "register_block_core_term_description (callback)",
           "trace_id": 0,
-          "span_id": 104,
-          "parent_id": 15,
+          "span_id": 98,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1595,8 +1344,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_core_block_types_from_metadata (callback)",
           "trace_id": 0,
-          "span_id": 105,
-          "parent_id": 15,
+          "span_id": 99,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1609,8 +1358,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_register_theme_block_patterns (callback)",
           "trace_id": 0,
-          "span_id": 106,
-          "parent_id": 15,
+          "span_id": 100,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1623,8 +1372,8 @@
           "service": "wordpress_61_test_app",
           "resource": "register_legacy_post_comments_block (callback)",
           "trace_id": 0,
-          "span_id": 107,
-          "parent_id": 15,
+          "span_id": 101,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1637,8 +1386,8 @@
           "service": "wordpress_61_test_app",
           "resource": "WP_Block_Supports::init (callback)",
           "trace_id": 0,
-          "span_id": 108,
-          "parent_id": 15,
+          "span_id": 102,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1651,8 +1400,8 @@
           "service": "wordpress_61_test_app",
           "resource": "check_theme_switched (callback)",
           "trace_id": 0,
-          "span_id": 109,
-          "parent_id": 15,
+          "span_id": 103,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1660,34 +1409,12 @@
             "wordpress.hook": "init"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp_options WHERE option_name = 'theme_switched' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 123,
-             "parent_id": 109,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_61_test_app",
        "resource": "wp_loaded (hook)",
        "trace_id": 0,
-       "span_id": 16,
+       "span_id": 10,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -1700,8 +1427,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_custom_header_background_just_in_time (callback)",
           "trace_id": 0,
-          "span_id": 110,
-          "parent_id": 16,
+          "span_id": 104,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1714,8 +1441,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_add_template_loader_filters (callback)",
           "trace_id": 0,
-          "span_id": 111,
-          "parent_id": 16,
+          "span_id": 105,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1728,8 +1455,8 @@
           "service": "wordpress_61_test_app",
           "resource": "Closure (callback)",
           "trace_id": 0,
-          "span_id": 112,
-          "parent_id": 16,
+          "span_id": 106,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "closure.declaration": "/home/circleci/datadog/tests/Frameworks/WordPress/Version_6_1/wp-includes/script-loader.php:3398",
@@ -1738,35 +1465,13 @@
             "wordpress.hook": "wp_loaded"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\t\t\t\tSELECT   wp_posts.ID\n\t\t\t\t\tFROM wp_posts \n\t\t\t\t\tWHERE 1=1  AND ( \n  0 = 1\n) AND wp_posts.post_type = 'wp_global_styles' AND ((wp_posts.post_status = 'publish'))\n\t\t\t\t\tGROUP BY wp_posts.ID\n\t\t\t\t\tORDER BY wp_posts.post_date DESC\n\t\t\t\t\tLIMIT 0, 1\n\t\t\t\t",
-             "trace_id": 0,
-             "span_id": 124,
-             "parent_id": 112,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
         {
           "name": "callback",
           "service": "wordpress_61_test_app",
           "resource": "_wp_cron (callback)",
           "trace_id": 0,
-          "span_id": 113,
-          "parent_id": 16,
+          "span_id": 107,
+          "parent_id": 10,
           "type": "web",
           "meta": {
             "component": "wordpress",
@@ -1779,7 +1484,7 @@
        "service": "wordpress_61_test_app",
        "resource": "WP.main",
        "trace_id": 0,
-       "span_id": 17,
+       "span_id": 11,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -1791,8 +1496,8 @@
           "service": "wordpress_61_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 114,
-          "parent_id": 17,
+          "span_id": 108,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -1803,60 +1508,19 @@
           "service": "wordpress_61_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 115,
-          "parent_id": 17,
+          "span_id": 109,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('rewrite_rules', 'a:93:{s:11:\\\"^wp-json/?$\\\";s:22:\\\"index.php?rest_route=/\\\";s:14:\\\"^wp-json/(.*)?\\\";s:33:\\\"index.php?rest_route=/$matches[1]\\\";s:21:\\\"^index.php/wp-json/?$\\\";s:22:\\\"index.php?rest_route=/\\\";s:24:\\\"^index.php/wp-json/(.*)?\\\";s:33:\\\"index.php?rest_route=/$matches[1]\\\";s:17:\\\"^wp-sitemap\\\\.xml$\\\";s:23:\\\"index.php?sitemap=index\\\";s:17:\\\"^wp-sitemap\\\\.xsl$\\\";s:36:\\\"index.php?sitemap-stylesheet=sitemap\\\";s:23:\\\"^wp-sitemap-index\\\\.xsl$\\\";s:34:\\\"index.php?sitemap-stylesheet=index\\\";s:48:\\\"^wp-sitemap-([a-z]+?)-([a-z\\\\d_-]+?)-(\\\\d+?)\\\\.xml$\\\";s:75:\\\"index.php?sitemap=$matches[1]&sitemap-subtype=$matches[2]&paged=$matches[3]\\\";s:34:\\\"^wp-sitemap-([a-z]+?)-(\\\\d+?)\\\\.xml$\\\";s:47:\\\"index.php?sitemap=$matches[1]&paged=$matches[2]\\\";s:47:\\\"category/(.+?)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:52:\\\"index.php?category_name=$matches[1]&feed=$matches[2]\\\";s:42:\\\"category/(.+?)/(feed|rdf|rss|rss2|atom)/?$\\\";s:52:\\\"index.php?category_name=$matches[1]&feed=$matches[2]\\\";s:23:\\\"category/(.+?)/embed/?$\\\";s:46:\\\"index.php?category_name=$matches[1]&embed=true\\\";s:35:\\\"category/(.+?)/page/?([0-9]{1,})/?$\\\";s:53:\\\"index.php?category_name=$matches[1]&paged=$matches[2]\\\";s:17:\\\"category/(.+?)/?$\\\";s:35:\\\"index.php?category_name=$matches[1]\\\";s:44:\\\"tag/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?tag=$matches[1]&feed=$matches[2]\\\";s:39:\\\"tag/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?tag=$matches[1]&feed=$matches[2]\\\";s:20:\\\"tag/([^/]+)/embed/?$\\\";s:36:\\\"index.php?tag=$matches[1]&embed=true\\\";s:32:\\\"tag/([^/]+)/page/?([0-9]{1,})/?$\\\";s:43:\\\"index.php?tag=$matches[1]&paged=$matches[2]\\\";s:14:\\\"tag/([^/]+)/?$\\\";s:25:\\\"index.php?tag=$matches[1]\\\";s:45:\\\"type/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?post_format=$matches[1]&feed=$matches[2]\\\";s:40:\\\"type/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?post_format=$matches[1]&feed=$matches[2]\\\";s:21:\\\"type/([^/]+)/embed/?$\\\";s:44:\\\"index.php?post_format=$matches[1]&embed=true\\\";s:33:\\\"type/([^/]+)/page/?([0-9]{1,})/?$\\\";s:51:\\\"index.php?post_format=$matches[1]&paged=$matches[2]\\\";s:15:\\\"type/([^/]+)/?$\\\";s:33:\\\"index.php?post_format=$matches[1]\\\";s:12:\\\"robots\\\\.txt$\\\";s:18:\\\"index.php?robots=1\\\";s:13:\\\"favicon\\\\.ico$\\\";s:19:\\\"index.php?favicon=1\\\";s:48:\\\".*wp-(atom|rdf|rss|rss2|feed|commentsrss2)\\\\.php$\\\";s:18:\\\"index.php?feed=old\\\";s:20:\\\".*wp-app\\\\.php(/.*)?$\\\";s:19:\\\"index.php?error=403\\\";s:18:\\\".*wp-register.php$\\\";s:23:\\\"index.php?register=true\\\";s:32:\\\"feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:27:\\\"index.php?&feed=$matches[1]\\\";s:27:\\\"(feed|rdf|rss|rss2|atom)/?$\\\";s:27:\\\"index.php?&feed=$matches[1]\\\";s:8:\\\"embed/?$\\\";s:21:\\\"index.php?&embed=true\\\";s:20:\\\"page/?([0-9]{1,})/?$\\\";s:28:\\\"index.php?&paged=$matches[1]\\\";s:41:\\\"comments/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?&feed=$matches[1]&withcomments=1\\\";s:36:\\\"comments/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?&feed=$matches[1]&withcomments=1\\\";s:17:\\\"comments/embed/?$\\\";s:21:\\\"index.php?&embed=true\\\";s:44:\\\"search/(.+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:40:\\\"index.php?s=$matches[1]&feed=$matches[2]\\\";s:39:\\\"search/(.+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:40:\\\"index.php?s=$matches[1]&feed=$matches[2]\\\";s:20:\\\"search/(.+)/embed/?$\\\";s:34:\\\"index.php?s=$matches[1]&embed=true\\\";s:32:\\\"search/(.+)/page/?([0-9]{1,})/?$\\\";s:41:\\\"index.php?s=$matches[1]&paged=$matches[2]\\\";s:14:\\\"search/(.+)/?$\\\";s:23:\\\"index.php?s=$matches[1]\\\";s:47:\\\"author/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?author_name=$matches[1]&feed=$matches[2]\\\";s:42:\\\"author/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?author_name=$matches[1]&feed=$matches[2]\\\";s:23:\\\"author/([^/]+)/embed/?$\\\";s:44:\\\"index.php?author_name=$matches[1]&embed=true\\\";s:35:\\\"author/([^/]+)/page/?([0-9]{1,})/?$\\\";s:51:\\\"index.php?author_name=$matches[1]&paged=$matches[2]\\\";s:17:\\\"author/([^/]+)/?$\\\";s:33:\\\"index.php?author_name=$matches[1]\\\";s:69:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:80:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&feed=$matches[4]\\\";s:64:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/(feed|rdf|rss|rss2|atom)/?$\\\";s:80:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&feed=$matches[4]\\\";s:45:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/embed/?$\\\";s:74:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&embed=true\\\";s:57:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/page/?([0-9]{1,})/?$\\\";s:81:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&paged=$matches[4]\\\";s:39:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/?$\\\";s:63:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]\\\";s:56:\\\"([0-9]{4})/([0-9]{1,2})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:64:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&feed=$matches[3]\\\";s:51:\\\"([0-9]{4})/([0-9]{1,2})/(feed|rdf|rss|rss2|atom)/?$\\\";s:64:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&feed=$matches[3]\\\";s:32:\\\"([0-9]{4})/([0-9]{1,2})/embed/?$\\\";s:58:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&embed=true\\\";s:44:\\\"([0-9]{4})/([0-9]{1,2})/page/?([0-9]{1,})/?$\\\";s:65:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&paged=$matches[3]\\\";s:26:\\\"([0-9]{4})/([0-9]{1,2})/?$\\\";s:47:\\\"index.php?year=$matches[1]&monthnum=$matches[2]\\\";s:43:\\\"([0-9]{4})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?year=$matches[1]&feed=$matches[2]\\\";s:38:\\\"([0-9]{4})/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?year=$matches[1]&feed=$matches[2]\\\";s:19:\\\"([0-9]{4})/embed/?$\\\";s:37:\\\"index.php?year=$matches[1]&embed=true\\\";s:31:\\\"([0-9]{4})/page/?([0-9]{1,})/?$\\\";s:44:\\\"index.php?year=$matches[1]&paged=$matches[2]\\\";s:13:\\\"([0-9]{4})/?$\\\";s:26:\\\"index.php?year=$matches[1]\\\";s:27:\\\".?.+?/attachment/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:37:\\\".?.+?/attachment/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:57:\\\".?.+?/attachment/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\".?.+?/attachment/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\".?.+?/attachment/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:33:\\\".?.+?/attachment/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";s:16:\\\"(.?.+?)/embed/?$\\\";s:41:\\\"index.php?pagename=$matches[1]&embed=true\\\";s:20:\\\"(.?.+?)/trackback/?$\\\";s:35:\\\"index.php?pagename=$matches[1]&tb=1\\\";s:40:\\\"(.?.+?)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&feed=$matches[2]\\\";s:35:\\\"(.?.+?)/(feed|rdf|rss|rss2|atom)/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&feed=$matches[2]\\\";s:28:\\\"(.?.+?)/page/?([0-9]{1,})/?$\\\";s:48:\\\"index.php?pagename=$matches[1]&paged=$matches[2]\\\";s:35:\\\"(.?.+?)/comment-page-([0-9]{1,})/?$\\\";s:48:\\\"index.php?pagename=$matches[1]&cpage=$matches[2]\\\";s:24:\\\"(.?.+?)(?:/([0-9]+))?/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&page=$matches[2]\\\";s:27:\\\"[^/]+/attachment/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:37:\\\"[^/]+/attachment/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:57:\\\"[^/]+/attachment/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\"[^/]+/attachment/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\"[^/]+/attachment/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:33:\\\"[^/]+/attachment/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";s:16:\\\"([^/]+)/embed/?$\\\";s:37:\\\"index.php?name=$matches[1]&embed=true\\\";s:20:\\\"([^/]+)/trackback/?$\\\";s:31:\\\"index.php?name=$matches[1]&tb=1\\\";s:40:\\\"([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?name=$matches[1]&feed=$matches[2]\\\";s:35:\\\"([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?name=$matches[1]&feed=$matches[2]\\\";s:28:\\\"([^/]+)/page/?([0-9]{1,})/?$\\\";s:44:\\\"index.php?name=$matches[1]&paged=$matches[2]\\\";s:35:\\\"([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:44:\\\"index.php?name=$matches[1]&cpage=$matches[2]\\\";s:24:\\\"([^/]+)(?:/([0-9]+))?/?$\\\";s:43:\\\"index.php?name=$matches[1]&page=$matches[2]\\\";s:16:\\\"[^/]+/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:26:\\\"[^/]+/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:46:\\\"[^/]+/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:41:\\\"[^/]+/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:41:\\\"[^/]+/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:22:\\\"[^/]+/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";}', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)",
-             "trace_id": 0,
-             "span_id": 125,
-             "parent_id": 115,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp_posts\n\t\tWHERE post_name IN ('simple_view')\n\t\tAND post_type IN ('page','attachment')\n\t",
-             "trace_id": 0,
-             "span_id": 126,
-             "parent_id": 115,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_61_test_app",
        "resource": "shutdown (hook)",
        "trace_id": 0,
-       "span_id": 18,
+       "span_id": 12,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -1869,8 +1533,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_ob_end_flush_all (callback)",
           "trace_id": 0,
-          "span_id": 116,
-          "parent_id": 18,
+          "span_id": 110,
+          "parent_id": 12,
           "type": "web",
           "meta": {
             "component": "wordpress",

--- a/tests/snapshots/tests.integrations.word_press.v6_1.common_scenarios_legacy_test.test_scenario_get_return_string.json
+++ b/tests/snapshots/tests.integrations.word_press.v6_1.common_scenarios_legacy_test.test_scenario_get_return_string.json
@@ -5,17 +5,17 @@
     "resource": "GET /simple",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 17379863541528788903,
+    "parent_id": 2014609833228665378,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "65ba25f300000000",
+      "_dd.p.tid": "65e6fec200000000",
       "component": "wordpress",
       "http.method": "GET",
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/simple?key=value&<redacted>",
-      "runtime-id": "c0c1678e-f15d-4075-a7d0-2f83d7bd246f",
+      "runtime-id": "a74fb120-98e7-4f1d-910b-24090a13a540",
       "span.kind": "server"
     },
     "metrics": {
@@ -38,81 +38,6 @@
          "db.user": "test"
        }
      },
-        {
-          "name": "mysqli_real_connect",
-          "service": "mysqli",
-          "resource": "mysqli_real_connect",
-          "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-          "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT @@SESSION.sql_mode",
-          "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 1.0
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-          "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_61_test_app",
@@ -125,28 +50,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_name, option_value FROM wp_options WHERE autoload = 'yes'",
-          "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 3,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 118.0
-          }
-        },
      {
        "name": "create_initial_taxonomies",
        "service": "wordpress_61_test_app",
@@ -219,28 +122,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'WPLANG' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 9,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.init",
        "service": "wordpress_61_test_app",
@@ -294,35 +175,13 @@
           "service": "wordpress_61_test_app",
           "resource": "SELECT option_value FROM wp_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
           "trace_id": 0,
-          "span_id": 28,
+          "span_id": 22,
           "parent_id": 13,
           "type": "sql",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 38,
-             "parent_id": 28,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
      {
        "name": "wpdb.query",
        "service": "wordpress_61_test_app",
@@ -335,28 +194,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "\n\t\t\tSELECT  t.term_id\n\t\t\tFROM wp_terms AS t  INNER JOIN wp_term_taxonomy AS tt ON t.term_id = tt.term_id\n\t\t\tWHERE tt.taxonomy IN ('wp_theme') AND t.name IN ('twentytwentythree')\n\t\t\t\n\t\t\tLIMIT 1\n\t\t",
-          "trace_id": 0,
-          "span_id": 29,
-          "parent_id": 14,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_61_test_app",
@@ -369,28 +206,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "\n\t\t\tSELECT   wp_posts.*\n\t\t\tFROM wp_posts \n\t\t\tWHERE 1=1  AND ( \n  0 = 1\n) AND wp_posts.post_type = 'wp_template_part' AND ((wp_posts.post_status = 'publish'))\n\t\t\tGROUP BY wp_posts.ID\n\t\t\tORDER BY wp_posts.post_date DESC\n\t\t\t\n\t\t",
-          "trace_id": 0,
-          "span_id": 30,
-          "parent_id": 15,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_61_test_app",
@@ -403,28 +218,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'medium_crop' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 31,
-          "parent_id": 16,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_61_test_app",
@@ -437,28 +230,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'medium_large_crop' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 32,
-          "parent_id": 17,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_61_test_app",
@@ -471,28 +242,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'large_crop' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 33,
-          "parent_id": 18,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_61_test_app",
@@ -505,28 +254,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'theme_switched' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 34,
-          "parent_id": 19,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_61_test_app",
@@ -539,28 +266,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "\n\t\t\t\t\tSELECT   wp_posts.ID\n\t\t\t\t\tFROM wp_posts \n\t\t\t\t\tWHERE 1=1  AND ( \n  0 = 1\n) AND wp_posts.post_type = 'wp_global_styles' AND ((wp_posts.post_status = 'publish'))\n\t\t\t\t\tGROUP BY wp_posts.ID\n\t\t\t\t\tORDER BY wp_posts.post_date DESC\n\t\t\t\t\tLIMIT 0, 1\n\t\t\t\t",
-          "trace_id": 0,
-          "span_id": 35,
-          "parent_id": 20,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.main",
        "service": "wordpress_61_test_app",
@@ -578,7 +283,7 @@
           "service": "wordpress_61_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 36,
+          "span_id": 23,
           "parent_id": 21,
           "type": "web",
           "meta": {
@@ -590,7 +295,7 @@
           "service": "wordpress_61_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 37,
+          "span_id": 24,
           "parent_id": 21,
           "type": "web",
           "meta": {
@@ -602,63 +307,22 @@
              "service": "wordpress_61_test_app",
              "resource": "INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('rewrite_rules', 'a:93:{s:11:\\\"^wp-json/?$\\\";s:22:\\\"index.php?rest_route=/\\\";s:14:\\\"^wp-json/(.*)?\\\";s:33:\\\"index.php?rest_route=/$matches[1]\\\";s:21:\\\"^index.php/wp-json/?$\\\";s:22:\\\"index.php?rest_route=/\\\";s:24:\\\"^index.php/wp-json/(.*)?\\\";s:33:\\\"index.php?rest_route=/$matches[1]\\\";s:17:\\\"^wp-sitemap\\\\.xml$\\\";s:23:\\\"index.php?sitemap=index\\\";s:17:\\\"^wp-sitemap\\\\.xsl$\\\";s:36:\\\"index.php?sitemap-stylesheet=sitemap\\\";s:23:\\\"^wp-sitemap-index\\\\.xsl$\\\";s:34:\\\"index.php?sitemap-stylesheet=index\\\";s:48:\\\"^wp-sitemap-([a-z]+?)-([a-z\\\\d_-]+?)-(\\\\d+?)\\\\.xml$\\\";s:75:\\\"index.php?sitemap=$matches[1]&sitemap-subtype=$matches[2]&paged=$matches[3]\\\";s:34:\\\"^wp-sitemap-([a-z]+?)-(\\\\d+?)\\\\.xml$\\\";s:47:\\\"index.php?sitemap=$matches[1]&paged=$matches[2]\\\";s:47:\\\"category/(.+?)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:52:\\\"index.php?category_name=$matches[1]&feed=$matches[2]\\\";s:42:\\\"category/(.+?)/(feed|rdf|rss|rss2|atom)/?$\\\";s:52:\\\"index.php?category_name=$matches[1]&feed=$matches[2]\\\";s:23:\\\"category/(.+?)/embed/?$\\\";s:46:\\\"index.php?category_name=$matches[1]&embed=true\\\";s:35:\\\"category/(.+?)/page/?([0-9]{1,})/?$\\\";s:53:\\\"index.php?category_name=$matches[1]&paged=$matches[2]\\\";s:17:\\\"category/(.+?)/?$\\\";s:35:\\\"index.php?category_name=$matches[1]\\\";s:44:\\\"tag/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?tag=$matches[1]&feed=$matches[2]\\\";s:39:\\\"tag/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?tag=$matches[1]&feed=$matches[2]\\\";s:20:\\\"tag/([^/]+)/embed/?$\\\";s:36:\\\"index.php?tag=$matches[1]&embed=true\\\";s:32:\\\"tag/([^/]+)/page/?([0-9]{1,})/?$\\\";s:43:\\\"index.php?tag=$matches[1]&paged=$matches[2]\\\";s:14:\\\"tag/([^/]+)/?$\\\";s:25:\\\"index.php?tag=$matches[1]\\\";s:45:\\\"type/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?post_format=$matches[1]&feed=$matches[2]\\\";s:40:\\\"type/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?post_format=$matches[1]&feed=$matches[2]\\\";s:21:\\\"type/([^/]+)/embed/?$\\\";s:44:\\\"index.php?post_format=$matches[1]&embed=true\\\";s:33:\\\"type/([^/]+)/page/?([0-9]{1,})/?$\\\";s:51:\\\"index.php?post_format=$matches[1]&paged=$matches[2]\\\";s:15:\\\"type/([^/]+)/?$\\\";s:33:\\\"index.php?post_format=$matches[1]\\\";s:12:\\\"robots\\\\.txt$\\\";s:18:\\\"index.php?robots=1\\\";s:13:\\\"favicon\\\\.ico$\\\";s:19:\\\"index.php?favicon=1\\\";s:48:\\\".*wp-(atom|rdf|rss|rss2|feed|commentsrss2)\\\\.php$\\\";s:18:\\\"index.php?feed=old\\\";s:20:\\\".*wp-app\\\\.php(/.*)?$\\\";s:19:\\\"index.php?error=403\\\";s:18:\\\".*wp-register.php$\\\";s:23:\\\"index.php?register=true\\\";s:32:\\\"feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:27:\\\"index.php?&feed=$matches[1]\\\";s:27:\\\"(feed|rdf|rss|rss2|atom)/?$\\\";s:27:\\\"index.php?&feed=$matches[1]\\\";s:8:\\\"embed/?$\\\";s:21:\\\"index.php?&embed=true\\\";s:20:\\\"page/?([0-9]{1,})/?$\\\";s:28:\\\"index.php?&paged=$matches[1]\\\";s:41:\\\"comments/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?&feed=$matches[1]&withcomments=1\\\";s:36:\\\"comments/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?&feed=$matches[1]&withcomments=1\\\";s:17:\\\"comments/embed/?$\\\";s:21:\\\"index.php?&embed=true\\\";s:44:\\\"search/(.+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:40:\\\"index.php?s=$matches[1]&feed=$matches[2]\\\";s:39:\\\"search/(.+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:40:\\\"index.php?s=$matches[1]&feed=$matches[2]\\\";s:20:\\\"search/(.+)/embed/?$\\\";s:34:\\\"index.php?s=$matches[1]&embed=true\\\";s:32:\\\"search/(.+)/page/?([0-9]{1,})/?$\\\";s:41:\\\"index.php?s=$matches[1]&paged=$matches[2]\\\";s:14:\\\"search/(.+)/?$\\\";s:23:\\\"index.php?s=$matches[1]\\\";s:47:\\\"author/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?author_name=$matches[1]&feed=$matches[2]\\\";s:42:\\\"author/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?author_name=$matches[1]&feed=$matches[2]\\\";s:23:\\\"author/([^/]+)/embed/?$\\\";s:44:\\\"index.php?author_name=$matches[1]&embed=true\\\";s:35:\\\"author/([^/]+)/page/?([0-9]{1,})/?$\\\";s:51:\\\"index.php?author_name=$matches[1]&paged=$matches[2]\\\";s:17:\\\"author/([^/]+)/?$\\\";s:33:\\\"index.php?author_name=$matches[1]\\\";s:69:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:80:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&feed=$matches[4]\\\";s:64:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/(feed|rdf|rss|rss2|atom)/?$\\\";s:80:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&feed=$matches[4]\\\";s:45:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/embed/?$\\\";s:74:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&embed=true\\\";s:57:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/page/?([0-9]{1,})/?$\\\";s:81:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&paged=$matches[4]\\\";s:39:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/?$\\\";s:63:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]\\\";s:56:\\\"([0-9]{4})/([0-9]{1,2})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:64:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&feed=$matches[3]\\\";s:51:\\\"([0-9]{4})/([0-9]{1,2})/(feed|rdf|rss|rss2|atom)/?$\\\";s:64:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&feed=$matches[3]\\\";s:32:\\\"([0-9]{4})/([0-9]{1,2})/embed/?$\\\";s:58:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&embed=true\\\";s:44:\\\"([0-9]{4})/([0-9]{1,2})/page/?([0-9]{1,})/?$\\\";s:65:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&paged=$matches[3]\\\";s:26:\\\"([0-9]{4})/([0-9]{1,2})/?$\\\";s:47:\\\"index.php?year=$matches[1]&monthnum=$matches[2]\\\";s:43:\\\"([0-9]{4})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?year=$matches[1]&feed=$matches[2]\\\";s:38:\\\"([0-9]{4})/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?year=$matches[1]&feed=$matches[2]\\\";s:19:\\\"([0-9]{4})/embed/?$\\\";s:37:\\\"index.php?year=$matches[1]&embed=true\\\";s:31:\\\"([0-9]{4})/page/?([0-9]{1,})/?$\\\";s:44:\\\"index.php?year=$matches[1]&paged=$matches[2]\\\";s:13:\\\"([0-9]{4})/?$\\\";s:26:\\\"index.php?year=$matches[1]\\\";s:27:\\\".?.+?/attachment/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:37:\\\".?.+?/attachment/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:57:\\\".?.+?/attachment/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\".?.+?/attachment/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\".?.+?/attachment/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:33:\\\".?.+?/attachment/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";s:16:\\\"(.?.+?)/embed/?$\\\";s:41:\\\"index.php?pagename=$matches[1]&embed=true\\\";s:20:\\\"(.?.+?)/trackback/?$\\\";s:35:\\\"index.php?pagename=$matches[1]&tb=1\\\";s:40:\\\"(.?.+?)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&feed=$matches[2]\\\";s:35:\\\"(.?.+?)/(feed|rdf|rss|rss2|atom)/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&feed=$matches[2]\\\";s:28:\\\"(.?.+?)/page/?([0-9]{1,})/?$\\\";s:48:\\\"index.php?pagename=$matches[1]&paged=$matches[2]\\\";s:35:\\\"(.?.+?)/comment-page-([0-9]{1,})/?$\\\";s:48:\\\"index.php?pagename=$matches[1]&cpage=$matches[2]\\\";s:24:\\\"(.?.+?)(?:/([0-9]+))?/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&page=$matches[2]\\\";s:27:\\\"[^/]+/attachment/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:37:\\\"[^/]+/attachment/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:57:\\\"[^/]+/attachment/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\"[^/]+/attachment/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\"[^/]+/attachment/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:33:\\\"[^/]+/attachment/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";s:16:\\\"([^/]+)/embed/?$\\\";s:37:\\\"index.php?name=$matches[1]&embed=true\\\";s:20:\\\"([^/]+)/trackback/?$\\\";s:31:\\\"index.php?name=$matches[1]&tb=1\\\";s:40:\\\"([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?name=$matches[1]&feed=$matches[2]\\\";s:35:\\\"([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?name=$matches[1]&feed=$matches[2]\\\";s:28:\\\"([^/]+)/page/?([0-9]{1,})/?$\\\";s:44:\\\"index.php?name=$matches[1]&paged=$matches[2]\\\";s:35:\\\"([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:44:\\\"index.php?name=$matches[1]&cpage=$matches[2]\\\";s:24:\\\"([^/]+)(?:/([0-9]+))?/?$\\\";s:43:\\\"index.php?name=$matches[1]&page=$matches[2]\\\";s:16:\\\"[^/]+/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:26:\\\"[^/]+/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:46:\\\"[^/]+/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:41:\\\"[^/]+/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:41:\\\"[^/]+/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:22:\\\"[^/]+/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";}', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)",
              "trace_id": 0,
-             "span_id": 39,
-             "parent_id": 37,
+             "span_id": 25,
+             "parent_id": 24,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('rewrite_rules', 'a:93:{s:11:\\\"^wp-json/?$\\\";s:22:\\\"index.php?rest_route=/\\\";s:14:\\\"^wp-json/(.*)?\\\";s:33:\\\"index.php?rest_route=/$matches[1]\\\";s:21:\\\"^index.php/wp-json/?$\\\";s:22:\\\"index.php?rest_route=/\\\";s:24:\\\"^index.php/wp-json/(.*)?\\\";s:33:\\\"index.php?rest_route=/$matches[1]\\\";s:17:\\\"^wp-sitemap\\\\.xml$\\\";s:23:\\\"index.php?sitemap=index\\\";s:17:\\\"^wp-sitemap\\\\.xsl$\\\";s:36:\\\"index.php?sitemap-stylesheet=sitemap\\\";s:23:\\\"^wp-sitemap-index\\\\.xsl$\\\";s:34:\\\"index.php?sitemap-stylesheet=index\\\";s:48:\\\"^wp-sitemap-([a-z]+?)-([a-z\\\\d_-]+?)-(\\\\d+?)\\\\.xml$\\\";s:75:\\\"index.php?sitemap=$matches[1]&sitemap-subtype=$matches[2]&paged=$matches[3]\\\";s:34:\\\"^wp-sitemap-([a-z]+?)-(\\\\d+?)\\\\.xml$\\\";s:47:\\\"index.php?sitemap=$matches[1]&paged=$matches[2]\\\";s:47:\\\"category/(.+?)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:52:\\\"index.php?category_name=$matches[1]&feed=$matches[2]\\\";s:42:\\\"category/(.+?)/(feed|rdf|rss|rss2|atom)/?$\\\";s:52:\\\"index.php?category_name=$matches[1]&feed=$matches[2]\\\";s:23:\\\"category/(.+?)/embed/?$\\\";s:46:\\\"index.php?category_name=$matches[1]&embed=true\\\";s:35:\\\"category/(.+?)/page/?([0-9]{1,})/?$\\\";s:53:\\\"index.php?category_name=$matches[1]&paged=$matches[2]\\\";s:17:\\\"category/(.+?)/?$\\\";s:35:\\\"index.php?category_name=$matches[1]\\\";s:44:\\\"tag/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?tag=$matches[1]&feed=$matches[2]\\\";s:39:\\\"tag/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?tag=$matches[1]&feed=$matches[2]\\\";s:20:\\\"tag/([^/]+)/embed/?$\\\";s:36:\\\"index.php?tag=$matches[1]&embed=true\\\";s:32:\\\"tag/([^/]+)/page/?([0-9]{1,})/?$\\\";s:43:\\\"index.php?tag=$matches[1]&paged=$matches[2]\\\";s:14:\\\"tag/([^/]+)/?$\\\";s:25:\\\"index.php?tag=$matches[1]\\\";s:45:\\\"type/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?post_format=$matches[1]&feed=$matches[2]\\\";s:40:\\\"type/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?post_format=$matches[1]&feed=$matches[2]\\\";s:21:\\\"type/([^/]+)/embed/?$\\\";s:44:\\\"index.php?post_format=$matches[1]&embed=true\\\";s:33:\\\"type/([^/]+)/page/?([0-9]{1,})/?$\\\";s:51:\\\"index.php?post_format=$matches[1]&paged=$matches[2]\\\";s:15:\\\"type/([^/]+)/?$\\\";s:33:\\\"index.php?post_format=$matches[1]\\\";s:12:\\\"robots\\\\.txt$\\\";s:18:\\\"index.php?robots=1\\\";s:13:\\\"favicon\\\\.ico$\\\";s:19:\\\"index.php?favicon=1\\\";s:48:\\\".*wp-(atom|rdf|rss|rss2|feed|commentsrss2)\\\\.php$\\\";s:18:\\\"index.php?feed=old\\\";s:20:\\\".*wp-app\\\\.php(/.*)?$\\\";s:19:\\\"index.php?error=403\\\";s:18:\\\".*wp-register.php$\\\";s:23:\\\"index.php?register=true\\\";s:32:\\\"feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:27:\\\"index.php?&feed=$matches[1]\\\";s:27:\\\"(feed|rdf|rss|rss2|atom)/?$\\\";s:27:\\\"index.php?&feed=$matches[1]\\\";s:8:\\\"embed/?$\\\";s:21:\\\"index.php?&embed=true\\\";s:20:\\\"page/?([0-9]{1,})/?$\\\";s:28:\\\"index.php?&paged=$matches[1]\\\";s:41:\\\"comments/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?&feed=$matches[1]&withcomments=1\\\";s:36:\\\"comments/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?&feed=$matches[1]&withcomments=1\\\";s:17:\\\"comments/embed/?$\\\";s:21:\\\"index.php?&embed=true\\\";s:44:\\\"search/(.+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:40:\\\"index.php?s=$matches[1]&feed=$matches[2]\\\";s:39:\\\"search/(.+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:40:\\\"index.php?s=$matches[1]&feed=$matches[2]\\\";s:20:\\\"search/(.+)/embed/?$\\\";s:34:\\\"index.php?s=$matches[1]&embed=true\\\";s:32:\\\"search/(.+)/page/?([0-9]{1,})/?$\\\";s:41:\\\"index.php?s=$matches[1]&paged=$matches[2]\\\";s:14:\\\"search/(.+)/?$\\\";s:23:\\\"index.php?s=$matches[1]\\\";s:47:\\\"author/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?author_name=$matches[1]&feed=$matches[2]\\\";s:42:\\\"author/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?author_name=$matches[1]&feed=$matches[2]\\\";s:23:\\\"author/([^/]+)/embed/?$\\\";s:44:\\\"index.php?author_name=$matches[1]&embed=true\\\";s:35:\\\"author/([^/]+)/page/?([0-9]{1,})/?$\\\";s:51:\\\"index.php?author_name=$matches[1]&paged=$matches[2]\\\";s:17:\\\"author/([^/]+)/?$\\\";s:33:\\\"index.php?author_name=$matches[1]\\\";s:69:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:80:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&feed=$matches[4]\\\";s:64:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/(feed|rdf|rss|rss2|atom)/?$\\\";s:80:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&feed=$matches[4]\\\";s:45:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/embed/?$\\\";s:74:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&embed=true\\\";s:57:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/page/?([0-9]{1,})/?$\\\";s:81:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&paged=$matches[4]\\\";s:39:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/?$\\\";s:63:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]\\\";s:56:\\\"([0-9]{4})/([0-9]{1,2})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:64:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&feed=$matches[3]\\\";s:51:\\\"([0-9]{4})/([0-9]{1,2})/(feed|rdf|rss|rss2|atom)/?$\\\";s:64:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&feed=$matches[3]\\\";s:32:\\\"([0-9]{4})/([0-9]{1,2})/embed/?$\\\";s:58:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&embed=true\\\";s:44:\\\"([0-9]{4})/([0-9]{1,2})/page/?([0-9]{1,})/?$\\\";s:65:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&paged=$matches[3]\\\";s:26:\\\"([0-9]{4})/([0-9]{1,2})/?$\\\";s:47:\\\"index.php?year=$matches[1]&monthnum=$matches[2]\\\";s:43:\\\"([0-9]{4})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?year=$matches[1]&feed=$matches[2]\\\";s:38:\\\"([0-9]{4})/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?year=$matches[1]&feed=$matches[2]\\\";s:19:\\\"([0-9]{4})/embed/?$\\\";s:37:\\\"index.php?year=$matches[1]&embed=true\\\";s:31:\\\"([0-9]{4})/page/?([0-9]{1,})/?$\\\";s:44:\\\"index.php?year=$matches[1]&paged=$matches[2]\\\";s:13:\\\"([0-9]{4})/?$\\\";s:26:\\\"index.php?year=$matches[1]\\\";s:27:\\\".?.+?/attachment/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:37:\\\".?.+?/attachment/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:57:\\\".?.+?/attachment/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\".?.+?/attachment/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\".?.+?/attachment/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:33:\\\".?.+?/attachment/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";s:16:\\\"(.?.+?)/embed/?$\\\";s:41:\\\"index.php?pagename=$matches[1]&embed=true\\\";s:20:\\\"(.?.+?)/trackback/?$\\\";s:35:\\\"index.php?pagename=$matches[1]&tb=1\\\";s:40:\\\"(.?.+?)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&feed=$matches[2]\\\";s:35:\\\"(.?.+?)/(feed|rdf|rss|rss2|atom)/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&feed=$matches[2]\\\";s:28:\\\"(.?.+?)/page/?([0-9]{1,})/?$\\\";s:48:\\\"index.php?pagename=$matches[1]&paged=$matches[2]\\\";s:35:\\\"(.?.+?)/comment-page-([0-9]{1,})/?$\\\";s:48:\\\"index.php?pagename=$matches[1]&cpage=$matches[2]\\\";s:24:\\\"(.?.+?)(?:/([0-9]+))?/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&page=$matches[2]\\\";s:27:\\\"[^/]+/attachment/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:37:\\\"[^/]+/attachment/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:57:\\\"[^/]+/attachment/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\"[^/]+/attachment/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\"[^/]+/attachment/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:33:\\\"[^/]+/attachment/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";s:16:\\\"([^/]+)/embed/?$\\\";s:37:\\\"index.php?name=$matches[1]&embed=true\\\";s:20:\\\"([^/]+)/trackback/?$\\\";s:31:\\\"index.php?name=$matches[1]&tb=1\\\";s:40:\\\"([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?name=$matches[1]&feed=$matches[2]\\\";s:35:\\\"([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?name=$matches[1]&feed=$matches[2]\\\";s:28:\\\"([^/]+)/page/?([0-9]{1,})/?$\\\";s:44:\\\"index.php?name=$matches[1]&paged=$matches[2]\\\";s:35:\\\"([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:44:\\\"index.php?name=$matches[1]&cpage=$matches[2]\\\";s:24:\\\"([^/]+)(?:/([0-9]+))?/?$\\\";s:43:\\\"index.php?name=$matches[1]&page=$matches[2]\\\";s:16:\\\"[^/]+/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:26:\\\"[^/]+/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:46:\\\"[^/]+/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:41:\\\"[^/]+/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:41:\\\"[^/]+/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:22:\\\"[^/]+/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";}', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)",
-                "trace_id": 0,
-                "span_id": 41,
-                "parent_id": 39,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_61_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                }
-              },
            {
              "name": "wpdb.query",
              "service": "wordpress_61_test_app",
              "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp_posts\n\t\tWHERE post_name IN ('simple')\n\t\tAND post_type IN ('page','attachment')\n\t",
              "trace_id": 0,
-             "span_id": 40,
-             "parent_id": 37,
+             "span_id": 26,
+             "parent_id": 24,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
-           },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp_posts\n\t\tWHERE post_name IN ('simple')\n\t\tAND post_type IN ('page','attachment')\n\t",
-                "trace_id": 0,
-                "span_id": 42,
-                "parent_id": 40,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_61_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              }]]
+           }]]

--- a/tests/snapshots/tests.integrations.word_press.v6_1.common_scenarios_legacy_test.test_scenario_get_with_exception.json
+++ b/tests/snapshots/tests.integrations.word_press.v6_1.common_scenarios_legacy_test.test_scenario_get_with_exception.json
@@ -5,12 +5,12 @@
     "resource": "GET /error",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 6743992944235371295,
+    "parent_id": 13169942877179647881,
     "type": "web",
     "error": 1,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "65ba260a00000000",
+      "_dd.p.tid": "65e6fede00000000",
       "component": "wordpress",
       "error.message": "Uncaught Exception: Oops! in /home/circleci/datadog/tests/Frameworks/WordPress/Version_6_1/wp-content/plugins/datadog/datadog.php:20",
       "error.stack": "#0 /home/circleci/datadog/tests/Frameworks/WordPress/Version_6_1/wp-includes/class-wp-hook.php(308): datadog_parse_request()\n#1 /home/circleci/datadog/tests/Frameworks/WordPress/Version_6_1/wp-includes/class-wp-hook.php(332): WP_Hook->apply_filters()\n#2 /home/circleci/datadog/tests/Frameworks/WordPress/Version_6_1/wp-includes/plugin.php(565): WP_Hook->do_action()\n#3 /home/circleci/datadog/tests/Frameworks/WordPress/Version_6_1/wp-includes/class-wp.php(399): do_action_ref_array()\n#4 /home/circleci/datadog/tests/Frameworks/WordPress/Version_6_1/wp-includes/class-wp.php(780): WP->parse_request()\n#5 /home/circleci/datadog/tests/Frameworks/WordPress/Version_6_1/wp-includes/functions.php(1332): WP->main()\n#6 /home/circleci/datadog/tests/Frameworks/WordPress/Version_6_1/wp-blog-header.php(16): wp()\n#7 /home/circleci/datadog/tests/Frameworks/WordPress/Version_6_1/index.php(17): require()\n#8 {main}",
@@ -19,7 +19,7 @@
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/error?key=value&<redacted>",
-      "runtime-id": "c0c1678e-f15d-4075-a7d0-2f83d7bd246f",
+      "runtime-id": "a74fb120-98e7-4f1d-910b-24090a13a540",
       "span.kind": "server"
     },
     "metrics": {
@@ -42,81 +42,6 @@
          "db.user": "test"
        }
      },
-        {
-          "name": "mysqli_real_connect",
-          "service": "mysqli",
-          "resource": "mysqli_real_connect",
-          "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-          "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT @@SESSION.sql_mode",
-          "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 1.0
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-          "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_61_test_app",
@@ -129,28 +54,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_name, option_value FROM wp_options WHERE autoload = 'yes'",
-          "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 3,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 118.0
-          }
-        },
      {
        "name": "create_initial_taxonomies",
        "service": "wordpress_61_test_app",
@@ -223,28 +126,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'WPLANG' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 9,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.init",
        "service": "wordpress_61_test_app",
@@ -298,35 +179,13 @@
           "service": "wordpress_61_test_app",
           "resource": "SELECT option_value FROM wp_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
           "trace_id": 0,
-          "span_id": 28,
+          "span_id": 22,
           "parent_id": 13,
           "type": "sql",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 38,
-             "parent_id": 28,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
      {
        "name": "wpdb.query",
        "service": "wordpress_61_test_app",
@@ -339,28 +198,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "\n\t\t\tSELECT  t.term_id\n\t\t\tFROM wp_terms AS t  INNER JOIN wp_term_taxonomy AS tt ON t.term_id = tt.term_id\n\t\t\tWHERE tt.taxonomy IN ('wp_theme') AND t.name IN ('twentytwentythree')\n\t\t\t\n\t\t\tLIMIT 1\n\t\t",
-          "trace_id": 0,
-          "span_id": 29,
-          "parent_id": 14,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_61_test_app",
@@ -373,28 +210,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "\n\t\t\tSELECT   wp_posts.*\n\t\t\tFROM wp_posts \n\t\t\tWHERE 1=1  AND ( \n  0 = 1\n) AND wp_posts.post_type = 'wp_template_part' AND ((wp_posts.post_status = 'publish'))\n\t\t\tGROUP BY wp_posts.ID\n\t\t\tORDER BY wp_posts.post_date DESC\n\t\t\t\n\t\t",
-          "trace_id": 0,
-          "span_id": 30,
-          "parent_id": 15,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_61_test_app",
@@ -407,28 +222,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'medium_crop' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 31,
-          "parent_id": 16,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_61_test_app",
@@ -441,28 +234,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'medium_large_crop' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 32,
-          "parent_id": 17,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_61_test_app",
@@ -475,28 +246,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'large_crop' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 33,
-          "parent_id": 18,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_61_test_app",
@@ -509,28 +258,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'theme_switched' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 34,
-          "parent_id": 19,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_61_test_app",
@@ -543,28 +270,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "\n\t\t\t\t\tSELECT   wp_posts.ID\n\t\t\t\t\tFROM wp_posts \n\t\t\t\t\tWHERE 1=1  AND ( \n  0 = 1\n) AND wp_posts.post_type = 'wp_global_styles' AND ((wp_posts.post_status = 'publish'))\n\t\t\t\t\tGROUP BY wp_posts.ID\n\t\t\t\t\tORDER BY wp_posts.post_date DESC\n\t\t\t\t\tLIMIT 0, 1\n\t\t\t\t",
-          "trace_id": 0,
-          "span_id": 35,
-          "parent_id": 20,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.main",
        "service": "wordpress_61_test_app",
@@ -586,7 +291,7 @@
           "service": "wordpress_61_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 36,
+          "span_id": 23,
           "parent_id": 21,
           "type": "web",
           "meta": {
@@ -598,7 +303,7 @@
           "service": "wordpress_61_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 37,
+          "span_id": 24,
           "parent_id": 21,
           "type": "web",
           "error": 1,
@@ -614,63 +319,22 @@
              "service": "wordpress_61_test_app",
              "resource": "INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('rewrite_rules', 'a:93:{s:11:\\\"^wp-json/?$\\\";s:22:\\\"index.php?rest_route=/\\\";s:14:\\\"^wp-json/(.*)?\\\";s:33:\\\"index.php?rest_route=/$matches[1]\\\";s:21:\\\"^index.php/wp-json/?$\\\";s:22:\\\"index.php?rest_route=/\\\";s:24:\\\"^index.php/wp-json/(.*)?\\\";s:33:\\\"index.php?rest_route=/$matches[1]\\\";s:17:\\\"^wp-sitemap\\\\.xml$\\\";s:23:\\\"index.php?sitemap=index\\\";s:17:\\\"^wp-sitemap\\\\.xsl$\\\";s:36:\\\"index.php?sitemap-stylesheet=sitemap\\\";s:23:\\\"^wp-sitemap-index\\\\.xsl$\\\";s:34:\\\"index.php?sitemap-stylesheet=index\\\";s:48:\\\"^wp-sitemap-([a-z]+?)-([a-z\\\\d_-]+?)-(\\\\d+?)\\\\.xml$\\\";s:75:\\\"index.php?sitemap=$matches[1]&sitemap-subtype=$matches[2]&paged=$matches[3]\\\";s:34:\\\"^wp-sitemap-([a-z]+?)-(\\\\d+?)\\\\.xml$\\\";s:47:\\\"index.php?sitemap=$matches[1]&paged=$matches[2]\\\";s:47:\\\"category/(.+?)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:52:\\\"index.php?category_name=$matches[1]&feed=$matches[2]\\\";s:42:\\\"category/(.+?)/(feed|rdf|rss|rss2|atom)/?$\\\";s:52:\\\"index.php?category_name=$matches[1]&feed=$matches[2]\\\";s:23:\\\"category/(.+?)/embed/?$\\\";s:46:\\\"index.php?category_name=$matches[1]&embed=true\\\";s:35:\\\"category/(.+?)/page/?([0-9]{1,})/?$\\\";s:53:\\\"index.php?category_name=$matches[1]&paged=$matches[2]\\\";s:17:\\\"category/(.+?)/?$\\\";s:35:\\\"index.php?category_name=$matches[1]\\\";s:44:\\\"tag/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?tag=$matches[1]&feed=$matches[2]\\\";s:39:\\\"tag/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?tag=$matches[1]&feed=$matches[2]\\\";s:20:\\\"tag/([^/]+)/embed/?$\\\";s:36:\\\"index.php?tag=$matches[1]&embed=true\\\";s:32:\\\"tag/([^/]+)/page/?([0-9]{1,})/?$\\\";s:43:\\\"index.php?tag=$matches[1]&paged=$matches[2]\\\";s:14:\\\"tag/([^/]+)/?$\\\";s:25:\\\"index.php?tag=$matches[1]\\\";s:45:\\\"type/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?post_format=$matches[1]&feed=$matches[2]\\\";s:40:\\\"type/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?post_format=$matches[1]&feed=$matches[2]\\\";s:21:\\\"type/([^/]+)/embed/?$\\\";s:44:\\\"index.php?post_format=$matches[1]&embed=true\\\";s:33:\\\"type/([^/]+)/page/?([0-9]{1,})/?$\\\";s:51:\\\"index.php?post_format=$matches[1]&paged=$matches[2]\\\";s:15:\\\"type/([^/]+)/?$\\\";s:33:\\\"index.php?post_format=$matches[1]\\\";s:12:\\\"robots\\\\.txt$\\\";s:18:\\\"index.php?robots=1\\\";s:13:\\\"favicon\\\\.ico$\\\";s:19:\\\"index.php?favicon=1\\\";s:48:\\\".*wp-(atom|rdf|rss|rss2|feed|commentsrss2)\\\\.php$\\\";s:18:\\\"index.php?feed=old\\\";s:20:\\\".*wp-app\\\\.php(/.*)?$\\\";s:19:\\\"index.php?error=403\\\";s:18:\\\".*wp-register.php$\\\";s:23:\\\"index.php?register=true\\\";s:32:\\\"feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:27:\\\"index.php?&feed=$matches[1]\\\";s:27:\\\"(feed|rdf|rss|rss2|atom)/?$\\\";s:27:\\\"index.php?&feed=$matches[1]\\\";s:8:\\\"embed/?$\\\";s:21:\\\"index.php?&embed=true\\\";s:20:\\\"page/?([0-9]{1,})/?$\\\";s:28:\\\"index.php?&paged=$matches[1]\\\";s:41:\\\"comments/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?&feed=$matches[1]&withcomments=1\\\";s:36:\\\"comments/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?&feed=$matches[1]&withcomments=1\\\";s:17:\\\"comments/embed/?$\\\";s:21:\\\"index.php?&embed=true\\\";s:44:\\\"search/(.+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:40:\\\"index.php?s=$matches[1]&feed=$matches[2]\\\";s:39:\\\"search/(.+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:40:\\\"index.php?s=$matches[1]&feed=$matches[2]\\\";s:20:\\\"search/(.+)/embed/?$\\\";s:34:\\\"index.php?s=$matches[1]&embed=true\\\";s:32:\\\"search/(.+)/page/?([0-9]{1,})/?$\\\";s:41:\\\"index.php?s=$matches[1]&paged=$matches[2]\\\";s:14:\\\"search/(.+)/?$\\\";s:23:\\\"index.php?s=$matches[1]\\\";s:47:\\\"author/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?author_name=$matches[1]&feed=$matches[2]\\\";s:42:\\\"author/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?author_name=$matches[1]&feed=$matches[2]\\\";s:23:\\\"author/([^/]+)/embed/?$\\\";s:44:\\\"index.php?author_name=$matches[1]&embed=true\\\";s:35:\\\"author/([^/]+)/page/?([0-9]{1,})/?$\\\";s:51:\\\"index.php?author_name=$matches[1]&paged=$matches[2]\\\";s:17:\\\"author/([^/]+)/?$\\\";s:33:\\\"index.php?author_name=$matches[1]\\\";s:69:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:80:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&feed=$matches[4]\\\";s:64:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/(feed|rdf|rss|rss2|atom)/?$\\\";s:80:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&feed=$matches[4]\\\";s:45:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/embed/?$\\\";s:74:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&embed=true\\\";s:57:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/page/?([0-9]{1,})/?$\\\";s:81:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&paged=$matches[4]\\\";s:39:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/?$\\\";s:63:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]\\\";s:56:\\\"([0-9]{4})/([0-9]{1,2})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:64:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&feed=$matches[3]\\\";s:51:\\\"([0-9]{4})/([0-9]{1,2})/(feed|rdf|rss|rss2|atom)/?$\\\";s:64:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&feed=$matches[3]\\\";s:32:\\\"([0-9]{4})/([0-9]{1,2})/embed/?$\\\";s:58:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&embed=true\\\";s:44:\\\"([0-9]{4})/([0-9]{1,2})/page/?([0-9]{1,})/?$\\\";s:65:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&paged=$matches[3]\\\";s:26:\\\"([0-9]{4})/([0-9]{1,2})/?$\\\";s:47:\\\"index.php?year=$matches[1]&monthnum=$matches[2]\\\";s:43:\\\"([0-9]{4})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?year=$matches[1]&feed=$matches[2]\\\";s:38:\\\"([0-9]{4})/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?year=$matches[1]&feed=$matches[2]\\\";s:19:\\\"([0-9]{4})/embed/?$\\\";s:37:\\\"index.php?year=$matches[1]&embed=true\\\";s:31:\\\"([0-9]{4})/page/?([0-9]{1,})/?$\\\";s:44:\\\"index.php?year=$matches[1]&paged=$matches[2]\\\";s:13:\\\"([0-9]{4})/?$\\\";s:26:\\\"index.php?year=$matches[1]\\\";s:27:\\\".?.+?/attachment/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:37:\\\".?.+?/attachment/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:57:\\\".?.+?/attachment/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\".?.+?/attachment/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\".?.+?/attachment/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:33:\\\".?.+?/attachment/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";s:16:\\\"(.?.+?)/embed/?$\\\";s:41:\\\"index.php?pagename=$matches[1]&embed=true\\\";s:20:\\\"(.?.+?)/trackback/?$\\\";s:35:\\\"index.php?pagename=$matches[1]&tb=1\\\";s:40:\\\"(.?.+?)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&feed=$matches[2]\\\";s:35:\\\"(.?.+?)/(feed|rdf|rss|rss2|atom)/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&feed=$matches[2]\\\";s:28:\\\"(.?.+?)/page/?([0-9]{1,})/?$\\\";s:48:\\\"index.php?pagename=$matches[1]&paged=$matches[2]\\\";s:35:\\\"(.?.+?)/comment-page-([0-9]{1,})/?$\\\";s:48:\\\"index.php?pagename=$matches[1]&cpage=$matches[2]\\\";s:24:\\\"(.?.+?)(?:/([0-9]+))?/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&page=$matches[2]\\\";s:27:\\\"[^/]+/attachment/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:37:\\\"[^/]+/attachment/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:57:\\\"[^/]+/attachment/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\"[^/]+/attachment/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\"[^/]+/attachment/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:33:\\\"[^/]+/attachment/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";s:16:\\\"([^/]+)/embed/?$\\\";s:37:\\\"index.php?name=$matches[1]&embed=true\\\";s:20:\\\"([^/]+)/trackback/?$\\\";s:31:\\\"index.php?name=$matches[1]&tb=1\\\";s:40:\\\"([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?name=$matches[1]&feed=$matches[2]\\\";s:35:\\\"([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?name=$matches[1]&feed=$matches[2]\\\";s:28:\\\"([^/]+)/page/?([0-9]{1,})/?$\\\";s:44:\\\"index.php?name=$matches[1]&paged=$matches[2]\\\";s:35:\\\"([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:44:\\\"index.php?name=$matches[1]&cpage=$matches[2]\\\";s:24:\\\"([^/]+)(?:/([0-9]+))?/?$\\\";s:43:\\\"index.php?name=$matches[1]&page=$matches[2]\\\";s:16:\\\"[^/]+/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:26:\\\"[^/]+/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:46:\\\"[^/]+/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:41:\\\"[^/]+/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:41:\\\"[^/]+/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:22:\\\"[^/]+/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";}', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)",
              "trace_id": 0,
-             "span_id": 39,
-             "parent_id": 37,
+             "span_id": 25,
+             "parent_id": 24,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('rewrite_rules', 'a:93:{s:11:\\\"^wp-json/?$\\\";s:22:\\\"index.php?rest_route=/\\\";s:14:\\\"^wp-json/(.*)?\\\";s:33:\\\"index.php?rest_route=/$matches[1]\\\";s:21:\\\"^index.php/wp-json/?$\\\";s:22:\\\"index.php?rest_route=/\\\";s:24:\\\"^index.php/wp-json/(.*)?\\\";s:33:\\\"index.php?rest_route=/$matches[1]\\\";s:17:\\\"^wp-sitemap\\\\.xml$\\\";s:23:\\\"index.php?sitemap=index\\\";s:17:\\\"^wp-sitemap\\\\.xsl$\\\";s:36:\\\"index.php?sitemap-stylesheet=sitemap\\\";s:23:\\\"^wp-sitemap-index\\\\.xsl$\\\";s:34:\\\"index.php?sitemap-stylesheet=index\\\";s:48:\\\"^wp-sitemap-([a-z]+?)-([a-z\\\\d_-]+?)-(\\\\d+?)\\\\.xml$\\\";s:75:\\\"index.php?sitemap=$matches[1]&sitemap-subtype=$matches[2]&paged=$matches[3]\\\";s:34:\\\"^wp-sitemap-([a-z]+?)-(\\\\d+?)\\\\.xml$\\\";s:47:\\\"index.php?sitemap=$matches[1]&paged=$matches[2]\\\";s:47:\\\"category/(.+?)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:52:\\\"index.php?category_name=$matches[1]&feed=$matches[2]\\\";s:42:\\\"category/(.+?)/(feed|rdf|rss|rss2|atom)/?$\\\";s:52:\\\"index.php?category_name=$matches[1]&feed=$matches[2]\\\";s:23:\\\"category/(.+?)/embed/?$\\\";s:46:\\\"index.php?category_name=$matches[1]&embed=true\\\";s:35:\\\"category/(.+?)/page/?([0-9]{1,})/?$\\\";s:53:\\\"index.php?category_name=$matches[1]&paged=$matches[2]\\\";s:17:\\\"category/(.+?)/?$\\\";s:35:\\\"index.php?category_name=$matches[1]\\\";s:44:\\\"tag/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?tag=$matches[1]&feed=$matches[2]\\\";s:39:\\\"tag/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?tag=$matches[1]&feed=$matches[2]\\\";s:20:\\\"tag/([^/]+)/embed/?$\\\";s:36:\\\"index.php?tag=$matches[1]&embed=true\\\";s:32:\\\"tag/([^/]+)/page/?([0-9]{1,})/?$\\\";s:43:\\\"index.php?tag=$matches[1]&paged=$matches[2]\\\";s:14:\\\"tag/([^/]+)/?$\\\";s:25:\\\"index.php?tag=$matches[1]\\\";s:45:\\\"type/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?post_format=$matches[1]&feed=$matches[2]\\\";s:40:\\\"type/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?post_format=$matches[1]&feed=$matches[2]\\\";s:21:\\\"type/([^/]+)/embed/?$\\\";s:44:\\\"index.php?post_format=$matches[1]&embed=true\\\";s:33:\\\"type/([^/]+)/page/?([0-9]{1,})/?$\\\";s:51:\\\"index.php?post_format=$matches[1]&paged=$matches[2]\\\";s:15:\\\"type/([^/]+)/?$\\\";s:33:\\\"index.php?post_format=$matches[1]\\\";s:12:\\\"robots\\\\.txt$\\\";s:18:\\\"index.php?robots=1\\\";s:13:\\\"favicon\\\\.ico$\\\";s:19:\\\"index.php?favicon=1\\\";s:48:\\\".*wp-(atom|rdf|rss|rss2|feed|commentsrss2)\\\\.php$\\\";s:18:\\\"index.php?feed=old\\\";s:20:\\\".*wp-app\\\\.php(/.*)?$\\\";s:19:\\\"index.php?error=403\\\";s:18:\\\".*wp-register.php$\\\";s:23:\\\"index.php?register=true\\\";s:32:\\\"feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:27:\\\"index.php?&feed=$matches[1]\\\";s:27:\\\"(feed|rdf|rss|rss2|atom)/?$\\\";s:27:\\\"index.php?&feed=$matches[1]\\\";s:8:\\\"embed/?$\\\";s:21:\\\"index.php?&embed=true\\\";s:20:\\\"page/?([0-9]{1,})/?$\\\";s:28:\\\"index.php?&paged=$matches[1]\\\";s:41:\\\"comments/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?&feed=$matches[1]&withcomments=1\\\";s:36:\\\"comments/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?&feed=$matches[1]&withcomments=1\\\";s:17:\\\"comments/embed/?$\\\";s:21:\\\"index.php?&embed=true\\\";s:44:\\\"search/(.+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:40:\\\"index.php?s=$matches[1]&feed=$matches[2]\\\";s:39:\\\"search/(.+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:40:\\\"index.php?s=$matches[1]&feed=$matches[2]\\\";s:20:\\\"search/(.+)/embed/?$\\\";s:34:\\\"index.php?s=$matches[1]&embed=true\\\";s:32:\\\"search/(.+)/page/?([0-9]{1,})/?$\\\";s:41:\\\"index.php?s=$matches[1]&paged=$matches[2]\\\";s:14:\\\"search/(.+)/?$\\\";s:23:\\\"index.php?s=$matches[1]\\\";s:47:\\\"author/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?author_name=$matches[1]&feed=$matches[2]\\\";s:42:\\\"author/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?author_name=$matches[1]&feed=$matches[2]\\\";s:23:\\\"author/([^/]+)/embed/?$\\\";s:44:\\\"index.php?author_name=$matches[1]&embed=true\\\";s:35:\\\"author/([^/]+)/page/?([0-9]{1,})/?$\\\";s:51:\\\"index.php?author_name=$matches[1]&paged=$matches[2]\\\";s:17:\\\"author/([^/]+)/?$\\\";s:33:\\\"index.php?author_name=$matches[1]\\\";s:69:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:80:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&feed=$matches[4]\\\";s:64:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/(feed|rdf|rss|rss2|atom)/?$\\\";s:80:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&feed=$matches[4]\\\";s:45:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/embed/?$\\\";s:74:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&embed=true\\\";s:57:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/page/?([0-9]{1,})/?$\\\";s:81:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&paged=$matches[4]\\\";s:39:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/?$\\\";s:63:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]\\\";s:56:\\\"([0-9]{4})/([0-9]{1,2})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:64:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&feed=$matches[3]\\\";s:51:\\\"([0-9]{4})/([0-9]{1,2})/(feed|rdf|rss|rss2|atom)/?$\\\";s:64:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&feed=$matches[3]\\\";s:32:\\\"([0-9]{4})/([0-9]{1,2})/embed/?$\\\";s:58:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&embed=true\\\";s:44:\\\"([0-9]{4})/([0-9]{1,2})/page/?([0-9]{1,})/?$\\\";s:65:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&paged=$matches[3]\\\";s:26:\\\"([0-9]{4})/([0-9]{1,2})/?$\\\";s:47:\\\"index.php?year=$matches[1]&monthnum=$matches[2]\\\";s:43:\\\"([0-9]{4})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?year=$matches[1]&feed=$matches[2]\\\";s:38:\\\"([0-9]{4})/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?year=$matches[1]&feed=$matches[2]\\\";s:19:\\\"([0-9]{4})/embed/?$\\\";s:37:\\\"index.php?year=$matches[1]&embed=true\\\";s:31:\\\"([0-9]{4})/page/?([0-9]{1,})/?$\\\";s:44:\\\"index.php?year=$matches[1]&paged=$matches[2]\\\";s:13:\\\"([0-9]{4})/?$\\\";s:26:\\\"index.php?year=$matches[1]\\\";s:27:\\\".?.+?/attachment/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:37:\\\".?.+?/attachment/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:57:\\\".?.+?/attachment/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\".?.+?/attachment/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\".?.+?/attachment/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:33:\\\".?.+?/attachment/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";s:16:\\\"(.?.+?)/embed/?$\\\";s:41:\\\"index.php?pagename=$matches[1]&embed=true\\\";s:20:\\\"(.?.+?)/trackback/?$\\\";s:35:\\\"index.php?pagename=$matches[1]&tb=1\\\";s:40:\\\"(.?.+?)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&feed=$matches[2]\\\";s:35:\\\"(.?.+?)/(feed|rdf|rss|rss2|atom)/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&feed=$matches[2]\\\";s:28:\\\"(.?.+?)/page/?([0-9]{1,})/?$\\\";s:48:\\\"index.php?pagename=$matches[1]&paged=$matches[2]\\\";s:35:\\\"(.?.+?)/comment-page-([0-9]{1,})/?$\\\";s:48:\\\"index.php?pagename=$matches[1]&cpage=$matches[2]\\\";s:24:\\\"(.?.+?)(?:/([0-9]+))?/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&page=$matches[2]\\\";s:27:\\\"[^/]+/attachment/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:37:\\\"[^/]+/attachment/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:57:\\\"[^/]+/attachment/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\"[^/]+/attachment/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\"[^/]+/attachment/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:33:\\\"[^/]+/attachment/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";s:16:\\\"([^/]+)/embed/?$\\\";s:37:\\\"index.php?name=$matches[1]&embed=true\\\";s:20:\\\"([^/]+)/trackback/?$\\\";s:31:\\\"index.php?name=$matches[1]&tb=1\\\";s:40:\\\"([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?name=$matches[1]&feed=$matches[2]\\\";s:35:\\\"([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?name=$matches[1]&feed=$matches[2]\\\";s:28:\\\"([^/]+)/page/?([0-9]{1,})/?$\\\";s:44:\\\"index.php?name=$matches[1]&paged=$matches[2]\\\";s:35:\\\"([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:44:\\\"index.php?name=$matches[1]&cpage=$matches[2]\\\";s:24:\\\"([^/]+)(?:/([0-9]+))?/?$\\\";s:43:\\\"index.php?name=$matches[1]&page=$matches[2]\\\";s:16:\\\"[^/]+/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:26:\\\"[^/]+/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:46:\\\"[^/]+/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:41:\\\"[^/]+/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:41:\\\"[^/]+/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:22:\\\"[^/]+/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";}', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)",
-                "trace_id": 0,
-                "span_id": 41,
-                "parent_id": 39,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_61_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                }
-              },
            {
              "name": "wpdb.query",
              "service": "wordpress_61_test_app",
              "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp_posts\n\t\tWHERE post_name IN ('error')\n\t\tAND post_type IN ('page','attachment')\n\t",
              "trace_id": 0,
-             "span_id": 40,
-             "parent_id": 37,
+             "span_id": 26,
+             "parent_id": 24,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
-           },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp_posts\n\t\tWHERE post_name IN ('error')\n\t\tAND post_type IN ('page','attachment')\n\t",
-                "trace_id": 0,
-                "span_id": 42,
-                "parent_id": 40,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_61_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              }]]
+           }]]

--- a/tests/snapshots/tests.integrations.word_press.v6_1.common_scenarios_legacy_test.test_scenario_get_with_view.json
+++ b/tests/snapshots/tests.integrations.word_press.v6_1.common_scenarios_legacy_test.test_scenario_get_with_view.json
@@ -5,17 +5,17 @@
     "resource": "GET /simple_view",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 11244774607770248483,
+    "parent_id": 832122390158969470,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "65ba25f900000000",
+      "_dd.p.tid": "65e6fed200000000",
       "component": "wordpress",
       "http.method": "GET",
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/simple_view?key=value&<redacted>",
-      "runtime-id": "c0c1678e-f15d-4075-a7d0-2f83d7bd246f",
+      "runtime-id": "a74fb120-98e7-4f1d-910b-24090a13a540",
       "span.kind": "server"
     },
     "metrics": {
@@ -38,81 +38,6 @@
          "db.user": "test"
        }
      },
-        {
-          "name": "mysqli_real_connect",
-          "service": "mysqli",
-          "resource": "mysqli_real_connect",
-          "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-          "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT @@SESSION.sql_mode",
-          "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 1.0
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-          "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 2,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_61_test_app",
@@ -125,28 +50,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_name, option_value FROM wp_options WHERE autoload = 'yes'",
-          "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 3,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 118.0
-          }
-        },
      {
        "name": "create_initial_taxonomies",
        "service": "wordpress_61_test_app",
@@ -219,28 +122,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'WPLANG' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 9,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.init",
        "service": "wordpress_61_test_app",
@@ -294,35 +175,13 @@
           "service": "wordpress_61_test_app",
           "resource": "SELECT option_value FROM wp_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
           "trace_id": 0,
-          "span_id": 28,
+          "span_id": 22,
           "parent_id": 13,
           "type": "sql",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "SELECT option_value FROM wp_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-             "trace_id": 0,
-             "span_id": 38,
-             "parent_id": 28,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 1.0
-             }
-           },
      {
        "name": "wpdb.query",
        "service": "wordpress_61_test_app",
@@ -335,28 +194,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "\n\t\t\tSELECT  t.term_id\n\t\t\tFROM wp_terms AS t  INNER JOIN wp_term_taxonomy AS tt ON t.term_id = tt.term_id\n\t\t\tWHERE tt.taxonomy IN ('wp_theme') AND t.name IN ('twentytwentythree')\n\t\t\t\n\t\t\tLIMIT 1\n\t\t",
-          "trace_id": 0,
-          "span_id": 29,
-          "parent_id": 14,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_61_test_app",
@@ -369,28 +206,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "\n\t\t\tSELECT   wp_posts.*\n\t\t\tFROM wp_posts \n\t\t\tWHERE 1=1  AND ( \n  0 = 1\n) AND wp_posts.post_type = 'wp_template_part' AND ((wp_posts.post_status = 'publish'))\n\t\t\tGROUP BY wp_posts.ID\n\t\t\tORDER BY wp_posts.post_date DESC\n\t\t\t\n\t\t",
-          "trace_id": 0,
-          "span_id": 30,
-          "parent_id": 15,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_61_test_app",
@@ -403,28 +218,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'medium_crop' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 31,
-          "parent_id": 16,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_61_test_app",
@@ -437,28 +230,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'medium_large_crop' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 32,
-          "parent_id": 17,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_61_test_app",
@@ -471,28 +242,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'large_crop' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 33,
-          "parent_id": 18,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_61_test_app",
@@ -505,28 +254,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'theme_switched' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 34,
-          "parent_id": 19,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "wpdb.query",
        "service": "wordpress_61_test_app",
@@ -539,28 +266,6 @@
          "component": "wordpress"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "\n\t\t\t\t\tSELECT   wp_posts.ID\n\t\t\t\t\tFROM wp_posts \n\t\t\t\t\tWHERE 1=1  AND ( \n  0 = 1\n) AND wp_posts.post_type = 'wp_global_styles' AND ((wp_posts.post_status = 'publish'))\n\t\t\t\t\tGROUP BY wp_posts.ID\n\t\t\t\t\tORDER BY wp_posts.post_date DESC\n\t\t\t\t\tLIMIT 0, 1\n\t\t\t\t",
-          "trace_id": 0,
-          "span_id": 35,
-          "parent_id": 20,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.main",
        "service": "wordpress_61_test_app",
@@ -578,7 +283,7 @@
           "service": "wordpress_61_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 36,
+          "span_id": 23,
           "parent_id": 21,
           "type": "web",
           "meta": {
@@ -590,7 +295,7 @@
           "service": "wordpress_61_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 37,
+          "span_id": 24,
           "parent_id": 21,
           "type": "web",
           "meta": {
@@ -602,63 +307,22 @@
              "service": "wordpress_61_test_app",
              "resource": "INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('rewrite_rules', 'a:93:{s:11:\\\"^wp-json/?$\\\";s:22:\\\"index.php?rest_route=/\\\";s:14:\\\"^wp-json/(.*)?\\\";s:33:\\\"index.php?rest_route=/$matches[1]\\\";s:21:\\\"^index.php/wp-json/?$\\\";s:22:\\\"index.php?rest_route=/\\\";s:24:\\\"^index.php/wp-json/(.*)?\\\";s:33:\\\"index.php?rest_route=/$matches[1]\\\";s:17:\\\"^wp-sitemap\\\\.xml$\\\";s:23:\\\"index.php?sitemap=index\\\";s:17:\\\"^wp-sitemap\\\\.xsl$\\\";s:36:\\\"index.php?sitemap-stylesheet=sitemap\\\";s:23:\\\"^wp-sitemap-index\\\\.xsl$\\\";s:34:\\\"index.php?sitemap-stylesheet=index\\\";s:48:\\\"^wp-sitemap-([a-z]+?)-([a-z\\\\d_-]+?)-(\\\\d+?)\\\\.xml$\\\";s:75:\\\"index.php?sitemap=$matches[1]&sitemap-subtype=$matches[2]&paged=$matches[3]\\\";s:34:\\\"^wp-sitemap-([a-z]+?)-(\\\\d+?)\\\\.xml$\\\";s:47:\\\"index.php?sitemap=$matches[1]&paged=$matches[2]\\\";s:47:\\\"category/(.+?)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:52:\\\"index.php?category_name=$matches[1]&feed=$matches[2]\\\";s:42:\\\"category/(.+?)/(feed|rdf|rss|rss2|atom)/?$\\\";s:52:\\\"index.php?category_name=$matches[1]&feed=$matches[2]\\\";s:23:\\\"category/(.+?)/embed/?$\\\";s:46:\\\"index.php?category_name=$matches[1]&embed=true\\\";s:35:\\\"category/(.+?)/page/?([0-9]{1,})/?$\\\";s:53:\\\"index.php?category_name=$matches[1]&paged=$matches[2]\\\";s:17:\\\"category/(.+?)/?$\\\";s:35:\\\"index.php?category_name=$matches[1]\\\";s:44:\\\"tag/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?tag=$matches[1]&feed=$matches[2]\\\";s:39:\\\"tag/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?tag=$matches[1]&feed=$matches[2]\\\";s:20:\\\"tag/([^/]+)/embed/?$\\\";s:36:\\\"index.php?tag=$matches[1]&embed=true\\\";s:32:\\\"tag/([^/]+)/page/?([0-9]{1,})/?$\\\";s:43:\\\"index.php?tag=$matches[1]&paged=$matches[2]\\\";s:14:\\\"tag/([^/]+)/?$\\\";s:25:\\\"index.php?tag=$matches[1]\\\";s:45:\\\"type/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?post_format=$matches[1]&feed=$matches[2]\\\";s:40:\\\"type/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?post_format=$matches[1]&feed=$matches[2]\\\";s:21:\\\"type/([^/]+)/embed/?$\\\";s:44:\\\"index.php?post_format=$matches[1]&embed=true\\\";s:33:\\\"type/([^/]+)/page/?([0-9]{1,})/?$\\\";s:51:\\\"index.php?post_format=$matches[1]&paged=$matches[2]\\\";s:15:\\\"type/([^/]+)/?$\\\";s:33:\\\"index.php?post_format=$matches[1]\\\";s:12:\\\"robots\\\\.txt$\\\";s:18:\\\"index.php?robots=1\\\";s:13:\\\"favicon\\\\.ico$\\\";s:19:\\\"index.php?favicon=1\\\";s:48:\\\".*wp-(atom|rdf|rss|rss2|feed|commentsrss2)\\\\.php$\\\";s:18:\\\"index.php?feed=old\\\";s:20:\\\".*wp-app\\\\.php(/.*)?$\\\";s:19:\\\"index.php?error=403\\\";s:18:\\\".*wp-register.php$\\\";s:23:\\\"index.php?register=true\\\";s:32:\\\"feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:27:\\\"index.php?&feed=$matches[1]\\\";s:27:\\\"(feed|rdf|rss|rss2|atom)/?$\\\";s:27:\\\"index.php?&feed=$matches[1]\\\";s:8:\\\"embed/?$\\\";s:21:\\\"index.php?&embed=true\\\";s:20:\\\"page/?([0-9]{1,})/?$\\\";s:28:\\\"index.php?&paged=$matches[1]\\\";s:41:\\\"comments/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?&feed=$matches[1]&withcomments=1\\\";s:36:\\\"comments/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?&feed=$matches[1]&withcomments=1\\\";s:17:\\\"comments/embed/?$\\\";s:21:\\\"index.php?&embed=true\\\";s:44:\\\"search/(.+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:40:\\\"index.php?s=$matches[1]&feed=$matches[2]\\\";s:39:\\\"search/(.+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:40:\\\"index.php?s=$matches[1]&feed=$matches[2]\\\";s:20:\\\"search/(.+)/embed/?$\\\";s:34:\\\"index.php?s=$matches[1]&embed=true\\\";s:32:\\\"search/(.+)/page/?([0-9]{1,})/?$\\\";s:41:\\\"index.php?s=$matches[1]&paged=$matches[2]\\\";s:14:\\\"search/(.+)/?$\\\";s:23:\\\"index.php?s=$matches[1]\\\";s:47:\\\"author/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?author_name=$matches[1]&feed=$matches[2]\\\";s:42:\\\"author/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?author_name=$matches[1]&feed=$matches[2]\\\";s:23:\\\"author/([^/]+)/embed/?$\\\";s:44:\\\"index.php?author_name=$matches[1]&embed=true\\\";s:35:\\\"author/([^/]+)/page/?([0-9]{1,})/?$\\\";s:51:\\\"index.php?author_name=$matches[1]&paged=$matches[2]\\\";s:17:\\\"author/([^/]+)/?$\\\";s:33:\\\"index.php?author_name=$matches[1]\\\";s:69:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:80:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&feed=$matches[4]\\\";s:64:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/(feed|rdf|rss|rss2|atom)/?$\\\";s:80:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&feed=$matches[4]\\\";s:45:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/embed/?$\\\";s:74:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&embed=true\\\";s:57:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/page/?([0-9]{1,})/?$\\\";s:81:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&paged=$matches[4]\\\";s:39:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/?$\\\";s:63:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]\\\";s:56:\\\"([0-9]{4})/([0-9]{1,2})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:64:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&feed=$matches[3]\\\";s:51:\\\"([0-9]{4})/([0-9]{1,2})/(feed|rdf|rss|rss2|atom)/?$\\\";s:64:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&feed=$matches[3]\\\";s:32:\\\"([0-9]{4})/([0-9]{1,2})/embed/?$\\\";s:58:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&embed=true\\\";s:44:\\\"([0-9]{4})/([0-9]{1,2})/page/?([0-9]{1,})/?$\\\";s:65:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&paged=$matches[3]\\\";s:26:\\\"([0-9]{4})/([0-9]{1,2})/?$\\\";s:47:\\\"index.php?year=$matches[1]&monthnum=$matches[2]\\\";s:43:\\\"([0-9]{4})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?year=$matches[1]&feed=$matches[2]\\\";s:38:\\\"([0-9]{4})/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?year=$matches[1]&feed=$matches[2]\\\";s:19:\\\"([0-9]{4})/embed/?$\\\";s:37:\\\"index.php?year=$matches[1]&embed=true\\\";s:31:\\\"([0-9]{4})/page/?([0-9]{1,})/?$\\\";s:44:\\\"index.php?year=$matches[1]&paged=$matches[2]\\\";s:13:\\\"([0-9]{4})/?$\\\";s:26:\\\"index.php?year=$matches[1]\\\";s:27:\\\".?.+?/attachment/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:37:\\\".?.+?/attachment/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:57:\\\".?.+?/attachment/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\".?.+?/attachment/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\".?.+?/attachment/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:33:\\\".?.+?/attachment/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";s:16:\\\"(.?.+?)/embed/?$\\\";s:41:\\\"index.php?pagename=$matches[1]&embed=true\\\";s:20:\\\"(.?.+?)/trackback/?$\\\";s:35:\\\"index.php?pagename=$matches[1]&tb=1\\\";s:40:\\\"(.?.+?)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&feed=$matches[2]\\\";s:35:\\\"(.?.+?)/(feed|rdf|rss|rss2|atom)/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&feed=$matches[2]\\\";s:28:\\\"(.?.+?)/page/?([0-9]{1,})/?$\\\";s:48:\\\"index.php?pagename=$matches[1]&paged=$matches[2]\\\";s:35:\\\"(.?.+?)/comment-page-([0-9]{1,})/?$\\\";s:48:\\\"index.php?pagename=$matches[1]&cpage=$matches[2]\\\";s:24:\\\"(.?.+?)(?:/([0-9]+))?/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&page=$matches[2]\\\";s:27:\\\"[^/]+/attachment/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:37:\\\"[^/]+/attachment/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:57:\\\"[^/]+/attachment/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\"[^/]+/attachment/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\"[^/]+/attachment/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:33:\\\"[^/]+/attachment/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";s:16:\\\"([^/]+)/embed/?$\\\";s:37:\\\"index.php?name=$matches[1]&embed=true\\\";s:20:\\\"([^/]+)/trackback/?$\\\";s:31:\\\"index.php?name=$matches[1]&tb=1\\\";s:40:\\\"([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?name=$matches[1]&feed=$matches[2]\\\";s:35:\\\"([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?name=$matches[1]&feed=$matches[2]\\\";s:28:\\\"([^/]+)/page/?([0-9]{1,})/?$\\\";s:44:\\\"index.php?name=$matches[1]&paged=$matches[2]\\\";s:35:\\\"([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:44:\\\"index.php?name=$matches[1]&cpage=$matches[2]\\\";s:24:\\\"([^/]+)(?:/([0-9]+))?/?$\\\";s:43:\\\"index.php?name=$matches[1]&page=$matches[2]\\\";s:16:\\\"[^/]+/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:26:\\\"[^/]+/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:46:\\\"[^/]+/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:41:\\\"[^/]+/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:41:\\\"[^/]+/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:22:\\\"[^/]+/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";}', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)",
              "trace_id": 0,
-             "span_id": 39,
-             "parent_id": 37,
+             "span_id": 25,
+             "parent_id": 24,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('rewrite_rules', 'a:93:{s:11:\\\"^wp-json/?$\\\";s:22:\\\"index.php?rest_route=/\\\";s:14:\\\"^wp-json/(.*)?\\\";s:33:\\\"index.php?rest_route=/$matches[1]\\\";s:21:\\\"^index.php/wp-json/?$\\\";s:22:\\\"index.php?rest_route=/\\\";s:24:\\\"^index.php/wp-json/(.*)?\\\";s:33:\\\"index.php?rest_route=/$matches[1]\\\";s:17:\\\"^wp-sitemap\\\\.xml$\\\";s:23:\\\"index.php?sitemap=index\\\";s:17:\\\"^wp-sitemap\\\\.xsl$\\\";s:36:\\\"index.php?sitemap-stylesheet=sitemap\\\";s:23:\\\"^wp-sitemap-index\\\\.xsl$\\\";s:34:\\\"index.php?sitemap-stylesheet=index\\\";s:48:\\\"^wp-sitemap-([a-z]+?)-([a-z\\\\d_-]+?)-(\\\\d+?)\\\\.xml$\\\";s:75:\\\"index.php?sitemap=$matches[1]&sitemap-subtype=$matches[2]&paged=$matches[3]\\\";s:34:\\\"^wp-sitemap-([a-z]+?)-(\\\\d+?)\\\\.xml$\\\";s:47:\\\"index.php?sitemap=$matches[1]&paged=$matches[2]\\\";s:47:\\\"category/(.+?)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:52:\\\"index.php?category_name=$matches[1]&feed=$matches[2]\\\";s:42:\\\"category/(.+?)/(feed|rdf|rss|rss2|atom)/?$\\\";s:52:\\\"index.php?category_name=$matches[1]&feed=$matches[2]\\\";s:23:\\\"category/(.+?)/embed/?$\\\";s:46:\\\"index.php?category_name=$matches[1]&embed=true\\\";s:35:\\\"category/(.+?)/page/?([0-9]{1,})/?$\\\";s:53:\\\"index.php?category_name=$matches[1]&paged=$matches[2]\\\";s:17:\\\"category/(.+?)/?$\\\";s:35:\\\"index.php?category_name=$matches[1]\\\";s:44:\\\"tag/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?tag=$matches[1]&feed=$matches[2]\\\";s:39:\\\"tag/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?tag=$matches[1]&feed=$matches[2]\\\";s:20:\\\"tag/([^/]+)/embed/?$\\\";s:36:\\\"index.php?tag=$matches[1]&embed=true\\\";s:32:\\\"tag/([^/]+)/page/?([0-9]{1,})/?$\\\";s:43:\\\"index.php?tag=$matches[1]&paged=$matches[2]\\\";s:14:\\\"tag/([^/]+)/?$\\\";s:25:\\\"index.php?tag=$matches[1]\\\";s:45:\\\"type/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?post_format=$matches[1]&feed=$matches[2]\\\";s:40:\\\"type/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?post_format=$matches[1]&feed=$matches[2]\\\";s:21:\\\"type/([^/]+)/embed/?$\\\";s:44:\\\"index.php?post_format=$matches[1]&embed=true\\\";s:33:\\\"type/([^/]+)/page/?([0-9]{1,})/?$\\\";s:51:\\\"index.php?post_format=$matches[1]&paged=$matches[2]\\\";s:15:\\\"type/([^/]+)/?$\\\";s:33:\\\"index.php?post_format=$matches[1]\\\";s:12:\\\"robots\\\\.txt$\\\";s:18:\\\"index.php?robots=1\\\";s:13:\\\"favicon\\\\.ico$\\\";s:19:\\\"index.php?favicon=1\\\";s:48:\\\".*wp-(atom|rdf|rss|rss2|feed|commentsrss2)\\\\.php$\\\";s:18:\\\"index.php?feed=old\\\";s:20:\\\".*wp-app\\\\.php(/.*)?$\\\";s:19:\\\"index.php?error=403\\\";s:18:\\\".*wp-register.php$\\\";s:23:\\\"index.php?register=true\\\";s:32:\\\"feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:27:\\\"index.php?&feed=$matches[1]\\\";s:27:\\\"(feed|rdf|rss|rss2|atom)/?$\\\";s:27:\\\"index.php?&feed=$matches[1]\\\";s:8:\\\"embed/?$\\\";s:21:\\\"index.php?&embed=true\\\";s:20:\\\"page/?([0-9]{1,})/?$\\\";s:28:\\\"index.php?&paged=$matches[1]\\\";s:41:\\\"comments/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?&feed=$matches[1]&withcomments=1\\\";s:36:\\\"comments/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?&feed=$matches[1]&withcomments=1\\\";s:17:\\\"comments/embed/?$\\\";s:21:\\\"index.php?&embed=true\\\";s:44:\\\"search/(.+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:40:\\\"index.php?s=$matches[1]&feed=$matches[2]\\\";s:39:\\\"search/(.+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:40:\\\"index.php?s=$matches[1]&feed=$matches[2]\\\";s:20:\\\"search/(.+)/embed/?$\\\";s:34:\\\"index.php?s=$matches[1]&embed=true\\\";s:32:\\\"search/(.+)/page/?([0-9]{1,})/?$\\\";s:41:\\\"index.php?s=$matches[1]&paged=$matches[2]\\\";s:14:\\\"search/(.+)/?$\\\";s:23:\\\"index.php?s=$matches[1]\\\";s:47:\\\"author/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?author_name=$matches[1]&feed=$matches[2]\\\";s:42:\\\"author/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?author_name=$matches[1]&feed=$matches[2]\\\";s:23:\\\"author/([^/]+)/embed/?$\\\";s:44:\\\"index.php?author_name=$matches[1]&embed=true\\\";s:35:\\\"author/([^/]+)/page/?([0-9]{1,})/?$\\\";s:51:\\\"index.php?author_name=$matches[1]&paged=$matches[2]\\\";s:17:\\\"author/([^/]+)/?$\\\";s:33:\\\"index.php?author_name=$matches[1]\\\";s:69:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:80:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&feed=$matches[4]\\\";s:64:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/(feed|rdf|rss|rss2|atom)/?$\\\";s:80:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&feed=$matches[4]\\\";s:45:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/embed/?$\\\";s:74:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&embed=true\\\";s:57:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/page/?([0-9]{1,})/?$\\\";s:81:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&paged=$matches[4]\\\";s:39:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/?$\\\";s:63:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]\\\";s:56:\\\"([0-9]{4})/([0-9]{1,2})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:64:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&feed=$matches[3]\\\";s:51:\\\"([0-9]{4})/([0-9]{1,2})/(feed|rdf|rss|rss2|atom)/?$\\\";s:64:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&feed=$matches[3]\\\";s:32:\\\"([0-9]{4})/([0-9]{1,2})/embed/?$\\\";s:58:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&embed=true\\\";s:44:\\\"([0-9]{4})/([0-9]{1,2})/page/?([0-9]{1,})/?$\\\";s:65:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&paged=$matches[3]\\\";s:26:\\\"([0-9]{4})/([0-9]{1,2})/?$\\\";s:47:\\\"index.php?year=$matches[1]&monthnum=$matches[2]\\\";s:43:\\\"([0-9]{4})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?year=$matches[1]&feed=$matches[2]\\\";s:38:\\\"([0-9]{4})/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?year=$matches[1]&feed=$matches[2]\\\";s:19:\\\"([0-9]{4})/embed/?$\\\";s:37:\\\"index.php?year=$matches[1]&embed=true\\\";s:31:\\\"([0-9]{4})/page/?([0-9]{1,})/?$\\\";s:44:\\\"index.php?year=$matches[1]&paged=$matches[2]\\\";s:13:\\\"([0-9]{4})/?$\\\";s:26:\\\"index.php?year=$matches[1]\\\";s:27:\\\".?.+?/attachment/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:37:\\\".?.+?/attachment/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:57:\\\".?.+?/attachment/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\".?.+?/attachment/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\".?.+?/attachment/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:33:\\\".?.+?/attachment/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";s:16:\\\"(.?.+?)/embed/?$\\\";s:41:\\\"index.php?pagename=$matches[1]&embed=true\\\";s:20:\\\"(.?.+?)/trackback/?$\\\";s:35:\\\"index.php?pagename=$matches[1]&tb=1\\\";s:40:\\\"(.?.+?)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&feed=$matches[2]\\\";s:35:\\\"(.?.+?)/(feed|rdf|rss|rss2|atom)/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&feed=$matches[2]\\\";s:28:\\\"(.?.+?)/page/?([0-9]{1,})/?$\\\";s:48:\\\"index.php?pagename=$matches[1]&paged=$matches[2]\\\";s:35:\\\"(.?.+?)/comment-page-([0-9]{1,})/?$\\\";s:48:\\\"index.php?pagename=$matches[1]&cpage=$matches[2]\\\";s:24:\\\"(.?.+?)(?:/([0-9]+))?/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&page=$matches[2]\\\";s:27:\\\"[^/]+/attachment/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:37:\\\"[^/]+/attachment/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:57:\\\"[^/]+/attachment/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\"[^/]+/attachment/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\"[^/]+/attachment/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:33:\\\"[^/]+/attachment/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";s:16:\\\"([^/]+)/embed/?$\\\";s:37:\\\"index.php?name=$matches[1]&embed=true\\\";s:20:\\\"([^/]+)/trackback/?$\\\";s:31:\\\"index.php?name=$matches[1]&tb=1\\\";s:40:\\\"([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?name=$matches[1]&feed=$matches[2]\\\";s:35:\\\"([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?name=$matches[1]&feed=$matches[2]\\\";s:28:\\\"([^/]+)/page/?([0-9]{1,})/?$\\\";s:44:\\\"index.php?name=$matches[1]&paged=$matches[2]\\\";s:35:\\\"([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:44:\\\"index.php?name=$matches[1]&cpage=$matches[2]\\\";s:24:\\\"([^/]+)(?:/([0-9]+))?/?$\\\";s:43:\\\"index.php?name=$matches[1]&page=$matches[2]\\\";s:16:\\\"[^/]+/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:26:\\\"[^/]+/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:46:\\\"[^/]+/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:41:\\\"[^/]+/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:41:\\\"[^/]+/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:22:\\\"[^/]+/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";}', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)",
-                "trace_id": 0,
-                "span_id": 41,
-                "parent_id": 39,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_61_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                }
-              },
            {
              "name": "wpdb.query",
              "service": "wordpress_61_test_app",
              "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp_posts\n\t\tWHERE post_name IN ('simple_view')\n\t\tAND post_type IN ('page','attachment')\n\t",
              "trace_id": 0,
-             "span_id": 40,
-             "parent_id": 37,
+             "span_id": 26,
+             "parent_id": 24,
              "type": "sql",
              "meta": {
                "component": "wordpress"
              }
-           },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp_posts\n\t\tWHERE post_name IN ('simple_view')\n\t\tAND post_type IN ('page','attachment')\n\t",
-                "trace_id": 0,
-                "span_id": 42,
-                "parent_id": 40,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_61_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 0.0
-                }
-              }]]
+           }]]

--- a/tests/snapshots/tests.integrations.word_press.v6_1.common_scenarios_test.test_scenario_get_return_string.json
+++ b/tests/snapshots/tests.integrations.word_press.v6_1.common_scenarios_test.test_scenario_get_return_string.json
@@ -5,17 +5,17 @@
     "resource": "GET /simple",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 9600884620227477604,
+    "parent_id": 9686591903190107059,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "65ba261100000000",
+      "_dd.p.tid": "65e6feeb00000000",
       "component": "wordpress",
       "http.method": "GET",
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/simple?key=value&<redacted>",
-      "runtime-id": "0671a639-c22e-442f-9aa1-7b401adeb25c",
+      "runtime-id": "df54db4d-0cc0-4b1c-9fce-8004a54aa78b",
       "span.kind": "server"
     },
     "metrics": {
@@ -23,108 +23,11 @@
     }
   },
      {
-       "name": "mysqli_real_connect",
-       "service": "mysqli",
-       "resource": "mysqli_real_connect",
-       "trace_id": 0,
-       "span_id": 2,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-       "trace_id": 0,
-       "span_id": 3,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT @@SESSION.sql_mode",
-       "trace_id": 0,
-       "span_id": 4,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 1.0
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-       "trace_id": 0,
-       "span_id": 5,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_name, option_value FROM wp_options WHERE autoload = 'yes'",
-       "trace_id": 0,
-       "span_id": 6,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 118.0
-       }
-     },
-     {
        "name": "create_initial_taxonomies",
        "service": "wordpress_61_test_app",
        "resource": "create_initial_taxonomies",
        "trace_id": 0,
-       "span_id": 7,
+       "span_id": 2,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -136,7 +39,7 @@
        "service": "wordpress_61_test_app",
        "resource": "create_initial_post_types",
        "trace_id": 0,
-       "span_id": 8,
+       "span_id": 3,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -148,7 +51,7 @@
        "service": "wordpress_61_test_app",
        "resource": "datadog (plugin)",
        "trace_id": 0,
-       "span_id": 9,
+       "span_id": 4,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -161,7 +64,7 @@
        "service": "wordpress_61_test_app",
        "resource": "plugins_loaded (hook)",
        "trace_id": 0,
-       "span_id": 10,
+       "span_id": 5,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -174,8 +77,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_maybe_load_widgets",
           "trace_id": 0,
-          "span_id": 19,
-          "parent_id": 10,
+          "span_id": 13,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -186,8 +89,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_maybe_load_embeds",
           "trace_id": 0,
-          "span_id": 20,
-          "parent_id": 10,
+          "span_id": 14,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -198,8 +101,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_wp_customize_include",
           "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 10,
+          "span_id": 15,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -210,7 +113,7 @@
        "service": "wordpress_61_test_app",
        "resource": "setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 11,
+       "span_id": 6,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -219,33 +122,11 @@
        }
      },
      {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_value FROM wp_options WHERE option_name = 'WPLANG' LIMIT 1",
-       "trace_id": 0,
-       "span_id": 12,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 0.0
-       }
-     },
-     {
        "name": "action",
        "service": "wordpress_61_test_app",
        "resource": "after_setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 13,
+       "span_id": 7,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -258,7 +139,7 @@
        "service": "wordpress_61_test_app",
        "resource": "WP.init",
        "trace_id": 0,
-       "span_id": 14,
+       "span_id": 8,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -270,7 +151,7 @@
        "service": "wordpress_61_test_app",
        "resource": "init (hook)",
        "trace_id": 0,
-       "span_id": 15,
+       "span_id": 9,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -283,8 +164,8 @@
           "service": "wordpress_61_test_app",
           "resource": "create_initial_post_types",
           "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 15,
+          "span_id": 16,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -295,8 +176,8 @@
           "service": "wordpress_61_test_app",
           "resource": "create_initial_taxonomies",
           "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 15,
+          "span_id": 17,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -307,8 +188,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_widgets_init",
           "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 15,
+          "span_id": 18,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -319,173 +200,19 @@
              "service": "wordpress_61_test_app",
              "resource": "WP_Widget_Factory._register_widgets",
              "trace_id": 0,
-             "span_id": 34,
-             "parent_id": 24,
+             "span_id": 21,
+             "parent_id": 18,
              "type": "web",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT option_value FROM wp_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-                "trace_id": 0,
-                "span_id": 37,
-                "parent_id": 34,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_61_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "\n\t\t\tSELECT  t.term_id\n\t\t\tFROM wp_terms AS t  INNER JOIN wp_term_taxonomy AS tt ON t.term_id = tt.term_id\n\t\t\tWHERE tt.taxonomy IN ('wp_theme') AND t.name IN ('twentytwentythree')\n\t\t\t\n\t\t\tLIMIT 1\n\t\t",
-          "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 15,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "\n\t\t\tSELECT   wp_posts.*\n\t\t\tFROM wp_posts \n\t\t\tWHERE 1=1  AND ( \n  0 = 1\n) AND wp_posts.post_type = 'wp_template_part' AND ((wp_posts.post_status = 'publish'))\n\t\t\tGROUP BY wp_posts.ID\n\t\t\tORDER BY wp_posts.post_date DESC\n\t\t\t\n\t\t",
-          "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 15,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'medium_crop' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 15,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'medium_large_crop' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 28,
-          "parent_id": 15,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'large_crop' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 29,
-          "parent_id": 15,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'theme_switched' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 30,
-          "parent_id": 15,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "action",
        "service": "wordpress_61_test_app",
        "resource": "wp_loaded (hook)",
        "trace_id": 0,
-       "span_id": 16,
+       "span_id": 10,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -493,34 +220,12 @@
          "wordpress.hook": "wp_loaded"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "\n\t\t\t\t\tSELECT   wp_posts.ID\n\t\t\t\t\tFROM wp_posts \n\t\t\t\t\tWHERE 1=1  AND ( \n  0 = 1\n) AND wp_posts.post_type = 'wp_global_styles' AND ((wp_posts.post_status = 'publish'))\n\t\t\t\t\tGROUP BY wp_posts.ID\n\t\t\t\t\tORDER BY wp_posts.post_date DESC\n\t\t\t\t\tLIMIT 0, 1\n\t\t\t\t",
-          "trace_id": 0,
-          "span_id": 31,
-          "parent_id": 16,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.main",
        "service": "wordpress_61_test_app",
        "resource": "WP.main",
        "trace_id": 0,
-       "span_id": 17,
+       "span_id": 11,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -532,8 +237,8 @@
           "service": "wordpress_61_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 32,
-          "parent_id": 17,
+          "span_id": 19,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -544,60 +249,19 @@
           "service": "wordpress_61_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 33,
-          "parent_id": 17,
+          "span_id": 20,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('rewrite_rules', 'a:93:{s:11:\\\"^wp-json/?$\\\";s:22:\\\"index.php?rest_route=/\\\";s:14:\\\"^wp-json/(.*)?\\\";s:33:\\\"index.php?rest_route=/$matches[1]\\\";s:21:\\\"^index.php/wp-json/?$\\\";s:22:\\\"index.php?rest_route=/\\\";s:24:\\\"^index.php/wp-json/(.*)?\\\";s:33:\\\"index.php?rest_route=/$matches[1]\\\";s:17:\\\"^wp-sitemap\\\\.xml$\\\";s:23:\\\"index.php?sitemap=index\\\";s:17:\\\"^wp-sitemap\\\\.xsl$\\\";s:36:\\\"index.php?sitemap-stylesheet=sitemap\\\";s:23:\\\"^wp-sitemap-index\\\\.xsl$\\\";s:34:\\\"index.php?sitemap-stylesheet=index\\\";s:48:\\\"^wp-sitemap-([a-z]+?)-([a-z\\\\d_-]+?)-(\\\\d+?)\\\\.xml$\\\";s:75:\\\"index.php?sitemap=$matches[1]&sitemap-subtype=$matches[2]&paged=$matches[3]\\\";s:34:\\\"^wp-sitemap-([a-z]+?)-(\\\\d+?)\\\\.xml$\\\";s:47:\\\"index.php?sitemap=$matches[1]&paged=$matches[2]\\\";s:47:\\\"category/(.+?)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:52:\\\"index.php?category_name=$matches[1]&feed=$matches[2]\\\";s:42:\\\"category/(.+?)/(feed|rdf|rss|rss2|atom)/?$\\\";s:52:\\\"index.php?category_name=$matches[1]&feed=$matches[2]\\\";s:23:\\\"category/(.+?)/embed/?$\\\";s:46:\\\"index.php?category_name=$matches[1]&embed=true\\\";s:35:\\\"category/(.+?)/page/?([0-9]{1,})/?$\\\";s:53:\\\"index.php?category_name=$matches[1]&paged=$matches[2]\\\";s:17:\\\"category/(.+?)/?$\\\";s:35:\\\"index.php?category_name=$matches[1]\\\";s:44:\\\"tag/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?tag=$matches[1]&feed=$matches[2]\\\";s:39:\\\"tag/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?tag=$matches[1]&feed=$matches[2]\\\";s:20:\\\"tag/([^/]+)/embed/?$\\\";s:36:\\\"index.php?tag=$matches[1]&embed=true\\\";s:32:\\\"tag/([^/]+)/page/?([0-9]{1,})/?$\\\";s:43:\\\"index.php?tag=$matches[1]&paged=$matches[2]\\\";s:14:\\\"tag/([^/]+)/?$\\\";s:25:\\\"index.php?tag=$matches[1]\\\";s:45:\\\"type/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?post_format=$matches[1]&feed=$matches[2]\\\";s:40:\\\"type/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?post_format=$matches[1]&feed=$matches[2]\\\";s:21:\\\"type/([^/]+)/embed/?$\\\";s:44:\\\"index.php?post_format=$matches[1]&embed=true\\\";s:33:\\\"type/([^/]+)/page/?([0-9]{1,})/?$\\\";s:51:\\\"index.php?post_format=$matches[1]&paged=$matches[2]\\\";s:15:\\\"type/([^/]+)/?$\\\";s:33:\\\"index.php?post_format=$matches[1]\\\";s:12:\\\"robots\\\\.txt$\\\";s:18:\\\"index.php?robots=1\\\";s:13:\\\"favicon\\\\.ico$\\\";s:19:\\\"index.php?favicon=1\\\";s:48:\\\".*wp-(atom|rdf|rss|rss2|feed|commentsrss2)\\\\.php$\\\";s:18:\\\"index.php?feed=old\\\";s:20:\\\".*wp-app\\\\.php(/.*)?$\\\";s:19:\\\"index.php?error=403\\\";s:18:\\\".*wp-register.php$\\\";s:23:\\\"index.php?register=true\\\";s:32:\\\"feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:27:\\\"index.php?&feed=$matches[1]\\\";s:27:\\\"(feed|rdf|rss|rss2|atom)/?$\\\";s:27:\\\"index.php?&feed=$matches[1]\\\";s:8:\\\"embed/?$\\\";s:21:\\\"index.php?&embed=true\\\";s:20:\\\"page/?([0-9]{1,})/?$\\\";s:28:\\\"index.php?&paged=$matches[1]\\\";s:41:\\\"comments/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?&feed=$matches[1]&withcomments=1\\\";s:36:\\\"comments/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?&feed=$matches[1]&withcomments=1\\\";s:17:\\\"comments/embed/?$\\\";s:21:\\\"index.php?&embed=true\\\";s:44:\\\"search/(.+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:40:\\\"index.php?s=$matches[1]&feed=$matches[2]\\\";s:39:\\\"search/(.+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:40:\\\"index.php?s=$matches[1]&feed=$matches[2]\\\";s:20:\\\"search/(.+)/embed/?$\\\";s:34:\\\"index.php?s=$matches[1]&embed=true\\\";s:32:\\\"search/(.+)/page/?([0-9]{1,})/?$\\\";s:41:\\\"index.php?s=$matches[1]&paged=$matches[2]\\\";s:14:\\\"search/(.+)/?$\\\";s:23:\\\"index.php?s=$matches[1]\\\";s:47:\\\"author/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?author_name=$matches[1]&feed=$matches[2]\\\";s:42:\\\"author/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?author_name=$matches[1]&feed=$matches[2]\\\";s:23:\\\"author/([^/]+)/embed/?$\\\";s:44:\\\"index.php?author_name=$matches[1]&embed=true\\\";s:35:\\\"author/([^/]+)/page/?([0-9]{1,})/?$\\\";s:51:\\\"index.php?author_name=$matches[1]&paged=$matches[2]\\\";s:17:\\\"author/([^/]+)/?$\\\";s:33:\\\"index.php?author_name=$matches[1]\\\";s:69:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:80:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&feed=$matches[4]\\\";s:64:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/(feed|rdf|rss|rss2|atom)/?$\\\";s:80:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&feed=$matches[4]\\\";s:45:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/embed/?$\\\";s:74:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&embed=true\\\";s:57:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/page/?([0-9]{1,})/?$\\\";s:81:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&paged=$matches[4]\\\";s:39:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/?$\\\";s:63:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]\\\";s:56:\\\"([0-9]{4})/([0-9]{1,2})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:64:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&feed=$matches[3]\\\";s:51:\\\"([0-9]{4})/([0-9]{1,2})/(feed|rdf|rss|rss2|atom)/?$\\\";s:64:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&feed=$matches[3]\\\";s:32:\\\"([0-9]{4})/([0-9]{1,2})/embed/?$\\\";s:58:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&embed=true\\\";s:44:\\\"([0-9]{4})/([0-9]{1,2})/page/?([0-9]{1,})/?$\\\";s:65:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&paged=$matches[3]\\\";s:26:\\\"([0-9]{4})/([0-9]{1,2})/?$\\\";s:47:\\\"index.php?year=$matches[1]&monthnum=$matches[2]\\\";s:43:\\\"([0-9]{4})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?year=$matches[1]&feed=$matches[2]\\\";s:38:\\\"([0-9]{4})/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?year=$matches[1]&feed=$matches[2]\\\";s:19:\\\"([0-9]{4})/embed/?$\\\";s:37:\\\"index.php?year=$matches[1]&embed=true\\\";s:31:\\\"([0-9]{4})/page/?([0-9]{1,})/?$\\\";s:44:\\\"index.php?year=$matches[1]&paged=$matches[2]\\\";s:13:\\\"([0-9]{4})/?$\\\";s:26:\\\"index.php?year=$matches[1]\\\";s:27:\\\".?.+?/attachment/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:37:\\\".?.+?/attachment/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:57:\\\".?.+?/attachment/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\".?.+?/attachment/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\".?.+?/attachment/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:33:\\\".?.+?/attachment/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";s:16:\\\"(.?.+?)/embed/?$\\\";s:41:\\\"index.php?pagename=$matches[1]&embed=true\\\";s:20:\\\"(.?.+?)/trackback/?$\\\";s:35:\\\"index.php?pagename=$matches[1]&tb=1\\\";s:40:\\\"(.?.+?)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&feed=$matches[2]\\\";s:35:\\\"(.?.+?)/(feed|rdf|rss|rss2|atom)/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&feed=$matches[2]\\\";s:28:\\\"(.?.+?)/page/?([0-9]{1,})/?$\\\";s:48:\\\"index.php?pagename=$matches[1]&paged=$matches[2]\\\";s:35:\\\"(.?.+?)/comment-page-([0-9]{1,})/?$\\\";s:48:\\\"index.php?pagename=$matches[1]&cpage=$matches[2]\\\";s:24:\\\"(.?.+?)(?:/([0-9]+))?/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&page=$matches[2]\\\";s:27:\\\"[^/]+/attachment/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:37:\\\"[^/]+/attachment/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:57:\\\"[^/]+/attachment/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\"[^/]+/attachment/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\"[^/]+/attachment/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:33:\\\"[^/]+/attachment/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";s:16:\\\"([^/]+)/embed/?$\\\";s:37:\\\"index.php?name=$matches[1]&embed=true\\\";s:20:\\\"([^/]+)/trackback/?$\\\";s:31:\\\"index.php?name=$matches[1]&tb=1\\\";s:40:\\\"([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?name=$matches[1]&feed=$matches[2]\\\";s:35:\\\"([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?name=$matches[1]&feed=$matches[2]\\\";s:28:\\\"([^/]+)/page/?([0-9]{1,})/?$\\\";s:44:\\\"index.php?name=$matches[1]&paged=$matches[2]\\\";s:35:\\\"([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:44:\\\"index.php?name=$matches[1]&cpage=$matches[2]\\\";s:24:\\\"([^/]+)(?:/([0-9]+))?/?$\\\";s:43:\\\"index.php?name=$matches[1]&page=$matches[2]\\\";s:16:\\\"[^/]+/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:26:\\\"[^/]+/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:46:\\\"[^/]+/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:41:\\\"[^/]+/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:41:\\\"[^/]+/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:22:\\\"[^/]+/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";}', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)",
-             "trace_id": 0,
-             "span_id": 35,
-             "parent_id": 33,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp_posts\n\t\tWHERE post_name IN ('simple')\n\t\tAND post_type IN ('page','attachment')\n\t",
-             "trace_id": 0,
-             "span_id": 36,
-             "parent_id": 33,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_61_test_app",
        "resource": "shutdown (hook)",
        "trace_id": 0,
-       "span_id": 18,
+       "span_id": 12,
        "parent_id": 1,
        "type": "web",
        "meta": {

--- a/tests/snapshots/tests.integrations.word_press.v6_1.common_scenarios_test.test_scenario_get_with_exception.json
+++ b/tests/snapshots/tests.integrations.word_press.v6_1.common_scenarios_test.test_scenario_get_with_exception.json
@@ -5,12 +5,12 @@
     "resource": "GET /error",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 4275905078744150253,
+    "parent_id": 2903246136547172026,
     "type": "web",
     "error": 1,
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "65ba262c00000000",
+      "_dd.p.tid": "65e6ff0700000000",
       "component": "wordpress",
       "error.message": "Uncaught Exception: Oops! in /home/circleci/datadog/tests/Frameworks/WordPress/Version_6_1/wp-content/plugins/datadog/datadog.php:20",
       "error.stack": "#0 /home/circleci/datadog/tests/Frameworks/WordPress/Version_6_1/wp-includes/class-wp-hook.php(308): datadog_parse_request()\n#1 /home/circleci/datadog/tests/Frameworks/WordPress/Version_6_1/wp-includes/class-wp-hook.php(332): WP_Hook->apply_filters()\n#2 /home/circleci/datadog/tests/Frameworks/WordPress/Version_6_1/wp-includes/plugin.php(565): WP_Hook->do_action()\n#3 /home/circleci/datadog/tests/Frameworks/WordPress/Version_6_1/wp-includes/class-wp.php(399): do_action_ref_array()\n#4 /home/circleci/datadog/tests/Frameworks/WordPress/Version_6_1/wp-includes/class-wp.php(780): WP->parse_request()\n#5 /home/circleci/datadog/tests/Frameworks/WordPress/Version_6_1/wp-includes/functions.php(1332): WP->main()\n#6 /home/circleci/datadog/tests/Frameworks/WordPress/Version_6_1/wp-blog-header.php(16): wp()\n#7 /home/circleci/datadog/tests/Frameworks/WordPress/Version_6_1/index.php(17): require()\n#8 {main}",
@@ -19,7 +19,7 @@
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/error?key=value&<redacted>",
-      "runtime-id": "0671a639-c22e-442f-9aa1-7b401adeb25c",
+      "runtime-id": "df54db4d-0cc0-4b1c-9fce-8004a54aa78b",
       "span.kind": "server"
     },
     "metrics": {
@@ -27,108 +27,11 @@
     }
   },
      {
-       "name": "mysqli_real_connect",
-       "service": "mysqli",
-       "resource": "mysqli_real_connect",
-       "trace_id": 0,
-       "span_id": 2,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-       "trace_id": 0,
-       "span_id": 3,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT @@SESSION.sql_mode",
-       "trace_id": 0,
-       "span_id": 4,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 1.0
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-       "trace_id": 0,
-       "span_id": 5,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_name, option_value FROM wp_options WHERE autoload = 'yes'",
-       "trace_id": 0,
-       "span_id": 6,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 118.0
-       }
-     },
-     {
        "name": "create_initial_taxonomies",
        "service": "wordpress_61_test_app",
        "resource": "create_initial_taxonomies",
        "trace_id": 0,
-       "span_id": 7,
+       "span_id": 2,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -140,7 +43,7 @@
        "service": "wordpress_61_test_app",
        "resource": "create_initial_post_types",
        "trace_id": 0,
-       "span_id": 8,
+       "span_id": 3,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -152,7 +55,7 @@
        "service": "wordpress_61_test_app",
        "resource": "datadog (plugin)",
        "trace_id": 0,
-       "span_id": 9,
+       "span_id": 4,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -165,7 +68,7 @@
        "service": "wordpress_61_test_app",
        "resource": "plugins_loaded (hook)",
        "trace_id": 0,
-       "span_id": 10,
+       "span_id": 5,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -178,8 +81,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_maybe_load_widgets",
           "trace_id": 0,
-          "span_id": 19,
-          "parent_id": 10,
+          "span_id": 13,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -190,8 +93,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_maybe_load_embeds",
           "trace_id": 0,
-          "span_id": 20,
-          "parent_id": 10,
+          "span_id": 14,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -202,8 +105,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_wp_customize_include",
           "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 10,
+          "span_id": 15,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -214,7 +117,7 @@
        "service": "wordpress_61_test_app",
        "resource": "setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 11,
+       "span_id": 6,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -223,33 +126,11 @@
        }
      },
      {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_value FROM wp_options WHERE option_name = 'WPLANG' LIMIT 1",
-       "trace_id": 0,
-       "span_id": 12,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 0.0
-       }
-     },
-     {
        "name": "action",
        "service": "wordpress_61_test_app",
        "resource": "after_setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 13,
+       "span_id": 7,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -262,7 +143,7 @@
        "service": "wordpress_61_test_app",
        "resource": "WP.init",
        "trace_id": 0,
-       "span_id": 14,
+       "span_id": 8,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -274,7 +155,7 @@
        "service": "wordpress_61_test_app",
        "resource": "init (hook)",
        "trace_id": 0,
-       "span_id": 15,
+       "span_id": 9,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -287,8 +168,8 @@
           "service": "wordpress_61_test_app",
           "resource": "create_initial_post_types",
           "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 15,
+          "span_id": 16,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -299,8 +180,8 @@
           "service": "wordpress_61_test_app",
           "resource": "create_initial_taxonomies",
           "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 15,
+          "span_id": 17,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -311,8 +192,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_widgets_init",
           "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 15,
+          "span_id": 18,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -323,173 +204,19 @@
              "service": "wordpress_61_test_app",
              "resource": "WP_Widget_Factory._register_widgets",
              "trace_id": 0,
-             "span_id": 34,
-             "parent_id": 24,
+             "span_id": 21,
+             "parent_id": 18,
              "type": "web",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT option_value FROM wp_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-                "trace_id": 0,
-                "span_id": 37,
-                "parent_id": 34,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_61_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "\n\t\t\tSELECT  t.term_id\n\t\t\tFROM wp_terms AS t  INNER JOIN wp_term_taxonomy AS tt ON t.term_id = tt.term_id\n\t\t\tWHERE tt.taxonomy IN ('wp_theme') AND t.name IN ('twentytwentythree')\n\t\t\t\n\t\t\tLIMIT 1\n\t\t",
-          "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 15,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "\n\t\t\tSELECT   wp_posts.*\n\t\t\tFROM wp_posts \n\t\t\tWHERE 1=1  AND ( \n  0 = 1\n) AND wp_posts.post_type = 'wp_template_part' AND ((wp_posts.post_status = 'publish'))\n\t\t\tGROUP BY wp_posts.ID\n\t\t\tORDER BY wp_posts.post_date DESC\n\t\t\t\n\t\t",
-          "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 15,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'medium_crop' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 15,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'medium_large_crop' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 28,
-          "parent_id": 15,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'large_crop' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 29,
-          "parent_id": 15,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'theme_switched' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 30,
-          "parent_id": 15,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "action",
        "service": "wordpress_61_test_app",
        "resource": "wp_loaded (hook)",
        "trace_id": 0,
-       "span_id": 16,
+       "span_id": 10,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -497,34 +224,12 @@
          "wordpress.hook": "wp_loaded"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "\n\t\t\t\t\tSELECT   wp_posts.ID\n\t\t\t\t\tFROM wp_posts \n\t\t\t\t\tWHERE 1=1  AND ( \n  0 = 1\n) AND wp_posts.post_type = 'wp_global_styles' AND ((wp_posts.post_status = 'publish'))\n\t\t\t\t\tGROUP BY wp_posts.ID\n\t\t\t\t\tORDER BY wp_posts.post_date DESC\n\t\t\t\t\tLIMIT 0, 1\n\t\t\t\t",
-          "trace_id": 0,
-          "span_id": 31,
-          "parent_id": 16,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.main",
        "service": "wordpress_61_test_app",
        "resource": "WP.main",
        "trace_id": 0,
-       "span_id": 17,
+       "span_id": 11,
        "parent_id": 1,
        "type": "web",
        "error": 1,
@@ -540,8 +245,8 @@
           "service": "wordpress_61_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 32,
-          "parent_id": 17,
+          "span_id": 19,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -552,8 +257,8 @@
           "service": "wordpress_61_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 33,
-          "parent_id": 17,
+          "span_id": 20,
+          "parent_id": 11,
           "type": "web",
           "error": 1,
           "meta": {
@@ -563,53 +268,12 @@
             "error.type": "Exception"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('rewrite_rules', 'a:93:{s:11:\\\"^wp-json/?$\\\";s:22:\\\"index.php?rest_route=/\\\";s:14:\\\"^wp-json/(.*)?\\\";s:33:\\\"index.php?rest_route=/$matches[1]\\\";s:21:\\\"^index.php/wp-json/?$\\\";s:22:\\\"index.php?rest_route=/\\\";s:24:\\\"^index.php/wp-json/(.*)?\\\";s:33:\\\"index.php?rest_route=/$matches[1]\\\";s:17:\\\"^wp-sitemap\\\\.xml$\\\";s:23:\\\"index.php?sitemap=index\\\";s:17:\\\"^wp-sitemap\\\\.xsl$\\\";s:36:\\\"index.php?sitemap-stylesheet=sitemap\\\";s:23:\\\"^wp-sitemap-index\\\\.xsl$\\\";s:34:\\\"index.php?sitemap-stylesheet=index\\\";s:48:\\\"^wp-sitemap-([a-z]+?)-([a-z\\\\d_-]+?)-(\\\\d+?)\\\\.xml$\\\";s:75:\\\"index.php?sitemap=$matches[1]&sitemap-subtype=$matches[2]&paged=$matches[3]\\\";s:34:\\\"^wp-sitemap-([a-z]+?)-(\\\\d+?)\\\\.xml$\\\";s:47:\\\"index.php?sitemap=$matches[1]&paged=$matches[2]\\\";s:47:\\\"category/(.+?)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:52:\\\"index.php?category_name=$matches[1]&feed=$matches[2]\\\";s:42:\\\"category/(.+?)/(feed|rdf|rss|rss2|atom)/?$\\\";s:52:\\\"index.php?category_name=$matches[1]&feed=$matches[2]\\\";s:23:\\\"category/(.+?)/embed/?$\\\";s:46:\\\"index.php?category_name=$matches[1]&embed=true\\\";s:35:\\\"category/(.+?)/page/?([0-9]{1,})/?$\\\";s:53:\\\"index.php?category_name=$matches[1]&paged=$matches[2]\\\";s:17:\\\"category/(.+?)/?$\\\";s:35:\\\"index.php?category_name=$matches[1]\\\";s:44:\\\"tag/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?tag=$matches[1]&feed=$matches[2]\\\";s:39:\\\"tag/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?tag=$matches[1]&feed=$matches[2]\\\";s:20:\\\"tag/([^/]+)/embed/?$\\\";s:36:\\\"index.php?tag=$matches[1]&embed=true\\\";s:32:\\\"tag/([^/]+)/page/?([0-9]{1,})/?$\\\";s:43:\\\"index.php?tag=$matches[1]&paged=$matches[2]\\\";s:14:\\\"tag/([^/]+)/?$\\\";s:25:\\\"index.php?tag=$matches[1]\\\";s:45:\\\"type/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?post_format=$matches[1]&feed=$matches[2]\\\";s:40:\\\"type/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?post_format=$matches[1]&feed=$matches[2]\\\";s:21:\\\"type/([^/]+)/embed/?$\\\";s:44:\\\"index.php?post_format=$matches[1]&embed=true\\\";s:33:\\\"type/([^/]+)/page/?([0-9]{1,})/?$\\\";s:51:\\\"index.php?post_format=$matches[1]&paged=$matches[2]\\\";s:15:\\\"type/([^/]+)/?$\\\";s:33:\\\"index.php?post_format=$matches[1]\\\";s:12:\\\"robots\\\\.txt$\\\";s:18:\\\"index.php?robots=1\\\";s:13:\\\"favicon\\\\.ico$\\\";s:19:\\\"index.php?favicon=1\\\";s:48:\\\".*wp-(atom|rdf|rss|rss2|feed|commentsrss2)\\\\.php$\\\";s:18:\\\"index.php?feed=old\\\";s:20:\\\".*wp-app\\\\.php(/.*)?$\\\";s:19:\\\"index.php?error=403\\\";s:18:\\\".*wp-register.php$\\\";s:23:\\\"index.php?register=true\\\";s:32:\\\"feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:27:\\\"index.php?&feed=$matches[1]\\\";s:27:\\\"(feed|rdf|rss|rss2|atom)/?$\\\";s:27:\\\"index.php?&feed=$matches[1]\\\";s:8:\\\"embed/?$\\\";s:21:\\\"index.php?&embed=true\\\";s:20:\\\"page/?([0-9]{1,})/?$\\\";s:28:\\\"index.php?&paged=$matches[1]\\\";s:41:\\\"comments/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?&feed=$matches[1]&withcomments=1\\\";s:36:\\\"comments/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?&feed=$matches[1]&withcomments=1\\\";s:17:\\\"comments/embed/?$\\\";s:21:\\\"index.php?&embed=true\\\";s:44:\\\"search/(.+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:40:\\\"index.php?s=$matches[1]&feed=$matches[2]\\\";s:39:\\\"search/(.+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:40:\\\"index.php?s=$matches[1]&feed=$matches[2]\\\";s:20:\\\"search/(.+)/embed/?$\\\";s:34:\\\"index.php?s=$matches[1]&embed=true\\\";s:32:\\\"search/(.+)/page/?([0-9]{1,})/?$\\\";s:41:\\\"index.php?s=$matches[1]&paged=$matches[2]\\\";s:14:\\\"search/(.+)/?$\\\";s:23:\\\"index.php?s=$matches[1]\\\";s:47:\\\"author/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?author_name=$matches[1]&feed=$matches[2]\\\";s:42:\\\"author/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?author_name=$matches[1]&feed=$matches[2]\\\";s:23:\\\"author/([^/]+)/embed/?$\\\";s:44:\\\"index.php?author_name=$matches[1]&embed=true\\\";s:35:\\\"author/([^/]+)/page/?([0-9]{1,})/?$\\\";s:51:\\\"index.php?author_name=$matches[1]&paged=$matches[2]\\\";s:17:\\\"author/([^/]+)/?$\\\";s:33:\\\"index.php?author_name=$matches[1]\\\";s:69:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:80:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&feed=$matches[4]\\\";s:64:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/(feed|rdf|rss|rss2|atom)/?$\\\";s:80:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&feed=$matches[4]\\\";s:45:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/embed/?$\\\";s:74:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&embed=true\\\";s:57:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/page/?([0-9]{1,})/?$\\\";s:81:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&paged=$matches[4]\\\";s:39:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/?$\\\";s:63:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]\\\";s:56:\\\"([0-9]{4})/([0-9]{1,2})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:64:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&feed=$matches[3]\\\";s:51:\\\"([0-9]{4})/([0-9]{1,2})/(feed|rdf|rss|rss2|atom)/?$\\\";s:64:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&feed=$matches[3]\\\";s:32:\\\"([0-9]{4})/([0-9]{1,2})/embed/?$\\\";s:58:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&embed=true\\\";s:44:\\\"([0-9]{4})/([0-9]{1,2})/page/?([0-9]{1,})/?$\\\";s:65:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&paged=$matches[3]\\\";s:26:\\\"([0-9]{4})/([0-9]{1,2})/?$\\\";s:47:\\\"index.php?year=$matches[1]&monthnum=$matches[2]\\\";s:43:\\\"([0-9]{4})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?year=$matches[1]&feed=$matches[2]\\\";s:38:\\\"([0-9]{4})/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?year=$matches[1]&feed=$matches[2]\\\";s:19:\\\"([0-9]{4})/embed/?$\\\";s:37:\\\"index.php?year=$matches[1]&embed=true\\\";s:31:\\\"([0-9]{4})/page/?([0-9]{1,})/?$\\\";s:44:\\\"index.php?year=$matches[1]&paged=$matches[2]\\\";s:13:\\\"([0-9]{4})/?$\\\";s:26:\\\"index.php?year=$matches[1]\\\";s:27:\\\".?.+?/attachment/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:37:\\\".?.+?/attachment/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:57:\\\".?.+?/attachment/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\".?.+?/attachment/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\".?.+?/attachment/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:33:\\\".?.+?/attachment/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";s:16:\\\"(.?.+?)/embed/?$\\\";s:41:\\\"index.php?pagename=$matches[1]&embed=true\\\";s:20:\\\"(.?.+?)/trackback/?$\\\";s:35:\\\"index.php?pagename=$matches[1]&tb=1\\\";s:40:\\\"(.?.+?)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&feed=$matches[2]\\\";s:35:\\\"(.?.+?)/(feed|rdf|rss|rss2|atom)/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&feed=$matches[2]\\\";s:28:\\\"(.?.+?)/page/?([0-9]{1,})/?$\\\";s:48:\\\"index.php?pagename=$matches[1]&paged=$matches[2]\\\";s:35:\\\"(.?.+?)/comment-page-([0-9]{1,})/?$\\\";s:48:\\\"index.php?pagename=$matches[1]&cpage=$matches[2]\\\";s:24:\\\"(.?.+?)(?:/([0-9]+))?/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&page=$matches[2]\\\";s:27:\\\"[^/]+/attachment/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:37:\\\"[^/]+/attachment/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:57:\\\"[^/]+/attachment/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\"[^/]+/attachment/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\"[^/]+/attachment/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:33:\\\"[^/]+/attachment/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";s:16:\\\"([^/]+)/embed/?$\\\";s:37:\\\"index.php?name=$matches[1]&embed=true\\\";s:20:\\\"([^/]+)/trackback/?$\\\";s:31:\\\"index.php?name=$matches[1]&tb=1\\\";s:40:\\\"([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?name=$matches[1]&feed=$matches[2]\\\";s:35:\\\"([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?name=$matches[1]&feed=$matches[2]\\\";s:28:\\\"([^/]+)/page/?([0-9]{1,})/?$\\\";s:44:\\\"index.php?name=$matches[1]&paged=$matches[2]\\\";s:35:\\\"([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:44:\\\"index.php?name=$matches[1]&cpage=$matches[2]\\\";s:24:\\\"([^/]+)(?:/([0-9]+))?/?$\\\";s:43:\\\"index.php?name=$matches[1]&page=$matches[2]\\\";s:16:\\\"[^/]+/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:26:\\\"[^/]+/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:46:\\\"[^/]+/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:41:\\\"[^/]+/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:41:\\\"[^/]+/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:22:\\\"[^/]+/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";}', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)",
-             "trace_id": 0,
-             "span_id": 35,
-             "parent_id": 33,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp_posts\n\t\tWHERE post_name IN ('error')\n\t\tAND post_type IN ('page','attachment')\n\t",
-             "trace_id": 0,
-             "span_id": 36,
-             "parent_id": 33,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_61_test_app",
        "resource": "shutdown (hook)",
        "trace_id": 0,
-       "span_id": 18,
+       "span_id": 12,
        "parent_id": 1,
        "type": "web",
        "meta": {

--- a/tests/snapshots/tests.integrations.word_press.v6_1.common_scenarios_test.test_scenario_get_with_view.json
+++ b/tests/snapshots/tests.integrations.word_press.v6_1.common_scenarios_test.test_scenario_get_with_view.json
@@ -5,17 +5,17 @@
     "resource": "GET /simple_view",
     "trace_id": 0,
     "span_id": 1,
-    "parent_id": 8825335792662815593,
+    "parent_id": 3899062437396679011,
     "type": "web",
     "meta": {
       "_dd.p.dm": "-0",
-      "_dd.p.tid": "65ba261c00000000",
+      "_dd.p.tid": "65e6fef600000000",
       "component": "wordpress",
       "http.method": "GET",
       "http.route": "([^/]+)(?:/([0-9]+))?/?$",
       "http.status_code": "200",
       "http.url": "http://localhost:9999/simple_view?key=value&<redacted>",
-      "runtime-id": "0671a639-c22e-442f-9aa1-7b401adeb25c",
+      "runtime-id": "df54db4d-0cc0-4b1c-9fce-8004a54aa78b",
       "span.kind": "server"
     },
     "metrics": {
@@ -23,108 +23,11 @@
     }
   },
      {
-       "name": "mysqli_real_connect",
-       "service": "mysqli",
-       "resource": "mysqli_real_connect",
-       "trace_id": 0,
-       "span_id": 2,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET NAMES 'utf8mb4' COLLATE 'utf8mb4_unicode_520_ci'",
-       "trace_id": 0,
-       "span_id": 3,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT @@SESSION.sql_mode",
-       "trace_id": 0,
-       "span_id": 4,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 1.0
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SET SESSION sql_mode='NO_ENGINE_SUBSTITUTION'",
-       "trace_id": 0,
-       "span_id": 5,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       }
-     },
-     {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_name, option_value FROM wp_options WHERE autoload = 'yes'",
-       "trace_id": 0,
-       "span_id": 6,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 118.0
-       }
-     },
-     {
        "name": "create_initial_taxonomies",
        "service": "wordpress_61_test_app",
        "resource": "create_initial_taxonomies",
        "trace_id": 0,
-       "span_id": 7,
+       "span_id": 2,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -136,7 +39,7 @@
        "service": "wordpress_61_test_app",
        "resource": "create_initial_post_types",
        "trace_id": 0,
-       "span_id": 8,
+       "span_id": 3,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -148,7 +51,7 @@
        "service": "wordpress_61_test_app",
        "resource": "datadog (plugin)",
        "trace_id": 0,
-       "span_id": 9,
+       "span_id": 4,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -161,7 +64,7 @@
        "service": "wordpress_61_test_app",
        "resource": "plugins_loaded (hook)",
        "trace_id": 0,
-       "span_id": 10,
+       "span_id": 5,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -174,8 +77,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_maybe_load_widgets",
           "trace_id": 0,
-          "span_id": 19,
-          "parent_id": 10,
+          "span_id": 13,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -186,8 +89,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_maybe_load_embeds",
           "trace_id": 0,
-          "span_id": 20,
-          "parent_id": 10,
+          "span_id": 14,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -198,8 +101,8 @@
           "service": "wordpress_61_test_app",
           "resource": "_wp_customize_include",
           "trace_id": 0,
-          "span_id": 21,
-          "parent_id": 10,
+          "span_id": 15,
+          "parent_id": 5,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -210,7 +113,7 @@
        "service": "wordpress_61_test_app",
        "resource": "setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 11,
+       "span_id": 6,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -219,33 +122,11 @@
        }
      },
      {
-       "name": "mysqli_query",
-       "service": "mysqli",
-       "resource": "SELECT option_value FROM wp_options WHERE option_name = 'WPLANG' LIMIT 1",
-       "trace_id": 0,
-       "span_id": 12,
-       "parent_id": 1,
-       "type": "sql",
-       "meta": {
-         "_dd.base_service": "wordpress_61_test_app",
-         "component": "mysqli",
-         "db.name": "test",
-         "db.system": "mysql",
-         "db.type": "mysql",
-         "out.host": "mysql_integration",
-         "out.port": "3306",
-         "span.kind": "client"
-       },
-       "metrics": {
-         "db.row_count": 0.0
-       }
-     },
-     {
        "name": "action",
        "service": "wordpress_61_test_app",
        "resource": "after_setup_theme (hook)",
        "trace_id": 0,
-       "span_id": 13,
+       "span_id": 7,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -258,7 +139,7 @@
        "service": "wordpress_61_test_app",
        "resource": "WP.init",
        "trace_id": 0,
-       "span_id": 14,
+       "span_id": 8,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -270,7 +151,7 @@
        "service": "wordpress_61_test_app",
        "resource": "init (hook)",
        "trace_id": 0,
-       "span_id": 15,
+       "span_id": 9,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -283,8 +164,8 @@
           "service": "wordpress_61_test_app",
           "resource": "create_initial_post_types",
           "trace_id": 0,
-          "span_id": 22,
-          "parent_id": 15,
+          "span_id": 16,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -295,8 +176,8 @@
           "service": "wordpress_61_test_app",
           "resource": "create_initial_taxonomies",
           "trace_id": 0,
-          "span_id": 23,
-          "parent_id": 15,
+          "span_id": 17,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -307,8 +188,8 @@
           "service": "wordpress_61_test_app",
           "resource": "wp_widgets_init",
           "trace_id": 0,
-          "span_id": 24,
-          "parent_id": 15,
+          "span_id": 18,
+          "parent_id": 9,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -319,173 +200,19 @@
              "service": "wordpress_61_test_app",
              "resource": "WP_Widget_Factory._register_widgets",
              "trace_id": 0,
-             "span_id": 34,
-             "parent_id": 24,
+             "span_id": 21,
+             "parent_id": 18,
              "type": "web",
              "meta": {
                "component": "wordpress"
              }
            },
-              {
-                "name": "mysqli_query",
-                "service": "mysqli",
-                "resource": "SELECT option_value FROM wp_options WHERE option_name = 'can_compress_scripts' LIMIT 1",
-                "trace_id": 0,
-                "span_id": 37,
-                "parent_id": 34,
-                "type": "sql",
-                "meta": {
-                  "_dd.base_service": "wordpress_61_test_app",
-                  "component": "mysqli",
-                  "db.name": "test",
-                  "db.system": "mysql",
-                  "db.type": "mysql",
-                  "out.host": "mysql_integration",
-                  "out.port": "3306",
-                  "span.kind": "client"
-                },
-                "metrics": {
-                  "db.row_count": 1.0
-                }
-              },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "\n\t\t\tSELECT  t.term_id\n\t\t\tFROM wp_terms AS t  INNER JOIN wp_term_taxonomy AS tt ON t.term_id = tt.term_id\n\t\t\tWHERE tt.taxonomy IN ('wp_theme') AND t.name IN ('twentytwentythree')\n\t\t\t\n\t\t\tLIMIT 1\n\t\t",
-          "trace_id": 0,
-          "span_id": 25,
-          "parent_id": 15,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "\n\t\t\tSELECT   wp_posts.*\n\t\t\tFROM wp_posts \n\t\t\tWHERE 1=1  AND ( \n  0 = 1\n) AND wp_posts.post_type = 'wp_template_part' AND ((wp_posts.post_status = 'publish'))\n\t\t\tGROUP BY wp_posts.ID\n\t\t\tORDER BY wp_posts.post_date DESC\n\t\t\t\n\t\t",
-          "trace_id": 0,
-          "span_id": 26,
-          "parent_id": 15,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'medium_crop' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 27,
-          "parent_id": 15,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'medium_large_crop' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 28,
-          "parent_id": 15,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'large_crop' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 29,
-          "parent_id": 15,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "SELECT option_value FROM wp_options WHERE option_name = 'theme_switched' LIMIT 1",
-          "trace_id": 0,
-          "span_id": 30,
-          "parent_id": 15,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "action",
        "service": "wordpress_61_test_app",
        "resource": "wp_loaded (hook)",
        "trace_id": 0,
-       "span_id": 16,
+       "span_id": 10,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -493,34 +220,12 @@
          "wordpress.hook": "wp_loaded"
        }
      },
-        {
-          "name": "mysqli_query",
-          "service": "mysqli",
-          "resource": "\n\t\t\t\t\tSELECT   wp_posts.ID\n\t\t\t\t\tFROM wp_posts \n\t\t\t\t\tWHERE 1=1  AND ( \n  0 = 1\n) AND wp_posts.post_type = 'wp_global_styles' AND ((wp_posts.post_status = 'publish'))\n\t\t\t\t\tGROUP BY wp_posts.ID\n\t\t\t\t\tORDER BY wp_posts.post_date DESC\n\t\t\t\t\tLIMIT 0, 1\n\t\t\t\t",
-          "trace_id": 0,
-          "span_id": 31,
-          "parent_id": 16,
-          "type": "sql",
-          "meta": {
-            "_dd.base_service": "wordpress_61_test_app",
-            "component": "mysqli",
-            "db.name": "test",
-            "db.system": "mysql",
-            "db.type": "mysql",
-            "out.host": "mysql_integration",
-            "out.port": "3306",
-            "span.kind": "client"
-          },
-          "metrics": {
-            "db.row_count": 0.0
-          }
-        },
      {
        "name": "WP.main",
        "service": "wordpress_61_test_app",
        "resource": "WP.main",
        "trace_id": 0,
-       "span_id": 17,
+       "span_id": 11,
        "parent_id": 1,
        "type": "web",
        "meta": {
@@ -532,8 +237,8 @@
           "service": "wordpress_61_test_app",
           "resource": "WP.init",
           "trace_id": 0,
-          "span_id": 32,
-          "parent_id": 17,
+          "span_id": 19,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress"
@@ -544,60 +249,19 @@
           "service": "wordpress_61_test_app",
           "resource": "WP.parse_request",
           "trace_id": 0,
-          "span_id": 33,
-          "parent_id": 17,
+          "span_id": 20,
+          "parent_id": 11,
           "type": "web",
           "meta": {
             "component": "wordpress"
           }
         },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "INSERT INTO `wp_options` (`option_name`, `option_value`, `autoload`) VALUES ('rewrite_rules', 'a:93:{s:11:\\\"^wp-json/?$\\\";s:22:\\\"index.php?rest_route=/\\\";s:14:\\\"^wp-json/(.*)?\\\";s:33:\\\"index.php?rest_route=/$matches[1]\\\";s:21:\\\"^index.php/wp-json/?$\\\";s:22:\\\"index.php?rest_route=/\\\";s:24:\\\"^index.php/wp-json/(.*)?\\\";s:33:\\\"index.php?rest_route=/$matches[1]\\\";s:17:\\\"^wp-sitemap\\\\.xml$\\\";s:23:\\\"index.php?sitemap=index\\\";s:17:\\\"^wp-sitemap\\\\.xsl$\\\";s:36:\\\"index.php?sitemap-stylesheet=sitemap\\\";s:23:\\\"^wp-sitemap-index\\\\.xsl$\\\";s:34:\\\"index.php?sitemap-stylesheet=index\\\";s:48:\\\"^wp-sitemap-([a-z]+?)-([a-z\\\\d_-]+?)-(\\\\d+?)\\\\.xml$\\\";s:75:\\\"index.php?sitemap=$matches[1]&sitemap-subtype=$matches[2]&paged=$matches[3]\\\";s:34:\\\"^wp-sitemap-([a-z]+?)-(\\\\d+?)\\\\.xml$\\\";s:47:\\\"index.php?sitemap=$matches[1]&paged=$matches[2]\\\";s:47:\\\"category/(.+?)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:52:\\\"index.php?category_name=$matches[1]&feed=$matches[2]\\\";s:42:\\\"category/(.+?)/(feed|rdf|rss|rss2|atom)/?$\\\";s:52:\\\"index.php?category_name=$matches[1]&feed=$matches[2]\\\";s:23:\\\"category/(.+?)/embed/?$\\\";s:46:\\\"index.php?category_name=$matches[1]&embed=true\\\";s:35:\\\"category/(.+?)/page/?([0-9]{1,})/?$\\\";s:53:\\\"index.php?category_name=$matches[1]&paged=$matches[2]\\\";s:17:\\\"category/(.+?)/?$\\\";s:35:\\\"index.php?category_name=$matches[1]\\\";s:44:\\\"tag/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?tag=$matches[1]&feed=$matches[2]\\\";s:39:\\\"tag/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?tag=$matches[1]&feed=$matches[2]\\\";s:20:\\\"tag/([^/]+)/embed/?$\\\";s:36:\\\"index.php?tag=$matches[1]&embed=true\\\";s:32:\\\"tag/([^/]+)/page/?([0-9]{1,})/?$\\\";s:43:\\\"index.php?tag=$matches[1]&paged=$matches[2]\\\";s:14:\\\"tag/([^/]+)/?$\\\";s:25:\\\"index.php?tag=$matches[1]\\\";s:45:\\\"type/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?post_format=$matches[1]&feed=$matches[2]\\\";s:40:\\\"type/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?post_format=$matches[1]&feed=$matches[2]\\\";s:21:\\\"type/([^/]+)/embed/?$\\\";s:44:\\\"index.php?post_format=$matches[1]&embed=true\\\";s:33:\\\"type/([^/]+)/page/?([0-9]{1,})/?$\\\";s:51:\\\"index.php?post_format=$matches[1]&paged=$matches[2]\\\";s:15:\\\"type/([^/]+)/?$\\\";s:33:\\\"index.php?post_format=$matches[1]\\\";s:12:\\\"robots\\\\.txt$\\\";s:18:\\\"index.php?robots=1\\\";s:13:\\\"favicon\\\\.ico$\\\";s:19:\\\"index.php?favicon=1\\\";s:48:\\\".*wp-(atom|rdf|rss|rss2|feed|commentsrss2)\\\\.php$\\\";s:18:\\\"index.php?feed=old\\\";s:20:\\\".*wp-app\\\\.php(/.*)?$\\\";s:19:\\\"index.php?error=403\\\";s:18:\\\".*wp-register.php$\\\";s:23:\\\"index.php?register=true\\\";s:32:\\\"feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:27:\\\"index.php?&feed=$matches[1]\\\";s:27:\\\"(feed|rdf|rss|rss2|atom)/?$\\\";s:27:\\\"index.php?&feed=$matches[1]\\\";s:8:\\\"embed/?$\\\";s:21:\\\"index.php?&embed=true\\\";s:20:\\\"page/?([0-9]{1,})/?$\\\";s:28:\\\"index.php?&paged=$matches[1]\\\";s:41:\\\"comments/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?&feed=$matches[1]&withcomments=1\\\";s:36:\\\"comments/(feed|rdf|rss|rss2|atom)/?$\\\";s:42:\\\"index.php?&feed=$matches[1]&withcomments=1\\\";s:17:\\\"comments/embed/?$\\\";s:21:\\\"index.php?&embed=true\\\";s:44:\\\"search/(.+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:40:\\\"index.php?s=$matches[1]&feed=$matches[2]\\\";s:39:\\\"search/(.+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:40:\\\"index.php?s=$matches[1]&feed=$matches[2]\\\";s:20:\\\"search/(.+)/embed/?$\\\";s:34:\\\"index.php?s=$matches[1]&embed=true\\\";s:32:\\\"search/(.+)/page/?([0-9]{1,})/?$\\\";s:41:\\\"index.php?s=$matches[1]&paged=$matches[2]\\\";s:14:\\\"search/(.+)/?$\\\";s:23:\\\"index.php?s=$matches[1]\\\";s:47:\\\"author/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?author_name=$matches[1]&feed=$matches[2]\\\";s:42:\\\"author/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:50:\\\"index.php?author_name=$matches[1]&feed=$matches[2]\\\";s:23:\\\"author/([^/]+)/embed/?$\\\";s:44:\\\"index.php?author_name=$matches[1]&embed=true\\\";s:35:\\\"author/([^/]+)/page/?([0-9]{1,})/?$\\\";s:51:\\\"index.php?author_name=$matches[1]&paged=$matches[2]\\\";s:17:\\\"author/([^/]+)/?$\\\";s:33:\\\"index.php?author_name=$matches[1]\\\";s:69:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:80:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&feed=$matches[4]\\\";s:64:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/(feed|rdf|rss|rss2|atom)/?$\\\";s:80:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&feed=$matches[4]\\\";s:45:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/embed/?$\\\";s:74:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&embed=true\\\";s:57:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/page/?([0-9]{1,})/?$\\\";s:81:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]&paged=$matches[4]\\\";s:39:\\\"([0-9]{4})/([0-9]{1,2})/([0-9]{1,2})/?$\\\";s:63:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&day=$matches[3]\\\";s:56:\\\"([0-9]{4})/([0-9]{1,2})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:64:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&feed=$matches[3]\\\";s:51:\\\"([0-9]{4})/([0-9]{1,2})/(feed|rdf|rss|rss2|atom)/?$\\\";s:64:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&feed=$matches[3]\\\";s:32:\\\"([0-9]{4})/([0-9]{1,2})/embed/?$\\\";s:58:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&embed=true\\\";s:44:\\\"([0-9]{4})/([0-9]{1,2})/page/?([0-9]{1,})/?$\\\";s:65:\\\"index.php?year=$matches[1]&monthnum=$matches[2]&paged=$matches[3]\\\";s:26:\\\"([0-9]{4})/([0-9]{1,2})/?$\\\";s:47:\\\"index.php?year=$matches[1]&monthnum=$matches[2]\\\";s:43:\\\"([0-9]{4})/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?year=$matches[1]&feed=$matches[2]\\\";s:38:\\\"([0-9]{4})/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?year=$matches[1]&feed=$matches[2]\\\";s:19:\\\"([0-9]{4})/embed/?$\\\";s:37:\\\"index.php?year=$matches[1]&embed=true\\\";s:31:\\\"([0-9]{4})/page/?([0-9]{1,})/?$\\\";s:44:\\\"index.php?year=$matches[1]&paged=$matches[2]\\\";s:13:\\\"([0-9]{4})/?$\\\";s:26:\\\"index.php?year=$matches[1]\\\";s:27:\\\".?.+?/attachment/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:37:\\\".?.+?/attachment/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:57:\\\".?.+?/attachment/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\".?.+?/attachment/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\".?.+?/attachment/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:33:\\\".?.+?/attachment/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";s:16:\\\"(.?.+?)/embed/?$\\\";s:41:\\\"index.php?pagename=$matches[1]&embed=true\\\";s:20:\\\"(.?.+?)/trackback/?$\\\";s:35:\\\"index.php?pagename=$matches[1]&tb=1\\\";s:40:\\\"(.?.+?)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&feed=$matches[2]\\\";s:35:\\\"(.?.+?)/(feed|rdf|rss|rss2|atom)/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&feed=$matches[2]\\\";s:28:\\\"(.?.+?)/page/?([0-9]{1,})/?$\\\";s:48:\\\"index.php?pagename=$matches[1]&paged=$matches[2]\\\";s:35:\\\"(.?.+?)/comment-page-([0-9]{1,})/?$\\\";s:48:\\\"index.php?pagename=$matches[1]&cpage=$matches[2]\\\";s:24:\\\"(.?.+?)(?:/([0-9]+))?/?$\\\";s:47:\\\"index.php?pagename=$matches[1]&page=$matches[2]\\\";s:27:\\\"[^/]+/attachment/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:37:\\\"[^/]+/attachment/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:57:\\\"[^/]+/attachment/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\"[^/]+/attachment/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:52:\\\"[^/]+/attachment/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:33:\\\"[^/]+/attachment/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";s:16:\\\"([^/]+)/embed/?$\\\";s:37:\\\"index.php?name=$matches[1]&embed=true\\\";s:20:\\\"([^/]+)/trackback/?$\\\";s:31:\\\"index.php?name=$matches[1]&tb=1\\\";s:40:\\\"([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?name=$matches[1]&feed=$matches[2]\\\";s:35:\\\"([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:43:\\\"index.php?name=$matches[1]&feed=$matches[2]\\\";s:28:\\\"([^/]+)/page/?([0-9]{1,})/?$\\\";s:44:\\\"index.php?name=$matches[1]&paged=$matches[2]\\\";s:35:\\\"([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:44:\\\"index.php?name=$matches[1]&cpage=$matches[2]\\\";s:24:\\\"([^/]+)(?:/([0-9]+))?/?$\\\";s:43:\\\"index.php?name=$matches[1]&page=$matches[2]\\\";s:16:\\\"[^/]+/([^/]+)/?$\\\";s:32:\\\"index.php?attachment=$matches[1]\\\";s:26:\\\"[^/]+/([^/]+)/trackback/?$\\\";s:37:\\\"index.php?attachment=$matches[1]&tb=1\\\";s:46:\\\"[^/]+/([^/]+)/feed/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:41:\\\"[^/]+/([^/]+)/(feed|rdf|rss|rss2|atom)/?$\\\";s:49:\\\"index.php?attachment=$matches[1]&feed=$matches[2]\\\";s:41:\\\"[^/]+/([^/]+)/comment-page-([0-9]{1,})/?$\\\";s:50:\\\"index.php?attachment=$matches[1]&cpage=$matches[2]\\\";s:22:\\\"[^/]+/([^/]+)/embed/?$\\\";s:43:\\\"index.php?attachment=$matches[1]&embed=true\\\";}', 'yes') ON DUPLICATE KEY UPDATE `option_name` = VALUES(`option_name`), `option_value` = VALUES(`option_value`), `autoload` = VALUES(`autoload`)",
-             "trace_id": 0,
-             "span_id": 35,
-             "parent_id": 33,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             }
-           },
-           {
-             "name": "mysqli_query",
-             "service": "mysqli",
-             "resource": "\n\t\tSELECT ID, post_name, post_parent, post_type\n\t\tFROM wp_posts\n\t\tWHERE post_name IN ('simple_view')\n\t\tAND post_type IN ('page','attachment')\n\t",
-             "trace_id": 0,
-             "span_id": 36,
-             "parent_id": 33,
-             "type": "sql",
-             "meta": {
-               "_dd.base_service": "wordpress_61_test_app",
-               "component": "mysqli",
-               "db.name": "test",
-               "db.system": "mysql",
-               "db.type": "mysql",
-               "out.host": "mysql_integration",
-               "out.port": "3306",
-               "span.kind": "client"
-             },
-             "metrics": {
-               "db.row_count": 0.0
-             }
-           },
      {
        "name": "action",
        "service": "wordpress_61_test_app",
        "resource": "shutdown (hook)",
        "trace_id": 0,
-       "span_id": 18,
+       "span_id": 12,
        "parent_id": 1,
        "type": "web",
        "meta": {


### PR DESCRIPTION
### Description

Needed for #2550

> Additionally, there were two additional mysqli_query spans in [one test](https://circleci.com/gh/DataDog/dd-trace-php/3914710) from this PR. Let's just test what we want actually to test.

With this PR, `mysqli` spans are stripped-off from WordPress snapshots. They will be easier to maintain, read, and that's anyway what we do for other suites.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
