### PR TITLE
refactor(profiling): shrink env/service/version and simplify

### DIFF
--- a/profiling/src/config.rs
+++ b/profiling/src/config.rs
@@ -570,14 +570,14 @@ unsafe fn get_system_str(config_id: ConfigId) -> Option<Cow<'static, str>> {
     }
 }
 
-unsafe fn get_str(id: ConfigId) -> Option<Cow<'static, str>> {
+unsafe fn get_str(id: ConfigId) -> Option<String> {
     let value = get_value(id);
     match String::try_from(value) {
         Ok(value) => {
             if value.is_empty() {
                 None
             } else {
-                Some(Cow::Owned(value))
+                Some(value)
             }
         }
         Err(_err) => None,
@@ -602,21 +602,21 @@ unsafe fn agent_host() -> Option<Cow<'static, str>> {
 /// # Safety
 /// This function must only be called after config has been initialized in
 /// rinit, and before it is uninitialized in mshutdown.
-pub(crate) unsafe fn env() -> Option<Cow<'static, str>> {
+pub(crate) unsafe fn env() -> Option<String> {
     get_str(Env)
 }
 
 /// # Safety
 /// This function must only be called after config has been initialized in
 /// rinit, and before it is uninitialized in mshutdown.
-pub(crate) unsafe fn service() -> Option<Cow<'static, str>> {
+pub(crate) unsafe fn service() -> Option<String> {
     get_str(Service)
 }
 
 /// # Safety
 /// This function must only be called after config has been initialized in
 /// rinit, and before it is uninitialized in mshutdown.
-pub(crate) unsafe fn version() -> Option<Cow<'static, str>> {
+pub(crate) unsafe fn version() -> Option<String> {
     get_str(Version)
 }
 

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -322,14 +322,14 @@ extern "C" fn prshutdown() -> ZendResult {
 }
 
 pub struct RequestLocals {
-    pub env: Option<Cow<'static, str>>,
-    pub service: Option<Cow<'static, str>>,
-    pub version: Option<Cow<'static, str>>,
+    pub env: Option<String>,
+    pub service: Option<String>,
+    pub version: Option<String>,
 
     /// SystemSettings are global. Note that if this is being read in fringe
     /// conditions such as in mshutdown when there were no requests served,
-    /// then the settings are still memory safe but they may not have the real
-    /// configuration. Instead they have a best-effort values such as
+    /// then the settings are still memory safe, but they may not have the
+    /// real configuration. Instead, they have a best-effort values such as
     /// INITIAL_SYSTEM_SETTINGS, or possibly the values which were available
     /// in MINIT.
     pub system_settings: ptr::NonNull<SystemSettings>,
@@ -426,9 +426,10 @@ extern "C" fn rinit(_type: c_int, _module_number: c_int) -> ZendResult {
                     Sapi::Cli => {
                         // Safety: sapi globals are safe to access during rinit
                         SAPI.request_script_name(datadog_sapi_globals_request_info())
-                            .or(Some(Cow::Borrowed("cli.command")))
+                            .map(Cow::into_owned)
+                            .or(Some(String::from("cli.command")))
                     }
-                    _ => Some(Cow::Borrowed("web.request")),
+                    _ => Some(String::from("web.request")),
                 }
             });
             locals.version = config::version();
@@ -786,7 +787,7 @@ unsafe extern "C" fn minfo(module_ptr: *mut zend::ModuleEntry) {
 
         for (key, value) in vars {
             let mut value = match value {
-                Some(cowstr) => cowstr.clone().into_owned(),
+                Some(string) => string.clone(),
                 None => String::new(),
             };
             value.push('\0');


### PR DESCRIPTION
### Description

This changes the fields `env`, `service`, and `version` in `RequestLocals` from `Option<Cow<'static, str>>` to `Option<String>`. In practice they were rarely a borrowed string. Doing this shrinks the size of the request locals and is simpler to work with.

### Reviewer checklist
- [x] Test coverage seems ok.
- [x] Appropriate labels assigned.
