### PR TITLE
ci(profiling): add exceptions benchmark

### DIFF
--- a/benchmark/runall.sh
+++ b/benchmark/runall.sh
@@ -10,6 +10,8 @@ if [ "$SCENARIO" = "profiler" ]; then
 
   sirun benches/timeline.json > "$ARTIFACTS_DIR/sirun_timeline.ndjson"
 
+  sirun benches/exceptions.json > "$ARTIFACTS_DIR/sirun_exceptions.ndjson"
+
   sed -i -e "s/crate-type.*$/crate-type = [\"rlib\"]/g" Cargo.toml
 
   cargo bench --features stack_walking_tests -- --noplot

--- a/profiling/benches/exceptions.json
+++ b/profiling/benches/exceptions.json
@@ -1,0 +1,28 @@
+{
+    "name": "php-profiler-exceptions",
+    "run": "php -d extension=../target/release/libdatadog_php_profiling.so benches/exceptions.php",
+    "timeout": 20,
+    "iterations": 5,
+    "env": {
+        "DD_PROFILING_LOG_LEVEL": "off"
+    },
+    "variants": {
+        "control": {
+            "env": {
+                "DD_PROFILING_ENABLED": "false"
+            }
+        },
+        "with-profiler": {
+            "env": {
+                "DD_PROFILING_ENABLED": "true",
+                "DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED": "false"
+            }
+        },
+        "with-profiler-and-timeline": {
+            "env": {
+                "DD_PROFILING_ENABLED": "true",
+                "DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED": "true"
+            }
+        }
+    }
+}

--- a/profiling/benches/exceptions.php
+++ b/profiling/benches/exceptions.php
@@ -1,0 +1,11 @@
+<?php
+// the only purpose this script has is to trigger as much cheap timeline samples
+// as possible
+
+for ($i = 0; $i < 100_000; $i++) {
+    try {
+        throw new \Exception('FooBar');
+    } catch (\Exception $e) {
+        // we do not care ;-P
+    }
+}


### PR DESCRIPTION
### Description

This PR will add benchmarks for exceptions, this is also done in preparation for adding exception events to the timeline, so we already gather benchmark data.

Merge together with https://github.com/DataDog/benchmarking-platform/pull/46

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
