### PR TITLE
Fix compilation on macOS

### DIFF
--- a/compile_rust.sh
+++ b/compile_rust.sh
@@ -9,4 +9,10 @@ if test -n "$SHARED"; then
   RUSTFLAGS="$RUSTFLAGS --cfg php_shared_build"
 fi
 
+case "${host_os}" in
+  darwin*)
+    RUSTFLAGS="$RUSTFLAGS -Clink-arg=-undefined -Clink-arg=dynamic_lookup";
+    ;;
+esac
+
 RUSTFLAGS="$RUSTFLAGS" RUSTC_BOOTSTRAP=1 "${DDTRACE_CARGO:-cargo}" build $(test "${PROFILE:-debug}" = "debug" || echo --profile "$PROFILE") "$@"


### PR DESCRIPTION
### Description

Fix compilation of the rust crate on macOS when using the `php_shared_build` config option.

Error was:
```
  = note: Undefined symbols for architecture arm64:
            "_DDTRACE_MOCK_PHP", referenced from:
                _ddog_sidecar_connect_php in ddtrace_php.ddtrace_php.5b56db22beb5c715-cgu.0.rcgu.o
            "_DDTRACE_MOCK_PHP_SIZE", referenced from:
                _ddog_sidecar_connect_php in ddtrace_php.ddtrace_php.5b56db22beb5c715-cgu.0.rcgu.o
          ld: symbol(s) not found for architecture arm64
          clang: error: linker command failed with exit code 1 (use -v to see invocation)
```

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
