### PR TITLE
disable Appsec when FrankenPHP SAPI is detected

### DIFF
--- a/appsec/src/extension/ddappsec.c
+++ b/appsec/src/extension/ddappsec.c
@@ -354,7 +354,8 @@ __thread void *unspecnull TSRMLS_CACHE = NULL;
 static void _check_enabled()
 {
     if ((!get_global_DD_APPSEC_TESTING() && !dd_trace_enabled()) ||
-        (strcmp(sapi_module.name, "cli") != 0 && sapi_module.phpinfo_as_text)) {
+        (strcmp(sapi_module.name, "cli") != 0 && sapi_module.phpinfo_as_text) ||
+        (strcmp(sapi_module.name, "frankenphp") == 0)) {
         DDAPPSEC_G(enabled) = APPSEC_FULLY_DISABLED;
         DDAPPSEC_G(active) = false;
         DDAPPSEC_G(to_be_configured) = false;


### PR DESCRIPTION
### Description

When installing via `php datadog-setup.php` appsec will also be installed but crash FrankenPHP after few HTTP requests with the following stack trace:

```
Thread 21 "thpool-7" received signal SIGSEGV, Segmentation fault.
[Switching to Thread 0xffff68f9f020 (LWP 835)]
dd_entity_body_rinit () at /home/circleci/datadog/appsec/src/extension/entity_body.c:112
112	/home/circleci/datadog/appsec/src/extension/entity_body.c: No such file or directory.
(gdb) bt
#0  dd_entity_body_rinit () at /home/circleci/datadog/appsec/src/extension/entity_body.c:112
#1  0x0000ffff80ccbf68 in zm_activate_ddappsec (type=<optimized out>, module_number=<optimized out>) at /home/circleci/datadog/appsec/src/extension/ddappsec.c:266
#2  0x0000fffff72130e4 in zend_activate_modules () at /usr/local/src/php/Zend/zend_API.c:3218
#3  0x0000fffff70ef4dc in php_request_startup () at /usr/local/src/php/main/main.c:1811
#4  0x000000000169058c in frankenphp_request_startup () at frankenphp.c:818
#5  0x000000000169060c in frankenphp_execute_script (file_name=0xffff40078b20 "/go/src/app/testdata/session.php") at frankenphp.c:833
#6  0x000000000168dce4 in _cgo_b7d6fd74a0c8_Cfunc_frankenphp_execute_script (v=0x4000718da8) at /tmp/go-build/cgo-gcc-prolog:55
#7  0x000000000047e66c in runtime.asmcgocall () at /usr/local/go/src/runtime/asm_arm64.s:999
#8  0x00000040007308c0 in ?? ()
#9  0x0000ffff68f9e5a0 in ?? ()
#10 0xf94013f54b0003e0 in ?? ()
``` 

This PR will deactivate appsec when it detects the FrankenPHP SAPI.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [x] Appropriate labels assigned.
