### PR TITLE
Compile tracer version into sidecar

### DIFF
--- a/compile_rust.sh
+++ b/compile_rust.sh
@@ -15,4 +15,4 @@ case "${host_os}" in
     ;;
 esac
 
-RUSTFLAGS="$RUSTFLAGS" RUSTC_BOOTSTRAP=1 "${DDTRACE_CARGO:-cargo}" build $(test "${PROFILE:-debug}" = "debug" || echo --profile "$PROFILE") "$@"
+SIDECAR_VERSION=$(cat ../VERSION) RUSTFLAGS="$RUSTFLAGS" RUSTC_BOOTSTRAP=1 "${DDTRACE_CARGO:-cargo}" build $(test "${PROFILE:-debug}" = "debug" || echo --profile "$PROFILE") "$@"

--- a/package.xml
+++ b/package.xml
@@ -98,6 +98,7 @@ This changeset is on top of 1.0.0beta1.
 ### Internal
 - Update to maintain compatibility with libdatadog #2634, #2661
 - Minor cbindgen improvements #2651
+- Compile tracer version into sidecar #2678
 
 ## Profiling
 


### PR DESCRIPTION
Ensures that telemetry from the sidecar points to a proper version.