### PR TITLE
fix: Callback after Swoole Server instance creation

### DIFF
--- a/src/DDTrace/Integrations/Swoole/SwooleIntegration.php
+++ b/src/DDTrace/Integrations/Swoole/SwooleIntegration.php
@@ -141,8 +141,13 @@ class SwooleIntegration extends Integration
         \DDTrace\hook_method(
             'Swoole\Http\Server',
             '__construct',
+            null,
             function ($server) use ($integration) {
-                foreach (['workerstart', 'workerstop', 'workerexit', 'workererror'] as $serverEvent) {
+                $server->on('workerstart', function () {
+                    swoole_set_process_name("");
+                });
+
+                foreach (['workerstop', 'workerexit', 'workererror'] as $serverEvent) {
                     $server->on($serverEvent, function () { });
                 }
             }


### PR DESCRIPTION
### Description

Trying to set the callbacks **before** the instance is created is senseless: That's the bug.

This PR defers the dummy callbacks to the posthook, so that we have an instance.

`workerstart` is a bit special, as it needs a process name/title to be set. Most notably, Laravel Octane also [sets a process name](https://github.com/laravel/octane/blob/93c0e044e9464c58e5e1a1483c0f9d53ef0826da/src/Swoole/SwooleExtension.php#L35) on [the workerstart event](https://github.com/laravel/octane/blob/93c0e044e9464c58e5e1a1483c0f9d53ef0826da/src/Swoole/Handlers/OnWorkerStart.php#L46-L49).

I'm using an empty value as doing `cli_get_process_title` during this callbacks returns an empty value as well. Alternatively, we could have set it to `Task Worker Process` or `Worker Process` depending on the worker type, but it doesn't appear to be the default behavior of Swoole.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
