### PR TITLE
Fix PHPRedisIntegration::init method signature (ddtrace-1.0.0)

### DIFF
--- a/src/DDTrace/Integrations/PHPRedis/PHPRedisIntegration.php
+++ b/src/DDTrace/Integrations/PHPRedis/PHPRedisIntegration.php
@@ -43,7 +43,7 @@ class PHPRedisIntegration extends Integration
         return self::NAME;
     }
 
-    public function init()
+    public function init(): int
     {
         $traceConnectOpen = function (SpanData $span, $args) {
             Common::handleOrphan($span);


### PR DESCRIPTION
### Description

Broken by https://github.com/DataDog/dd-trace-php/commit/700085c2407d64c2bbe1322012ed9512adfd50a6#diff-2222cf9adbccf7c0c2da75d4b0544f0a03b32c5ee63b7daeb69616f68257a2edR46

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
