### PR TITLE
ci(profiling) notify if correctness job fails on master

### DIFF
--- a/.github/workflows/prof_correctness.yml
+++ b/.github/workflows/prof_correctness.yml
@@ -150,3 +150,10 @@ jobs:
         with:
           expected_json: profiling/tests/correctness/exceptions.json
           pprof_path: profiling/tests/correctness/exceptions/
+
+      - name: Notify Slack
+        if: failure() && github.ref == 'refs/heads/master'
+        run: |
+          curl -X POST "${{ secrets.SLACK_WEBHOOK }}" \
+            -H 'Content-Type: application/json' \
+            -d "{'scenarios': 'PHP', 'failed_run_url': '${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}'}"


### PR DESCRIPTION
### Description

This will notify the `#prof-correctness` channel if the correctness test fails in `master`

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
