### PR TITLE
Implement SpanData::setTag + OTel perf improvements

### DIFF
--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -944,10 +944,6 @@ PHP_METHOD(DDTrace_SpanData, hexId) {
 
 
 void add_distributed_tag(zend_string *key, zval *value) {
-    if (!get_DD_TRACE_ENABLED()) {
-        return;
-    }
-
     zend_string *prefixed_key = zend_strpprintf(0, "_dd.p.%s", ZSTR_VAL(key));
 
     zend_array *target_table, *propagated;

--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -944,6 +944,10 @@ PHP_METHOD(DDTrace_SpanData, hexId) {
 
 
 void add_distributed_tag(zend_string *key, zval *value) {
+    if (!get_DD_TRACE_ENABLED()) {
+        return;
+    }
+    
     zend_string *prefixed_key = zend_strpprintf(0, "_dd.p.%s", ZSTR_VAL(key));
 
     zend_array *target_table, *propagated;

--- a/ext/ddtrace.stub.php
+++ b/ext/ddtrace.stub.php
@@ -149,6 +149,14 @@ namespace DDTrace {
          * @return Returns the span id as zero-padded 16 character hexadecimal string.
          */
         public function hexId(): string {}
+
+        /**
+         * Set a tag on the span
+         * @var string $key The tag key. If the key starts with "_dd.p.", a distributed tag will be added instead.
+         * @var mixed $value The tag value. If it is null, removes the entry if it exists.
+         * @return SpanData The span instance
+         */
+        public function setTag(string $key, ?mixed $value): SpanData {}
     }
 
     class RootSpanData extends SpanData {

--- a/ext/ddtrace_arginfo.h
+++ b/ext/ddtrace_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 9356ea34a0a1611519c3a3d1b1731b3e3e1c9c7d */
+ * Stub hash: 4215611ee5594833d1392f2ce1be80eed4293c28 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_trace_method, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, className, IS_STRING, 0)
@@ -282,6 +282,11 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_DDTrace_SpanData_hexId arginfo_DDTrace_startup_logs
 
+ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_class_DDTrace_SpanData_setTag, 0, 2, DDTrace\\SpanData, 0)
+	ZEND_ARG_TYPE_INFO(0, key, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, value, IS_MIXED, 1)
+ZEND_END_ARG_INFO()
+
 #define arginfo_class_DDTrace_Integration_init arginfo_dd_trace_dd_get_memory_limit
 
 
@@ -364,6 +369,7 @@ ZEND_METHOD(DDTrace_SpanData, getDuration);
 ZEND_METHOD(DDTrace_SpanData, getStartTime);
 ZEND_METHOD(DDTrace_SpanData, getLink);
 ZEND_METHOD(DDTrace_SpanData, hexId);
+ZEND_METHOD(DDTrace_SpanData, setTag);
 
 
 static const zend_function_entry ext_functions[] = {
@@ -457,6 +463,7 @@ static const zend_function_entry class_DDTrace_SpanData_methods[] = {
 	ZEND_ME(DDTrace_SpanData, getStartTime, arginfo_class_DDTrace_SpanData_getStartTime, ZEND_ACC_PUBLIC)
 	ZEND_ME(DDTrace_SpanData, getLink, arginfo_class_DDTrace_SpanData_getLink, ZEND_ACC_PUBLIC)
 	ZEND_ME(DDTrace_SpanData, hexId, arginfo_class_DDTrace_SpanData_hexId, ZEND_ACC_PUBLIC)
+	ZEND_ME(DDTrace_SpanData, setTag, arginfo_class_DDTrace_SpanData_setTag, ZEND_ACC_PUBLIC)
 	ZEND_FE_END
 };
 

--- a/src/DDTrace/OpenTelemetry/Context.php
+++ b/src/DDTrace/OpenTelemetry/Context.php
@@ -178,16 +178,15 @@ final class Context implements ContextInterface
         $traceState = new API\TraceState($traceContext['tracestate'] ?? null);
 
         // Check for span links
-        $links = [];
-        foreach ($currentSpan->links as $spanLink) {
+        $links = array_map(function ($spanLink) {
             $linkSpanContext = API\SpanContext::create(
                 $spanLink->traceId,
                 $spanLink->spanId,
                 API\TraceFlags::DEFAULT,
-                new API\TraceState($spanLink->traceState ?? null),
+                new API\TraceState($spanLink->traceState ?? null)
             );
-            $links[] = new SDK\Link($linkSpanContext, Attributes::create($spanLink->attributes));
-        }
+            return new SDK\Link($linkSpanContext, Attributes::create($spanLink->attributes));
+        }, $currentSpan->links);
 
         $OTelCurrentSpan = SDK\Span::startSpan(
             $currentSpan,

--- a/src/DDTrace/OpenTelemetry/Context.php
+++ b/src/DDTrace/OpenTelemetry/Context.php
@@ -197,7 +197,7 @@ final class Context implements ContextInterface
             $parentContext, // $parentContext
             NoopSpanProcessor::getInstance(), // $spanProcessor
             ResourceInfoFactory::emptyResource(), // $resource
-            (new AttributesFactory())->builder(), // $attributesBuilder
+            [], // $attributesBuilder
             $links, // $links
             count($links), // $totalRecordedLinks
             false // The span was created using the DD Api

--- a/src/DDTrace/OpenTelemetry/Span.php
+++ b/src/DDTrace/OpenTelemetry/Span.php
@@ -261,28 +261,10 @@ final class Span extends API\Span implements ReadWriteSpanInterface
         return !$this->hasEnded();
     }
 
-    private static function _setAttribute(SpanData $span, string $key, $value): void
-    {
-        if ($value === null && isset($span->meta[$key])) {
-            unset($span->meta[$key]);
-        } elseif ($value === null && isset($span->metrics[$key])) {
-            unset($span->metrics[$key]);
-        } elseif (strpos($key, '_dd.p.') === 0) {
-            $distributedKey = substr($key, 6); // strlen('_dd.p.') === 6
-            \DDTrace\add_distributed_tag($distributedKey, $value);
-        } elseif (is_float($value)
-            || is_int($value)
-            || (is_array($value) && count($value) > 0 && is_numeric($value[0]))) { // Note: Assumes attribute with primitive, homogeneous array values
-            $span->metrics[$key] = $value;
-        } else {
-            $span->meta[$key] = $value;
-        }
-    }
-
     private static function _setAttributes(SpanData $span, iterable $attributes): void
     {
         foreach ($attributes as $key => $value) {
-            self::_setAttribute($span, $key, $value);
+            $span->setTag($key, $value);
         }
     }
 
@@ -299,7 +281,7 @@ final class Span extends API\Span implements ReadWriteSpanInterface
     public function setAttribute(string $key, $value): SpanInterface
     {
         if (!$this->hasEnded()) {
-            self::_setAttribute($this->span, $key, $value);
+            $this->span->setTag($key, $value);
         }
 
         $this->updateConvention();

--- a/src/DDTrace/OpenTelemetry/Span.php
+++ b/src/DDTrace/OpenTelemetry/Span.php
@@ -132,12 +132,11 @@ final class Span extends API\Span implements ReadWriteSpanInterface
         ContextInterface $parentContext,
         SpanProcessorInterface $spanProcessor,
         ResourceInfo $resource,
-        AttributesBuilderInterface $attributesBuilder,
+        array $attributes,
         array $links,
         int $totalRecordedLinks,
         bool $isRemapped = true // Answers the question "Was the span created using the OTel API?"
     ): self {
-        $attributes = $attributesBuilder->build()->toArray();
         self::_setAttributes($span, $attributes);
 
         $resourceAttributes = $resource->getAttributes()->toArray();

--- a/src/DDTrace/OpenTelemetry/SpanContext.php
+++ b/src/DDTrace/OpenTelemetry/SpanContext.php
@@ -29,6 +29,10 @@ final class SpanContext implements SpanContextInterface
 
     private bool $isValid = true;
 
+    private ?string $currentTracestateString = null;
+
+    private ?TraceStateInterface $currentTracestateInstance = null;
+
     private function __construct(SpanData $span, bool $sampled, bool $remote, ?string $traceId = null, ?string $spanId = null)
     {
         $this->span = $span;
@@ -74,8 +78,21 @@ final class SpanContext implements SpanContextInterface
 
     public function getTraceState(): ?TraceStateInterface
     {
+        if ($this->currentTracestateInstance === null) {
+            $this->currentTracestateString = generate_distributed_tracing_headers(['tracecontext'])['tracestate'] ?? null;
+            $this->currentTracestateInstance = new TraceState($this->currentTracestateString);
+            return $this->currentTracestateInstance;
+        }
+
         $traceContext = generate_distributed_tracing_headers(['tracecontext']);
-        return new TraceState($traceContext['tracestate'] ?? null);
+        $newTracestate = $traceContext['tracestate'] ?? null;
+        if ($this->currentTracestateString !== $newTracestate) {
+            $this->currentTracestateString = $newTracestate;
+            $this->currentTracestateInstance = new TraceState($newTracestate);
+
+        }
+
+        return $this->currentTracestateInstance;
     }
 
     public function isSampled(): bool

--- a/src/DDTrace/OpenTelemetry/SpanContext.php
+++ b/src/DDTrace/OpenTelemetry/SpanContext.php
@@ -78,18 +78,12 @@ final class SpanContext implements SpanContextInterface
 
     public function getTraceState(): ?TraceStateInterface
     {
-        if ($this->currentTracestateInstance === null) {
-            $this->currentTracestateString = generate_distributed_tracing_headers(['tracecontext'])['tracestate'] ?? null;
-            $this->currentTracestateInstance = new TraceState($this->currentTracestateString);
-            return $this->currentTracestateInstance;
-        }
-
         $traceContext = generate_distributed_tracing_headers(['tracecontext']);
         $newTracestate = $traceContext['tracestate'] ?? null;
-        if ($this->currentTracestateString !== $newTracestate) {
+
+        if ($this->currentTracestateInstance === null || $this->currentTracestateString !== $newTracestate) {
             $this->currentTracestateString = $newTracestate;
             $this->currentTracestateInstance = new TraceState($newTracestate);
-
         }
 
         return $this->currentTracestateInstance;

--- a/src/DDTrace/Util/ObjectKVStore.php
+++ b/src/DDTrace/Util/ObjectKVStore.php
@@ -207,8 +207,8 @@ class ObjectKVStore
     {
         return
             empty($instance)
-            || !is_object($instance)
             || empty($key)
-            || !is_string($key);
+            || !is_string($key)
+            || !is_object($instance);
     }
 }

--- a/tests/ext/DDTrace_SpanData_setTag.phpt
+++ b/tests/ext/DDTrace_SpanData_setTag.phpt
@@ -1,0 +1,81 @@
+--TEST--
+SpanData::setTag
+--FILE--
+<?php
+
+$span = \DDTrace\start_span();
+
+$span->setTag('nil', 'none');
+
+$span->setTag('foo', 'bar')
+    ->setTag('bar', 123)
+    ->setTag('empty-arr', [])
+    ->setTag('int-arr', [1, 2, 3])
+    ->setTag('nil', null)
+    ->setTag('_dd.p.key', 'val')
+    ->setTag('_dd.p.fl', 1.2)
+    ->setTag('nested', ['foo' => 'bar', 'bar' => 'baz', 'alone'])
+    ->setTag("string-array", ["a", "b", "c"]);
+
+var_dump(\DDTrace\generate_distributed_tracing_headers(['tracecontext'])['tracestate']);
+
+\DDTrace\close_span();
+
+var_dump(dd_trace_serialize_closed_spans());
+
+?>
+--EXPECTF--
+string(29) "dd=t.key:val;t.fl:1.2;t.dm:-0"
+array(1) {
+  [0]=>
+  array(11) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["parent_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(0) ""
+    ["resource"]=>
+    string(0) ""
+    ["service"]=>
+    string(27) "DDTrace_SpanData_setTag.php"
+    ["type"]=>
+    string(3) "cli"
+    ["meta"]=>
+    array(8) {
+      ["foo"]=>
+      string(3) "bar"
+      ["empty-arr"]=>
+      string(0) ""
+      ["nested.foo"]=>
+      string(3) "bar"
+      ["nested.bar"]=>
+      string(3) "baz"
+      ["nested.0"]=>
+      string(5) "alone"
+      ["string-array.0"]=>
+      string(1) "a"
+      ["string-array.1"]=>
+      string(1) "b"
+      ["string-array.2"]=>
+      string(1) "c"
+    }
+    ["metrics"]=>
+    array(4) {
+      ["bar"]=>
+      float(123)
+      ["int-arr.0"]=>
+      float(1)
+      ["int-arr.1"]=>
+      float(2)
+      ["int-arr.2"]=>
+      float(3)
+    }
+  }
+}

--- a/tests/ext/DDTrace_SpanData_setTag.phpt
+++ b/tests/ext/DDTrace_SpanData_setTag.phpt
@@ -19,6 +19,16 @@ $span->setTag('foo', 'bar')
 
 var_dump(\DDTrace\generate_distributed_tracing_headers(['tracecontext'])['tracestate']);
 
+$child = \DDTrace\start_span();
+$child->setTag('_dd.p.user', 12)
+    ->setTag('num', 1.0);
+
+var_dump(\DDTrace\generate_distributed_tracing_headers(['tracecontext'])['tracestate']);
+
+$child->setTag('num', null);
+
+\DDTrace\close_span();
+
 \DDTrace\close_span();
 
 var_dump(dd_trace_serialize_closed_spans());
@@ -26,7 +36,8 @@ var_dump(dd_trace_serialize_closed_spans());
 ?>
 --EXPECTF--
 string(29) "dd=t.key:val;t.fl:1.2;t.dm:-0"
-array(1) {
+string(39) "dd=t.key:val;t.fl:1.2;t.dm:-0;t.user:12"
+array(2) {
   [0]=>
   array(11) {
     ["trace_id"]=>
@@ -77,5 +88,26 @@ array(1) {
       ["int-arr.2"]=>
       float(3)
     }
+  }
+  [1]=>
+  array(9) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["parent_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(0) ""
+    ["resource"]=>
+    string(0) ""
+    ["service"]=>
+    string(27) "DDTrace_SpanData_setTag.php"
+    ["type"]=>
+    string(3) "cli"
   }
 }


### PR DESCRIPTION
### Description

[Profile](https://app.datadoghq.eu/profiling/explorer?query=service%3Abench%20&fromUser=true&my_code=disabled&op_filter=focus_on%28function%3A%22benchOpenTelemetryAPI%20%28SpanBench.php%29%22%29&selected_tf=1709885445555.1682%2C1709885921205.251&viz=flame_graph&zoom=849697138&start=1709885355798&end=1709886255798&paused=true) (v0.98.1)

<img width="791" alt="image" src="https://github.com/DataDog/dd-trace-php/assets/42672104/dd29188c-3633-43fa-abbf-203171ee31dc">


The _set_attribute operation in OTel takes 20% (!!!!!!) of the CPU time in the profiles, which is absurdly high for such an operation.

I implemented SpanData::setTag to move the logic in the extension and see if it leads to any perf improvements.

--- 

After making the above change, we end up with the following [Profile](https://app.datadoghq.eu/profiling/explorer?query=service%3Abench2%20&attribute=line&fromUser=true&my_code=disabled&op_filter=focus_on%28function%3A%22benchOpenTelemetryAPI%20%28SpanBench.php%29%22%29&profile_type=cpu-time&selected_tf=1709895286115.567%2C1709895761765.567&viz=flame_graph&zoom=2177478488&start=1709884959166&end=1709899359166&paused=true) (this branch)

![image](https://github.com/DataDog/dd-trace-php/assets/42672104/2cc4907d-9b20-4bf1-a0f1-6f09801f6888)

Two things:
- We can save some time by not always re-creating a TraceState instance, which implies string parsing
- We could re-use the empty resource instance ([upstream PR](https://github.com/open-telemetry/opentelemetry-php/pull/1251))


<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
