### PR TITLE
fix: Host Scopes not being removed

### DIFF
--- a/src/DDTrace/ScopeManager.php
+++ b/src/DDTrace/ScopeManager.php
@@ -82,6 +82,8 @@ final class ScopeManager implements ScopeManagerInterface
         if ($span instanceof Span && ObjectKVStore::get($span->internalSpan, 'ddtrace_scope_activated') !== null) {
             ObjectKVStore::put($span->internalSpan, 'ddtrace_scope_activated', false);
         }
+
+        array_splice($this->hostRootScopes, array_search($scope, $this->hostRootScopes, true), 1);
     }
 
     /** @internal */
@@ -151,6 +153,5 @@ final class ScopeManager implements ScopeManagerInterface
         foreach ($this->hostRootScopes as $scope) {
             $scope->close();
         }
-        $this->hostRootScopes = [];
     }
 }

--- a/src/DDTrace/ScopeManager.php
+++ b/src/DDTrace/ScopeManager.php
@@ -68,6 +68,14 @@ final class ScopeManager implements ScopeManagerInterface
         return null;
     }
 
+    private function deactivateHostRoot(Scope $scope)
+    {
+        $i = array_search($scope, $this->hostRootScopes, true);
+        if (false !== $i) {
+            array_splice($this->hostRootScopes, $i, 1);
+        }
+    }
+
     public function deactivate(Scope $scope)
     {
         $i = array_search($scope, $this->scopes, true);
@@ -83,7 +91,9 @@ final class ScopeManager implements ScopeManagerInterface
             ObjectKVStore::put($span->internalSpan, 'ddtrace_scope_activated', false);
         }
 
-        array_splice($this->hostRootScopes, array_search($scope, $this->hostRootScopes, true), 1);
+        if ($span->getContext()->isHostRoot()) {
+            $this->deactivateHostRoot($scope);
+        }
     }
 
     /** @internal */

--- a/src/DDTrace/ScopeManager.php
+++ b/src/DDTrace/ScopeManager.php
@@ -151,5 +151,6 @@ final class ScopeManager implements ScopeManagerInterface
         foreach ($this->hostRootScopes as $scope) {
             $scope->close();
         }
+        $this->hostRootScopes = [];
     }
 }

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -301,6 +301,7 @@ final class Tracer implements TracerInterface
         }
 
         $this->transport->send($this);
+        $this->scopeManager->close();
     }
 
     /**

--- a/tests/Unit/GlobalTracerTest.php
+++ b/tests/Unit/GlobalTracerTest.php
@@ -9,6 +9,34 @@ use DDTrace\Tests\Common\BaseTestCase;
 
 final class GlobalTracerTest extends BaseTestCase
 {
+    private static function startTracingTest() {
+        $tracer = GlobalTracer::get();
+        GlobalTracer::set($tracer);
+        $tracer->startRootSpan('foo');
+
+        GlobalTracer::get()->getRootScope()->close();
+        GlobalTracer::get()->flush();
+    }
+
+    public function testMemoryResetAfterFlush()
+    {
+        self::putenv('DD_TRACE_GENERATE_ROOT_SPAN=0');
+        dd_trace_internal_fn('ddtrace_reload_config');
+
+        try {
+            self::startTracingTest();
+            $mem1 = memory_get_usage();
+            self::startTracingTest();
+            $mem2 = memory_get_usage();
+        } catch (\Throwable $e) {
+            self::putenv('DD_TRACE_GENERATE_ROOT_SPAN=');
+            throw $e;
+        } finally {
+            $this->assertEquals($mem1, $mem2);
+            self::putenv('DD_TRACE_GENERATE_ROOT_SPAN=');
+        }
+    }
+
     public function testDDTracerIsSetAsIs()
     {
         $tracer = new Tracer(new Noop());


### PR DESCRIPTION
### Description

May address #2592 

Using the reproducer added as a test, the host scopes would keep on growing, hence slowly but surely increasing memory usage

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
