### PR TITLE
Add libdatadog-apm as codeowners.

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,5 +13,5 @@ compile_rust.sh @Datadog/libdatadog-apm
 
 # Release files
 Cargo.lock @DataDog/apm-php @DataDog/profiling-php @Datadog/libdatadog-apm
-package.xml @DataDog/apm-php @DataDog/profiling-php @Datadog/asm-php @Datadog/libdatadog-apm
-VERSION @DataDog/apm-php @DataDog/profiling-php @Datadog/asm-php @Datadog/libdatadog-apm
+package.xml @DataDog/apm-php @DataDog/profiling-php @Datadog/asm-php
+VERSION @DataDog/apm-php @DataDog/profiling-php @Datadog/asm-php

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,7 +7,11 @@
 # ASM Team
 /appsec/ @DataDog/asm-php
 
+# APM libdatadog
+/components-rs/ @Datadog/libdatadog-apm
+compile_rust.sh @Datadog/libdatadog-apm
+
 # Release files
-Cargo.lock @DataDog/apm-php @DataDog/profiling-php
-package.xml @DataDog/apm-php @DataDog/profiling-php @Datadog/asm-php
-VERSION @DataDog/apm-php @DataDog/profiling-php @Datadog/asm-php
+Cargo.lock @DataDog/apm-php @DataDog/profiling-php @Datadog/libdatadog-apm
+package.xml @DataDog/apm-php @DataDog/profiling-php @Datadog/asm-php @Datadog/libdatadog-apm
+VERSION @DataDog/apm-php @DataDog/profiling-php @Datadog/asm-php @Datadog/libdatadog-apm


### PR DESCRIPTION
### Description
Add libdatadog-apm team as co-codeowners of libdatdog's related code.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
