### PR TITLE
Move env and version from meta to span properties

### DIFF
--- a/ext/compat_string.c
+++ b/ext/compat_string.c
@@ -78,9 +78,5 @@ try_again:
 
 void ddtrace_convert_to_string(zval *dst, zval *src) {
     zend_string *str = ddtrace_convert_to_str(src);
-    if (str) {
-        ZVAL_STR(dst, str);
-    } else {
-        ZVAL_NULL(dst);
-    }
+    ZVAL_STR(dst, str);
 }

--- a/ext/compatibility.h
+++ b/ext/compatibility.h
@@ -446,10 +446,8 @@ static zend_always_inline zend_result zend_call_function_with_return_value(zend_
 
 #if PHP_VERSION_ID < 80400
 #define zend_parse_arg_func(arg, dest_fci, dest_fcc, check_null, error, free_trampoline) zend_parse_arg_func(arg, dest_fci, dest_fcc, check_null, error)
-#endif
-
-#if PHP_VERSION_ID < 80400
-#define zend_parse_arg_func(arg, dest_fci, dest_fcc, check_null, error, free_trampoline) zend_parse_arg_func(arg, dest_fci, dest_fcc, check_null, error)
+#undef ZEND_RAW_FENTRY
+#define ZEND_RAW_FENTRY(zend_name, name, arg_info, flags, ...)   { zend_name, name, arg_info, (uint32_t) (sizeof(arg_info)/sizeof(struct _zend_internal_arg_info)-1), flags },
 #endif
 
 #endif  // DD_COMPATIBILITY_H

--- a/ext/configuration.h
+++ b/ext/configuration.h
@@ -94,7 +94,7 @@ enum ddtrace_sampling_rules_format {
     CONFIG(BOOL, DD_AUTOFINISH_SPANS, "false")                                                                 \
     CONFIG(BOOL, DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED, "true")                                               \
     CONFIG(BOOL, DD_HTTP_SERVER_ROUTE_BASED_NAMING, "true")                                                    \
-    CONFIG(STRING, DD_SERVICE, "")                                                                             \
+    CONFIG(STRING, DD_SERVICE, "", .ini_change = ddtrace_alter_dd_service)                                     \
     CONFIG(MAP, DD_SERVICE_MAPPING, "")                                                                        \
     CONFIG(MAP, DD_TAGS, "")                                                                                   \
     CONFIG(INT, DD_TRACE_AGENT_PORT, "0", .ini_change = zai_config_system_ini_change)                          \

--- a/ext/ddtrace.h
+++ b/ext/ddtrace.h
@@ -48,6 +48,7 @@ void ddtrace_disable_tracing_in_current_request(void);
 bool ddtrace_alter_dd_trace_disabled_config(zval *old_value, zval *new_value);
 bool ddtrace_alter_sampling_rules_file_config(zval *old_value, zval *new_value);
 bool ddtrace_alter_default_propagation_style(zval *old_value, zval *new_value);
+bool ddtrace_alter_dd_service(zval *old_value, zval *new_value);
 bool ddtrace_alter_dd_env(zval *old_value, zval *new_value);
 bool ddtrace_alter_dd_version(zval *old_value, zval *new_value);
 void dd_force_shutdown_tracing(void);

--- a/ext/ddtrace.stub.php
+++ b/ext/ddtrace.stub.php
@@ -83,6 +83,18 @@ namespace DDTrace {
         public string|null $service = "";
 
         /**
+         * @var string The environment you are tracing. Defaults to active environment at the time of span creation
+         * (i.e., the parent span), or datadog.env initialization settings if no parent exists
+         */
+        public string $env = "";
+
+        /**
+         * @var string The version of the application you are tracing. Defaults to active version at the time of
+         * span creation (i.e., the parent span), or datadog.version initialization settings if no parent exists
+         */
+        public string $version = "";
+
+        /**
          * @var string|null The type of request which can be set to: web, db, cache, or custom (Optional). Inherited
          * from parent.
          */

--- a/ext/ddtrace_arginfo.h
+++ b/ext/ddtrace_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 206c9d9eefe4af1076007627bb6d5651e23202ce */
+ * Stub hash: cbd454866b5b3f34bee057c9a35d7807c6e718ca */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_trace_method, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, className, IS_STRING, 0)
@@ -271,7 +271,6 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_class_DDTrace_Integration_init arginfo_dd_trace_dd_get_memory_limit
 
-
 ZEND_FUNCTION(DDTrace_trace_method);
 ZEND_FUNCTION(DDTrace_trace_function);
 ZEND_FUNCTION(DDTrace_hook_function);
@@ -346,49 +345,48 @@ ZEND_METHOD(DDTrace_SpanData, getStartTime);
 ZEND_METHOD(DDTrace_SpanData, getLink);
 ZEND_METHOD(DDTrace_SpanData, hexId);
 
-
 static const zend_function_entry ext_functions[] = {
-	ZEND_NS_FALIAS("DDTrace", trace_method, DDTrace_trace_method, arginfo_DDTrace_trace_method)
-	ZEND_NS_FALIAS("DDTrace", trace_function, DDTrace_trace_function, arginfo_DDTrace_trace_function)
-	ZEND_NS_FALIAS("DDTrace", hook_function, DDTrace_hook_function, arginfo_DDTrace_hook_function)
-	ZEND_NS_FALIAS("DDTrace", hook_method, DDTrace_hook_method, arginfo_DDTrace_hook_method)
-	ZEND_NS_FALIAS("DDTrace", add_global_tag, DDTrace_add_global_tag, arginfo_DDTrace_add_global_tag)
-	ZEND_NS_FALIAS("DDTrace", add_distributed_tag, DDTrace_add_distributed_tag, arginfo_DDTrace_add_distributed_tag)
-	ZEND_NS_FALIAS("DDTrace", set_user, DDTrace_set_user, arginfo_DDTrace_set_user)
-	ZEND_NS_FALIAS("DDTrace", close_spans_until, DDTrace_close_spans_until, arginfo_DDTrace_close_spans_until)
-	ZEND_NS_FALIAS("DDTrace", active_span, DDTrace_active_span, arginfo_DDTrace_active_span)
-	ZEND_NS_FALIAS("DDTrace", root_span, DDTrace_root_span, arginfo_DDTrace_root_span)
-	ZEND_NS_FALIAS("DDTrace", start_span, DDTrace_start_span, arginfo_DDTrace_start_span)
-	ZEND_NS_FALIAS("DDTrace", close_span, DDTrace_close_span, arginfo_DDTrace_close_span)
-	ZEND_NS_FALIAS("DDTrace", update_span_duration, DDTrace_update_span_duration, arginfo_DDTrace_update_span_duration)
-	ZEND_NS_FALIAS("DDTrace", start_trace_span, DDTrace_start_trace_span, arginfo_DDTrace_start_trace_span)
-	ZEND_NS_FALIAS("DDTrace", active_stack, DDTrace_active_stack, arginfo_DDTrace_active_stack)
-	ZEND_NS_FALIAS("DDTrace", create_stack, DDTrace_create_stack, arginfo_DDTrace_create_stack)
-	ZEND_NS_FALIAS("DDTrace", switch_stack, DDTrace_switch_stack, arginfo_DDTrace_switch_stack)
-	ZEND_NS_FALIAS("DDTrace", set_priority_sampling, DDTrace_set_priority_sampling, arginfo_DDTrace_set_priority_sampling)
-	ZEND_NS_FALIAS("DDTrace", get_priority_sampling, DDTrace_get_priority_sampling, arginfo_DDTrace_get_priority_sampling)
-	ZEND_NS_FALIAS("DDTrace", get_sanitized_exception_trace, DDTrace_get_sanitized_exception_trace, arginfo_DDTrace_get_sanitized_exception_trace)
-	ZEND_NS_FALIAS("DDTrace", consume_distributed_tracing_headers, DDTrace_consume_distributed_tracing_headers, arginfo_DDTrace_consume_distributed_tracing_headers)
-	ZEND_NS_FALIAS("DDTrace", generate_distributed_tracing_headers, DDTrace_generate_distributed_tracing_headers, arginfo_DDTrace_generate_distributed_tracing_headers)
-	ZEND_NS_FALIAS("DDTrace", find_active_exception, DDTrace_find_active_exception, arginfo_DDTrace_find_active_exception)
-	ZEND_NS_FALIAS("DDTrace", extract_ip_from_headers, DDTrace_extract_ip_from_headers, arginfo_DDTrace_extract_ip_from_headers)
-	ZEND_NS_FALIAS("DDTrace", startup_logs, DDTrace_startup_logs, arginfo_DDTrace_startup_logs)
-	ZEND_NS_FALIAS("DDTrace", trace_id, DDTrace_trace_id, arginfo_DDTrace_trace_id)
-	ZEND_NS_FALIAS("DDTrace", logs_correlation_trace_id, DDTrace_logs_correlation_trace_id, arginfo_DDTrace_logs_correlation_trace_id)
-	ZEND_NS_FALIAS("DDTrace", current_context, DDTrace_current_context, arginfo_DDTrace_current_context)
-	ZEND_NS_FALIAS("DDTrace", set_distributed_tracing_context, DDTrace_set_distributed_tracing_context, arginfo_DDTrace_set_distributed_tracing_context)
-	ZEND_NS_FALIAS("DDTrace", flush, DDTrace_flush, arginfo_DDTrace_flush)
-	ZEND_NS_FALIAS("DDTrace", curl_multi_exec_get_request_spans, DDTrace_curl_multi_exec_get_request_spans, arginfo_DDTrace_curl_multi_exec_get_request_spans)
-	ZEND_NS_FALIAS("DDTrace\\System", container_id, DDTrace_System_container_id, arginfo_DDTrace_System_container_id)
-	ZEND_NS_FALIAS("DDTrace\\Config", integration_analytics_enabled, DDTrace_Config_integration_analytics_enabled, arginfo_DDTrace_Config_integration_analytics_enabled)
-	ZEND_NS_FALIAS("DDTrace\\Config", integration_analytics_sample_rate, DDTrace_Config_integration_analytics_sample_rate, arginfo_DDTrace_Config_integration_analytics_sample_rate)
-	ZEND_NS_FALIAS("DDTrace\\UserRequest", has_listeners, DDTrace_UserRequest_has_listeners, arginfo_DDTrace_UserRequest_has_listeners)
-	ZEND_NS_FALIAS("DDTrace\\UserRequest", notify_start, DDTrace_UserRequest_notify_start, arginfo_DDTrace_UserRequest_notify_start)
-	ZEND_NS_FALIAS("DDTrace\\UserRequest", notify_commit, DDTrace_UserRequest_notify_commit, arginfo_DDTrace_UserRequest_notify_commit)
-	ZEND_NS_FALIAS("DDTrace\\UserRequest", set_blocking_function, DDTrace_UserRequest_set_blocking_function, arginfo_DDTrace_UserRequest_set_blocking_function)
-	ZEND_NS_FALIAS("DDTrace\\Testing", trigger_error, DDTrace_Testing_trigger_error, arginfo_DDTrace_Testing_trigger_error)
-	ZEND_NS_FALIAS("DDTrace\\Internal", add_span_flag, DDTrace_Internal_add_span_flag, arginfo_DDTrace_Internal_add_span_flag)
-	ZEND_NS_FALIAS("DDTrace\\Internal", handle_fork, DDTrace_Internal_handle_fork, arginfo_DDTrace_Internal_handle_fork)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "trace_method"), zif_DDTrace_trace_method, arginfo_DDTrace_trace_method, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "trace_function"), zif_DDTrace_trace_function, arginfo_DDTrace_trace_function, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "hook_function"), zif_DDTrace_hook_function, arginfo_DDTrace_hook_function, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "hook_method"), zif_DDTrace_hook_method, arginfo_DDTrace_hook_method, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "add_global_tag"), zif_DDTrace_add_global_tag, arginfo_DDTrace_add_global_tag, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "add_distributed_tag"), zif_DDTrace_add_distributed_tag, arginfo_DDTrace_add_distributed_tag, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "set_user"), zif_DDTrace_set_user, arginfo_DDTrace_set_user, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "close_spans_until"), zif_DDTrace_close_spans_until, arginfo_DDTrace_close_spans_until, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "active_span"), zif_DDTrace_active_span, arginfo_DDTrace_active_span, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "root_span"), zif_DDTrace_root_span, arginfo_DDTrace_root_span, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "start_span"), zif_DDTrace_start_span, arginfo_DDTrace_start_span, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "close_span"), zif_DDTrace_close_span, arginfo_DDTrace_close_span, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "update_span_duration"), zif_DDTrace_update_span_duration, arginfo_DDTrace_update_span_duration, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "start_trace_span"), zif_DDTrace_start_trace_span, arginfo_DDTrace_start_trace_span, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "active_stack"), zif_DDTrace_active_stack, arginfo_DDTrace_active_stack, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "create_stack"), zif_DDTrace_create_stack, arginfo_DDTrace_create_stack, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "switch_stack"), zif_DDTrace_switch_stack, arginfo_DDTrace_switch_stack, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "set_priority_sampling"), zif_DDTrace_set_priority_sampling, arginfo_DDTrace_set_priority_sampling, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "get_priority_sampling"), zif_DDTrace_get_priority_sampling, arginfo_DDTrace_get_priority_sampling, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "get_sanitized_exception_trace"), zif_DDTrace_get_sanitized_exception_trace, arginfo_DDTrace_get_sanitized_exception_trace, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "consume_distributed_tracing_headers"), zif_DDTrace_consume_distributed_tracing_headers, arginfo_DDTrace_consume_distributed_tracing_headers, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "generate_distributed_tracing_headers"), zif_DDTrace_generate_distributed_tracing_headers, arginfo_DDTrace_generate_distributed_tracing_headers, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "find_active_exception"), zif_DDTrace_find_active_exception, arginfo_DDTrace_find_active_exception, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "extract_ip_from_headers"), zif_DDTrace_extract_ip_from_headers, arginfo_DDTrace_extract_ip_from_headers, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "startup_logs"), zif_DDTrace_startup_logs, arginfo_DDTrace_startup_logs, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "trace_id"), zif_DDTrace_trace_id, arginfo_DDTrace_trace_id, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "logs_correlation_trace_id"), zif_DDTrace_logs_correlation_trace_id, arginfo_DDTrace_logs_correlation_trace_id, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "current_context"), zif_DDTrace_current_context, arginfo_DDTrace_current_context, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "set_distributed_tracing_context"), zif_DDTrace_set_distributed_tracing_context, arginfo_DDTrace_set_distributed_tracing_context, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "flush"), zif_DDTrace_flush, arginfo_DDTrace_flush, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "curl_multi_exec_get_request_spans"), zif_DDTrace_curl_multi_exec_get_request_spans, arginfo_DDTrace_curl_multi_exec_get_request_spans, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace\\System", "container_id"), zif_DDTrace_System_container_id, arginfo_DDTrace_System_container_id, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace\\Config", "integration_analytics_enabled"), zif_DDTrace_Config_integration_analytics_enabled, arginfo_DDTrace_Config_integration_analytics_enabled, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace\\Config", "integration_analytics_sample_rate"), zif_DDTrace_Config_integration_analytics_sample_rate, arginfo_DDTrace_Config_integration_analytics_sample_rate, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace\\UserRequest", "has_listeners"), zif_DDTrace_UserRequest_has_listeners, arginfo_DDTrace_UserRequest_has_listeners, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace\\UserRequest", "notify_start"), zif_DDTrace_UserRequest_notify_start, arginfo_DDTrace_UserRequest_notify_start, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace\\UserRequest", "notify_commit"), zif_DDTrace_UserRequest_notify_commit, arginfo_DDTrace_UserRequest_notify_commit, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace\\UserRequest", "set_blocking_function"), zif_DDTrace_UserRequest_set_blocking_function, arginfo_DDTrace_UserRequest_set_blocking_function, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace\\Testing", "trigger_error"), zif_DDTrace_Testing_trigger_error, arginfo_DDTrace_Testing_trigger_error, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace\\Internal", "add_span_flag"), zif_DDTrace_Internal_add_span_flag, arginfo_DDTrace_Internal_add_span_flag, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace\\Internal", "handle_fork"), zif_DDTrace_Internal_handle_fork, arginfo_DDTrace_Internal_handle_fork, 0, NULL, NULL)
 	ZEND_FE(dd_trace_env_config, arginfo_dd_trace_env_config)
 	ZEND_FE(dd_trace_disable_in_request, arginfo_dd_trace_disable_in_request)
 	ZEND_FE(dd_trace_reset, arginfo_dd_trace_reset)
@@ -411,20 +409,18 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_FE(dd_trace_serialize_closed_spans, arginfo_dd_trace_serialize_closed_spans)
 	ZEND_FE(dd_trace_peek_span_id, arginfo_dd_trace_peek_span_id)
 	ZEND_FE(dd_trace_close_all_spans_and_flush, arginfo_dd_trace_close_all_spans_and_flush)
-	ZEND_FALIAS(dd_trace_function, DDTrace_trace_function, arginfo_dd_trace_function)
-	ZEND_FALIAS(dd_trace_method, DDTrace_trace_method, arginfo_dd_trace_method)
+	ZEND_RAW_FENTRY("dd_trace_function", zif_DDTrace_trace_function, arginfo_dd_trace_function, 0, NULL, NULL)
+	ZEND_RAW_FENTRY("dd_trace_method", zif_DDTrace_trace_method, arginfo_dd_trace_method, 0, NULL, NULL)
 	ZEND_FE(dd_untrace, arginfo_dd_untrace)
 	ZEND_FE(dd_trace_synchronous_flush, arginfo_dd_trace_synchronous_flush)
 	ZEND_FE_END
 };
-
 
 static const zend_function_entry class_DDTrace_SpanLink_methods[] = {
 	ZEND_ME(DDTrace_SpanLink, jsonSerialize, arginfo_class_DDTrace_SpanLink_jsonSerialize, ZEND_ACC_PUBLIC)
 	ZEND_ME(DDTrace_SpanLink, fromHeaders, arginfo_class_DDTrace_SpanLink_fromHeaders, ZEND_ACC_PUBLIC|ZEND_ACC_STATIC)
 	ZEND_FE_END
 };
-
 
 static const zend_function_entry class_DDTrace_SpanData_methods[] = {
 	ZEND_ME(DDTrace_SpanData, getDuration, arginfo_class_DDTrace_SpanData_getDuration, ZEND_ACC_PUBLIC)
@@ -434,19 +430,16 @@ static const zend_function_entry class_DDTrace_SpanData_methods[] = {
 	ZEND_FE_END
 };
 
-
 static const zend_function_entry class_DDTrace_RootSpanData_methods[] = {
 	ZEND_FE_END
 };
-
 
 static const zend_function_entry class_DDTrace_SpanStack_methods[] = {
 	ZEND_FE_END
 };
 
-
 static const zend_function_entry class_DDTrace_Integration_methods[] = {
-	ZEND_ABSTRACT_ME_WITH_FLAGS(DDTrace_Integration, init, arginfo_class_DDTrace_Integration_init, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT)
+	ZEND_RAW_FENTRY("init", NULL, arginfo_class_DDTrace_Integration_init, ZEND_ACC_PUBLIC|ZEND_ACC_ABSTRACT, NULL, NULL)
 	ZEND_FE_END
 };
 
@@ -531,6 +524,18 @@ static zend_class_entry *register_class_DDTrace_SpanData(void)
 	zend_string *property_service_name = zend_string_init("service", sizeof("service") - 1, 1);
 	zend_declare_typed_property(class_entry, property_service_name, &property_service_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 	zend_string_release(property_service_name);
+
+	zval property_env_default_value;
+	ZVAL_EMPTY_STRING(&property_env_default_value);
+	zend_string *property_env_name = zend_string_init("env", sizeof("env") - 1, 1);
+	zend_declare_typed_property(class_entry, property_env_name, &property_env_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_env_name);
+
+	zval property_version_default_value;
+	ZVAL_EMPTY_STRING(&property_version_default_value);
+	zend_string *property_version_name = zend_string_init("version", sizeof("version") - 1, 1);
+	zend_declare_typed_property(class_entry, property_version_name, &property_version_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
+	zend_string_release(property_version_name);
 
 	zval property_type_default_value;
 	ZVAL_EMPTY_STRING(&property_type_default_value);

--- a/ext/priority_sampling/priority_sampling.c
+++ b/ext/priority_sampling/priority_sampling.c
@@ -219,6 +219,9 @@ static void dd_decide_on_sampling(ddtrace_root_span_data *span) {
 
             if (DDTRACE_G(agent_rate_by_service)) {
                 zval *env = zend_hash_str_find(ddtrace_property_array(&span->property_meta), ZEND_STRL("env"));
+                if (!env) {
+                    env = &span->property_env;
+                }
                 zval *sample_rate_zv = NULL;
                 zval *service = &span->property_service;
                 if (Z_TYPE_P(service) == IS_STRING && env && Z_TYPE_P(env) == IS_STRING) {

--- a/ext/serializer.c
+++ b/ext/serializer.c
@@ -761,12 +761,48 @@ static void dd_set_entrypoint_root_span_props(struct superglob_equiv *data, ddtr
     }
 }
 
+void ddtrace_inherit_span_properties(ddtrace_span_data *span, ddtrace_span_data *parent) {
+    zval *prop_service = &span->property_service;
+    zval_ptr_dtor(prop_service);
+    ZVAL_COPY(prop_service, &parent->property_service);
+    zval *prop_type = &span->property_type;
+    zval_ptr_dtor(prop_type);
+    ZVAL_COPY(prop_type, &parent->property_type);
+
+    zend_array *parent_meta = ddtrace_property_array(&parent->property_meta);
+
+    zval *prop_version = &span->property_version;
+    zval_ptr_dtor(prop_version);
+    zval *version;
+    if ((version = zend_hash_str_find(parent_meta, ZEND_STRL("version")))) {
+        zval old = *version;
+        ddtrace_convert_to_string(version, version);
+        zval_ptr_dtor(&old);
+    } else {
+        version = &parent->property_version;
+    }
+    ZVAL_COPY(prop_version, version);
+
+    zval *prop_env = &span->property_env;
+    zval_ptr_dtor(prop_env);
+    zval *env;
+    if ((env = zend_hash_str_find(parent_meta, ZEND_STRL("env")))) {
+        zval old = *env;
+        ddtrace_convert_to_string(env, env);
+        zval_ptr_dtor(&old);
+    } else {
+        env = &parent->property_env;
+    }
+    ZVAL_COPY(prop_env, env);
+}
+
 void ddtrace_set_root_span_properties(ddtrace_root_span_data *span) {
     ddtrace_update_root_id_properties(span);
 
     span->sampling_rule.rule = INT32_MAX;
 
     zend_array *meta = ddtrace_property_array(&span->property_meta);
+    zend_array *metrics = ddtrace_property_array(&span->property_metrics);
 
     zend_hash_copy(meta, &DDTRACE_G(root_span_tags_preset), (copy_ctor_func_t)zval_add_ref);
 
@@ -816,35 +852,17 @@ void ddtrace_set_root_span_properties(ddtrace_root_span_data *span) {
         }
     }
 
-    zend_array *metrics = ddtrace_property_array(&span->property_metrics);
-    zval *prop_type = &span->property_type;
-    zval *prop_name = &span->property_name;
-    zval *prop_service = &span->property_service;
-    zval value;
-
     ddtrace_root_span_data *parent_root = span->stack->parent_stack->root_span;
     if (parent_root) {
-        zval_ptr_dtor(prop_type);
-        ZVAL_COPY(prop_type, &parent_root->property_type);
-        zval_ptr_dtor(prop_service);
-        ZVAL_COPY(prop_service, &parent_root->property_service);
-
-        zend_array *parent_meta = ddtrace_property_array(&parent_root->property_meta);
-
-        zval *version = zend_hash_str_find(parent_meta, ZEND_STRL("version"));
-        if (version) {
-            Z_TRY_ADDREF_P(version);
-            zend_hash_str_add_new(meta, ZEND_STRL("version"), version);
-        }
-
-        zval *env = zend_hash_str_find(parent_meta, ZEND_STRL("env"));
-        if (env) {
-            Z_TRY_ADDREF_P(env);
-            zend_hash_str_add_new(meta, ZEND_STRL("env"), env);
-        }
-
+        ddtrace_inherit_span_properties(&span->span, &parent_root->span);
         ZVAL_COPY(&span->property_origin, &parent_root->property_origin);
     } else {
+        zval *prop_type = &span->property_type;
+        zval *prop_name = &span->property_name;
+        zval *prop_service = &span->property_service;
+        zval *prop_env = &span->property_env;
+        zval *prop_version = &span->property_version;
+
         if (strcmp(sapi_module.name, "cli") == 0) {
             zval_ptr_dtor(prop_type);
             ZVAL_STR(prop_type, zend_string_init(ZEND_STRL("cli"), 0));
@@ -863,16 +881,17 @@ void ddtrace_set_root_span_properties(ddtrace_root_span_data *span) {
         zval_ptr_dtor(prop_service);
         ZVAL_STR_COPY(prop_service, ZSTR_LEN(get_DD_SERVICE()) ? get_DD_SERVICE() : Z_STR_P(prop_name));
 
+
         zend_string *version = get_DD_VERSION();
         if (ZSTR_LEN(version) > 0) {  // non-empty
-            ZVAL_STR_COPY(&value, version);
-            zend_hash_str_add_new(meta, ZEND_STRL("version"), &value);
+            zval_ptr_dtor(prop_version);
+            ZVAL_STR_COPY(prop_version, version);
         }
 
         zend_string *env = get_DD_ENV();
         if (ZSTR_LEN(env) > 0) {  // non-empty
-            ZVAL_STR_COPY(&value, env);
-            zend_hash_str_add_new(meta, ZEND_STRL("env"), &value);
+            zval_ptr_dtor(prop_env);
+            ZVAL_STR_COPY(prop_env, env);
         }
 
         if (DDTRACE_G(dd_origin)) {
@@ -1152,19 +1171,44 @@ static void _serialize_meta(zval *el, ddtrace_span_data *span) {
                     continue;
                 }
 
-                if (!span->parent && zend_string_equals_literal_ci(str_key, "env")) {
-                    if (DDTRACE_G(last_flushed_root_env_name)) {
-                        zend_string_release(DDTRACE_G(last_flushed_root_env_name));
-                    }
-                    DDTRACE_G(last_flushed_root_env_name) = zend_string_copy(Z_STR_P(orig_val));
-                }
-
                 dd_serialize_array_meta_recursively(Z_ARRVAL(meta_zv), str_key, orig_val);
             }
         }
         ZEND_HASH_FOREACH_END();
     }
     meta = &meta_zv;
+
+    zval *existing_env, new_env;
+    if ((existing_env = zend_hash_str_find(Z_ARRVAL_P(meta), ZEND_STRL("env")))) {
+        LOG(DEPRECATED, "Using \"env\" in meta is deprecated. Instead specify the env property directly on the span.");
+    } else {
+        ddtrace_convert_to_string(&new_env, &span->property_env);
+        if (Z_STRLEN(new_env)) {
+            existing_env = zend_hash_str_add_new(Z_ARRVAL_P(meta), ZEND_STRL("env"), &new_env);
+        } else {
+            zval_ptr_dtor(&new_env);
+            ZVAL_EMPTY_STRING(&new_env);
+            existing_env = &new_env;
+        }
+    }
+    if (!span->parent) {
+        if (DDTRACE_G(last_flushed_root_env_name)) {
+            zend_string_release(DDTRACE_G(last_flushed_root_env_name));
+        }
+        DDTRACE_G(last_flushed_root_env_name) = zend_string_copy(Z_STR_P(existing_env));
+    }
+
+    zval new_version;
+    if (zend_hash_str_exists(Z_ARRVAL_P(meta), ZEND_STRL("version"))) {
+        LOG(DEPRECATED, "Using \"version\" in meta is deprecated. Instead specify the version property directly on the span.");
+    } else {
+        ddtrace_convert_to_string(&new_version, &span->property_version);
+        if (Z_STRLEN(new_version)) {
+            zend_hash_str_add_new(Z_ARRVAL_P(meta), ZEND_STRL("version"), &new_version);
+        } else {
+            zval_ptr_dtor(&new_version);
+        }
+    }
 
     zval *exception_zv = &span->property_exception;
     bool has_exception = Z_TYPE_P(exception_zv) == IS_OBJECT && instanceof_function(Z_OBJCE_P(exception_zv), zend_ce_throwable);

--- a/ext/serializer.h
+++ b/ext/serializer.h
@@ -12,6 +12,7 @@ void ddtrace_save_active_error_to_metadata(void);
 void ddtrace_set_global_span_properties(ddtrace_span_data *span);
 void ddtrace_set_root_span_properties(ddtrace_root_span_data *span);
 void ddtrace_update_root_id_properties(ddtrace_root_span_data *span);
+void ddtrace_inherit_span_properties(ddtrace_span_data *span, ddtrace_span_data *parent);
 
 void ddtrace_initialize_span_sampling_limiter(void);
 void ddtrace_shutdown_span_sampling_limiter(void);

--- a/ext/span.c
+++ b/ext/span.c
@@ -202,25 +202,7 @@ ddtrace_span_data *ddtrace_open_span(enum ddtrace_span_dataype type) {
     } else {
         // do not copy the parent, it was active span before, just transfer that reference
         ZVAL_OBJ(&span->property_parent, &parent_span->std);
-        zval *prop_service = &span->property_service;
-        zval_ptr_dtor(prop_service);
-        ZVAL_COPY(prop_service, &parent_span->property_service);
-        zval *prop_type = &span->property_type;
-        zval_ptr_dtor(prop_type);
-        ZVAL_COPY(prop_type, &parent_span->property_type);
-
-        zend_array *meta = ddtrace_property_array(&span->property_meta), *parent_meta = ddtrace_property_array(&parent_span->property_meta);
-        zval *version;
-        if ((version = zend_hash_str_find(parent_meta, ZEND_STRL("version")))) {
-            Z_TRY_ADDREF_P(version);
-            zend_hash_str_add_new(meta, ZEND_STRL("version"), version);
-        }
-
-        zval *env;
-        if ((env = zend_hash_str_find(parent_meta, ZEND_STRL("env")))) {
-            Z_TRY_ADDREF_P(env);
-            zend_hash_str_add_new(meta, ZEND_STRL("env"), env);
-        }
+        ddtrace_inherit_span_properties(span, parent_span);
     }
 
     span->root = DDTRACE_G(active_stack)->root_span;

--- a/ext/span.h
+++ b/ext/span.h
@@ -43,6 +43,8 @@ typedef union ddtrace_span_properties {
         zval property_name;
         zval property_resource;
         zval property_service;
+        zval property_env;
+        zval property_version;
         zval property_type;
         zval property_meta;
         zval property_metrics;

--- a/src/DDTrace/Integrations/DatabaseIntegrationHelper.php
+++ b/src/DDTrace/Integrations/DatabaseIntegrationHelper.php
@@ -66,7 +66,7 @@ class DatabaseIntegrationHelper
             $tags["dddbs"] = $databaseService;
         }
 
-        $env = $rootSpan->meta["env"] ?? "";
+        $env = $rootSpan->meta["env"] ?? $rootSpan->env ?? "";
         if ($env == "") {
             $env = ini_get("datadog.env");
         }
@@ -86,7 +86,7 @@ class DatabaseIntegrationHelper
             $tags["ddps"] = $service;
         }
 
-        $version = $rootSpan->meta["version"] ?? "";
+        $version = $rootSpan->meta["version"] ?? $rootSpan->version ?? "";
         if ($version == "") {
             $version = ini_get("datadog.version");
         }

--- a/src/DDTrace/Span.php
+++ b/src/DDTrace/Span.php
@@ -206,6 +206,10 @@ class Span extends DataSpan
     {
         if (isset($this->internalSpan->meta) && array_key_exists($key, $this->internalSpan->meta)) {
             return $this->internalSpan->meta[$key];
+        } elseif ($key === "env") {
+            return $this->internalSpan->env;
+        } elseif ($key === "version") {
+            return $this->internalSpan->version;
         }
 
         return null;

--- a/tests/Integration/DatabaseMonitoringTest.php
+++ b/tests/Integration/DatabaseMonitoringTest.php
@@ -228,7 +228,7 @@ class DatabaseMonitoringTest extends IntegrationTestCase
         $rootSpan = \DDTrace\root_span();
         $rootSpan->service = "";
         $rootSpan->meta["version"] = "0";
-        $rootSpan->meta["env"] = "0";
+        $rootSpan->env = "0";
         $commented = DatabaseIntegrationHelper::propagateViaSqlComments("q", "", \DDTrace\DBM_PROPAGATION_SERVICE);
         $this->assertSame("/*dde='0',ddpv='0'*/ q", $commented);
 

--- a/tests/Integration/ErrorReporting/ErrorReportingTest.php
+++ b/tests/Integration/ErrorReporting/ErrorReportingTest.php
@@ -30,7 +30,6 @@ final class ErrorReportingTest extends WebFrameworkTestCase
         $traces = $this->tracesFromWebRequest(function () {
             $this->call(GetSpec::create('', '/unhandled-user-error-index'));
         });
-        echo json_encode($traces, JSON_PRETTY_PRINT) . PHP_EOL;
         $this->assertError($traces[0][0], "Index message", [['index.php', '{main}']]);
         // open task: depends on internal status code tracking (separate PR)
         // $this->assertSame('500', $traces[0][0]['meta']['http.status_code']);

--- a/tests/OpenTracer1Unit/TracerTest.php
+++ b/tests/OpenTracer1Unit/TracerTest.php
@@ -34,8 +34,8 @@ final class TracerTest extends BaseTestCase
         $tracer = new Tracer();
 
         $span = $tracer->startSpan(self::OPERATION_NAME)->unwrapped();
-        $this->assertNull($span->getTag(Tag::ENV));
-        $this->assertNull($span->getTag(Tag::VERSION));
+        $this->assertSame("", $span->getTag(Tag::ENV));
+        $this->assertSame("", $span->getTag(Tag::VERSION));
     }
 
     public function testTracerWithConstructorArg()
@@ -43,8 +43,8 @@ final class TracerTest extends BaseTestCase
         $tracer = new Tracer(\DDTrace\GlobalTracer::get());
 
         $span = $tracer->startSpan(self::OPERATION_NAME)->unwrapped();
-        $this->assertNull($span->getTag(Tag::ENV));
-        $this->assertNull($span->getTag(Tag::VERSION));
+        $this->assertSame("", $span->getTag(Tag::ENV));
+        $this->assertSame("", $span->getTag(Tag::VERSION));
     }
 
     public function testCreateSpanWithDefaultTags()
@@ -52,27 +52,13 @@ final class TracerTest extends BaseTestCase
         $tracer = Tracer::make(new NoopTransport());
 
         $span = $tracer->startSpan(self::OPERATION_NAME)->unwrapped();
-        $this->assertNull($span->getTag(Tag::ENV));
-        $this->assertNull($span->getTag(Tag::VERSION));
+        $this->assertSame("", $span->getTag(Tag::ENV));
+        $this->assertSame("", $span->getTag(Tag::VERSION));
     }
 
     public function testCreateSpanWithEnvAndVersionConfigured()
     {
         $this->putEnvAndReloadConfig(['DD_ENV=' . self::ENVIRONMENT, 'DD_VERSION=' . self::VERSION]);
-        $tracer = Tracer::make(new NoopTransport());
-
-        $span = $tracer->startSpan(self::OPERATION_NAME)->unwrapped();
-        $this->assertSame(self::ENVIRONMENT, $span->getTag(Tag::ENV));
-        $this->assertSame(self::VERSION, $span->getTag(Tag::VERSION));
-    }
-
-    public function testCreateSpanWithEnvAndVersionPrecedence()
-    {
-        $this->putEnvAndReloadConfig([
-            'DD_ENV=' . self::ENVIRONMENT,
-            'DD_VERSION=' . self::VERSION,
-            'DD_TAGS=env:global-tag-env,version:4.5.6',
-        ]);
         $tracer = Tracer::make(new NoopTransport());
 
         $span = $tracer->startSpan(self::OPERATION_NAME)->unwrapped();

--- a/tests/OpenTracerUnit/TracerTest.php
+++ b/tests/OpenTracerUnit/TracerTest.php
@@ -41,8 +41,8 @@ final class TracerTest extends BaseTestCase
         $tracer = new Tracer(); //  Tracer::make(new NoopTransport());
 
         $span = $tracer->startSpan(self::OPERATION_NAME)->unwrapped();
-        $this->assertNull($span->getTag(Tag::ENV));
-        $this->assertNull($span->getTag(Tag::VERSION));
+        $this->assertSame("", $span->getTag(Tag::ENV));
+        $this->assertSame("", $span->getTag(Tag::VERSION));
     }
 
     public function testTracerWithConstructorArg()
@@ -50,8 +50,8 @@ final class TracerTest extends BaseTestCase
         $tracer = new Tracer(\DDTrace\GlobalTracer::get());
 
         $span = $tracer->startSpan(self::OPERATION_NAME)->unwrapped();
-        $this->assertNull($span->getTag(Tag::ENV));
-        $this->assertNull($span->getTag(Tag::VERSION));
+        $this->assertSame("", $span->getTag(Tag::ENV));
+        $this->assertSame("", $span->getTag(Tag::VERSION));
     }
 
     public function testCreateSpanWithDefaultTags()
@@ -59,27 +59,13 @@ final class TracerTest extends BaseTestCase
         $tracer = Tracer::make(new NoopTransport());
 
         $span = $tracer->startSpan(self::OPERATION_NAME)->unwrapped();
-        $this->assertNull($span->getTag(Tag::ENV));
-        $this->assertNull($span->getTag(Tag::VERSION));
+        $this->assertSame("", $span->getTag(Tag::ENV));
+        $this->assertSame("", $span->getTag(Tag::VERSION));
     }
 
     public function testCreateSpanWithEnvAndVersionConfigured()
     {
         $this->putEnvAndReloadConfig(['DD_ENV=' . self::ENVIRONMENT, 'DD_VERSION=' . self::VERSION]);
-        $tracer = Tracer::make(new NoopTransport());
-
-        $span = $tracer->startSpan(self::OPERATION_NAME)->unwrapped();
-        $this->assertSame(self::ENVIRONMENT, $span->getTag(Tag::ENV));
-        $this->assertSame(self::VERSION, $span->getTag(Tag::VERSION));
-    }
-
-    public function testCreateSpanWithEnvAndVersionPrecedence()
-    {
-        $this->putEnvAndReloadConfig([
-            'DD_ENV=' . self::ENVIRONMENT,
-            'DD_VERSION=' . self::VERSION,
-            'DD_TAGS=env:global-tag-env,version:4.5.6',
-        ]);
         $tracer = Tracer::make(new NoopTransport());
 
         $span = $tracer->startSpan(self::OPERATION_NAME)->unwrapped();

--- a/tests/ext/active_span.phpt
+++ b/tests/ext/active_span.phpt
@@ -28,13 +28,17 @@ var_dump(DDTrace\active_span() == DDTrace\active_span());
 Hello, Datadog.
 greet tracer.
 bool(true)
-object(DDTrace\RootSpanData)#%d (16) {
+object(DDTrace\RootSpanData)#%d (18) {
   ["name"]=>
   string(15) "active_span.php"
   ["resource"]=>
   string(0) ""
   ["service"]=>
   string(15) "active_span.php"
+  ["env"]=>
+  string(0) ""
+  ["version"]=>
+  string(0) ""
   ["type"]=>
   string(3) "cli"
   ["meta"]=>

--- a/tests/ext/background-sender/agent_sampling.phpt
+++ b/tests/ext/background-sender/agent_sampling.phpt
@@ -40,7 +40,7 @@ echo "Generic sampling: {$get_sampling()}\n";
 
 $s = \DDTrace\start_span();
 $s->service = "foo";
-$s->meta["env"] = "none";
+$s->env = "none";
 \DDTrace\close_span();
 
 $rr->waitForFlush();

--- a/tests/ext/inherit_meta_from_parent.phpt
+++ b/tests/ext/inherit_meta_from_parent.phpt
@@ -24,8 +24,8 @@ var_dump(array_intersect_key(dd_trace_serialize_closed_spans()[1]["meta"], [
 ?>
 --EXPECT--
 array(2) {
-  ["version"]=>
-  string(11) "goodversion"
   ["env"]=>
   string(7) "goodenv"
+  ["version"]=>
+  string(11) "goodversion"
 }

--- a/tests/ext/runtime_ini_env_version_change.phpt
+++ b/tests/ext/runtime_ini_env_version_change.phpt
@@ -3,17 +3,17 @@ Change the env and version INIs at runtime
 --FILE--
 <?php
 
-var_dump(isset(\DDTrace\root_span()->meta["env"]), isset(\DDTrace\root_span()->meta["version"]));
+var_dump(\DDTrace\root_span()->env, \DDTrace\root_span()->version);
 
 ini_set("datadog.env", "test");
 ini_set("datadog.version", "1.0.0");
 
-echo "New env: ", \DDTrace\root_span()->meta["env"], "\n";
-echo "New version: ", \DDTrace\root_span()->meta["version"], "\n";
+echo "New env: ", \DDTrace\root_span()->env, "\n";
+echo "New version: ", \DDTrace\root_span()->version, "\n";
 
 ?>
 --EXPECT--
-bool(false)
-bool(false)
+string(0) ""
+string(0) ""
 New env: test
 New version: 1.0.0

--- a/tests/ext/sandbox/span_clone.phpt
+++ b/tests/ext/sandbox/span_clone.phpt
@@ -24,13 +24,17 @@ var_dump(dd_trace_serialize_closed_spans());
 
 ?>
 --EXPECTF--
-object(DDTrace\RootSpanData)#%d (16) {
+object(DDTrace\RootSpanData)#%d (18) {
   ["name"]=>
   string(3) "foo"
   ["resource"]=>
   string(3) "abc"
   ["service"]=>
   string(14) "span_clone.php"
+  ["env"]=>
+  string(0) ""
+  ["version"]=>
+  string(0) ""
   ["type"]=>
   string(3) "cli"
   ["meta"]=>
@@ -78,13 +82,17 @@ object(DDTrace\RootSpanData)#%d (16) {
   ["traceId"]=>
   string(32) "%s"
 }
-object(DDTrace\RootSpanData)#%d (16) {
+object(DDTrace\RootSpanData)#%d (18) {
   ["name"]=>
   string(5) "dummy"
   ["resource"]=>
   string(3) "abc"
   ["service"]=>
   string(14) "span_clone.php"
+  ["env"]=>
+  string(0) ""
+  ["version"]=>
+  string(0) ""
   ["type"]=>
   string(3) "cli"
   ["meta"]=>
@@ -119,13 +127,17 @@ object(DDTrace\RootSpanData)#%d (16) {
       NULL
     }
     ["active"]=>
-    object(DDTrace\RootSpanData)#%d (16) {
+    object(DDTrace\RootSpanData)#%d (18) {
       ["name"]=>
       string(3) "foo"
       ["resource"]=>
       string(3) "abc"
       ["service"]=>
       string(14) "span_clone.php"
+      ["env"]=>
+      string(0) ""
+      ["version"]=>
+      string(0) ""
       ["type"]=>
       string(3) "cli"
       ["meta"]=>


### PR DESCRIPTION
As a fallback, direct assignments to $span->meta["env"] (or version) do still take precedence over the new properties. This was deprecated, and will be eventually removed.

Side note: There were tests for DD_TAGS vs DD_ENV and DD_VERSION. These tests started failing. I elected to remove the tests instead of adding special handling in ddtrace_set_global_span_properties() (if key equals env and property_env non-empty, then ignore). These tests came from a 4 year old migration, at which time these tags had to be set via DD_TAGS, thus prioritizing DD_ENV and DD_VERSION explicitly made sense. By now it would just be a waste of CPU cycles to check that.

This change is important for being able to track changes to service/env/version in the future context of remote configuration.