### PR TITLE
Fix rejected distributed sampling decision overwrite

### DIFF
--- a/ext/priority_sampling/priority_sampling.c
+++ b/ext/priority_sampling/priority_sampling.c
@@ -352,7 +352,8 @@ void ddtrace_set_priority_sampling_on_span(ddtrace_root_span_data *root_span, ze
 
     if (priority != DDTRACE_PRIORITY_SAMPLING_UNKNOWN) {
         dd_update_decision_maker_tag(root_span, mechanism);
-        root_span->explicit_sampling_priority = true;
+        // Default is never explicit - e.g. distributed tracing.
+        root_span->explicit_sampling_priority = mechanism != DD_MECHANISM_DEFAULT;
     }
 }
 

--- a/tests/ext/priority_sampling/023-manual.keep-distributed_overwrite.phpt
+++ b/tests/ext/priority_sampling/023-manual.keep-distributed_overwrite.phpt
@@ -1,0 +1,32 @@
+--TEST--
+manual.keep will overwrite a rejected distributed sampling decision
+--ENV--
+DD_TRACE_SAMPLE_RATE=0
+DD_TRACE_GENERATE_ROOT_SPAN=1
+--FILE--
+<?php
+
+$root = \DDTrace\root_span();
+
+DDTrace\consume_distributed_tracing_headers(function ($header) {
+    return [
+            "x-datadog-trace-id" => 42,
+            "x-datadog-parent-id" => 10,
+            "x-datadog-sampling-priority" => -1,
+        ][$header] ?? null;
+});
+
+$root->meta["manual.keep"] = true;
+
+if (!isset($root->metrics["_dd.rule_psr"]) && \DDTrace\get_priority_sampling() == \DD_TRACE_PRIORITY_SAMPLING_USER_KEEP) {
+    echo "OK\n";
+} else {
+    echo "metrics[_dd.rule_psr] = {$root->metrics["_dd.rule_psr"]}\n";
+}
+
+echo "_dd.p.dm = {$root->meta["_dd.p.dm"]}\n";
+
+?>
+--EXPECT--
+OK
+_dd.p.dm = -4


### PR DESCRIPTION
This particular issue only applied when the distributed headers were extracted onto an existing root span. Thus it worked as expected for normal http root spans, but just posed issues with messaging (e.g. laravelqueue).