### PR TITLE
[OTel] Only set resource info on root spans

### DIFF
--- a/src/DDTrace/OpenTelemetry/Context.php
+++ b/src/DDTrace/OpenTelemetry/Context.php
@@ -197,7 +197,7 @@ final class Context implements ContextInterface
             API\Span::fromContext($parentContext), // $parentSpan (TODO: Handle null parent span) ?
             $parentContext, // $parentContext
             NoopSpanProcessor::getInstance(), // $spanProcessor
-            ResourceInfoFactory::defaultResource(), // $resource
+            ResourceInfoFactory::emptyResource(), // $resource
             (new AttributesFactory())->builder(), // $attributesBuilder
             $links, // $links
             count($links), // $totalRecordedLinks

--- a/src/DDTrace/OpenTelemetry/SpanBuilder.php
+++ b/src/DDTrace/OpenTelemetry/SpanBuilder.php
@@ -15,6 +15,7 @@ use OpenTelemetry\Context\Context;
 use OpenTelemetry\Context\ContextInterface;
 use OpenTelemetry\SDK\Common\Attribute\AttributesBuilderInterface;
 use OpenTelemetry\SDK\Common\Instrumentation\InstrumentationScopeInterface;
+use OpenTelemetry\SDK\Resource\ResourceInfoFactory;
 
 final class SpanBuilder implements API\SpanBuilderInterface
 {
@@ -196,7 +197,7 @@ final class SpanBuilder implements API\SpanBuilderInterface
             $parentSpan,
             $parentContext,
             $this->tracerSharedState->getSpanProcessor(),
-            $this->tracerSharedState->getResource(),
+            $parentSpanContext->isValid() ? ResourceInfoFactory::emptyResource() : $this->tracerSharedState->getResource(),
             $attributesBuilder,
             $this->links,
             $this->totalNumberOfLinksAdded,

--- a/tests/OpenTelemetry/Integration/InteroperabilityTest.php
+++ b/tests/OpenTelemetry/Integration/InteroperabilityTest.php
@@ -113,9 +113,6 @@ final class InteroperabilityTest extends BaseTestCase
     /** @noinspection PhpParamsInspection */
     public function testMixingOpenTelemetrylAndDatadogBasic()
     {
-        //$this->markTestSkipped("d");
-        self::putEnvAndReloadConfig(["DD_TRACE_DEBUG=1"]);
-
         $traces = $this->isolateTracer(function () {
             $tracer = (new TracerProvider())->getTracer('test.tracer');
             $span = $tracer->spanBuilder("test.span")->startSpan();


### PR DESCRIPTION
### Description

This PR removes redundant resource info from being set on _all_ OTel (native or remapped) spans. It fundamentally is a breaking change (since we are removing data from some spans), so if we want to do it, now is the time.

**What is Resource Info?**
From [OTel Doc](https://opentelemetry.io/docs/languages/php/resources/):
- environment
- host information
- host operating system
- current process
- runtime

**Why should we remove it?**
- First, a customer would ingest "many" irrelevant bytes.

Here is a sample payload without resources (9 tags)

```json
{
                "trace_id": "65ddafdb0000000007b244ca5366620e",
                "span_id": "805384663926885947",
                "parent_id": "9429929380169505464",
                "start": 1709027293.039369,
                "end": 1709027293.039381,
                "duration": 1.2125e-05,
                "type": "web",
                "service": "customer_app_web_service",
                "name": "laravel.event.handle",
                "resource": "Illuminate\\Foundation\\Http\\Events\\RequestHandled",
                "resource_hash": "5da477cef10a0ff3",
                "host_id": 439449322,
                "hostname": "docker-desktop",
                "env": "prod",
                "host_groups": [
                    "env:prod"
                ],
                "meta": {
                    "ddtags": "ingestion_reason:auto",
                    "component": "laravel",
                    "env": "prod",
                    "language": "php",
                    "_dd.p.ftid": "65ddafdb0000000007b244ca5366620e",
                    "_dd.agent_version": "7.50.3",
                    "_dd.agent_hostname": "docker-desktop",
                    "_dd.tracer_version": "0.98.0"
                },
                "metrics": {
                    "_sampling_priority_v1": 1.0
                },
                "ingestion_reason": "auto",
                "metadata": {
                    "sds_info": []
                },
                "children_ids": []
            }
```

Same operation with resource info (25 tags)

```json
{
                "trace_id": "65ddafdb0000000007b244ca5366620e",
                "span_id": "12568249948290625744",
                "parent_id": "15313292926888664709",
                "start": 1709027292.995515,
                "end": 1709027292.996892,
                "duration": 0.001376375,
                "type": "web",
                "service": "customer_app_web_service",
                "name": "laravel.event.handle",
                "resource": "Illuminate\\Database\\Events\\QueryExecuted",
                "resource_hash": "c49a35ffdaafe898",
                "host_id": 439449322,
                "hostname": "docker-desktop",
                "env": "prod",
                "host_groups": [
                    "env:prod"
                ],
                "meta": {
                    "process.executable.path": "/usr/local/sbin/php-fpm",
                    "component": "laravel",
                    "_dd.tracer_version": "0.98.0",
                    "host.arch": "aarch64",
                    "_dd.agent_version": "7.50.3",
                    "process.runtime.name": "fpm-fcgi",
                    "os.name": "Linux",
                    "telemetry.distro.version": "1.0.0",
                    "process.owner": "www-data",
                    "os.type": "linux",
                    "telemetry.sdk.language": "php",
                    "os.description": "6.5.11-linuxkit",
                    "telemetry.sdk.name": "opentelemetry",
                    "telemetry.sdk.version": "1.0.8",
                    "language": "php",
                    "ddtags": "ingestion_reason:auto",
                    "process.runtime.version": "8.2.12",
                    "_dd.p.ftid": "65ddafdb0000000007b244ca5366620e",
                    "env": "prod",
                    "os.version": "#1 SMP PREEMPT Wed Dec  6 17:08:31 UTC 2023",
                    "telemetry.distro.name": "opentelemetry-php-instrumentation",
                    "service.version": "1.0.0+no-version-set",
                    "host.name": "61cd348cc3c2",
                    "_dd.agent_hostname": "docker-desktop"
                },
                "metrics": {
                    "_sampling_priority_v1": 1.0,
                    "process.pid": 9859.0
                },
                "ingestion_reason": "auto",
                "metadata": {
                    "sds_info": []
                },
                "children_ids": [
                    "12622166295660867307",
                    "12074790514185832795",
                    "4622667366984769435",
                    "10340755233058322318"
                ]
            }
```


That's a 178% increase! 🚀 

- Second, this information was already there in the root span. We have no value from having it in the children

- Some of this same information is already available from other tabs (e.g., Infrastructure or Processes). 

- Finally, it has a performance impact (as shown by the benchmarks) because of the instances and added serialization work needed.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
