### PR TITLE
Mark Laravel Octane requests as `laravel.request`

### DIFF
--- a/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
+++ b/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
@@ -220,6 +220,13 @@ class LaravelIntegration extends Integration
                     $span->service = $integration->getServiceName();
                     $span->resource = is_object($args[0]) ? get_class($args[0]) : $args[0];
                     $span->meta[Tag::COMPONENT] = LaravelIntegration::NAME;
+
+                    if ($span->resource === 'Laravel\Octane\Events\RequestReceived') {
+                        $rootSpan = \DDTrace\root_span();
+                        $rootSpan->name = 'laravel.request';
+                        $rootSpan->service = $integration->getServiceName();
+                        $rootSpan->meta[Tag::COMPONENT] = LaravelIntegration::NAME;
+                    }
                 },
                 'recurse' => true,
             ]

--- a/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
+++ b/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
@@ -220,13 +220,6 @@ class LaravelIntegration extends Integration
                     $span->service = $integration->getServiceName();
                     $span->resource = is_object($args[0]) ? get_class($args[0]) : $args[0];
                     $span->meta[Tag::COMPONENT] = LaravelIntegration::NAME;
-
-                    if ($span->resource === 'Laravel\Octane\Events\RequestReceived') {
-                        $rootSpan = \DDTrace\root_span();
-                        $rootSpan->name = 'laravel.request';
-                        $rootSpan->service = $integration->getServiceName();
-                        $rootSpan->meta[Tag::COMPONENT] = LaravelIntegration::NAME;
-                    }
                 },
                 'recurse' => true,
             ]
@@ -447,6 +440,22 @@ class LaravelIntegration extends Integration
                     [],
                     true
                 );
+            }
+        );
+
+        // Laravel Octane
+        \DDTrace\hook_method(
+            'Laravel\Octane\Worker',
+            'handle',
+            function () use ($integration) {
+                $rootSpan = \DDTrace\root_span();
+                if ($rootSpan === null) {
+                    return;
+                }
+
+                $rootSpan->name = 'laravel.request';
+                $rootSpan->service = $integration->getServiceName();
+                $rootSpan->meta[Tag::COMPONENT] = LaravelIntegration::NAME;
             }
         );
 

--- a/src/DDTrace/Integrations/Swoole/SwooleIntegration.php
+++ b/src/DDTrace/Integrations/Swoole/SwooleIntegration.php
@@ -141,6 +141,7 @@ class SwooleIntegration extends Integration
         \DDTrace\hook_method(
             'Swoole\Http\Server',
             '__construct',
+            null,
             function ($server) use ($integration) {
                 foreach (['workerstart', 'workerstop', 'workerexit', 'workererror'] as $serverEvent) {
                     $server->on($serverEvent, function () { });

--- a/src/DDTrace/Integrations/Swoole/SwooleIntegration.php
+++ b/src/DDTrace/Integrations/Swoole/SwooleIntegration.php
@@ -141,7 +141,6 @@ class SwooleIntegration extends Integration
         \DDTrace\hook_method(
             'Swoole\Http\Server',
             '__construct',
-            null,
             function ($server) use ($integration) {
                 foreach (['workerstart', 'workerstop', 'workerexit', 'workererror'] as $serverEvent) {
                     $server->on($serverEvent, function () { });

--- a/tests/Integrations/Laravel/Octane/CommonScenariosTest.php
+++ b/tests/Integrations/Laravel/Octane/CommonScenariosTest.php
@@ -68,7 +68,11 @@ class CommonScenariosTest extends WebFrameworkTestCase
 
             foreach ($traces as $trace) {
                 foreach ($trace as $span) {
-                    if ($span && isset($span["name"]) && $span["name"] === "web.request") {
+                    if ($span
+                        && isset($span["name"])
+                        && $span["name"] === "laravel.request"
+                        && (str_contains($span["resource"], 'App\\Http\\Controllers') || $span["resource"] === 'GET /does_not_exist')
+                    ) {
                         return true;
                     }
                 }
@@ -88,14 +92,14 @@ class CommonScenariosTest extends WebFrameworkTestCase
 
         $webRequestTrace = null;
         foreach ($traces as $trace) {
-            if ($trace[0]["name"] === "web.request") {
+            if ($trace[0]["name"] === "laravel.request") {
                 $webRequestTrace = $trace;
             }
         }
 
         $this->assertFlameGraph([$webRequestTrace], [
             SpanAssertion::build(
-                'web.request',
+                'laravel.request',
                 'swoole_test_app',
                 'web',
                 'App\Http\Controllers\CommonSpecsController@simple simple_route'
@@ -105,7 +109,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                 Tag::HTTP_ROUTE => 'simple',
                 Tag::HTTP_STATUS_CODE => '200',
                 Tag::SPAN_KIND => 'server',
-                Tag::COMPONENT => 'swoole',
+                Tag::COMPONENT => 'laravel',
                 'laravel.route.name' => 'simple_route',
                 'laravel.route.action' => 'App\Http\Controllers\CommonSpecsController@simple',
             ])->withChildren([
@@ -134,7 +138,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
 
             foreach ($traces as $trace) {
                 foreach ($trace as $span) {
-                    if ($span && isset($span["name"]) && $span["name"] === "web.request") {
+                    if ($span && isset($span["name"]) && $span["name"] === "laravel.request") {
                         return true;
                     }
                 }
@@ -154,14 +158,14 @@ class CommonScenariosTest extends WebFrameworkTestCase
 
         $webRequestTrace = null;
         foreach ($traces as $trace) {
-            if ($trace[0]["name"] === "web.request") {
+            if ($trace[0]["name"] === "laravel.request") {
                 $webRequestTrace = $trace;
             }
         }
 
         $this->assertFlameGraph([$webRequestTrace], [
             SpanAssertion::build(
-                'web.request',
+                'laravel.request',
                 'swoole_test_app',
                 'web',
                 'App\Http\Controllers\CommonSpecsController@simple_view unnamed_route'
@@ -171,7 +175,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                 Tag::HTTP_ROUTE => 'simple_view',
                 Tag::HTTP_STATUS_CODE => '200',
                 Tag::SPAN_KIND => 'server',
-                Tag::COMPONENT => 'swoole',
+                Tag::COMPONENT => 'laravel',
                 'laravel.route.name' => 'unnamed_route',
                 'laravel.route.action' => 'App\Http\Controllers\CommonSpecsController@simple_view',
             ])->withChildren([
@@ -217,7 +221,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
 
             foreach ($traces as $trace) {
                 foreach ($trace as $span) {
-                    if ($span && isset($span["name"]) && $span["name"] === "web.request") {
+                    if ($span && isset($span["name"]) && $span["name"] === "laravel.request") {
                         return true;
                     }
                 }
@@ -237,14 +241,14 @@ class CommonScenariosTest extends WebFrameworkTestCase
 
         $webRequestTrace = null;
         foreach ($traces as $trace) {
-            if ($trace[0]["name"] === "web.request") {
+            if ($trace[0]["name"] === "laravel.request") {
                 $webRequestTrace = $trace;
             }
         }
 
         $this->assertFlameGraph([$webRequestTrace], [
             SpanAssertion::build(
-                'web.request',
+                'laravel.request',
                 'swoole_test_app',
                 'web',
                 'App\Http\Controllers\CommonSpecsController@error unnamed_route'
@@ -254,7 +258,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                 Tag::HTTP_ROUTE => 'error',
                 Tag::HTTP_STATUS_CODE => '500',
                 Tag::SPAN_KIND => 'server',
-                Tag::COMPONENT => 'swoole',
+                Tag::COMPONENT => 'laravel',
                 'laravel.route.name' => 'unnamed_route',
                 'laravel.route.action' => 'App\Http\Controllers\CommonSpecsController@error',
             ])->setError('Exception', 'Controller error', true)->withChildren([
@@ -282,7 +286,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
 
             foreach ($traces as $trace) {
                 foreach ($trace as $span) {
-                    if ($span && isset($span["name"]) && $span["name"] === "web.request") {
+                    if ($span && isset($span["name"]) && $span["name"] === "laravel.request") {
                         return true;
                     }
                 }
@@ -302,14 +306,14 @@ class CommonScenariosTest extends WebFrameworkTestCase
 
         $webRequestTrace = null;
         foreach ($traces as $trace) {
-            if ($trace[0]["name"] === "web.request") {
+            if ($trace[0]["name"] === "laravel.request") {
                 $webRequestTrace = $trace;
             }
         }
 
         $this->assertFlameGraph([$webRequestTrace], [
             SpanAssertion::build(
-                'web.request',
+                'laravel.request',
                 'swoole_test_app',
                 'web',
                 'GET /does_not_exist'
@@ -318,7 +322,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                 Tag::HTTP_URL => 'http://localhost:9999/does_not_exist?key=value&<redacted>',
                 Tag::HTTP_STATUS_CODE => '404',
                 Tag::SPAN_KIND => 'server',
-                Tag::COMPONENT => 'swoole',
+                Tag::COMPONENT => 'laravel',
             ])->withChildren([
                 SpanAssertion::build(
                     'laravel.view.render',


### PR DESCRIPTION
### Description

As surfaced in #2636

Currently, the root span from Laravel octane requests' will be `web.request`.

However, this can cause confusion on the Datadog UI, as the backend will most likely choose `laravel.request` as the primary operation, as seen from the screen below:
![image](https://github.com/DataDog/dd-trace-php/assets/42672104/08fde624-63a7-4018-b910-1987eba2ddae)

Therefore, this PR changes the operation name of Laravel octane requests (Swoole, Roadrunner, and beyond) from `web.request` to `laravel.request`, so that it is consistent with the default Laravel behavior.

This is a breaking change, but the next release is 1.0, right? 😉 

Additionally, with this change, if `DD_SERVICE` isn't set, then the request will use Laravel's APP_NAME instead of 'swoole', which is a better experience

---

Technically, I'm hooking `Laravel\Octane\Worker::handle` as it is guaranteed to happen for all incoming requests (Swoole, RR, etc.). What's more, it happens _after_ the prehook set on the `requeststart` event callback (hence ensuring `laravel.request` is not overwritten by `web.request` from the SwooleIntegration).


<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
