### PR TITLE
Allow hooking an inherited internal constructor

### DIFF
--- a/tests/ext/sandbox/install_hook/hook_internal_inherited_constructor.phpt
+++ b/tests/ext/sandbox/install_hook/hook_internal_inherited_constructor.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Test hooking inherited internal constructors via install_hook()
+--FILE--
+<?php
+
+\DDTrace\install_hook("X::__construct", function() { echo "hook 1\n"; });
+
+if (true) {
+    class X extends ArrayObject {}
+}
+
+\DDTrace\install_hook("X::__construct", function() { echo "hook 2\n"; });
+
+$a = (new X);
+$a->__construct();
+new ArrayObject; // must not trigger the hook
+
+?>
+--EXPECT--
+hook 1
+hook 2
+hook 1
+hook 2


### PR DESCRIPTION
### Description

Internal constructors are edge cases and need to be handled explicitly.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
