### PR TITLE
Make CI version naming consistent with telemetry

### DIFF
--- a/tests/Common/IntegrationTestCase.php
+++ b/tests/Common/IntegrationTestCase.php
@@ -23,12 +23,12 @@ abstract class IntegrationTestCase extends BaseTestCase
         $exts = get_loaded_extensions(false);
         $csv = '';
         foreach ($exts as $ext) {
-            $csv = $csv . "ext/" . $ext . ";" . phpversion($ext) . "\n";
+            $csv = $csv . "ext-" . $ext . ";" . phpversion($ext) . "\n";
         }
 
         $zendExts = get_loaded_extensions(true);
         foreach ($zendExts as $ext) {
-            $csv = $csv . "ext/" . $ext . ";" . phpversion($ext) . "\n";
+            $csv = $csv . "ext-" . $ext . ";" . phpversion($ext) . "\n";
         }
 
         $artifactsDir = "/tmp/artifacts";


### PR DESCRIPTION
### Description

Update CI reporting naming for extensions, to make it consistent with the naming reported by telemetry https://github.com/DataDog/dd-trace-php/blob/4c0dcf6ae38d439434b721dbd11ba8884113e982/ext/telemetry.c#L36

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
