### PR TITLE
fix(elasticsearch): Hook not being removed

### DIFF
--- a/src/Integrations/Integrations/ElasticSearch/V8/ElasticSearchIntegration.php
+++ b/src/Integrations/Integrations/ElasticSearch/V8/ElasticSearchIntegration.php
@@ -34,7 +34,7 @@ class ElasticSearchIntegration extends Integration
                 if (!$constructorCalled) {
                     foreach (get_class_methods('Elastic\Elasticsearch\Traits\NamespaceTrait') as $method) {
                         $hook = function ($obj, $scope, $args, $ret) use ($integration, $method) {
-                            \dd_untrace('Elastic\Elasticsearch\Traits\NamespaceTrait', $method);
+                            \dd_untrace('Elastic\Elasticsearch\Client', $method);
                             $class = get_class($ret);
                             foreach (get_class_methods($ret) as $method) {
                                 $integration->traceNamespaceMethod($class, $method);


### PR DESCRIPTION
### Description

As mentioned in this [GH comment](https://github.com/DataDog/dd-trace-php/issues/2427#issuecomment-2039673277) from #2427, an elasticsearch hook wasn't removed

> [ddtrace] [error] Could not add hook to Elastic\Elasticsearch\Endpoints\Indices::__construct with more than datadog.trace.hook_limit = 100 installed hooks in /opt/datadog-php/dd-trace-sources/bridge/_generated_integrations.php on line 5437; This message is only displayed once. Specify DD_TRACE_ONCE_LOGS=0 to show all messages.

`dd_untrace` was called on the Trait while it should have been called on the hooked class. With this PR, the installed hook is removed on the correct class.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
