### PR TITLE
Enable appsec by ini only when enable-appsec present

### DIFF
--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -688,8 +688,10 @@ function install($options)
                     '(datadog.appsec.helper_path\s*=.*)' => "datadog.appsec.helper_path = $appSecHelperPath",
                     // Update and comment rules path
                     '(^[\s;]*datadog.appsec.rules\s*=\s*' . $rulesPathRegex . ')m' => "; datadog.appsec.rules = " . $appSecRulesPath,
-                    '(^[\s;]*datadog.appsec.enabled\s*=.*)m' => 'datadog.appsec.enabled = ' . (is_truthy($options[OPT_ENABLE_APPSEC]) ? 'On' : 'Off'),
                 ];
+                if (is_truthy($options[OPT_ENABLE_APPSEC])) {
+                    $replacements += ['(^[\s;]*datadog.appsec.enabled\s*=.*)m' => 'datadog.appsec.enabled = On'];
+                }
             } else {
                 // Ensure AppSec isn't loaded if not compatible
                 $replacements['(^[\s;]*extension\s*=\s*.*ddappsec.*)m'] = "; extension = ddappsec" . (IS_WINDOWS ? "" : "." . EXTENSION_SUFFIX);


### PR DESCRIPTION
### Description

Amend bug which was setting `datadog.appsec.enabled` either `On` or `Off` on the `.ini` file.

When `enable-appsec` flag is not present , `datadog.appsec.enabled` should be commented out on the `.ini` file. This way, remote config will be able to enable appsec.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
