### PR TITLE
fix(bench): Pass sources path as an env var to the PHP process

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -479,7 +479,7 @@ cores:
 # TESTS
 ########################################################################################################################
 TRACER_SOURCES_INI := -d datadog.trace.sources_path=$(TRACER_SOURCE_DIR)
-ENV_OVERRIDE := $(shell [ -n "${DD_TRACE_DOCKER_DEBUG}" ] && echo DD_AUTOLOAD_NO_COMPILE=true) DD_TRACE_CLI_ENABLED=true
+ENV_OVERRIDE := $(shell [ -n "${DD_TRACE_DOCKER_DEBUG}" ] && echo DD_AUTOLOAD_NO_COMPILE=true DD_TRACE_SOURCES_PATH=$(TRACER_SOURCE_DIR)) DD_TRACE_CLI_ENABLED=true
 TEST_EXTRA_INI ?=
 TEST_EXTRA_ENV ?=
 


### PR DESCRIPTION
### Description

Looking at the debug logs, it appeared that the integrations weren't loaded, hence explaining why the baseline and overhead benchmarks were similar

```
[30-Apr-2024 13:20:46 UTC] [ddtrace] [warning] Error loading deferred integration DDTrace\Integrations\PDO\PDOIntegration: Class not loaded and not autoloadable
```

It seems like using CLI INIs doesn't make it through; using env var allows to properly pass the variable to the phpbench process and beyond.

[See Results](https://benchmarking.us1.prod.dog/benchmarks?benchmarkGroupPipelineId=33250223&benchmarkGroupSha=3cf562aaad06544c4daa351516c328263f4060f9&page=1&ciJobDateStart=1711894338881&ciJobDateEnd=1714486338881&benchmarkId=3441474) 🩸 

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
