### PR TITLE
fix(profiling): fully disable on fork

### DIFF
--- a/profiling/src/config.rs
+++ b/profiling/src/config.rs
@@ -135,7 +135,7 @@ impl SystemSettings {
 
     unsafe fn on_fork_in_child() {
         let system_settings = SYSTEM_SETTINGS.assume_init_mut();
-        system_settings.profiling_enabled;
+        system_settings.profiling_enabled = false;
         system_settings.profiling_experimental_features_enabled = false;
         system_settings.profiling_endpoint_collection_enabled = false;
         system_settings.profiling_experimental_cpu_time_enabled = false;


### PR DESCRIPTION
### Description

I wasn't able to find any bad effects when testing this. It's been this way for about 2 months when #2487 was merged.. I think we got lucky because the only not disabled profile type is time, and the time thread will not automatically spawn in the fork.

### Reviewer checklist
- [x] Test coverage seems ok.
- [x] Appropriate labels assigned.
