### PR TITLE
style(profiling): add eg! and sg! macros

### DIFF
--- a/profiling/build.rs
+++ b/profiling/build.rs
@@ -230,8 +230,6 @@ fn generate_bindings(php_config_includes: &str, fibers: bool) {
         .blocklist_item("zend_result")
         .blocklist_item("zend_register_extension")
         .blocklist_item("_zend_string")
-        // Block a few of functions that we'll provide defs for manually
-        .blocklist_item("datadog_php_profiling_vm_interrupt_addr")
         // I had to block these for some reason *shrug*
         .blocklist_item("FP_INFINITE")
         .blocklist_item("FP_INT_DOWNWARD")

--- a/profiling/src/bindings/mod.rs
+++ b/profiling/src/bindings/mod.rs
@@ -1,6 +1,8 @@
 mod ffi;
+mod tsrm;
 
 pub use ffi::*;
+pub use tsrm::*;
 
 use libc::{c_char, c_int, c_uchar, c_uint, c_ushort, c_void, size_t};
 use std::borrow::Cow;

--- a/profiling/src/bindings/tsrm.rs
+++ b/profiling/src/bindings/tsrm.rs
@@ -1,0 +1,84 @@
+#[cfg(php_zts)]
+mod raw {
+
+    #[macro_export]
+    macro_rules! tsrmg_fast_bulk {
+        ($offset:expr, $typ:ty) => {
+            ($crate::bindings::tsrm_get_ls_cache() as *mut ())
+                .add($offset)
+                .cast::<$typ>()
+        };
+    }
+
+    #[macro_export]
+    macro_rules! tsrmg_fast {
+        ($id:expr, $typ:ty, $element:ident) => {{
+            use core::ptr::addr_of_mut;
+            #[allow(unused_unsafe)]
+            let tmp = unsafe { addr_of_mut!((*$crate::tsrmg_fast_bulk!($id, $typ)).$element) };
+            tmp
+        }};
+    }
+
+    #[macro_export]
+    macro_rules! eg {
+        ($x:ident) => {
+            $crate::tsrmg_fast!(
+                crate::bindings::executor_globals_offset,
+                crate::bindings::zend_executor_globals,
+                $x
+            )
+        };
+    }
+
+    #[macro_export]
+    macro_rules! sg {
+        ($x:ident) => {
+            $crate::tsrmg_fast!(
+                crate::bindings::sapi_globals_offset,
+                crate::bindings::sapi_globals_struct,
+                $x
+            )
+        };
+    }
+
+    pub use eg;
+    pub use sg;
+    pub use tsrmg_fast;
+    pub use tsrmg_fast_bulk;
+}
+
+#[cfg(not(php_zts))]
+mod raw {
+
+    #[macro_export]
+    macro_rules! tsrmg_fast {
+        ($global:expr, $x:ident) => {{
+            use core::ptr::addr_of_mut;
+            let ptr = addr_of_mut!($global);
+            #[allow(unused_unsafe)]
+            let tmp = unsafe { addr_of_mut!((*ptr).$x) };
+            tmp
+        }};
+    }
+
+    #[macro_export]
+    macro_rules! eg {
+        ($x:ident) => {
+            $crate::tsrmg_fast!(crate::bindings::executor_globals, $x)
+        };
+    }
+
+    #[macro_export]
+    macro_rules! sg {
+        ($x:ident) => {
+            $crate::tsrmg_fast!(crate::bindings::sapi_globals, $x)
+        };
+    }
+
+    pub use eg;
+    pub use sg;
+    pub use tsrmg_fast;
+}
+
+pub use raw::*;

--- a/profiling/src/exception.rs
+++ b/profiling/src/exception.rs
@@ -80,11 +80,8 @@ impl ExceptionProfilingStats {
         if let Some(profiler) = PROFILER.lock().unwrap().as_ref() {
             // Safety: execute_data was provided by the engine, and the profiler doesn't mutate it.
             unsafe {
-                profiler.collect_exception(
-                    zend::ddog_php_prof_get_current_execute_data(),
-                    exception_name,
-                    message,
-                )
+                let execute_data = *zend::eg!(current_execute_data);
+                profiler.collect_exception(execute_data, exception_name, message)
             };
         }
     }

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -420,7 +420,7 @@ extern "C" fn rinit(_type: c_int, _module_number: c_int) -> ZendResult {
                 match *SAPI {
                     Sapi::Cli => {
                         // Safety: sapi globals are safe to access during rinit
-                        SAPI.request_script_name(*bindings::sg!(request_info))
+                        SAPI.request_script_name(&*bindings::sg!(request_info))
                             .or(Some(Cow::Borrowed("cli.command")))
                     }
                     _ => Some(Cow::Borrowed("web.request")),

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -42,8 +42,6 @@ use std::sync::{Arc, Mutex, Once};
 use std::time::{Duration, Instant};
 use uuid::Uuid;
 
-use crate::zend::datadog_sapi_globals_request_info;
-
 /// The global profiler. Profiler gets made during the first rinit after an
 /// minit, and is destroyed on mshutdown.
 static PROFILER: Mutex<Option<Profiler>> = Mutex::new(None);
@@ -422,7 +420,7 @@ extern "C" fn rinit(_type: c_int, _module_number: c_int) -> ZendResult {
                 match *SAPI {
                     Sapi::Cli => {
                         // Safety: sapi globals are safe to access during rinit
-                        SAPI.request_script_name(datadog_sapi_globals_request_info())
+                        SAPI.request_script_name(*bindings::sg!(request_info))
                             .or(Some(Cow::Borrowed("cli.command")))
                     }
                     _ => Some(Cow::Borrowed("web.request")),

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -71,10 +71,6 @@ static unsigned int php_version_id(void) {
 }
 #endif
 
-sapi_request_info datadog_sapi_globals_request_info() {
-    return SG(request_info);
-}
-
 /**
  * Returns the PHP_VERSION_ID of the engine at run-time, not the version the
  * extension was built against at compile-time.
@@ -221,6 +217,7 @@ void datadog_php_profiling_startup(zend_extension *extension) {
 #endif
 }
 
+/* Has a manual definition in Rust to cast return to *const AtomicBool */
 void *datadog_php_profiling_vm_interrupt_addr(void) { return &EG(vm_interrupt); }
 
 zend_module_entry *datadog_get_module_entry(const char *str, uintptr_t len) {
@@ -272,10 +269,6 @@ void ddog_php_prof_zend_mm_set_custom_handlers(zend_mm_heap *heap,
         memset(heap, ZEND_MM_CUSTOM_HEAP_NONE, sizeof(int));
     }
 #endif
-}
-
-zend_execute_data* ddog_php_prof_get_current_execute_data() {
-    return EG(current_execute_data);
 }
 
 #if CFG_FIBERS // defined by build.rs

--- a/profiling/src/php_ffi.h
+++ b/profiling/src/php_ffi.h
@@ -45,21 +45,11 @@ const char *datadog_extension_build_id(void);
 const char *datadog_module_build_id(void);
 
 /**
- * Returns the `sapi_request_info` from the SAPI_GLOBALS
- */
-sapi_request_info datadog_sapi_globals_request_info();
-
-/**
  * Lookup module by name in the module registry. Returns NULL if not found.
  * This is meant to be called from Rust, so it uses uintptr_t, not size_t, for
  * the length for convenience.
  */
 zend_module_entry *datadog_get_module_entry(const char *str, uintptr_t len);
-
-/**
- * Fetches the VM interrupt address of the calling PHP thread.
- */
-void *datadog_php_profiling_vm_interrupt_addr(void);
 
 /**
  * For Code Hotspots, we need the tracer's local root span id and the current
@@ -133,8 +123,6 @@ void ddog_php_prof_zend_mm_set_custom_handlers(zend_mm_heap *heap,
                                                void* (*_malloc)(size_t),
                                                void  (*_free)(void*),
                                                void* (*_realloc)(void*, size_t));
-
-zend_execute_data* ddog_php_prof_get_current_execute_data();
 
 #if CFG_FIBERS
 zend_fiber* ddog_php_prof_get_active_fiber();

--- a/profiling/src/sapi.rs
+++ b/profiling/src/sapi.rs
@@ -51,7 +51,7 @@ impl Sapi {
 
     pub fn request_script_name<'a>(
         &self,
-        sapi_request_info: sapi_request_info,
+        sapi_request_info: &sapi_request_info,
     ) -> Option<Cow<'a, str>> {
         match self {
             /* Right now all we need is CLI support, but theoretically it can

--- a/profiling/src/timeline.rs
+++ b/profiling/src/timeline.rs
@@ -444,7 +444,7 @@ unsafe extern "C" fn ddog_php_prof_compile_file(
 /// of a userland call  to `gc_collect_cycles()`, otherwise the engine decided
 /// to run it.
 unsafe fn gc_reason() -> &'static str {
-    let execute_data = zend::ddog_php_prof_get_current_execute_data();
+    let execute_data = *zend::eg!(current_execute_data);
     let fname = || execute_data.as_ref()?.func.as_ref()?.name();
     match fname() {
         Some(name) if name == b"gc_collect_cycles" => "induced",


### PR DESCRIPTION
### Description

Adds the `eg!` and `sg!` macros that mirror `EG` and `SG` in PHP internals. Works for both NTS and ZTS.

I'm not sure yet if this is better. Opening the PR to see if it works across versions (worked for PHP 8.3 locally).

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
