### PR TITLE
Peer Service Precursors for DBM

### DIFF
--- a/tests/Integration/DatabaseMonitoringTest.php
+++ b/tests/Integration/DatabaseMonitoringTest.php
@@ -244,7 +244,9 @@ class DatabaseMonitoringTest extends IntegrationTestCase
         $keys = array_map(function ($part) {
             return explode('=', $part)[0];
         }, $dbmCommentParts);
-        $this->assertSame(['dddb', 'dddbs', 'dde', 'ddh', 'ddprs', 'ddps', 'ddpv', 'traceparent'], $keys);
+        $sortedKeys = $keys;
+        sort($sortedKeys);
+        $this->assertSame($sortedKeys, $keys);
     }
 
     public function testEnvPropagation()


### PR DESCRIPTION
### Description

Please take a look at [AIT-10031](https://datadoghq.atlassian.net/browse/AIT-10031) for the full details (contains the short RFC).

**Changed**
- `dddbs`: It should NOT be overridden by peer.service. There is some fake service thingy in the RFC, but I don't believe it applies there? Or there is something that I'm unaware of

**Added**
- `ddh`: The hostname of the database server
- `dddb`: The schema/database/namespace
- `ddprs`: Value of peer.service if and only if the customer explicitly sets this

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.


[AIT-10031]: https://datadoghq.atlassian.net/browse/AIT-10031?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ