### PR TITLE
chore: add `apm-idm-php` to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -13,7 +13,6 @@ compile_rust.sh @Datadog/libdatadog-apm
 
 # APM IDM Team
 /src/ @DataDog/apm-idm-php
-/tests/ @DataDog/apm-idm-php
 
 # Release files
 Cargo.lock @DataDog/apm-php @DataDog/profiling-php @Datadog/libdatadog-apm

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -11,6 +11,10 @@
 /components-rs/ @Datadog/libdatadog-apm
 compile_rust.sh @Datadog/libdatadog-apm
 
+# APM IDM Team
+/src/ @DataDog/apm-idm-php
+/tests/ @DataDog/apm-idm-php
+
 # Release files
 Cargo.lock @DataDog/apm-php @DataDog/profiling-php @Datadog/libdatadog-apm
 package.xml @DataDog/apm-php @DataDog/profiling-php @Datadog/asm-php


### PR DESCRIPTION
### Description

[AIDM-68](https://datadoghq.atlassian.net/browse/AIDM-68)

The IDM team wants to limit notifications and narrow the scope of code ownership for Datadog tracing libraries, which is a part of that initiative.

I set the ownership for the IDM team to `/src/`, but it could theoretically be narrowed down even further (e.g., /src/Integrations, /src/OpenTelemetry/), but I think that's OK as is.

However, I see the following error and have no idea where it should be fixed. Maybe in the settings 🤔 
```
Unknown owner on line 15: make sure the team @DataDog/apm-idm-php exists, is publicly visible, and has write access to the repository
```

[Datadog/apm-idm-php team](https://github.com/orgs/DataDog/teams/apm-idm-php)

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.


[AIDM-68]: https://datadoghq.atlassian.net/browse/AIDM-68?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ