### PR TITLE
Make the root Makefile macOS compatible

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -656,6 +656,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "current_platform"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a74858bcfe44b22016cb49337d7b6f04618c58e5dbfdef61b06b8c434324a0bc"
+
+[[package]]
 name = "darling"
 version = "0.20.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2307,6 +2313,7 @@ name = "php_sidecar_mockgen"
 version = "0.1.0"
 dependencies = [
  "cc_utils",
+ "current_platform",
  "sidecar_mockgen",
 ]
 

--- a/components-rs/php_sidecar_mockgen/Cargo.toml
+++ b/components-rs/php_sidecar_mockgen/Cargo.toml
@@ -5,6 +5,7 @@ version = "0.1.0"
 
 [dependencies]
 cc_utils = { path = "../../libdatadog/tools/cc_utils" }
+current_platform = "0.2.0"
 sidecar_mockgen = { path = "../../libdatadog/tools/sidecar_mockgen" }
 
 [[bin]]

--- a/components-rs/php_sidecar_mockgen/src/bin/php_sidecar_mockgen.rs
+++ b/components-rs/php_sidecar_mockgen/src/bin/php_sidecar_mockgen.rs
@@ -44,7 +44,22 @@ fn main() {
     if fs::metadata("mock_php.shared_lib").map_or(true, |m| m.modified().unwrap() < source_modified) {
         env::set_var("OPT_LEVEL", "2");
 
+        let mut cc_build = cc::Build::new();
+
+        // The 'host' and 'target' options are required to compile.
+        // They can be provided using the HOST and TARGET environment variables.
+        // On Linux, these environment variables can be empty strings, but it's not the case on macOS.
+        let host = std::env::var("HOST").unwrap_or("".to_string());
+        if host == "" {
+            cc_build.host(current_platform::CURRENT_PLATFORM);
+        }
+        let target = std::env::var("TARGET").unwrap_or("".to_string());
+        if target == "" {
+            cc_build.target(current_platform::CURRENT_PLATFORM);
+        }
+
         cc_utils::ImprovedBuild::new()
+            .set_cc_builder(cc_build)
             .file("mock_php_syms.c")
             .link_dynamically("dl")
             .warnings(true)


### PR DESCRIPTION
### Description

Make `make install` works out of the box on MacOS, like on Linux.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
