### PR TITLE
Distinguish architectures on windows

### DIFF
--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -1106,7 +1106,16 @@ function is_alpine()
 function get_architecture()
 {
     if (IS_WINDOWS) {
-        return "x86_64";
+        if (PHP_INT_SIZE === 4) {
+            // we don't support that one, but we include it so that the installer can properly fail
+            return "x86";
+        } else {
+            if ($env = getenv("PROCESSOR_ARCHITECTURE")) {
+                return $env === "AMD64" ? "x86_64" : strtolower($env);
+            }
+            // fallback
+            return "x86_64";
+        }
     }
 
     return execute_or_exit(


### PR DESCRIPTION
### Description

Ensure the installer emits a proper error when trying to be installed on 32 bit architectures.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
