### PR TITLE
feat: Add `--ini` and `--extension-dir` installation option

### DIFF
--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -582,7 +582,7 @@ function install($options)
             $extensionSuffix .= '-zts';
         }
 
-        $extDir = $options[OPT_EXTENSION_DIR] ?? $phpProperties[EXTENSION_DIR];
+        $extDir = isset($options[OPT_EXTENSION_DIR]) ? $options[OPT_EXTENSION_DIR] : $phpProperties[EXTENSION_DIR];
         echo "Installing extension to $extDir\n";
 
         // Trace
@@ -902,7 +902,7 @@ function uninstall($options)
         echo "Uninstalling from binary: $binaryForLog\n";
 
         $phpProperties = ini_values($fullPath);
-        $extensionDir = $options[OPT_EXTENSION_DIR] ?? $phpProperties[EXTENSION_DIR];
+        $extensionDir = isset($options[OPT_EXTENSION_DIR]) ? $options[OPT_EXTENSION_DIR] : $phpProperties[EXTENSION_DIR];
 
         $extensionDestinations = [
             $extensionDir . '/' . EXTENSION_PREFIX . 'ddtrace.' . EXTENSION_SUFFIX,

--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -19,6 +19,7 @@ const CMD_CONFIG_LIST = 'config list';
 const OPT_HELP = 'help';
 const OPT_INSTALL_DIR = 'install-dir';
 const OPT_PHP_BIN = 'php-bin';
+const OPT_PHP_INI = 'ini';
 const OPT_FILE = 'file';
 const OPT_UNINSTALL = 'uninstall';
 const OPT_ENABLE_APPSEC = 'enable-appsec';
@@ -614,7 +615,11 @@ function install($options)
         }
         $appSecHelperPath = $installDir . '/bin/ddappsec-helper';
 
-        $iniFilePaths = find_main_ini_files($phpProperties);
+        if (isset($options[OPT_PHP_INI])) {
+            $iniFilePaths = $options[OPT_PHP_INI];
+        } else {
+            $iniFilePaths = find_main_ini_files($phpProperties);
+        }
 
         foreach ($iniFilePaths as $iniFilePath) {
             $replacements = [];
@@ -1252,6 +1257,12 @@ function parse_validate_user_options()
         $normalizedOptions[OPT_PHP_BIN] = is_array($options[OPT_PHP_BIN])
             ? $options[OPT_PHP_BIN]
             : [$options[OPT_PHP_BIN]];
+    }
+
+    if (isset($options[OPT_PHP_INI])) {
+        $normalizedOptions[OPT_PHP_INI] = is_array($options[OPT_PHP_INI])
+            ? $options[OPT_PHP_INI]
+            : [$options[OPT_PHP_INI]];
     }
 
     $normalizedOptions[OPT_INSTALL_DIR] = isset($options[OPT_INSTALL_DIR])

--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -18,6 +18,7 @@ const CMD_CONFIG_LIST = 'config list';
 // Options
 const OPT_HELP = 'help';
 const OPT_INSTALL_DIR = 'install-dir';
+const OPT_EXTENSION_DIR = 'extension-dir';
 const OPT_PHP_BIN = 'php-bin';
 const OPT_PHP_INI = 'ini';
 const OPT_FILE = 'file';
@@ -581,7 +582,7 @@ function install($options)
             $extensionSuffix .= '-zts';
         }
 
-        $extDir = $phpProperties[EXTENSION_DIR];
+        $extDir = $options[OPT_EXTENSION_DIR] ?? $phpProperties[EXTENSION_DIR];
 
         // Trace
         $extensionRealPath = "$tmpArchiveTraceRoot/ext/$extensionVersion/"
@@ -875,11 +876,12 @@ function uninstall($options)
         echo "Uninstalling from binary: $binaryForLog\n";
 
         $phpProperties = ini_values($fullPath);
+        $extensionDir = $options[OPT_EXTENSION_DIR] ?? $phpProperties[EXTENSION_DIR];
 
         $extensionDestinations = [
-            $phpProperties[EXTENSION_DIR] . '/' . EXTENSION_PREFIX . 'ddtrace.' . EXTENSION_SUFFIX,
-            $phpProperties[EXTENSION_DIR] . '/' . EXTENSION_PREFIX . 'datadog-profiling.' . EXTENSION_SUFFIX,
-            $phpProperties[EXTENSION_DIR] . '/' . EXTENSION_PREFIX . 'ddappsec.' . EXTENSION_SUFFIX,
+            $extensionDir . '/' . EXTENSION_PREFIX . 'ddtrace.' . EXTENSION_SUFFIX,
+            $extensionDir . '/' . EXTENSION_PREFIX . 'datadog-profiling.' . EXTENSION_SUFFIX,
+            $extensionDir . '/' . EXTENSION_PREFIX . 'ddappsec.' . EXTENSION_SUFFIX,
         ];
 
         $iniFileName = '98-ddtrace.ini';
@@ -1269,6 +1271,10 @@ function parse_validate_user_options()
         ? rtrim($options[OPT_INSTALL_DIR], '/')
         : DEFAULT_INSTALL_DIR;
     $normalizedOptions[OPT_INSTALL_DIR] = $normalizedOptions[OPT_INSTALL_DIR] . '/dd-library';
+
+    $normalizedOptions[OPT_EXTENSION_DIR] = isset($options[OPT_EXTENSION_DIR])
+        ? rtrim($options[OPT_EXTENSION_DIR], '/')
+        : null;
 
     $normalizedOptions[OPT_ENABLE_APPSEC] = isset($options[OPT_ENABLE_APPSEC]);
     $normalizedOptions[OPT_ENABLE_PROFILING] = isset($options[OPT_ENABLE_PROFILING]);

--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -656,12 +656,10 @@ function install($options)
             }
 
             if (isset($options[OPT_EXTENSION_DIR])) {
-                echo "Updating extension path in INI file to '$extensionDestination'\n";
                 $replacements += [
                     '(^\s*;?\s*extension\s*=\s*.*ddtrace.*)m' => "extension = $extensionDestination",
                 ];
             } else {
-                echo "Updating extension path in INI file to 'ddtrace." . EXTENSION_SUFFIX . "'\n";
                 $replacements += [
                     /* In order to support upgrading from legacy installation method to new installation method, we
                      * replace "extension = /opt/datadog-php/xyz.so" with "extension =  ddtrace.so" honoring trailing
@@ -678,11 +676,9 @@ function install($options)
                 // phpcs:disable Generic.Files.LineLength.TooLong
                 if ($shouldInstallProfiling) {
                     if (isset($options[OPT_EXTENSION_DIR])) {
-                        echo "Updating profiling extension path in INI file to '$profilingExtensionDestination'\n";
                         $replacements['(zend_extension\s*=\s*.*datadog-profiling.*)'] = "extension = $profilingExtensionDestination";
                         $replacements['(^\s*;?\s*extension\s*=\s*.*datadog-profiling.*)m'] = "extension = $profilingExtensionDestination";
                     } else {
-                        echo "Updating profiling extension path in INI file to 'datadog-profiling." . EXTENSION_SUFFIX . "'\n";
                         $replacements['(^\s*;?\s*extension\s*=\s*.*datadog-profiling.*)m'] = "extension = datadog-profiling" . (IS_WINDOWS ? "" : "." . EXTENSION_SUFFIX);
                     }
                 } else {
@@ -702,7 +698,6 @@ function install($options)
                 $iniAppsecExtension = isset($options[OPT_EXTENSION_DIR])
                     ? $appsecExtensionDestination
                     : ("ddappsec" . (IS_WINDOWS ? "" : "." . EXTENSION_SUFFIX));
-                echo "iniAppsecExtension: $iniAppsecExtension\n";
                 $replacements += [
                     '(^\s*;?\s*extension\s*=\s*.*ddappsec.*)m' => "extension = $iniAppsecExtension",
                     // Update helper path
@@ -714,7 +709,6 @@ function install($options)
                     $replacements += ['(^[\s;]*datadog.appsec.enabled\s*=.*)m' => 'datadog.appsec.enabled = On'];
                 }
             } else {
-                echo "Ensure AppSec isn't loaded if not compatible\n";
                 // Ensure AppSec isn't loaded if not compatible
                 $replacements['(^[\s;]*extension\s*=\s*.*ddappsec.*)m'] = "; extension = ddappsec" . (IS_WINDOWS ? "" : "." . EXTENSION_SUFFIX);
 
@@ -725,8 +719,6 @@ function install($options)
                     );
                 }
             }
-
-            var_dump($replacements);
 
             add_missing_ini_settings(
                 $iniFilePath,

--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -95,8 +95,10 @@ Options:
                                 option can be provided multiple times.
     --install-dir <path>        Install to a specific directory. Default: '$installdir'
     --uninstall                 Uninstall the library from the specified binaries.
+    --extension-dir <path>      Specify the extension directory. Default: PHP's extension directory.
+    --ini <path>                Specify the INI file to use. Default: <ini-dir>/98-ddtrace.ini
     --enable-appsec             Enable the application security monitoring module.
-    --enable-profiling          Enable the profiling module.
+    --enable-profiling           Enable the profiling module.
     -d setting[=value]          Used in conjunction with `config <set|get>`
                                 command to specify the INI setting to get or set.
 

--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -583,6 +583,7 @@ function install($options)
         }
 
         $extDir = $options[OPT_EXTENSION_DIR] ?? $phpProperties[EXTENSION_DIR];
+        echo "Installing extension to $extDir\n";
 
         // Trace
         $extensionRealPath = "$tmpArchiveTraceRoot/ext/$extensionVersion/"
@@ -652,22 +653,24 @@ function install($options)
                     '(datadog\.trace\.request_init_hook)' => 'datadog.trace.sources_path',
                     '((datadog\.trace\.sources_path)\s*=\s*.*)' => "$1 = $installDirSrcDir",
                 ];
+            }
 
-                if (isset($options[OPT_EXTENSION_DIR])) {
-                    $replacements += [
-                        '(^\s*;?\s*extension\s*=\s*.*ddtrace.*)m' => "extension = $extensionDestination",
-                    ];
-                } else {
-                    $replacements += [
-                        /* In order to support upgrading from legacy installation method to new installation method, we
-                         * replace "extension = /opt/datadog-php/xyz.so" with "extension =  ddtrace.so" honoring trailing
-                         * `;`, hence not automatically re-activating the extension if the user had commented it out.
-                         */
-                        '(^\s*;?\s*extension\s*=\s*.*ddtrace.*)m' => "extension = ddtrace" . (IS_WINDOWS ? "" : "." . EXTENSION_SUFFIX),
-                        // Support upgrading from the C based zend_extension.
-                        '(zend_extension\s*=\s*.*datadog-profiling.*)' => "extension = datadog-profiling" . (IS_WINDOWS ? "" : "." . EXTENSION_SUFFIX),
-                    ];
-                }
+            if (isset($options[OPT_EXTENSION_DIR])) {
+                echo "Updating extension path in INI file to '$extensionDestination'\n";
+                $replacements += [
+                    '(^\s*;?\s*extension\s*=\s*.*ddtrace.*)m' => "extension = $extensionDestination",
+                ];
+            } else {
+                echo "Updating extension path in INI file to 'ddtrace." . EXTENSION_SUFFIX . "'\n";
+                $replacements += [
+                    /* In order to support upgrading from legacy installation method to new installation method, we
+                     * replace "extension = /opt/datadog-php/xyz.so" with "extension =  ddtrace.so" honoring trailing
+                     * `;`, hence not automatically re-activating the extension if the user had commented it out.
+                     */
+                    '(^\s*;?\s*extension\s*=\s*.*ddtrace.*)m' => "extension = ddtrace" . (IS_WINDOWS ? "" : "." . EXTENSION_SUFFIX),
+                    // Support upgrading from the C based zend_extension.
+                    '(zend_extension\s*=\s*.*datadog-profiling.*)' => "extension = datadog-profiling" . (IS_WINDOWS ? "" : "." . EXTENSION_SUFFIX),
+                ];
             }
 
             // Enabling profiling
@@ -675,9 +678,11 @@ function install($options)
                 // phpcs:disable Generic.Files.LineLength.TooLong
                 if ($shouldInstallProfiling) {
                     if (isset($options[OPT_EXTENSION_DIR])) {
+                        echo "Updating profiling extension path in INI file to '$profilingExtensionDestination'\n";
                         $replacements['(zend_extension\s*=\s*.*datadog-profiling.*)'] = "extension = $profilingExtensionDestination";
                         $replacements['(^\s*;?\s*extension\s*=\s*.*datadog-profiling.*)m'] = "extension = $profilingExtensionDestination";
                     } else {
+                        echo "Updating profiling extension path in INI file to 'datadog-profiling." . EXTENSION_SUFFIX . "'\n";
                         $replacements['(^\s*;?\s*extension\s*=\s*.*datadog-profiling.*)m'] = "extension = datadog-profiling" . (IS_WINDOWS ? "" : "." . EXTENSION_SUFFIX);
                     }
                 } else {
@@ -697,8 +702,9 @@ function install($options)
                 $iniAppsecExtension = isset($options[OPT_EXTENSION_DIR])
                     ? $appsecExtensionDestination
                     : ("ddappsec" . (IS_WINDOWS ? "" : "." . EXTENSION_SUFFIX));
+                echo "iniAppsecExtension: $iniAppsecExtension\n";
                 $replacements += [
-                    '(^\s*;\s*extension\s*=\s*.*ddappsec.*)m' => "extension = $iniAppsecExtension",
+                    '(^\s*;?\s*extension\s*=\s*.*ddappsec.*)m' => "extension = $iniAppsecExtension",
                     // Update helper path
                     '(datadog.appsec.helper_path\s*=.*)' => "datadog.appsec.helper_path = $appSecHelperPath",
                     // Update and comment rules path
@@ -708,6 +714,7 @@ function install($options)
                     $replacements += ['(^[\s;]*datadog.appsec.enabled\s*=.*)m' => 'datadog.appsec.enabled = On'];
                 }
             } else {
+                echo "Ensure AppSec isn't loaded if not compatible\n";
                 // Ensure AppSec isn't loaded if not compatible
                 $replacements['(^[\s;]*extension\s*=\s*.*ddappsec.*)m'] = "; extension = ddappsec" . (IS_WINDOWS ? "" : "." . EXTENSION_SUFFIX);
 
@@ -718,6 +725,8 @@ function install($options)
                     );
                 }
             }
+
+            var_dump($replacements);
 
             add_missing_ini_settings(
                 $iniFilePath,
@@ -877,6 +886,15 @@ function safe_copy_extension($source, $destination)
         // We have to blackhole it in tempdir because it is likely currently loaded and may not be replaced in place.
         rename($destination, getenv("TEMP") . "\\" . time() . "-" . basename($destination));
     }
+
+    $destinationDir = dirname($destination);
+    if (!file_exists($destinationDir)) {
+        execute_or_exit(
+            "Cannot create directory '$destinationDir'",
+            "mkdir " . (IS_WINDOWS ? "" : "-p ") . escapeshellarg($destinationDir)
+        );
+    }
+
     $tmpName = $destination . '.tmp';
     copy($source, $tmpName);
     rename($tmpName, $destination);

--- a/dockerfiles/verify_packages/Makefile
+++ b/dockerfiles/verify_packages/Makefile
@@ -79,6 +79,7 @@ test_install_without_scan_dir.sh \
 test_install_add_missing_ini_settings.sh \
 test_install_custom_ini_name.sh \
 test_install_custom_ini_file.sh \
+test_install_custom_ext_dir_and_ini.sh \
 test_install_custom_installation_directory.sh \
 test_install_custom_extension_directory.sh \
 test_install_custom_installation_root.sh \

--- a/dockerfiles/verify_packages/Makefile
+++ b/dockerfiles/verify_packages/Makefile
@@ -79,6 +79,7 @@ test_install_without_scan_dir.sh \
 test_install_add_missing_ini_settings.sh \
 test_install_custom_ini_name.sh \
 test_install_custom_installation_directory.sh \
+test_install_custom_extension_directory.sh \
 test_install_custom_installation_root.sh \
 test_install_non_root_user.sh \
 test_install_subdir_from_file.sh \

--- a/dockerfiles/verify_packages/Makefile
+++ b/dockerfiles/verify_packages/Makefile
@@ -78,6 +78,7 @@ test_install_no_ldconfig_in_path.sh \
 test_install_without_scan_dir.sh \
 test_install_add_missing_ini_settings.sh \
 test_install_custom_ini_name.sh \
+test_install_custom_ini_file.sh \
 test_install_custom_installation_directory.sh \
 test_install_custom_extension_directory.sh \
 test_install_custom_installation_root.sh \

--- a/dockerfiles/verify_packages/installer/test_install_custom_ext_dir_and_ini.sh
+++ b/dockerfiles/verify_packages/installer/test_install_custom_ext_dir_and_ini.sh
@@ -10,7 +10,8 @@ assert_no_ddtrace
 # Install using the php installer
 trace_version="0.99.0"
 generate_installers "${trace_version}"
-php ./build/packages/datadog-setup.php --php-bin php --extension-dir /custom-ext-dir --enable-profiling
+custom_ini_file="$(get_php_conf_dir)/40-ddtrace.ini"
+php ./build/packages/datadog-setup.php --php-bin php --extension-dir /custom-ext-dir --enable-profiling --ini "$custom_ini_file"
 
 assert_file_exists /custom-ext-dir/ddtrace.so
 

--- a/dockerfiles/verify_packages/installer/test_install_custom_extension_directory.sh
+++ b/dockerfiles/verify_packages/installer/test_install_custom_extension_directory.sh
@@ -1,0 +1,24 @@
+#!/usr/bin/env sh
+
+set -e
+
+. "$(dirname ${0})/utils.sh"
+
+# Initially no ddtrace
+assert_no_ddtrace
+
+# Install using the php installer
+#trace_version=$(parse_trace_version)
+trace_version="0.99.0"
+generate_installers "${trace_version}"
+php ./build/packages/datadog-setup.php --php-bin php --extension-dir /custom-ext-dir
+
+ls -l /custom-ext-dir
+
+assert_file_exists /custom-ext-dir/ddtrace.so
+
+assert_ddtrace_version "${trace_version}"
+assert_profiler_installed
+assert_appsec_installed
+
+assert_request_init_hook_exists

--- a/dockerfiles/verify_packages/installer/test_install_custom_ini_file.sh
+++ b/dockerfiles/verify_packages/installer/test_install_custom_ini_file.sh
@@ -8,7 +8,6 @@ set -e
 assert_no_ddtrace
 
 # Install using the php installer
-#trace_version=$(parse_trace_version)
 trace_version="0.99.0"
 generate_installers "${trace_version}"
 custom_ini_file="$(get_php_conf_dir)/40-ddtrace.ini"

--- a/dockerfiles/verify_packages/installer/test_install_custom_ini_file.sh
+++ b/dockerfiles/verify_packages/installer/test_install_custom_ini_file.sh
@@ -1,0 +1,21 @@
+#!/usr/bin/env sh
+
+set -e
+
+. "$(dirname ${0})/utils.sh"
+
+# Initially no ddtrace
+assert_no_ddtrace
+
+# Install using the php installer
+#trace_version=$(parse_trace_version)
+trace_version="0.99.0"
+generate_installers "${trace_version}"
+custom_ini_file="$(get_php_conf_dir)/40-ddtrace.ini"
+php ./build/packages/datadog-setup.php --php-bin php --ini "$custom_ini_file" --enable-profiling
+
+assert_ddtrace_version "${trace_version}"
+assert_profiler_installed
+assert_appsec_installed
+
+assert_request_init_hook_exists

--- a/dockerfiles/verify_packages/installer/utils.sh
+++ b/dockerfiles/verify_packages/installer/utils.sh
@@ -81,6 +81,39 @@ assert_profiler_version() {
     fi
 }
 
+assert_tracer_installed() {
+    php_bin=${1:-php}
+    output="$($php_bin -v)"
+    if [ -z "${output##*with ddtrace*}" ]; then
+        echo "---\nOk: Tracer is installed\n---\n${output}\n---\n"
+    else
+        echo "---\nError: Tracer should be installed\n---\n${output}\n---\n"
+        exit 1
+    fi
+}
+
+assert_profiler_installed() {
+    php_bin=${1:-php}
+    output="$($php_bin -v)"
+    if [ -z "${output##*with datadog-profiling*}" ]; then
+        echo "---\nOk: Profiler is installed\n---\n${output}\n---\n"
+    else
+        echo "---\nError: Profiler should be installed\n---\n${output}\n---\n"
+        exit 1
+    fi
+}
+
+assert_appsec_installed() {
+    php_bin=${1:-php}
+    output="$($php_bin -m)"
+    if [ -z "${output##*ddappsec*}" ]; then
+        echo "---\nOk: AppSec is installed\n---\n${output}\n---\n"
+    else
+        echo "---\nError: AppSec should be installed\n---\n${output}\n---\n"
+        exit 1
+    fi
+}
+
 assert_appsec_enabled() {
     output="$(php --ri ddappsec)"
     if [ -z "${output##*datadog.appsec.enabled => On*}" ]; then

--- a/dockerfiles/verify_packages/installer/utils.sh
+++ b/dockerfiles/verify_packages/installer/utils.sh
@@ -164,6 +164,10 @@ fetch_setup_for_version() (
     cd -
 )
 
+parse_appsec_version() {
+    grep -oP 'VERSION \K\d+\.\d+\.\d+' appsec/CMakeLists.txt
+}
+
 dashed_print() {
     echo "---"
     for line in "$@" ; do


### PR DESCRIPTION
### Description

[FRAPMS-4418](https://datadoghq.atlassian.net/browse/FRAPMS-4418)

The setup script now has two new installation options: `--ini` and `--extension-dir`. This should allow customers more flexibility regarding which INI file should be used and where the `.so` files will be copied.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.


[FRAPMS-4418]: https://datadoghq.atlassian.net/browse/FRAPMS-4418?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ