### PR TITLE
Version reporting improvements

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -977,7 +977,7 @@ define run_composer_with_retry
 	done \
 
 	mkdir -p /tmp/artifacts
-	$(COMPOSER) --working-dir=$1 show -f json | grep -o '"name": "[^"]*\|"version": "[^"]*' | paste -d';' - - | sed 's/"name": //; s/"version": //' | tr -d '"' >> "/tmp/artifacts/web_versions.csv"
+	$(COMPOSER) --working-dir=$1 show -f json -D | grep -o '"name": "[^"]*\|"version": "[^"]*' | paste -d';' - - | sed 's/"name": //; s/"version": //' | tr -d '"' >> "/tmp/artifacts/web_versions.csv"
 endef
 
 define run_tests_without_coverage

--- a/Makefile
+++ b/Makefile
@@ -977,7 +977,7 @@ define run_composer_with_retry
 	done \
 
 	mkdir -p /tmp/artifacts
-	$(COMPOSER) --working-dir=$1 show -f json -D | grep -o '"name": "[^"]*\|"version": "[^"]*' | paste -d';' - - | sed 's/"name": //; s/"version": //' | tr -d '"' >> "/tmp/artifacts/web_versions.csv"
+	$(COMPOSER) --working-dir=$1 show -f json | grep -o '"name": "[^"]*\|"version": "[^"]*' | paste -d';' - - | sed 's/"name": //; s/"version": //' | tr -d '"' >> "/tmp/artifacts/web_versions.csv"
 endef
 
 define run_tests_without_coverage

--- a/tests/Common/IntegrationTestCase.php
+++ b/tests/Common/IntegrationTestCase.php
@@ -39,7 +39,7 @@ abstract class IntegrationTestCase extends BaseTestCase
         file_put_contents($artifactsDir . "/extension_versions.csv", $csv, FILE_APPEND);
 
         $csv = '';
-        $output = shell_exec('DD_TRACE_ENABLED=0 composer show -f json -D');
+        $output = shell_exec('DD_TRACE_ENABLED=0 composer --working-dir=./tests show -f json');
         $data = json_decode($output, true);
 
         foreach ($data['installed'] as $package) {

--- a/tests/Common/IntegrationTestCase.php
+++ b/tests/Common/IntegrationTestCase.php
@@ -39,7 +39,7 @@ abstract class IntegrationTestCase extends BaseTestCase
         file_put_contents($artifactsDir . "/extension_versions.csv", $csv, FILE_APPEND);
 
         $csv = '';
-        $output = shell_exec('DD_TRACE_ENABLED=0 composer --working-dir=./tests show -f json');
+        $output = shell_exec('DD_TRACE_ENABLED=0 composer --working-dir=./tests show -f json -D');
         $data = json_decode($output, true);
 
         foreach ($data['installed'] as $package) {

--- a/tests/Common/IntegrationTestCase.php
+++ b/tests/Common/IntegrationTestCase.php
@@ -39,7 +39,7 @@ abstract class IntegrationTestCase extends BaseTestCase
         file_put_contents($artifactsDir . "/extension_versions.csv", $csv, FILE_APPEND);
 
         $csv = '';
-        $output = shell_exec('DD_TRACE_ENABLED=0 composer --working-dir=./tests show -f json -D');
+        $output = shell_exec('DD_TRACE_ENABLED=0 composer --working-dir=./tests show -f json');
         $data = json_decode($output, true);
 
         foreach ($data['installed'] as $package) {

--- a/tests/Common/IntegrationTestCase.php
+++ b/tests/Common/IntegrationTestCase.php
@@ -36,7 +36,7 @@ abstract class IntegrationTestCase extends BaseTestCase
             mkdir($artifactsDir, 0777, true);
         }
 
-        file_put_contents($artifactsDir . "/extension_versions.csv", $csv);
+        file_put_contents($artifactsDir . "/extension_versions.csv", $csv, FILE_APPEND);
 
         $csv = '';
         $output = shell_exec('DD_TRACE_ENABLED=0 composer show -f json -D');
@@ -46,7 +46,7 @@ abstract class IntegrationTestCase extends BaseTestCase
             $csv = $csv . $package['name'] . ";" . $package['version'] . "\n";
         }
 
-        file_put_contents($artifactsDir . "/composer_versions.csv", $csv);
+        file_put_contents($artifactsDir . "/composer_versions.csv", $csv, FILE_APPEND);
     }
 
     public static function ddTearDownAfterClass()


### PR DESCRIPTION
### Description

Make changes in how supported versions are reported from CI
* Include all composer installed packages instead of only direct dependencies (Composer scenario dependencies are not considered direct dependencies)
* Append to files instead of overriding. The versions are written from within ddSetUpBeforeClass, so there were cases where they might have been overriden and information lost.
* Run composer show in the actual tests dir that it is used from.

<!---
Any description you feel is relevant and gives more background to this PR, if necessary.
-->

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
