### PR TITLE
Fix asan leak on fork in PHP 8.2 buster container

### DIFF
--- a/dockerfiles/ci/buster/0001-Delete-timers-on-fork.patch
+++ b/dockerfiles/ci/buster/0001-Delete-timers-on-fork.patch
@@ -1,0 +1,31 @@
+From 97c104a11dec32eb2d6eacc570d08a2d3174eac7 Mon Sep 17 00:00:00 2001
+From: Bob Weinand <bobwei9@hotmail.com>
+Date: Thu, 28 Mar 2024 19:55:12 +0100
+Subject: [PATCH] Delete timers on fork
+
+Works around https://github.com/php/php-src/issues/12298 and the related memory leaks.
+This is necessary with the relatively old version of glibc we are building against.
+
+Signed-off-by: Bob Weinand <bobwei9@hotmail.com>
+---
+ Zend/zend_max_execution_timer.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/Zend/zend_max_execution_timer.c b/Zend/zend_max_execution_timer.c
+index 48a4d1bd66..26dacd83ad 100644
+--- a/Zend/zend_max_execution_timer.c
++++ b/Zend/zend_max_execution_timer.c
+@@ -41,6 +41,10 @@ ZEND_API void zend_max_execution_timer_init(void) /* {{{ */
+ 		return;
+ 	}
+ 
++	if (EG(pid)) {
++		free(EG(max_execution_timer_timer));
++	}
++
+ 	struct sigevent sev;
+ 	sev.sigev_notify = SIGEV_THREAD_ID;
+ 	sev.sigev_value.sival_ptr = &EG(max_execution_timer_timer);
+-- 
+2.41.0
+

--- a/dockerfiles/ci/buster/docker-compose.yml
+++ b/dockerfiles/ci/buster/docker-compose.yml
@@ -30,8 +30,8 @@ services:
       x-bake: *bake
       args:
         phpVersion: "8.2"
-        phpTarGzUrl: https://www.php.net/distributions/php-8.2.13.tar.gz
-        phpSha256Hash: "6a194038f5a9e46d8f70a9d59c072c3b08d6edbdd8e304096e24ccf2225bcf1b"
+        phpTarGzUrl: https://www.php.net/distributions/php-8.2.17.tar.gz
+        phpSha256Hash: "1d8ab98e1c09518c672c5afcbef0e61f9003173c7638fc686461ae670d12742e"
 
   php-8.1:
     image: datadog/dd-trace-ci:php-8.1_buster

--- a/dockerfiles/ci/buster/php-8.2/Dockerfile
+++ b/dockerfiles/ci/buster/php-8.2/Dockerfile
@@ -6,13 +6,15 @@ ENV PHP_VERSION=${phpVersion}
 FROM --platform=$BUILDPLATFORM datadog/dd-trace-ci:buster as src
 ARG phpTarGzUrl
 ARG phpSha256Hash
+COPY 0001-Delete-timers-on-fork.patch /home/circleci
 RUN set -eux; \
     curl -fsSL -o /tmp/php.tar.gz "${phpTarGzUrl}"; \
     (echo "${phpSha256Hash} /tmp/php.tar.gz" | sha256sum -c -); \
     tar xf /tmp/php.tar.gz -C "${PHP_SRC_DIR}" --strip-components=1; \
     rm -f /tmp/php.tar.gz; \
     cd ${PHP_SRC_DIR}; \
-    ./buildconf --force;
+    ./buildconf --force; \
+    patch Zend/zend_max_execution_timer.c /home/circleci/0001-Delete-timers-on-fork.patch;
 
 FROM --platform=$BUILDPLATFORM datadog/dd-trace-ci:buster AS build
 ARG phpVersion

--- a/dockerfiles/ci/xfail_tests/8.2.list
+++ b/dockerfiles/ci/xfail_tests/8.2.list
@@ -43,6 +43,7 @@ ext/curl/tests/curl_int_cast.phpt
 ext/curl/tests/curl_postfields_array.phpt
 ext/curl/tests/curl_setopt_CURLOPT_ACCEPT_ENCODING.phpt
 ext/date/tests/bug52113.phpt
+ext/ffi/tests/gh12905.phpt
 ext/fileinfo/tests/finfo_open_error.phpt
 ext/mbstring/tests/zend_multibyte-01.phpt
 ext/mbstring/tests/zend_multibyte-02.phpt


### PR DESCRIPTION
### Description

Works around https://github.com/php/php-src/issues/12298 and the related memory leaks. This is necessary with the relatively old version of glibc we are building against.

The patch with free() is also specific to the glibc the buster container uses.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
