### PR TITLE
Update to use `DDOG_CHARSLICE_C` and new `DDOG_CHARSLICE_C_BARE` helpers

### DIFF
--- a/components-rs/common.h
+++ b/components-rs/common.h
@@ -12,7 +12,10 @@
 #include <stdint.h>
 
 #define DDOG_CHARSLICE_C(string) \
-/* NOTE: Compilation fails if you pass in a char* instead of a literal */ {.ptr = "" string, .len = sizeof(string) - 1}
+/* NOTE: Compilation fails if you pass in a char* instead of a literal */ ((ddog_CharSlice){ .ptr = "" string, .len = sizeof(string) - 1 })
+
+#define DDOG_CHARSLICE_C_BARE(string) \
+/* NOTE: Compilation fails if you pass in a char* instead of a literal */ { .ptr = "" string, .len = sizeof(string) - 1 }
 
 #if defined __GNUC__
 #  define DDOG_GNUC_VERSION(major) __GNUC__ >= major

--- a/components-rs/common.h
+++ b/components-rs/common.h
@@ -166,8 +166,59 @@ typedef enum ddog_LogLevel {
   DDOG_LOG_LEVEL_DEBUG,
 } ddog_LogLevel;
 
+typedef enum ddog_MetricNamespace {
+  DDOG_METRIC_NAMESPACE_TRACERS,
+  DDOG_METRIC_NAMESPACE_PROFILERS,
+  DDOG_METRIC_NAMESPACE_RUM,
+  DDOG_METRIC_NAMESPACE_APPSEC,
+  DDOG_METRIC_NAMESPACE_IDE_PLUGINS,
+  DDOG_METRIC_NAMESPACE_LIVE_DEBUGGER,
+  DDOG_METRIC_NAMESPACE_IAST,
+  DDOG_METRIC_NAMESPACE_GENERAL,
+  DDOG_METRIC_NAMESPACE_TELEMETRY,
+  DDOG_METRIC_NAMESPACE_APM,
+  DDOG_METRIC_NAMESPACE_SIDECAR,
+} ddog_MetricNamespace;
+
+typedef enum ddog_MetricType {
+  DDOG_METRIC_TYPE_GAUGE,
+  DDOG_METRIC_TYPE_COUNT,
+  DDOG_METRIC_TYPE_DISTRIBUTION,
+} ddog_MetricType;
+
+typedef enum ddog_TelemetryWorkerBuilderBoolProperty {
+  DDOG_TELEMETRY_WORKER_BUILDER_BOOL_PROPERTY_CONFIG_TELEMETRY_DEBUG_LOGGING_ENABLED,
+} ddog_TelemetryWorkerBuilderBoolProperty;
+
+typedef enum ddog_TelemetryWorkerBuilderEndpointProperty {
+  DDOG_TELEMETRY_WORKER_BUILDER_ENDPOINT_PROPERTY_CONFIG_ENDPOINT,
+} ddog_TelemetryWorkerBuilderEndpointProperty;
+
+typedef enum ddog_TelemetryWorkerBuilderStrProperty {
+  DDOG_TELEMETRY_WORKER_BUILDER_STR_PROPERTY_APPLICATION_SERVICE_VERSION,
+  DDOG_TELEMETRY_WORKER_BUILDER_STR_PROPERTY_APPLICATION_ENV,
+  DDOG_TELEMETRY_WORKER_BUILDER_STR_PROPERTY_APPLICATION_RUNTIME_NAME,
+  DDOG_TELEMETRY_WORKER_BUILDER_STR_PROPERTY_APPLICATION_RUNTIME_VERSION,
+  DDOG_TELEMETRY_WORKER_BUILDER_STR_PROPERTY_APPLICATION_RUNTIME_PATCHES,
+  DDOG_TELEMETRY_WORKER_BUILDER_STR_PROPERTY_HOST_CONTAINER_ID,
+  DDOG_TELEMETRY_WORKER_BUILDER_STR_PROPERTY_HOST_OS,
+  DDOG_TELEMETRY_WORKER_BUILDER_STR_PROPERTY_HOST_KERNEL_NAME,
+  DDOG_TELEMETRY_WORKER_BUILDER_STR_PROPERTY_HOST_KERNEL_RELEASE,
+  DDOG_TELEMETRY_WORKER_BUILDER_STR_PROPERTY_HOST_KERNEL_VERSION,
+  DDOG_TELEMETRY_WORKER_BUILDER_STR_PROPERTY_RUNTIME_ID,
+} ddog_TelemetryWorkerBuilderStrProperty;
+
 typedef struct ddog_TelemetryWorkerBuilder ddog_TelemetryWorkerBuilder;
 
+/**
+ * TelemetryWorkerHandle is a handle which allows interactions with the telemetry worker.
+ * The handle is safe to use across threads.
+ *
+ * The worker won't send data to the agent until you call `TelemetryWorkerHandle::send_start`
+ *
+ * To stop the worker, call `TelemetryWorkerHandle::send_stop` which trigger flush aynchronously
+ * then `TelemetryWorkerHandle::wait_for_shutdown`
+ */
 typedef struct ddog_TelemetryWorkerHandle ddog_TelemetryWorkerHandle;
 
 typedef enum ddog_Option_Bool_Tag {
@@ -183,6 +234,11 @@ typedef struct ddog_Option_Bool {
     };
   };
 } ddog_Option_Bool;
+
+typedef struct ddog_ContextKey {
+  uint32_t _0;
+  enum ddog_MetricType _1;
+} ddog_ContextKey;
 
 typedef struct ddog_AgentRemoteConfigReader ddog_AgentRemoteConfigReader;
 
@@ -214,6 +270,10 @@ typedef struct ddog_TracerHeaderTags {
   bool client_computed_top_level;
   bool client_computed_stats;
 } ddog_TracerHeaderTags;
+
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
 
 /**
  * # Safety
@@ -265,5 +325,9 @@ struct ddog_Vec_Tag_PushResult ddog_Vec_Tag_push(struct ddog_Vec_Tag *vec,
  * .len property.
  */
 DDOG_CHECK_RETURN struct ddog_Vec_Tag_ParseResult ddog_Vec_Tag_parse(ddog_CharSlice string);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
 
 #endif /* DDOG_COMMON_H */

--- a/components-rs/telemetry.h
+++ b/components-rs/telemetry.h
@@ -17,7 +17,7 @@ void ddog_MaybeError_drop(ddog_MaybeError);
  * # Safety
  * * builder should be a non null pointer to a null pointer to a builder
  */
-ddog_MaybeError ddog_builder_instantiate(struct ddog_TelemetryWorkerBuilder **builder,
+ddog_MaybeError ddog_builder_instantiate(struct ddog_TelemetryWorkerBuilder **out_builder,
                                          ddog_CharSlice service_name,
                                          ddog_CharSlice language_name,
                                          ddog_CharSlice language_version,
@@ -27,7 +27,7 @@ ddog_MaybeError ddog_builder_instantiate(struct ddog_TelemetryWorkerBuilder **bu
  * # Safety
  * * builder should be a non null pointer to a null pointer to a builder
  */
-ddog_MaybeError ddog_builder_instantiate_with_hostname(struct ddog_TelemetryWorkerBuilder **builder,
+ddog_MaybeError ddog_builder_instantiate_with_hostname(struct ddog_TelemetryWorkerBuilder **out_builder,
                                                        ddog_CharSlice hostname,
                                                        ddog_CharSlice service_name,
                                                        ddog_CharSlice language_name,
@@ -46,11 +46,181 @@ ddog_MaybeError ddog_builder_with_config(struct ddog_TelemetryWorkerBuilder *bui
                                          enum ddog_ConfigurationOrigin origin);
 
 /**
+ * Builds the telemetry worker and return a handle to it
+ *
  * # Safety
  * * handle should be a non null pointer to a null pointer
  */
 ddog_MaybeError ddog_builder_run(struct ddog_TelemetryWorkerBuilder *builder,
-                                 struct ddog_TelemetryWorkerHandle **handle);
+                                 struct ddog_TelemetryWorkerHandle **out_handle);
+
+/**
+ * Builds the telemetry worker and return a handle to it. The worker will only process and send
+ * telemetry metrics and telemetry logs. Any lifecyle/dependency/configuration event will be
+ * ignored
+ *
+ * # Safety
+ * * handle should be a non null pointer to a null pointer
+ */
+ddog_MaybeError ddog_builder_run_metric_logs(struct ddog_TelemetryWorkerBuilder *builder,
+                                             struct ddog_TelemetryWorkerHandle **out_handle);
+
+ddog_MaybeError ddog_builder_with_str_application_service_version(struct ddog_TelemetryWorkerBuilder *builder,
+                                                                  ddog_CharSlice param);
+
+ddog_MaybeError ddog_builder_with_str_application_env(struct ddog_TelemetryWorkerBuilder *builder,
+                                                      ddog_CharSlice param);
+
+ddog_MaybeError ddog_builder_with_str_application_runtime_name(struct ddog_TelemetryWorkerBuilder *builder,
+                                                               ddog_CharSlice param);
+
+ddog_MaybeError ddog_builder_with_str_application_runtime_version(struct ddog_TelemetryWorkerBuilder *builder,
+                                                                  ddog_CharSlice param);
+
+ddog_MaybeError ddog_builder_with_str_application_runtime_patches(struct ddog_TelemetryWorkerBuilder *builder,
+                                                                  ddog_CharSlice param);
+
+ddog_MaybeError ddog_builder_with_str_host_container_id(struct ddog_TelemetryWorkerBuilder *builder,
+                                                        ddog_CharSlice param);
+
+ddog_MaybeError ddog_builder_with_str_host_os(struct ddog_TelemetryWorkerBuilder *builder,
+                                              ddog_CharSlice param);
+
+ddog_MaybeError ddog_builder_with_str_host_kernel_name(struct ddog_TelemetryWorkerBuilder *builder,
+                                                       ddog_CharSlice param);
+
+ddog_MaybeError ddog_builder_with_str_host_kernel_release(struct ddog_TelemetryWorkerBuilder *builder,
+                                                          ddog_CharSlice param);
+
+ddog_MaybeError ddog_builder_with_str_host_kernel_version(struct ddog_TelemetryWorkerBuilder *builder,
+                                                          ddog_CharSlice param);
+
+ddog_MaybeError ddog_builder_with_str_runtime_id(struct ddog_TelemetryWorkerBuilder *builder,
+                                                 ddog_CharSlice param);
+
+/**
+ *      Sets a property from it's string value.
+ *
+ *     Available properties:
+ *
+ *     * application.service_version
+ *
+ *     * application.env
+ *
+ *     * application.runtime_name
+ *
+ *     * application.runtime_version
+ *
+ *     * application.runtime_patches
+ *
+ *     * host.container_id
+ *
+ *     * host.os
+ *
+ *     * host.kernel_name
+ *
+ *     * host.kernel_release
+ *
+ *     * host.kernel_version
+ *
+ *     * runtime_id
+ *
+ *
+ */
+ddog_MaybeError ddog_builder_with_property_str(struct ddog_TelemetryWorkerBuilder *builder,
+                                               enum ddog_TelemetryWorkerBuilderStrProperty property,
+                                               ddog_CharSlice param);
+
+/**
+ *      Sets a property from it's string value.
+ *
+ *     Available properties:
+ *
+ *     * application.service_version
+ *
+ *     * application.env
+ *
+ *     * application.runtime_name
+ *
+ *     * application.runtime_version
+ *
+ *     * application.runtime_patches
+ *
+ *     * host.container_id
+ *
+ *     * host.os
+ *
+ *     * host.kernel_name
+ *
+ *     * host.kernel_release
+ *
+ *     * host.kernel_version
+ *
+ *     * runtime_id
+ *
+ *
+ */
+ddog_MaybeError ddog_builder_with_str_named_property(struct ddog_TelemetryWorkerBuilder *builder,
+                                                     ddog_CharSlice property,
+                                                     ddog_CharSlice param);
+
+ddog_MaybeError ddog_builder_with_bool_config_telemetry_debug_logging_enabled(struct ddog_TelemetryWorkerBuilder *builder,
+                                                                              bool param);
+
+/**
+ *      Sets a property from it's string value.
+ *
+ *     Available properties:
+ *
+ *     * config.telemetry_debug_logging_enabled
+ *
+ *
+ */
+ddog_MaybeError ddog_builder_with_property_bool(struct ddog_TelemetryWorkerBuilder *builder,
+                                                enum ddog_TelemetryWorkerBuilderBoolProperty property,
+                                                bool param);
+
+/**
+ *      Sets a property from it's string value.
+ *
+ *     Available properties:
+ *
+ *     * config.telemetry_debug_logging_enabled
+ *
+ *
+ */
+ddog_MaybeError ddog_builder_with_bool_named_property(struct ddog_TelemetryWorkerBuilder *builder,
+                                                      ddog_CharSlice property,
+                                                      bool param);
+
+ddog_MaybeError ddog_builder_with_endpoint_config_endpoint(struct ddog_TelemetryWorkerBuilder *builder,
+                                                           const struct ddog_Endpoint *param);
+
+/**
+ *      Sets a property from it's string value.
+ *
+ *     Available properties:
+ *
+ *     * config.endpoint
+ *
+ *
+ */
+ddog_MaybeError ddog_builder_with_property_endpoint(struct ddog_TelemetryWorkerBuilder *builder,
+                                                    enum ddog_TelemetryWorkerBuilderEndpointProperty property,
+                                                    const struct ddog_Endpoint *param);
+
+/**
+ *      Sets a property from it's string value.
+ *
+ *     Available properties:
+ *
+ *     * config.endpoint
+ *
+ *
+ */
+ddog_MaybeError ddog_builder_with_endpoint_named_property(struct ddog_TelemetryWorkerBuilder *builder,
+                                                          ddog_CharSlice property,
+                                                          const struct ddog_Endpoint *param);
 
 ddog_MaybeError ddog_handle_add_dependency(const struct ddog_TelemetryWorkerHandle *handle,
                                            ddog_CharSlice dependency_name,
@@ -63,6 +233,12 @@ ddog_MaybeError ddog_handle_add_integration(const struct ddog_TelemetryWorkerHan
                                             struct ddog_Option_Bool compatible,
                                             struct ddog_Option_Bool auto_enabled);
 
+/**
+ * * indentifier: identifies a logging location uniquely. This can for instance be the template
+ *   using for the log message or the concatenated file + line of the origin of the log
+ * * stack_trace: stack trace associated with the log. If no stack trace is available, an empty
+ *   string should be passed
+ */
 ddog_MaybeError ddog_handle_add_log(const struct ddog_TelemetryWorkerHandle *handle,
                                     ddog_CharSlice indentifier,
                                     ddog_CharSlice message,
@@ -75,8 +251,40 @@ struct ddog_TelemetryWorkerHandle *ddog_handle_clone(const struct ddog_Telemetry
 
 ddog_MaybeError ddog_handle_stop(const struct ddog_TelemetryWorkerHandle *handle);
 
+/**
+ * * compatible: should be false if the metric is language specific, true otherwise
+ */
+struct ddog_ContextKey ddog_handle_register_metric_context(const struct ddog_TelemetryWorkerHandle *handle,
+                                                           ddog_CharSlice name,
+                                                           enum ddog_MetricType metric_type,
+                                                           struct ddog_Vec_Tag tags,
+                                                           bool common,
+                                                           enum ddog_MetricNamespace namespace_);
+
+ddog_MaybeError ddog_handle_add_point(const struct ddog_TelemetryWorkerHandle *handle,
+                                      const struct ddog_ContextKey *context_key,
+                                      double value);
+
+ddog_MaybeError ddog_handle_add_point_with_tags(const struct ddog_TelemetryWorkerHandle *handle,
+                                                const struct ddog_ContextKey *context_key,
+                                                double value,
+                                                struct ddog_Vec_Tag extra_tags);
+
+/**
+ * This function takes ownership of the handle. It should not be used after calling it
+ */
 void ddog_handle_wait_for_shutdown(struct ddog_TelemetryWorkerHandle *handle);
 
+/**
+ * This function takes ownership of the handle. It should not be used after calling it
+ */
+void ddog_handle_wait_for_shutdown_ms(struct ddog_TelemetryWorkerHandle *handle,
+                                      uint64_t wait_for_ms);
+
+/**
+ * Drops the handle without waiting for shutdown. The worker will continue running in the
+ * background until it exits by itself
+ */
 void ddog_handle_drop(struct ddog_TelemetryWorkerHandle *handle);
 
 #endif /* DDOG_TELEMETRY_H */

--- a/ext/auto_flush.c
+++ b/ext/auto_flush.c
@@ -58,10 +58,10 @@ ZEND_RESULT_CODE ddtrace_flush_tracer(bool force_on_startup, bool collect_cycles
                     if (written) {
                         ddog_TracerHeaderTags tags = {
                                 .container_id = ddtrace_get_container_id(),
-                                .lang = DDOG_CHARSLICE_C("php"),
+                                .lang = DDOG_CHARSLICE_C_BARE("php"),
                                 .lang_interpreter = (ddog_CharSlice) {.ptr = sapi_module.name, .len = strlen(sapi_module.name)},
-                                .lang_vendor = DDOG_CHARSLICE_C(""),
-                                .tracer_version = DDOG_CHARSLICE_C(PHP_DDTRACE_VERSION),
+                                .lang_vendor = DDOG_CHARSLICE_C_BARE(""),
+                                .tracer_version = DDOG_CHARSLICE_C_BARE(PHP_DDTRACE_VERSION),
                                 .lang_version = dd_zend_string_to_CharSlice(ddtrace_php_version),
                                 .client_computed_top_level = false,
                                 .client_computed_stats = false,

--- a/ext/logging.c
+++ b/ext/logging.c
@@ -14,9 +14,9 @@ static void dd_log_set_level(bool debug) {
     bool once = runtime_config_first_init ? get_DD_TRACE_ONCE_LOGS() : get_global_DD_TRACE_ONCE_LOGS();
     if (debug) {
         if (strcmp("cli", sapi_module.name) != 0 && (runtime_config_first_init ? get_DD_TRACE_STARTUP_LOGS() : get_global_DD_TRACE_STARTUP_LOGS())) {
-            ddog_set_log_level((ddog_CharSlice)DDOG_CHARSLICE_C("debug"), once);
+            ddog_set_log_level(DDOG_CHARSLICE_C("debug"), once);
         } else {
-            ddog_set_log_level((ddog_CharSlice)DDOG_CHARSLICE_C("debug,startup=error"), once);
+            ddog_set_log_level(DDOG_CHARSLICE_C("debug,startup=error"), once);
         }
     } else if (runtime_config_first_init) {
         ddog_set_log_level(dd_zend_string_to_CharSlice(get_DD_TRACE_LOG_LEVEL()), once);

--- a/ext/sidecar.c
+++ b/ext/sidecar.c
@@ -64,7 +64,7 @@ static bool dd_sidecar_connection_init(void) {
                                     get_global_DD_TRACE_AGENT_FLUSH_INTERVAL(),
                                     get_global_DD_TRACE_AGENT_STACK_INITIAL_SIZE(),
                                     get_global_DD_TRACE_AGENT_STACK_BACKLOG() * get_global_DD_TRACE_AGENT_MAX_PAYLOAD_SIZE(),
-                                    get_global_DD_TRACE_DEBUG() ? (ddog_CharSlice)DDOG_CHARSLICE_C("debug") : dd_zend_string_to_CharSlice(get_global_DD_TRACE_LOG_LEVEL()),
+                                    get_global_DD_TRACE_DEBUG() ? DDOG_CHARSLICE_C("debug") : dd_zend_string_to_CharSlice(get_global_DD_TRACE_LOG_LEVEL()),
                                     (ddog_CharSlice){ .ptr = logpath, .len = strlen(logpath) });
 
     return true;

--- a/ext/telemetry.c
+++ b/ext/telemetry.c
@@ -66,23 +66,23 @@ void ddtrace_telemetry_finalize(void) {
         ddtrace_integration *integration = &ddtrace_integrations[i];
         if (!integration->is_enabled()) {
             ddog_CharSlice integration_name = (ddog_CharSlice) {.len = integration->name_len, .ptr = integration->name_lcase};
-            ddog_sidecar_telemetry_addIntegration_buffer(buffer, integration_name, (ddog_CharSlice)DDOG_CHARSLICE_C(""), false);
+            ddog_sidecar_telemetry_addIntegration_buffer(buffer, integration_name, DDOG_CHARSLICE_C(""), false);
         }
     }
     ddog_sidecar_telemetry_buffer_flush(&ddtrace_sidecar, ddtrace_sidecar_instance_id, &DDTRACE_G(telemetry_queue_id), buffer);
 
-    ddog_CharSlice service_name = DDOG_CHARSLICE_C("unnamed-php-service");
+    ddog_CharSlice service_name = DDOG_CHARSLICE_C_BARE("unnamed-php-service");
     if (DDTRACE_G(last_flushed_root_service_name)) {
         service_name = dd_zend_string_to_CharSlice(DDTRACE_G(last_flushed_root_service_name));
     }
 
-    ddog_CharSlice env_name = DDOG_CHARSLICE_C("none");
+    ddog_CharSlice env_name = DDOG_CHARSLICE_C_BARE("none");
     if (DDTRACE_G(last_flushed_root_env_name)) {
         env_name = dd_zend_string_to_CharSlice(DDTRACE_G(last_flushed_root_env_name));
     }
 
     ddog_CharSlice php_version = dd_zend_string_to_CharSlice(Z_STR_P(zend_get_constant_str(ZEND_STRL("PHP_VERSION"))));
-    struct ddog_RuntimeMeta *meta = ddog_sidecar_runtimeMeta_build((ddog_CharSlice)DDOG_CHARSLICE_C("php"), php_version, (ddog_CharSlice)DDOG_CHARSLICE_C(PHP_DDTRACE_VERSION));
+    struct ddog_RuntimeMeta *meta = ddog_sidecar_runtimeMeta_build(DDOG_CHARSLICE_C("php"), php_version, DDOG_CHARSLICE_C(PHP_DDTRACE_VERSION));
 
     ddog_sidecar_telemetry_flushServiceData(&ddtrace_sidecar, ddtrace_sidecar_instance_id, &DDTRACE_G(telemetry_queue_id), meta, service_name, env_name);
 
@@ -95,6 +95,6 @@ void ddtrace_telemetry_notify_integration(const char *name, size_t name_len) {
     if (ddtrace_sidecar && get_global_DD_INSTRUMENTATION_TELEMETRY_ENABLED()) {
         ddog_CharSlice integration = (ddog_CharSlice) {.len = name_len, .ptr = name};
         ddog_sidecar_telemetry_addIntegration(&ddtrace_sidecar, ddtrace_sidecar_instance_id, &DDTRACE_G(telemetry_queue_id), integration,
-                                              (ddog_CharSlice)DDOG_CHARSLICE_C(""), true);
+                                              DDOG_CHARSLICE_C(""), true);
     }
 }


### PR DESCRIPTION
### Description

**What does this PR do?**

This PR updated dd-trace-php to use the helpers that were changed/ introduced in https://github.com/DataDog/libdatadog/pull/347 .

TL;DR: `DDOG_CHARSLICE_C` includes the cast to `(ddog_CharSlice)` to all uses of `(ddog_CharSlice) DDOG_CHARSLICE_C` in the codebase were converted to not have the cast; and `DDOG_CHARSLICE_C_BARE` does not have the cast, so all uses of `DDOG_CHARSLICE_C` without the cast in the codebase were converted to this one.

**Motivation:**

Update to match the latest libdatadog changes.

**Additional Notes:**

This is my first dd-trace-php contribution I think?

**How to test the change?**

I'm guessing CI should be able to validate this (?), not very familiar with our testing setup.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
