### PR TITLE
Fix fibers with tracer disabled

### DIFF
--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -1042,9 +1042,6 @@ static PHP_MINIT_FUNCTION(ddtrace) {
 #if ZAI_JIT_BLACKLIST_ACTIVE
     zai_jit_minit();
 #endif
-#if PHP_VERSION_ID >= 80100
-    ddtrace_setup_fiber_observers();
-#endif
 
 #if PHP_VERSION_ID < 70300 || (defined(_WIN32) && PHP_VERSION_ID >= 80300 && PHP_VERSION_ID < 80400)
     ddtrace_startup_hrtime();
@@ -1095,6 +1092,10 @@ static PHP_MINIT_FUNCTION(ddtrace) {
     if (ddtrace_disable) {
         return SUCCESS;
     }
+
+#if PHP_VERSION_ID >= 80100
+    ddtrace_setup_fiber_observers();
+#endif
 
 #ifndef _WIN32
     ddtrace_set_coredumpfilter();

--- a/tests/ext/fibers/fiber_switch_tracer_disabled.phpt
+++ b/tests/ext/fibers/fiber_switch_tracer_disabled.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Test executing fibers with tracer fully disabled
+--INI--
+ddtrace.disable=1
+--FILE--
+<?php
+
+function fiber() {
+    Fiber::suspend(1);
+    return 2;
+}
+
+$fiber = new Fiber(fiber(...));
+var_dump($fiber->start());
+$fiber->resume();
+var_dump($fiber->getReturn());
+
+?>
+--EXPECT--
+int(1)
+int(2)


### PR DESCRIPTION
### Description

Fibers were crashing when using ddtrace.disable=1.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
