### PR TITLE
Fix exception profiling in Generator->throw()

### DIFF
--- a/ext/handlers_api.c
+++ b/ext/handlers_api.c
@@ -2,12 +2,23 @@
 
 // This file is compiled by both the tracer and profiler.
 
-void datadog_php_install_handler(datadog_php_zif_handler handler) {
-    zend_function *old_handler;
-    old_handler = zend_hash_str_find_ptr(CG(function_table), handler.name, handler.name_len);
+static void datadog_php_install_table_handler(HashTable *table, datadog_php_zif_handler handler) {
+    zend_function *old_handler = zend_hash_str_find_ptr(table, handler.name, handler.name_len);
 
-    if (old_handler != NULL) {
+    if (old_handler) {
         *handler.old_handler = old_handler->internal_function.handler;
         old_handler->internal_function.handler = handler.new_handler;
+    }
+}
+
+void datadog_php_install_handler(datadog_php_zif_handler handler) {
+    datadog_php_install_table_handler(CG(function_table), handler);
+}
+
+void datadog_php_install_method_handler(datadog_php_zim_handler handler) {
+    zend_class_entry *ce = zend_hash_str_find_ptr(CG(class_table), handler.class_name, handler.class_name_len);
+
+    if (ce) {
+        datadog_php_install_table_handler(&ce->function_table, handler.zif);
     }
 }

--- a/ext/handlers_api.h
+++ b/ext/handlers_api.h
@@ -24,11 +24,18 @@ typedef struct datadog_php_zif_handler_s {
     zif_handler new_handler;
 } datadog_php_zif_handler;
 
+typedef struct datadog_php_zim_handler_s {
+    const char *class_name;
+    size_t class_name_len;
+    datadog_php_zif_handler zif;
+} datadog_php_zim_handler;
+
 /**
  * Installs the `handler` if the function represented by `name` + `name_len`
  * is found; otherwise does nothing.
  */
 void datadog_php_install_handler(datadog_php_zif_handler handler);
+void datadog_php_install_method_handler(datadog_php_zim_handler handler);
 
 #endif  // DDTRACE_HANDLERS_API_H
 

--- a/package.xml
+++ b/package.xml
@@ -105,6 +105,9 @@ This changeset is on top of 1.0.0beta1.
 ### Added
 - Add uptime information to profiles #2610
 
+### Fixed
+- Fix exception profiling in Generator->throw() #2682
+
 ### Internal
 - Stack walking cleanup #2638
 - Shrink env/service/version and simplify #2640

--- a/profiling/src/bindings/mod.rs
+++ b/profiling/src/bindings/mod.rs
@@ -379,6 +379,22 @@ unsafe impl Sync for ModuleDep {}
 pub type InternalFunctionHandler =
     Option<unsafe extern "C" fn(execute_data: *mut zend_execute_data, return_value: *mut zval)>;
 
+impl datadog_php_zim_handler {
+    pub fn new(
+        class_name: &'static CStr,
+        name: &'static CStr,
+        old_handler: *mut InternalFunctionHandler,
+        new_handler: InternalFunctionHandler,
+    ) -> Self {
+        let class_name = class_name.to_bytes();
+        Self {
+            class_name: class_name.as_ptr() as *const c_char,
+            class_name_len: class_name.len(),
+            zif: datadog_php_zif_handler::new(name, old_handler, new_handler),
+        }
+    }
+}
+
 impl datadog_php_zif_handler {
     pub fn new(
         name: &'static CStr,

--- a/profiling/src/php_ffi.h
+++ b/profiling/src/php_ffi.h
@@ -5,6 +5,7 @@
 #if CFG_FIBERS // defined by build.rs
 #include <Zend/zend_fibers.h>
 #endif
+#include <Zend/zend_generators.h>
 #include <Zend/zend_globals_macros.h>
 #include <Zend/zend_modules.h>
 #include <Zend/zend_alloc.h>

--- a/profiling/tests/phpt/exceptions_generator_throw.phpt
+++ b/profiling/tests/phpt/exceptions_generator_throw.phpt
@@ -1,0 +1,49 @@
+--TEST--
+[profiling] test exceptions being sampled in throwing generator
+--SKIPIF--
+<?php
+if (!extension_loaded('datadog-profiling'))
+    echo "skip: test requires Datadog Continuous Profiler\n";
+ob_start();
+phpinfo(INFO_MODULES);
+$info = ob_get_clean();
+if (strpos($info, 'Exception Profiling Enabled') === false)
+    echo "skip: datadog profiler is compiled without exception profiling support\n";
+?>
+--ENV--
+DD_PROFILING_ENABLED=yes
+DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED=no
+DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED=no
+DD_PROFILING_EXPERIMENTAL_EXCEPTION_ENABLED=true
+DD_PROFILING_EXPERIMENTAL_EXCEPTION_SAMPLING_DISTANCE=20
+DD_PROFILING_ALLOCATION_ENABLED=no
+--FILE--
+<?php
+
+function primeGenerator($g) {
+    $g->valid();
+}
+function spray() {}
+
+// Must not crash
+for ($i = 0; $i < 100; ++$i) {
+    try {
+        $g = (function() {
+            yield;
+        })();
+
+        primeGenerator($g);
+
+        spray(...range(1, 20));
+
+        $g->throw(new Error);
+    } catch (Error $e) {
+        # I care even less than in the other test
+    }
+}
+
+echo 'Done.';
+
+?>
+--EXPECT--
+Done.


### PR DESCRIPTION
The prev_execute_frame of fake frame of the generator is not fixed up when throwing. Only when executing afterwards.

[SCP-456](https://datadoghq.atlassian.net/browse/SCP-456)

[SCP-456]: https://datadoghq.atlassian.net/browse/SCP-456?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ