### PR TITLE
fix(elasticsearch): Hook not being removed

### DIFF
--- a/src/Integrations/Integrations/ElasticSearch/V8/ElasticSearchIntegration.php
+++ b/src/Integrations/Integrations/ElasticSearch/V8/ElasticSearchIntegration.php
@@ -2,11 +2,13 @@
 
 namespace DDTrace\Integrations\ElasticSearch\V8;
 
+use DDTrace\HookData;
 use DDTrace\Integrations\ElasticSearch\V1\ElasticSearchCommon;
 use DDTrace\Integrations\Integration;
 use DDTrace\SpanData;
 use DDTrace\Tag;
 use DDTrace\Type;
+use function DDTrace\install_hook;
 
 class ElasticSearchIntegration extends Integration
 {
@@ -33,14 +35,16 @@ class ElasticSearchIntegration extends Integration
             "posthook" => function (SpanData $span) use (&$constructorCalled, $integration) {
                 if (!$constructorCalled) {
                     foreach (get_class_methods('Elastic\Elasticsearch\Traits\NamespaceTrait') as $method) {
-                        $hook = function ($obj, $scope, $args, $ret) use ($integration, $method) {
-                            \dd_untrace('Elastic\Elasticsearch\Traits\NamespaceTrait', $method);
+                        $hook = function (HookData $hook) use ($integration, $method) {
+                            $ret = $hook->returned;
+                            \DDTrace\remove_hook($hook->id);
                             $class = get_class($ret);
                             foreach (get_class_methods($ret) as $method) {
                                 $integration->traceNamespaceMethod($class, $method);
                             }
                         };
-                        \DDTrace\hook_method('Elastic\Elasticsearch\Client', $method, null, $hook);
+
+                        \DDTrace\install_hook("Elastic\Elasticsearch\Client::$method", null, $hook);
                     }
                     foreach (get_class_methods('Elastic\Elasticsearch\Traits\ClientEndpointsTrait') as $method) {
                         $analyticsMethods = [

--- a/src/Integrations/Integrations/ElasticSearch/V8/ElasticSearchIntegration.php
+++ b/src/Integrations/Integrations/ElasticSearch/V8/ElasticSearchIntegration.php
@@ -8,7 +8,6 @@ use DDTrace\Integrations\Integration;
 use DDTrace\SpanData;
 use DDTrace\Tag;
 use DDTrace\Type;
-use function DDTrace\install_hook;
 
 class ElasticSearchIntegration extends Integration
 {


### PR DESCRIPTION
### Description

As mentioned in this [GH comment](https://github.com/DataDog/dd-trace-php/issues/2427#issuecomment-2039673277) from #2427, an elasticsearch hook wasn't removed

> [ddtrace] [error] Could not add hook to Elastic\Elasticsearch\Endpoints\Indices::__construct with more than datadog.trace.hook_limit = 100 installed hooks in /opt/datadog-php/dd-trace-sources/bridge/_generated_integrations.php on line 5437; This message is only displayed once. Specify DD_TRACE_ONCE_LOGS=0 to show all messages.

`dd_untrace` was called on the Trait while it should have been called on the hooked class. With this PR, the installed hook is removed on the correct class.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
