### PR TITLE
test(profiling): setting for wall-time enabled/disabled

### DIFF
--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -1086,6 +1086,7 @@ mod tests {
             profiling_timeline_enabled: false,
             profiling_exception_enabled: false,
             profiling_exception_message_enabled: false,
+            profiling_wall_time_enabled: true,
             output_pprof: None,
             profiling_exception_sampling_distance: 100,
             profiling_log_level: LevelFilter::Off,


### PR DESCRIPTION
### Description

Adds a setting for disabling the automatic collection of wall-time samples. This only disables the automatic collection, not the entire profile type.

This allows us to remove a source of non-determinism for tests. This is NOT meant for users. Note that if you set this to false, you probably want to disable CPU time.

### Reviewer checklist
- [x] Test coverage seems ok.
- [x] Appropriate labels assigned.
