### PR TITLE
refactor(profiling): use `php_version` when available

### DIFF
--- a/profiling/src/allocation.rs
+++ b/profiling/src/allocation.rs
@@ -154,7 +154,7 @@ pub fn alloc_prof_minit() {
 
 pub fn first_rinit_should_disable_due_to_jit() -> bool {
     if NEEDS_RUN_TIME_CHECK_FOR_ENABLED_JIT
-        && alloc_prof_needs_disabled_for_jit(unsafe { crate::PHP_VERSION_ID })
+        && alloc_prof_needs_disabled_for_jit(unsafe { crate::RUNTIME_PHP_VERSION_ID })
         && *JIT_ENABLED
     {
         error!("Memory allocation profiling will be disabled as long as JIT is active. To enable allocation profiling disable JIT or upgrade PHP to at least version 8.1.21 or 8.2.8. See https://github.com/DataDog/dd-trace-php/pull/2088");

--- a/profiling/src/bindings/mod.rs
+++ b/profiling/src/bindings/mod.rs
@@ -327,6 +327,10 @@ extern "C" {
     /// Returns the PHP_VERSION_ID of the engine at run-time, not the version
     /// the extension was built against at compile-time.
     pub fn ddog_php_prof_php_version_id() -> u32;
+
+    /// Returns the PHP_VERSION of the engine at run-time, not the version the
+    /// extension was built against at compile-time.
+    pub fn ddog_php_prof_php_version() -> *const c_char;
 }
 
 #[cfg(php_post_startup_cb)]


### PR DESCRIPTION
### Description

Refactors the code to get the `PHP_VERSION` info at run-time. Also renames `PHP_VERSION` to `RUNTIME_PHP_VERSION` and `PHP_VERSION_ID` to `RUNTIME_PHP_VERSION_ID` to be a little more specific.

This uses the `php_version` function I added in PHP 8.3 to grab the version of PHP at run-time when it's available. This still uses the `Reflection` module version as a fallback for older versions.

If we fail to get the version at run-time, then we just fall back to the compile-time version and emit a warning.


<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
