### PR TITLE
Switch 2 logs to logev to avoid useless work

### DIFF
--- a/ext/auto_flush.c
+++ b/ext/auto_flush.c
@@ -88,10 +88,12 @@ ZEND_RESULT_CODE ddtrace_flush_tracer(bool force_on_startup, bool collect_cycles
                                 }
                             }
 
-                            char *url = ddtrace_agent_url();
-                            LOG(INFO, "Flushing trace of size %d to send-queue for %s",
-                                zend_hash_num_elements(Z_ARR(trace)), url);
-                            free(url);
+                            LOGEV(INFO, {
+                                char *url = ddtrace_agent_url();
+                                log("Flushing trace of size %d to send-queue for %s",
+                                    zend_hash_num_elements(Z_ARR(trace)), url);
+                                free(url);
+                            });
                         } while (0);
                     } else {
                         ddog_drop_anon_shm_handle(shm);
@@ -113,10 +115,12 @@ ZEND_RESULT_CODE ddtrace_flush_tracer(bool force_on_startup, bool collect_cycles
             } else {
                 success = ddtrace_send_traces_via_thread(1, payload, size);
                 if (success) {
-                    char *url = ddtrace_agent_url();
-                    LOG(INFO, "Flushing trace of size %d to send-queue for %s",
-                                       zend_hash_num_elements(Z_ARR(trace)), url);
-                    free(url);
+                    LOGEV(INFO, {
+                        char *url = ddtrace_agent_url();
+                        log("Flushing trace of size %d to send-queue for %s",
+                                        zend_hash_num_elements(Z_ARR(trace)), url);
+                        free(url);
+                    });
                 }
                 dd_prepare_for_new_trace();
             }


### PR DESCRIPTION
### Description

Small improvement as I stumbled upon it. Default log level is `error` so no need to evaluate the agent_url in most cases

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
