### PR TITLE
fix: Update update_span_duration return type

### DIFF
--- a/ext/ddtrace.stub.php
+++ b/ext/ddtrace.stub.php
@@ -413,8 +413,9 @@ namespace DDTrace {
      *
      * @param SpanData $span The span to update.
      * @param float $finishTime Finish time in seconds. Defaults to now if zero.
+     * @return false|null 'false' if unexpected parameters were given, else 'null'
      */
-    function update_span_duration(SpanData $span, float $finishTime = 0): null {}
+    function update_span_duration(SpanData $span, float $finishTime = 0): false|null {}
 
     /**
      * Start a new trace

--- a/ext/ddtrace_arginfo.h
+++ b/ext/ddtrace_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 899dcc72fc2a852d8f1e8aad895c4b628cd17eb8 */
+ * Stub hash: 7fec613751ec101cba339b6dfa3a72fbaf38074f */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_trace_method, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, className, IS_STRING, 0)
@@ -56,7 +56,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_close_span, 0, 0, IS_FAL
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, finishTime, IS_DOUBLE, 0, "0")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_update_span_duration, 0, 1, IS_NULL, 1)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_update_span_duration, 0, 1, IS_FALSE, 1)
 	ZEND_ARG_OBJ_INFO(0, span, DDTrace\\SpanData, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, finishTime, IS_DOUBLE, 0, "0")
 ZEND_END_ARG_INFO()


### PR DESCRIPTION
### Description

Fixes #2585

Changes update_span_duration return type from null to false|null

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
