### PR TITLE
ci(profiling) add tests for exception profiling in ZTS builds

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -2920,6 +2920,21 @@ jobs:
             export TEST_PHP_EXECUTABLE=$(which php)
             php run-tests.php -d "extension=/mnt/ramdisk/cargo/release/libdatadog_php_profiling.so" --show-diff -g "FAIL,XFAIL,BORK,WARN,LEAK,XLEAK,SKIP" "phpt"
       - run:
+          name: Build ext-parallel
+          command: |
+            set -u
+            if ! [[ "$PHP_VERSION" =~ "7\." ]] ; then
+              echo "no ext-parallel for PHP 7"
+              exit 0;
+            fi
+            command -v switch-php && switch-php "${PHP_VERSION}-zts"
+            git clone https://github.com/krakjoe/parallel.git
+            cd parallel
+            phpize
+            ./configure
+            make
+            make install
+      - run:
           name: phpt tests ZTS
           command: |
             set -u
@@ -2934,7 +2949,7 @@ jobs:
             run_tests_php=$(find $(php-config --prefix) -name run-tests.php)
             cp -v "${run_tests_php}" .
             export TEST_PHP_EXECUTABLE=$(which php)
-            php run-tests.php -d "extension=/mnt/ramdisk/cargo/release/libdatadog_php_profiling.so" --show-diff -g "FAIL,XFAIL,BORK,WARN,LEAK,XLEAK,SKIP" "phpt"
+            php run-tests.php -d "extension=parallel" -d "extension=/mnt/ramdisk/cargo/release/libdatadog_php_profiling.so" --show-diff -g "FAIL,XFAIL,BORK,WARN,LEAK,XLEAK,SKIP" "phpt"
 
   compile_extension_centos:
     working_directory: ~/datadog

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -2920,21 +2920,6 @@ jobs:
             export TEST_PHP_EXECUTABLE=$(which php)
             php run-tests.php -d "extension=/mnt/ramdisk/cargo/release/libdatadog_php_profiling.so" --show-diff -g "FAIL,XFAIL,BORK,WARN,LEAK,XLEAK,SKIP" "phpt"
       - run:
-          name: Build ext-parallel
-          command: |
-            set -u
-            if ! [[ "$PHP_VERSION" =~ "7\." ]] ; then
-              echo "no ext-parallel for PHP 7"
-              exit 0;
-            fi
-            command -v switch-php && switch-php "${PHP_VERSION}-zts"
-            git clone https://github.com/krakjoe/parallel.git
-            cd parallel
-            phpize
-            ./configure
-            make
-            make install
-      - run:
           name: phpt tests ZTS
           command: |
             set -u
@@ -2949,7 +2934,7 @@ jobs:
             run_tests_php=$(find $(php-config --prefix) -name run-tests.php)
             cp -v "${run_tests_php}" .
             export TEST_PHP_EXECUTABLE=$(which php)
-            php run-tests.php -d "extension=parallel" -d "extension=/mnt/ramdisk/cargo/release/libdatadog_php_profiling.so" --show-diff -g "FAIL,XFAIL,BORK,WARN,LEAK,XLEAK,SKIP" "phpt"
+            php run-tests.php -d "extension=/mnt/ramdisk/cargo/release/libdatadog_php_profiling.so" --show-diff -g "FAIL,XFAIL,BORK,WARN,LEAK,XLEAK,SKIP" "phpt"
 
   compile_extension_centos:
     working_directory: ~/datadog

--- a/.github/workflows/prof_correctness.yml
+++ b/.github/workflows/prof_correctness.yml
@@ -10,8 +10,11 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-versions: ['8.1', '8.2', '8.3']
-        phpts: ['nts', 'zts']
+        php-version: [8.1, 8.2, 8.3]
+        phpts: [nts, zts]
+        include:
+          - phpts: zts
+            extensions: parallel
 
     steps:
       - name: Checkout
@@ -23,7 +26,8 @@ jobs:
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:
-          php-version: ${{ matrix.php-versions }}
+          php-version: ${{ matrix.php-version }}
+          extensions: ${{ matrix.extensions }}
         env:
           phpts: ${{ matrix.phpts }}
 
@@ -67,6 +71,7 @@ jobs:
         run: |
           export DD_PROFILING_ENABLED=Off
           export DD_PROFILING_EXPERIMENTAL_FEATURES_ENABLED=1
+          export DD_PROFILING_EXCEPTION_MESSAGE_ENABLED=1
           php -v
           php -d extension=target/release/libdatadog_php_profiling.so --ri datadog-profiling
           for test_case in "allocations" "time" "strange_frames" "timeline" "exceptions"; do
@@ -84,9 +89,25 @@ jobs:
           export DD_PROFILING_LOG_LEVEL=trace
           export DD_PROFILING_EXPERIMENTAL_FEATURES_ENABLED=1
           export DD_PROFILING_EXPERIMENTAL_EXCEPTION_SAMPLING_DISTANCE=1
+          export DD_PROFILING_EXCEPTION_MESSAGE_ENABLED=1
           php -v
           php -d extension=target/release/libdatadog_php_profiling.so --ri datadog-profiling
           for test_case in "allocations" "time" "strange_frames" "timeline" "exceptions"; do
+              mkdir -p profiling/tests/correctness/"$test_case"/
+              export DD_PROFILING_OUTPUT_PPROF=$PWD/profiling/tests/correctness/"$test_case"/test.pprof
+              php -d extension=$PWD/target/release/libdatadog_php_profiling.so profiling/tests/correctness/"$test_case".php
+          done
+
+      - name: Run ZTS tests
+        if: matrix.phpts == 'zts'
+        run: |
+          export DD_PROFILING_LOG_LEVEL=trace
+          export DD_PROFILING_EXPERIMENTAL_FEATURES_ENABLED=1
+          export DD_PROFILING_EXPERIMENTAL_EXCEPTION_SAMPLING_DISTANCE=1
+          export DD_PROFILING_EXCEPTION_MESSAGE_ENABLED=1
+          php -v
+          php -d extension=target/release/libdatadog_php_profiling.so --ri datadog-profiling
+          for test_case in "exceptions_zts"; do
               mkdir -p profiling/tests/correctness/"$test_case"/
               export DD_PROFILING_OUTPUT_PPROF=$PWD/profiling/tests/correctness/"$test_case"/test.pprof
               php -d extension=$PWD/target/release/libdatadog_php_profiling.so profiling/tests/correctness/"$test_case".php
@@ -116,6 +137,13 @@ jobs:
         with:
           expected_json: profiling/tests/correctness/timeline.json
           pprof_path: profiling/tests/correctness/timeline/
+
+      - name: Check profiler correctness for exceptions ZTS
+        if: matrix.phpts == 'zts'
+        uses: Datadog/prof-correctness/analyze@main
+        with:
+          expected_json: profiling/tests/correctness/exceptions_zts.json
+          pprof_path: profiling/tests/correctness/exceptions_zts/
 
       - name: Check profiler correctness for exceptions
         uses: Datadog/prof-correctness/analyze@main

--- a/.gitlab/ci-images.yml
+++ b/.gitlab/ci-images.yml
@@ -86,3 +86,31 @@ Ubuntu Bookworm:
     - cd dockerfiles/ci/bookworm
     - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_TOKEN" $CI_REGISTRY
     - docker buildx bake --no-cache --pull --push $PHP_VERSION
+
+Ubuntu Buster:
+  stage: ci-build
+  rules:
+    - when: manual
+  needs: []
+  tags: ["arch:amd64"]
+  timeout: 1h
+  image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:24.0.4-gbi-focal
+  parallel:
+    matrix:
+      - PHP_VERSION:
+        - base
+        - php-8.3
+        - php-8.2
+        - php-8.1
+        - php-8.0
+        - php-8.0-shared-ext
+        - php-7.4
+        - php-7.4-shared-ext
+        - php-7.3
+        - php-7.2
+        - php-7.1
+        - php-7.0
+  script:
+    - cd dockerfiles/ci/buster
+    - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_TOKEN" $CI_REGISTRY
+    - docker buildx bake --no-cache --pull --push $PHP_VERSION

--- a/dockerfiles/ci/bookworm/build-extensions.sh
+++ b/dockerfiles/ci/bookworm/build-extensions.sh
@@ -122,3 +122,9 @@ else
   done
   echo "zend_extension=opcache.so" >> ${iniDir}/../php-apache2handler.ini;
 fi
+
+# ext-parallel needs PHP 8
+if [[ $PHP_VERSION_ID -ge 80 ]]; then
+  pecl install parallel;
+  echo "extension=parallel" >> ${iniDir}/parallel.ini;
+fi

--- a/dockerfiles/ci/bookworm/build-extensions.sh
+++ b/dockerfiles/ci/bookworm/build-extensions.sh
@@ -4,6 +4,7 @@ set -eux
 # We can't match for "shared" only, as zend_test is built shared. Match something explicitly.
 SHARED_BUILD=$(if php -i | grep -q enable-pcntl=shared; then echo 1; else echo 0; fi)
 PHP_VERSION_ID=$(php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;')
+PHP_ZTS=$(php -r 'echo PHP_ZTS;')
 
 XDEBUG_VERSIONS=(-3.1.2)
 if [[ $PHP_VERSION_ID -le 70 ]]; then
@@ -121,10 +122,10 @@ else
     mv xdebug.so xdebug$VERSION.so;
   done
   echo "zend_extension=opcache.so" >> ${iniDir}/../php-apache2handler.ini;
-fi
 
-# ext-parallel needs PHP 8
-if [[ $PHP_VERSION_ID -ge 80 ]]; then
-  pecl install parallel;
-  echo "extension=parallel" >> ${iniDir}/parallel.ini;
+  # ext-parallel needs PHP 8
+  if [[ $PHP_VERSION_ID -ge 80 && $PHP_ZTS -eq 1 ]]; then
+    pecl install parallel;
+    echo "extension=parallel" >> ${iniDir}/parallel.ini;
+  fi
 fi

--- a/dockerfiles/ci/bookworm/build-extensions.sh
+++ b/dockerfiles/ci/bookworm/build-extensions.sh
@@ -47,6 +47,8 @@ elif [[ $PHP_VERSION_ID -le 71 ]]; then
   SQLSRV_VERSION=-5.6.1
 elif [[ $PHP_VERSION_ID -le 74 ]]; then
   SQLSRV_VERSION=-5.8.0
+elif [[ $PHP_VERSION_ID -le 80 ]]; then
+  SQLSRV_VERSION=-5.11.0
 fi
 
 HOST_ARCH=$(if [[ $(file $(readlink -f $(which php))) == *aarch64* ]]; then echo "aarch64"; else echo "x86_64"; fi)

--- a/dockerfiles/ci/buster/build-extensions.sh
+++ b/dockerfiles/ci/buster/build-extensions.sh
@@ -122,3 +122,9 @@ else
   done
   echo "zend_extension=opcache.so" >> ${iniDir}/../php-apache2handler.ini;
 fi
+
+# ext-parallel needs PHP 8
+if [[ $PHP_VERSION_ID -ge 80 ]]; then
+  pecl install parallel;
+  echo "extension=parallel" >> ${iniDir}/parallel.ini;
+fi

--- a/dockerfiles/ci/buster/build-extensions.sh
+++ b/dockerfiles/ci/buster/build-extensions.sh
@@ -4,6 +4,7 @@ set -eux
 # We can't match for "shared" only, as zend_test is built shared. Match something explicitly.
 SHARED_BUILD=$(if php -i | grep -q enable-pcntl=shared; then echo 1; else echo 0; fi)
 PHP_VERSION_ID=$(php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;')
+PHP_ZTS=$(php -r 'echo PHP_ZTS;')
 
 XDEBUG_VERSIONS=(-3.1.2)
 if [[ $PHP_VERSION_ID -le 70 ]]; then
@@ -121,10 +122,10 @@ else
     mv xdebug.so xdebug$VERSION.so;
   done
   echo "zend_extension=opcache.so" >> ${iniDir}/../php-apache2handler.ini;
-fi
 
-# ext-parallel needs PHP 8
-if [[ $PHP_VERSION_ID -ge 80 ]]; then
-  pecl install parallel;
-  echo "extension=parallel" >> ${iniDir}/parallel.ini;
+  # ext-parallel needs PHP 8
+  if [[ $PHP_VERSION_ID -ge 80 && $PHP_ZTS -eq 1 ]]; then
+    pecl install parallel;
+    echo "extension=parallel" >> ${iniDir}/parallel.ini;
+  fi
 fi

--- a/dockerfiles/ci/buster/build-extensions.sh
+++ b/dockerfiles/ci/buster/build-extensions.sh
@@ -47,6 +47,8 @@ elif [[ $PHP_VERSION_ID -le 71 ]]; then
   SQLSRV_VERSION=-5.6.1
 elif [[ $PHP_VERSION_ID -le 74 ]]; then
   SQLSRV_VERSION=-5.8.0
+elif [[ $PHP_VERSION_ID -le 80 ]]; then
+  SQLSRV_VERSION=-5.11.0
 fi
 
 HOST_ARCH=$(if [[ $(file $(readlink -f $(which php))) == *aarch64* ]]; then echo "aarch64"; else echo "x86_64"; fi)

--- a/dockerfiles/ci/centos/7/php.Dockerfile
+++ b/dockerfiles/ci/centos/7/php.Dockerfile
@@ -35,7 +35,7 @@ RUN bash -c 'set -eux; \
     && cp .libs/libphp*.so ${PHP_INSTALL_DIR_ZTS}/lib/apache2handler-libphp.so \
     && mkdir -p ${PHP_INSTALL_DIR_ZTS}/conf.d' \
     && [ $(expr substr ${PHP_VERSION} 1 1) = 7 ] || ${PHP_INSTALL_DIR_ZTS}/bin/pecl install parallel \
-    && [ $(expr substr ${PHP_VERSION} 1 1) = 7 ] || "extension=parallel" >> ${PHP_INSTALL_DIR_ZTS}/conf.d/parallel.ini
+    && [ $(expr substr ${PHP_VERSION} 1 1) = 7 ] || echo "extension=parallel" >> ${PHP_INSTALL_DIR_ZTS}/conf.d/parallel.ini
 
 FROM base as php-debug
 RUN bash -c 'set -eux; \

--- a/dockerfiles/ci/centos/7/php.Dockerfile
+++ b/dockerfiles/ci/centos/7/php.Dockerfile
@@ -33,7 +33,9 @@ RUN bash -c 'set -eux; \
     && make -j 2 \
     && make install \
     && cp .libs/libphp*.so ${PHP_INSTALL_DIR_ZTS}/lib/apache2handler-libphp.so \
-    && mkdir -p ${PHP_INSTALL_DIR_ZTS}/conf.d'
+    && mkdir -p ${PHP_INSTALL_DIR_ZTS}/conf.d' \
+    && [ $(expr substr ${PHP_VERSION} 1 1) = 7 ] || ${PHP_INSTALL_DIR_ZTS}/bin/pecl install parallel \
+    && [ $(expr substr ${PHP_VERSION} 1 1) = 7 ] || "extension=parallel" >> ${PHP_INSTALL_DIR_ZTS}/conf.d/parallel.ini
 
 FROM base as php-debug
 RUN bash -c 'set -eux; \

--- a/profiling/tests/correctness/exceptions_zts.json
+++ b/profiling/tests/correctness/exceptions_zts.json
@@ -1,0 +1,26 @@
+{
+    "test_name": "php_exception_zts",
+    "stacks": [
+        {
+            "profile-type": "exception-samples",
+            "stack-content": [
+                {
+                    "regular_expression": "<\\?php|{closure}",
+                    "percent": 100,
+                    "error_margin": 99,
+                    "labels": [
+                        {
+                            "key": "exception type",
+                            "values": [
+                                "Exception"
+                            ]
+                        }, {
+                            "key": "exception message",
+                            "values_regex": "Exception from (worker [0-9]|main thread)"
+                        }
+                    ]
+                }
+            ]
+        }
+    ]
+}

--- a/profiling/tests/correctness/exceptions_zts.php
+++ b/profiling/tests/correctness/exceptions_zts.php
@@ -1,0 +1,30 @@
+<?php
+
+for ($i = 0; $i < 10; $i++) {
+    $runtime[$i] = new \parallel\Runtime();
+    $future[$i] = $runtime[$i]->run(
+        function (int $worker) {
+            for ($i = 0; $i < 10; $i++) {
+                try {
+                    throw new Exception("Exception from worker " . $worker);
+                } catch (Exception $e) {
+                    // I do not care ;-)
+                }
+            }
+            return $worker;
+        },
+        [$i]
+    );
+}
+
+for ($i = 0; $i < 10; $i++) {
+    try {
+        throw new Exception("Exception from main thread");
+    } catch (Exception $e) {
+        // I do not care ;-)
+    }
+}
+
+for ($i = 0; $i < 10; $i++) {
+    printf("\nWorker %s exited\n", $future[$i]->value());
+}

--- a/profiling/tests/phpt/exceptions_01.phpt
+++ b/profiling/tests/phpt/exceptions_01.phpt
@@ -40,7 +40,7 @@ echo 'Done.';
 
 ?>
 --EXPECTREGEX--
-.* Exception profiling sampling distance initialized to 20
+.* Exception profiling initialized with sampling distance: 20
 .* Sent stack sample of 2 frames, 1 labels with Exception RuntimeException to profiler.
 .*Done..*
 .*

--- a/profiling/tests/phpt/exceptions_zts_01.phpt
+++ b/profiling/tests/phpt/exceptions_zts_01.phpt
@@ -1,0 +1,57 @@
+--TEST--
+[profiling] test exceptions being sampled
+--DESCRIPTION--
+This test will check that exceptions are being sampled and that a custom
+sampling rate will actually be used.
+--SKIPIF--
+<?php
+if (!extension_loaded('datadog-profiling'))
+    echo "skip: test requires Datadog Continuous Profiler\n";
+if (!extension_loaded('parallel'))
+    echo "skip: test requires `ext-parallel`\n";
+ob_start();
+phpinfo(INFO_MODULES);
+$info = ob_get_clean();
+if (strpos($info, 'Exception Profiling Enabled') === false)
+    echo "skip: datadog profiler is compiled without exception profiling support\n";
+?>
+--ENV--
+DD_PROFILING_ENABLED=yes
+DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED=no
+DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED=no
+DD_PROFILING_EXPERIMENTAL_EXCEPTION_ENABLED=true
+DD_PROFILING_EXPERIMENTAL_EXCEPTION_SAMPLING_DISTANCE=20
+DD_PROFILING_ALLOCATION_ENABLED=no
+DD_PROFILING_LOG_LEVEL=trace
+--FILE--
+<?php
+
+$generateExceptions = function(int $worker) {
+    for ($i = 0; $i <= 100; $i++) {
+        try {
+            throw new \RuntimeException($worker);
+        } catch (\RuntimeException $e) {
+            # I don't care :-P
+        }
+    }
+    return $worker;
+};
+
+for ($i = 0; $i < 10; $i++) {
+    $runtime[$i] = new \parallel\Runtime();
+    $future[$i] = $runtime[$i]->run($generateExceptions, [$i]);
+}
+
+for ($i = 0; $i < 10; $i++) {
+    printf("\nWorker %s exited\n", $future[$i]->value());
+}
+
+echo 'Done.';
+
+?>
+--EXPECTREGEX--
+.* Exception profiling sampling distance initialized to 20
+.* Sent stack sample of 1 frames, 1 labels with Exception RuntimeException to profiler.
+.*Worker [0-9] exited
+.*Done..*
+.*

--- a/profiling/tests/phpt/exceptions_zts_01.phpt
+++ b/profiling/tests/phpt/exceptions_zts_01.phpt
@@ -50,7 +50,7 @@ echo 'Done.';
 
 ?>
 --EXPECTREGEX--
-.* Exception profiling sampling distance initialized to 20
+.* Exception profiling initialized with sampling distance: 20
 .* Sent stack sample of 1 frames, 1 labels with Exception RuntimeException to profiler.
 .*Worker [0-9] exited
 .*Done..*

--- a/profiling/tests/phpt/zts_01.phpt
+++ b/profiling/tests/phpt/zts_01.phpt
@@ -1,0 +1,22 @@
+--TEST--
+[profiling] test that the profiler works in a ZTS build, loads and exists and does not segfault
+--SKIPIF--
+<?php
+if (!extension_loaded('datadog-profiling'))
+    echo "skip: test requires Datadog Continuous Profiler\n";
+if (!PHP_ZTS) {
+    echo "skip: test requires PHP ZTS\n";
+}
+?>
+--INI--
+datadog.profiling.enabled=yes
+datadog.profiling.log_level=debug
+--FILE--
+<?php
+usleep(10000);
+var_dump(PHP_ZTS);
+?>
+--EXPECTREGEX--
+.*Started with an upload period of 67 seconds and approximate wall-time period of 10 milliseconds.
+.*int\(1\)
+.*


### PR DESCRIPTION
### Description

This PR will add some tests for exception profiling in ZTS PHP builds:
- prof correctness test
- PHPT tests
- rebuild Buster and CentOS images to have `ext-parallel`

PROF-8923 / #2070 

### Reviewer checklist
- [x] Test coverage seems ok.
- [x] Appropriate labels assigned.
