### PR TITLE
Make use of the sidecar thread safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -297,6 +297,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cadence"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f338b979d9ebfff4bb9801ae8f3af0dc3615f7f1ca963f2e4782bcf9acb3753"
+dependencies = [
+ "crossbeam-channel",
+]
+
+[[package]]
 name = "cast"
 version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -813,6 +822,7 @@ dependencies = [
  "arrayref",
  "bincode",
  "bytes",
+ "cadence",
  "chrono",
  "console-subscriber",
  "datadog-ipc",

--- a/components-rs/common.h
+++ b/components-rs/common.h
@@ -176,8 +176,6 @@ typedef enum ddog_MetricNamespace {
   DDOG_METRIC_NAMESPACE_SIDECAR,
 } ddog_MetricNamespace;
 
-typedef struct ddog_BlockingTransport_SidecarInterfaceResponse__SidecarInterfaceRequest ddog_BlockingTransport_SidecarInterfaceResponse__SidecarInterfaceRequest;
-
 /**
  * `InstanceId` is a structure that holds session and runtime identifiers.
  */
@@ -186,15 +184,15 @@ typedef struct ddog_InstanceId ddog_InstanceId;
 typedef struct ddog_SidecarActionsBuffer ddog_SidecarActionsBuffer;
 
 /**
- * `SidecarTransport` is a type alias for the `BlockingTransport` struct from the `datadog_ipc`
- * crate. It is used for sending `SidecarInterfaceRequest` and receiving
- * `SidecarInterfaceResponse`.
+ * `SidecarTransport` is a wrapper around a BlockingTransport struct from the `datadog_ipc` crate
+ * that handles transparent reconnection.
+ * It is used for sending `SidecarInterfaceRequest` and receiving `SidecarInterfaceResponse`.
  *
  * This transport is used for communication between different parts of the sidecar service.
  * It is a blocking transport, meaning that it will block the current thread until the operation is
  * complete.
  */
-typedef struct ddog_BlockingTransport_SidecarInterfaceResponse__SidecarInterfaceRequest ddog_SidecarTransport;
+typedef struct ddog_SidecarTransport ddog_SidecarTransport;
 
 typedef enum ddog_LogLevel {
   DDOG_LOG_LEVEL_ERROR,

--- a/components-rs/ddtrace.h
+++ b/components-rs/ddtrace.h
@@ -151,7 +151,7 @@ void ddog_reset_logger(void);
 
 uint32_t ddog_get_logs_count(ddog_CharSlice level);
 
-bool ddtrace_detect_composer_installed_json(ddog_SidecarTransport **transport,
+bool ddtrace_detect_composer_installed_json(struct ddog_SidecarTransport **transport,
                                             const struct ddog_InstanceId *instance_id,
                                             const ddog_QueueId *queue_id,
                                             ddog_CharSlice path);
@@ -172,7 +172,7 @@ void ddog_sidecar_telemetry_enqueueConfig_buffer(struct ddog_SidecarActionsBuffe
                                                  ddog_CharSlice config_value,
                                                  enum ddog_ConfigurationOrigin origin);
 
-ddog_MaybeError ddog_sidecar_telemetry_buffer_flush(ddog_SidecarTransport **transport,
+ddog_MaybeError ddog_sidecar_telemetry_buffer_flush(struct ddog_SidecarTransport **transport,
                                                     const struct ddog_InstanceId *instance_id,
                                                     const ddog_QueueId *queue_id,
                                                     struct ddog_SidecarActionsBuffer *buffer);
@@ -186,7 +186,7 @@ void ddog_sidecar_telemetry_add_span_metric_point_buffer(struct ddog_SidecarActi
                                                          double metric_value,
                                                          ddog_CharSlice tags);
 
-ddog_MaybeError ddog_sidecar_connect_php(ddog_SidecarTransport **connection,
+ddog_MaybeError ddog_sidecar_connect_php(struct ddog_SidecarTransport **connection,
                                          const char *error_path,
                                          ddog_CharSlice log_level,
                                          bool enable_telemetry);

--- a/components-rs/sidecar.h
+++ b/components-rs/sidecar.h
@@ -60,15 +60,15 @@ void ddog_agent_remote_config_reader_drop(struct ddog_AgentRemoteConfigReader*);
 
 void ddog_agent_remote_config_writer_drop(struct ddog_AgentRemoteConfigWriter_ShmHandle*);
 
-void ddog_sidecar_transport_drop(ddog_SidecarTransport*);
+void ddog_sidecar_transport_drop(struct ddog_SidecarTransport*);
 
 /**
  * # Safety
  * Caller must ensure the process is safe to fork, at the time when this method is called
  */
-ddog_MaybeError ddog_sidecar_connect(ddog_SidecarTransport **connection);
+ddog_MaybeError ddog_sidecar_connect(struct ddog_SidecarTransport **connection);
 
-ddog_MaybeError ddog_sidecar_ping(ddog_SidecarTransport **transport);
+ddog_MaybeError ddog_sidecar_ping(struct ddog_SidecarTransport **transport);
 
 struct ddog_InstanceId *ddog_sidecar_instanceId_build(ddog_CharSlice session_id,
                                                       ddog_CharSlice runtime_id);
@@ -83,60 +83,94 @@ struct ddog_RuntimeMetadata *ddog_sidecar_runtimeMeta_build(ddog_CharSlice langu
 
 void ddog_sidecar_runtimeMeta_drop(struct ddog_RuntimeMetadata *meta);
 
-ddog_MaybeError ddog_sidecar_telemetry_enqueueConfig(ddog_SidecarTransport **transport,
+ddog_MaybeError ddog_sidecar_telemetry_enqueueConfig(struct ddog_SidecarTransport **transport,
                                                      const struct ddog_InstanceId *instance_id,
                                                      const ddog_QueueId *queue_id,
                                                      ddog_CharSlice config_key,
                                                      ddog_CharSlice config_value,
                                                      enum ddog_ConfigurationOrigin origin);
 
-ddog_MaybeError ddog_sidecar_telemetry_addDependency(ddog_SidecarTransport **transport,
+ddog_MaybeError ddog_sidecar_telemetry_addDependency(struct ddog_SidecarTransport **transport,
                                                      const struct ddog_InstanceId *instance_id,
                                                      const ddog_QueueId *queue_id,
                                                      ddog_CharSlice dependency_name,
                                                      ddog_CharSlice dependency_version);
 
-ddog_MaybeError ddog_sidecar_telemetry_addIntegration(ddog_SidecarTransport **transport,
+ddog_MaybeError ddog_sidecar_telemetry_addIntegration(struct ddog_SidecarTransport **transport,
                                                       const struct ddog_InstanceId *instance_id,
                                                       const ddog_QueueId *queue_id,
                                                       ddog_CharSlice integration_name,
                                                       ddog_CharSlice integration_version,
                                                       bool integration_enabled);
 
-ddog_MaybeError ddog_sidecar_telemetry_flushServiceData(ddog_SidecarTransport **transport,
+ddog_MaybeError ddog_sidecar_telemetry_flushServiceData(struct ddog_SidecarTransport **transport,
                                                         const struct ddog_InstanceId *instance_id,
                                                         const ddog_QueueId *queue_id,
                                                         const struct ddog_RuntimeMetadata *runtime_meta,
                                                         ddog_CharSlice service_name,
                                                         ddog_CharSlice env_name);
 
-ddog_MaybeError ddog_sidecar_telemetry_end(ddog_SidecarTransport **transport,
+ddog_MaybeError ddog_sidecar_telemetry_end(struct ddog_SidecarTransport **transport,
                                            const struct ddog_InstanceId *instance_id,
                                            const ddog_QueueId *queue_id);
 
-bool ddog_sidecar_is_closed(ddog_SidecarTransport **transport);
+bool ddog_sidecar_is_closed(struct ddog_SidecarTransport **transport);
 
-ddog_MaybeError ddog_sidecar_session_set_config(ddog_SidecarTransport **transport,
+ddog_MaybeError ddog_sidecar_session_set_config(struct ddog_SidecarTransport **transport,
                                                 ddog_CharSlice session_id,
-                                                const struct ddog_Endpoint *endpoint,
+                                                const struct ddog_Endpoint *agent_endpoint,
+                                                const struct ddog_Endpoint *dogstatsd_endpoint,
                                                 uint64_t flush_interval_milliseconds,
                                                 uintptr_t force_flush_size,
                                                 uintptr_t force_drop_size,
                                                 ddog_CharSlice log_level,
                                                 ddog_CharSlice log_path);
 
-ddog_MaybeError ddog_sidecar_send_trace_v04_shm(ddog_SidecarTransport **transport,
+ddog_MaybeError ddog_sidecar_send_trace_v04_shm(struct ddog_SidecarTransport **transport,
                                                 const struct ddog_InstanceId *instance_id,
                                                 struct ddog_ShmHandle *shm_handle,
                                                 const struct ddog_TracerHeaderTags *tracer_header_tags);
 
-ddog_MaybeError ddog_sidecar_send_trace_v04_bytes(ddog_SidecarTransport **transport,
+ddog_MaybeError ddog_sidecar_send_trace_v04_bytes(struct ddog_SidecarTransport **transport,
                                                   const struct ddog_InstanceId *instance_id,
                                                   ddog_CharSlice data,
                                                   const struct ddog_TracerHeaderTags *tracer_header_tags);
 
-ddog_CharSlice ddog_sidecar_dump(ddog_SidecarTransport **transport);
+ddog_CharSlice ddog_sidecar_dump(struct ddog_SidecarTransport **transport);
 
-ddog_CharSlice ddog_sidecar_stats(ddog_SidecarTransport **transport);
+ddog_CharSlice ddog_sidecar_stats(struct ddog_SidecarTransport **transport);
+
+ddog_MaybeError ddog_sidecar_dogstatsd_count(struct ddog_SidecarTransport **transport,
+                                             const struct ddog_InstanceId *instance_id,
+                                             ddog_CharSlice metric,
+                                             int64_t value,
+                                             const struct ddog_Vec_Tag *tags);
+
+ddog_MaybeError ddog_sidecar_dogstatsd_distribution(struct ddog_SidecarTransport **transport,
+                                                    const struct ddog_InstanceId *instance_id,
+                                                    ddog_CharSlice metric,
+                                                    double value,
+                                                    const struct ddog_Vec_Tag *tags);
+
+ddog_MaybeError ddog_sidecar_dogstatsd_gauge(struct ddog_SidecarTransport **transport,
+                                             const struct ddog_InstanceId *instance_id,
+                                             ddog_CharSlice metric,
+                                             double value,
+                                             const struct ddog_Vec_Tag *tags);
+
+ddog_MaybeError ddog_sidecar_dogstatsd_histogram(struct ddog_SidecarTransport **transport,
+                                                 const struct ddog_InstanceId *instance_id,
+                                                 ddog_CharSlice metric,
+                                                 double value,
+                                                 const struct ddog_Vec_Tag *tags);
+
+ddog_MaybeError ddog_sidecar_dogstatsd_set(struct ddog_SidecarTransport **transport,
+                                           const struct ddog_InstanceId *instance_id,
+                                           ddog_CharSlice metric,
+                                           int64_t value,
+                                           const struct ddog_Vec_Tag *tags);
+
+void ddog_sidecar_reconnect(struct ddog_SidecarTransport **transport,
+                            struct ddog_SidecarTransport *(*factory)(void));
 
 #endif /* DDOG_SIDECAR_H */

--- a/ext/sidecar.c
+++ b/ext/sidecar.c
@@ -11,15 +11,10 @@ ddog_Endpoint *ddtrace_endpoint;
 struct ddog_InstanceId *ddtrace_sidecar_instance_id;
 static uint8_t dd_sidecar_formatted_session_id[36];
 
-static void ddtrace_set_sidecar_globals(void) {
-    uint8_t formatted_run_time_id[36];
-    ddtrace_format_runtime_id(&formatted_run_time_id);
-    ddog_CharSlice runtime_id = (ddog_CharSlice) {.ptr = (char *) formatted_run_time_id, .len = sizeof(formatted_run_time_id)};
-    ddog_CharSlice session_id = (ddog_CharSlice) {.ptr = (char *) dd_sidecar_formatted_session_id, .len = sizeof(dd_sidecar_formatted_session_id)};
-    ddtrace_sidecar_instance_id = ddog_sidecar_instanceId_build(session_id, runtime_id);
-}
+// Set the globals that stay unchanged in case of fork
+static void ddtrace_set_non_resettable_sidecar_globals(void) {
+    ddtrace_format_runtime_id(&dd_sidecar_formatted_session_id);
 
-static bool dd_sidecar_connection_init(void) {
     if (get_global_DD_TRACE_AGENTLESS() && ZSTR_LEN(get_global_DD_API_KEY())) {
         ddtrace_endpoint = ddog_endpoint_from_api_key(dd_zend_string_to_CharSlice(get_global_DD_API_KEY()));
     } else {
@@ -27,11 +22,27 @@ static bool dd_sidecar_connection_init(void) {
         ddtrace_endpoint = ddog_endpoint_from_url((ddog_CharSlice) {.ptr = agent_url, .len = strlen(agent_url)});
         free(agent_url);
     }
+}
 
+// Set the globals that must be updated in case of fork
+static void ddtrace_set_resettable_sidecar_globals(void) {
+    uint8_t formatted_run_time_id[36];
+    ddtrace_format_runtime_id(&formatted_run_time_id);
+    ddog_CharSlice runtime_id = (ddog_CharSlice) {.ptr = (char *) formatted_run_time_id, .len = sizeof(formatted_run_time_id)};
+    ddog_CharSlice session_id = (ddog_CharSlice) {.ptr = (char *) dd_sidecar_formatted_session_id, .len = sizeof(dd_sidecar_formatted_session_id)};
+    ddtrace_sidecar_instance_id = ddog_sidecar_instanceId_build(session_id, runtime_id);
+}
+
+ddog_SidecarTransport *dd_sidecar_connection_factory(void) {
+    // Should not happen
     if (!ddtrace_endpoint) {
-        ddtrace_sidecar = NULL;
-        return false;
+        return NULL;
     }
+
+    ddog_Endpoint *dogstatsd_endpoint;
+    char *tmp = ddtrace_agent_url();
+    dogstatsd_endpoint = ddog_endpoint_from_url((ddog_CharSlice) {.ptr = tmp, .len = strlen(tmp)});
+    free(tmp);
 
 #ifdef _WIN32
     DDOG_PHP_FUNCTION = (const uint8_t *)zend_hash_func;
@@ -43,43 +54,43 @@ static bool dd_sidecar_connection_init(void) {
         *logpath = 0;
     }
 
-    if (!ddtrace_ffi_try("Failed connecting to the sidecar", ddog_sidecar_connect_php(&ddtrace_sidecar, logpath, dd_zend_string_to_CharSlice(get_global_DD_TRACE_LOG_LEVEL()), get_global_DD_INSTRUMENTATION_TELEMETRY_ENABLED()))) {
-        ddog_endpoint_drop(ddtrace_endpoint);
-        ddtrace_endpoint = NULL;
-        ddtrace_sidecar = NULL;
-        return false;
-    }
-
-    if (!ddtrace_sidecar_instance_id) {
-        ddtrace_format_runtime_id(&dd_sidecar_formatted_session_id);
-        ddtrace_set_sidecar_globals();
-
-        if (get_global_DD_INSTRUMENTATION_TELEMETRY_ENABLED()) {
-            ddtrace_telemetry_first_init();
-        }
+    ddog_SidecarTransport *sidecar_transport;
+    if (!ddtrace_ffi_try("Failed connecting to the sidecar", ddog_sidecar_connect_php(&sidecar_transport, logpath, dd_zend_string_to_CharSlice(get_global_DD_TRACE_LOG_LEVEL()), get_global_DD_INSTRUMENTATION_TELEMETRY_ENABLED()))) {
+        ddog_endpoint_drop(dogstatsd_endpoint);
+        return NULL;
     }
 
     ddog_CharSlice session_id = (ddog_CharSlice) {.ptr = (char *) dd_sidecar_formatted_session_id, .len = sizeof(dd_sidecar_formatted_session_id)};
-    ddog_sidecar_session_set_config(&ddtrace_sidecar, session_id, ddtrace_endpoint,
+    ddog_sidecar_session_set_config(&sidecar_transport, session_id, ddtrace_endpoint, dogstatsd_endpoint,
                                     get_global_DD_TRACE_AGENT_FLUSH_INTERVAL(),
                                     get_global_DD_TRACE_AGENT_STACK_INITIAL_SIZE(),
                                     get_global_DD_TRACE_AGENT_STACK_BACKLOG() * get_global_DD_TRACE_AGENT_MAX_PAYLOAD_SIZE(),
                                     get_global_DD_TRACE_DEBUG() ? DDOG_CHARSLICE_C("debug") : dd_zend_string_to_CharSlice(get_global_DD_TRACE_LOG_LEVEL()),
                                     (ddog_CharSlice){ .ptr = logpath, .len = strlen(logpath) });
 
-    return true;
+    ddog_endpoint_drop(dogstatsd_endpoint);
+
+    return sidecar_transport;
 }
 
 void ddtrace_sidecar_setup(void) {
-    dd_sidecar_connection_init();
+    ddtrace_set_non_resettable_sidecar_globals();
+    ddtrace_set_resettable_sidecar_globals();
+
+    ddtrace_sidecar = dd_sidecar_connection_factory();
+    if (!ddtrace_sidecar && ddtrace_endpoint) { // Something went wrong
+        ddog_endpoint_drop(ddtrace_endpoint);
+        ddtrace_endpoint = NULL;
+    }
+
+    if (get_global_DD_INSTRUMENTATION_TELEMETRY_ENABLED()) {
+        ddtrace_telemetry_first_init();
+    }
 }
 
 void ddtrace_sidecar_ensure_active(void) {
-    if (!ddtrace_sidecar || ddog_sidecar_is_closed(&ddtrace_sidecar)) {
-        if (ddtrace_sidecar) {
-            ddog_sidecar_transport_drop(ddtrace_sidecar);
-        }
-        dd_sidecar_connection_init();
+    if (ddtrace_sidecar) {
+        ddog_sidecar_reconnect(&ddtrace_sidecar, dd_sidecar_connection_factory);
     }
 }
 
@@ -98,6 +109,6 @@ void ddtrace_sidecar_shutdown(void) {
 void ddtrace_reset_sidecar_globals(void) {
     if (ddtrace_sidecar_instance_id) {
         ddog_sidecar_instanceId_drop(ddtrace_sidecar_instance_id);
-        ddtrace_set_sidecar_globals();
+        ddtrace_set_resettable_sidecar_globals();
     }
 }


### PR DESCRIPTION
### Description

The recreation of the sidecar transport in case of error (closed socket, sidecar crash, ...) was not thread safe.
This PR should fix that.

NOTE: because this PR needs a change in libdatadog (https://github.com/DataDog/libdatadog/pull/440), the generated header files also contain some changes of https://github.com/DataDog/dd-trace-php/pull/2639

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
