### PR TITLE
Use app name as service for laravel queue

### DIFF
--- a/src/DDTrace/Integrations/LaravelQueue/LaravelQueueIntegration.php
+++ b/src/DDTrace/Integrations/LaravelQueue/LaravelQueueIntegration.php
@@ -168,7 +168,7 @@ class LaravelQueueIntegration extends Integration
                         $span = $hook->span();
                         $span->name = 'laravel.queue.action';
                         $span->type = 'queue';
-                        $span->service = $integration->getName();
+                        $span->service = $integration->getAppName();
                         $span->resource = $class . '@' . $method;
                         $span->meta[Tag::COMPONENT] = LaravelQueueIntegration::NAME;
 

--- a/tests/snapshots/tests.integrations.laravel.v8_x.queue_test.test_broadcast.json
+++ b/tests/snapshots/tests.integrations.laravel.v8_x.queue_test.test_broadcast.json
@@ -289,14 +289,13 @@
                  },
                  {
                    "name": "laravel.queue.action",
-                   "service": "laravelqueue",
+                   "service": "laravel_queue_test",
                    "resource": "Illuminate\\Broadcasting\\BroadcastEvent@handle",
                    "trace_id": 0,
                    "span_id": 24,
                    "parent_id": 21,
                    "type": "queue",
                    "meta": {
-                     "_dd.base_service": "laravel_queue_test",
                      "component": "laravelqueue"
                    }
                  },


### PR DESCRIPTION
### Description

Fixes laravel queue integration issue with service naming described in #2637

<!---
Any description you feel is relevant and gives more background to this PR, if necessary.
-->

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
