### PR TITLE
Handle relative ext/ paths and test the windows installer

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -2183,6 +2183,23 @@ jobs:
           name: Test
           command: ./dockerfiles/verify_packages/verify_no_ext_json.sh
 
+  verify_windows:
+    working_directory: ~/datadog
+    resource_class: 'windows.medium'
+    machine:
+      image: 'windows-server-2019-vs2019:2022.08.1'
+      shell: 'powershell.exe -ExecutionPolicy Bypass'
+    parameters:
+      docker_image:
+        type: string
+    steps:
+      - checkout
+      - <<: *STEP_ATTACH_WORKSPACE
+      - run:
+          name: Build nts
+          shell: powershell.exe
+          command: .\dockerfiles\verify_packages\verify_windows.ps1
+
   installer_tests:
     working_directory: ~/datadog
     machine:

--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -1554,12 +1554,20 @@ function search_php_binaries($prefix = '')
             dirname(PHP_BINARY),
             PHP_BINDIR,
             $bootDisk . 'WINDOWS',
-            $bootDisk . 'tools', // chocolatey default location
         ];
 
         foreach (scandir($bootDisk) as $file) {
             if (stripos($file, "php") !== false) {
                 $standardPaths[] = "$bootDisk$file";
+            }
+        }
+
+        $chocolateyDir = getenv("ChocolateyToolsLocation") ?: $bootDisk . 'tools'; // chocolatey tools location
+        if (is_dir($chocolateyDir)) {
+            foreach (scandir($chocolateyDir) as $file) {
+                if (stripos($file, "php") !== false) {
+                    $standardPaths[] = "$chocolateyDir/$file";
+                }
             }
         }
 

--- a/dockerfiles/verify_packages/verify_windows.ps1
+++ b/dockerfiles/verify_packages/verify_windows.ps1
@@ -1,0 +1,12 @@
+# to run manually: docker run --rm -ti -v $pwd\..\..:c:\app -w c:\app chocolatey/choco:latest-windows powershell.exe .\dockerfiles\verify_packages\verify_windows.ps1
+
+Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
+
+choco install -y php
+choco install -y 7zip
+refreshenv
+
+php build/packages/datadog-setup.php --php-bin=all --file=$(ls build/packages/dd-library-php-*-x86_64-windows.tar.gz)
+
+# Check source directories present by triggering an integration
+echo "<?php shell_exec('echo 1'); if (dd_trace_serialize_closed_spans()[0]['meta']['cmd.shell'] !== 'echo 1') { echo 'No ExecIntegration present?'; exit(1); } echo 'SUCCESS';" | php "-ddatadog.trace.cli_enabled=1" "-ddatadog.trace.generate_root_span=0"


### PR DESCRIPTION
### Description

Fixes src/ dir copy and avoids the `.dll` suffix at all costs for windows.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
