### PR TITLE
Do not check get_DD_TRACE_ENABLED() outside of a request

### DIFF
--- a/ext/profiling.c
+++ b/ext/profiling.c
@@ -8,7 +8,7 @@ ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 
 DDTRACE_PUBLIC struct ddtrace_profiling_context ddtrace_get_profiling_context(void) {
     struct ddtrace_profiling_context context = {0, 0};
-    if (get_DD_TRACE_ENABLED() && DDTRACE_G(active_stack) && DDTRACE_G(active_stack)->root_span) {
+    if (DDTRACE_G(active_stack) && DDTRACE_G(active_stack)->root_span && get_DD_TRACE_ENABLED()) {
         context.local_root_span_id = DDTRACE_G(active_stack)->root_span->span_id;
         context.span_id = ddtrace_active_span()->span_id;
     }


### PR DESCRIPTION
get_DD_TRACE_ENABLED() must not be accessed outside of requests, given that it accesses a request local array of configs.

DDTRACE_G(active_stack) is supposed to be always properly reset between requests, so we can just put this first and then the calls to get_DD_TRACE_ENABLED() are always correct.

Fixes a crash in datadog_profiling::timeline::timeline_mshutdown doing collect_idle() and ultimately accessing the profiling_context here.

Not sure how to test this; it was reported with the pretty obvious backtrace by an user.