### PR TITLE
fix(ci): Install `php` during plesk installer test

### DIFF
--- a/dockerfiles/verify_packages/installer/test_install_on_plesk.sh
+++ b/dockerfiles/verify_packages/installer/test_install_on_plesk.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+service mysql start
+
 plesk installer --select-release-current --install-component php8.1
 
 . "$(dirname ${0})/utils.sh"

--- a/dockerfiles/verify_packages/installer/test_install_on_plesk.sh
+++ b/dockerfiles/verify_packages/installer/test_install_on_plesk.sh
@@ -2,6 +2,8 @@
 
 set -e
 
+apt-get update && apt-get install -y php
+
 . "$(dirname ${0})/utils.sh"
 
 # Install using the php installer

--- a/dockerfiles/verify_packages/installer/test_install_on_plesk.sh
+++ b/dockerfiles/verify_packages/installer/test_install_on_plesk.sh
@@ -2,7 +2,7 @@
 
 set -e
 
-apt-get update && apt-get install -y php
+plesk installer --select-release-current --install-component php8.1
 
 . "$(dirname ${0})/utils.sh"
 


### PR DESCRIPTION
### Description

The installer test job has been failing for quite some days now (e.g., [here](https://app.circleci.com/pipelines/github/DataDog/dd-trace-php/15754/workflows/b221448e-4c47-4c12-9606-b3de7c2b0d60/jobs/4296357?invite=true#step-105-1214)). It seems like a new `plesk/plesk` image was pushed which doesn't include `php`. 

This PR installs PHP in the relevant test environment _(the plesk way)._

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
