### PR TITLE
Send a correct size hint to the sidecar trace flusher

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -551,9 +551,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.5.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2bd12c1caf447e69cd4528f47f94d203fd2582878ecb9e9465484c4148a8223"
+checksum = "514de17de45fdb8dc022b1a7975556c53c86f9f0aa5f534b98977b171857c2c9"
 dependencies = [
  "serde",
 ]
@@ -1186,15 +1186,18 @@ name = "datadog-trace-utils"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "bytes",
  "datadog-trace-normalization",
  "datadog-trace-protobuf",
  "ddcommon 0.0.1",
  "flate2",
  "futures",
+ "httpmock",
  "hyper",
  "hyper-rustls",
  "log",
  "prost 0.11.9",
+ "rand 0.8.5",
  "rmp-serde",
  "serde",
  "serde_json",
@@ -1222,6 +1225,7 @@ dependencies = [
  "rustls",
  "rustls-native-certs",
  "serde",
+ "static_assertions",
  "tokio",
  "tokio-rustls",
 ]

--- a/components-rs/sidecar.h
+++ b/components-rs/sidecar.h
@@ -160,6 +160,7 @@ ddog_MaybeError ddog_sidecar_session_set_config(struct ddog_SidecarTransport **t
 ddog_MaybeError ddog_sidecar_send_trace_v04_shm(struct ddog_SidecarTransport **transport,
                                                 const struct ddog_InstanceId *instance_id,
                                                 struct ddog_ShmHandle *shm_handle,
+                                                uintptr_t len,
                                                 const struct ddog_TracerHeaderTags *tracer_header_tags);
 
 /**

--- a/ext/auto_flush.c
+++ b/ext/auto_flush.c
@@ -66,7 +66,7 @@ ZEND_RESULT_CODE ddtrace_flush_tracer(bool force_on_startup, bool collect_cycles
                                 .client_computed_top_level = false,
                                 .client_computed_stats = false,
                         };
-                        ddog_MaybeError send_error = ddog_sidecar_send_trace_v04_shm(&ddtrace_sidecar, ddtrace_sidecar_instance_id, shm, &tags);
+                        ddog_MaybeError send_error = ddog_sidecar_send_trace_v04_shm(&ddtrace_sidecar, ddtrace_sidecar_instance_id, shm, written, &tags);
                         do {
                             if (send_error.tag == DDOG_OPTION_ERROR_SOME_ERROR) {
                                 // retry sending it directly through the socket as last resort. May block though with large traces.

--- a/ext/sidecar.c
+++ b/ext/sidecar.c
@@ -70,7 +70,7 @@ ddog_SidecarTransport *dd_sidecar_connection_factory(void) {
     ddog_CharSlice session_id = (ddog_CharSlice) {.ptr = (char *) dd_sidecar_formatted_session_id, .len = sizeof(dd_sidecar_formatted_session_id)};
     ddog_sidecar_session_set_config(&sidecar_transport, session_id, ddtrace_endpoint, dogstatsd_endpoint,
                                     get_global_DD_TRACE_AGENT_FLUSH_INTERVAL(),
-                                    get_global_DD_TRACE_AGENT_STACK_INITIAL_SIZE(),
+                                    get_global_DD_TRACE_AGENT_MAX_PAYLOAD_SIZE() * get_DD_TRACE_BETA_HIGH_MEMORY_PRESSURE_PERCENT() / 100,
                                     get_global_DD_TRACE_AGENT_STACK_BACKLOG() * get_global_DD_TRACE_AGENT_MAX_PAYLOAD_SIZE(),
                                     get_global_DD_TRACE_DEBUG() ? DDOG_CHARSLICE_C("debug") : dd_zend_string_to_CharSlice(get_global_DD_TRACE_LOG_LEVEL()),
                                     (ddog_CharSlice){ .ptr = logpath, .len = strlen(logpath) });

--- a/package.xml
+++ b/package.xml
@@ -95,6 +95,7 @@ This changeset is on top of 1.0.0beta1.
 - Fix coalescing send data DataDog/libdatadog#451
 - Link libpthread into the spawn_worker trampoline Datadog/libdatadog#452
 - Make use of the sidecar thread safe #2671
+- Send a correct size hint to the sidecar trace flusher #2686
 
 ### Internal
 - Update to maintain compatibility with libdatadog #2634, #2661

--- a/tests/ext/background-sender/agent_headers.phpt
+++ b/tests/ext/background-sender/agent_headers.phpt
@@ -19,7 +19,6 @@ include __DIR__ . '/../includes/request_replayer.inc';
 \DDTrace\close_span();
 
 $rr = new RequestReplayer();
-$rr->waitForFlush();
 
 echo PHP_EOL;
 $headers = $rr->replayHeaders([

--- a/tests/ext/background-sender/agent_headers_container_id.phpt
+++ b/tests/ext/background-sender/agent_headers_container_id.phpt
@@ -22,7 +22,6 @@ include __DIR__ . '/../includes/request_replayer.inc';
 \DDTrace\close_span();
 
 $rr = new RequestReplayer();
-$rr->waitForFlush();
 
 echo PHP_EOL;
 $headers = $rr->replayHeaders([

--- a/tests/ext/background-sender/agent_headers_container_id_empty.phpt
+++ b/tests/ext/background-sender/agent_headers_container_id_empty.phpt
@@ -22,7 +22,6 @@ include __DIR__ . '/../includes/request_replayer.inc';
 \DDTrace\close_span();
 
 $rr = new RequestReplayer();
-$rr->waitForFlush();
 
 echo PHP_EOL;
 $headers = $rr->replayHeaders([

--- a/tests/ext/background-sender/agent_headers_container_id_fargate.phpt
+++ b/tests/ext/background-sender/agent_headers_container_id_fargate.phpt
@@ -22,7 +22,6 @@ include __DIR__ . '/../includes/request_replayer.inc';
 \DDTrace\close_span();
 
 $rr = new RequestReplayer();
-$rr->waitForFlush();
 
 $headers = $rr->replayHeaders();
 

--- a/tests/ext/background-sender/agent_headers_ignore_userland.phpt
+++ b/tests/ext/background-sender/agent_headers_ignore_userland.phpt
@@ -24,7 +24,6 @@ $payload = "\x91\x90";
 var_dump(dd_trace_send_traces_via_thread(1, $headersToIgnore, $payload));
 
 $rr = new RequestReplayer();
-$rr->waitForFlush();
 
 echo PHP_EOL;
 $headers = $rr->replayHeaders([

--- a/tests/ext/background-sender/agent_headers_unix_domain_socket.phpt
+++ b/tests/ext/background-sender/agent_headers_unix_domain_socket.phpt
@@ -21,7 +21,6 @@ RequestReplayer::launchUnixProxy(str_replace("unix://", "", getenv("DD_TRACE_AGE
 \DDTrace\close_span();
 
 $rr = new RequestReplayer();
-$rr->waitForFlush();
 
 echo PHP_EOL;
 $headers = $rr->replayHeaders([

--- a/tests/ext/dd_trace_send_traces_via_thread_001.phpt
+++ b/tests/ext/dd_trace_send_traces_via_thread_001.phpt
@@ -2,6 +2,8 @@
 background sender happy path
 --SKIPIF--
 <?php if (strncasecmp(PHP_OS, "WIN", 3) == 0) die('skip: There is no background sender on Windows'); ?>
+--ENV--
+DD_TRACE_SIDECAR_TRACE_SENDER=0
 --FILE--
 <?php
 

--- a/tests/ext/dd_trace_span_link_with_exception.phpt
+++ b/tests/ext/dd_trace_span_link_with_exception.phpt
@@ -47,11 +47,7 @@ try {
     echo 'Caught exception: ' . $e->getMessage() . PHP_EOL;
 }
 
-$rr->waitForFlush();
-if (!$replay = $rr->replayRequest()) {
-    $rr->waitForFlush();
-    $replay = $rr->replayRequest();
-}
+$replay = $rr->waitForDataAndReplay();
 $root = json_decode($replay["body"], true);
 $spans = $root["chunks"][0]["spans"] ?? $root[0];
 $span = $spans[0];

--- a/tests/ext/dogstatsd/metrics_over_udp.phpt
+++ b/tests/ext/dogstatsd/metrics_over_udp.phpt
@@ -24,14 +24,17 @@ class UDPServer {
         }
     }
 
-    public function dump($iter = 100, $usleep = 100) {
-        $buf = '';
+    public function dump($expected, $iter = 5000) {
+        $lines = [];
         for ($i = 0; $i < $iter; ++$i) {
-            usleep($usleep);
-            $r = socket_recvfrom($this->socket, $buf, 2048, MSG_DONTWAIT, $remote_ip, $remote_port);
-            if ($buf) {
-                echo $buf."\n";
-                $buf = '';
+            usleep(100);
+            if (socket_recvfrom($this->socket, $buf, 2048, MSG_DONTWAIT, $remote_ip, $remote_port)) {
+                $lines[] = "$buf\n";
+                if (count($lines) == $expected) {
+                    sort($lines, SORT_STRING);
+                    echo implode($lines);
+                    return;
+                }
             }
         }
     }
@@ -43,19 +46,19 @@ class UDPServer {
 
 $server = new UDPServer('127.0.0.1', 9876);
 
-\DDTrace\dogstatsd_count("simple-counter", 42, ['foo' => 'bar', 'bar' => true]);
+\DDTrace\dogstatsd_count("counter-simple", 42, ['foo' => 'bar', 'bar' => true]);
 \DDTrace\dogstatsd_gauge("gogogadget", 21.4);
-\DDTrace\dogstatsd_histogram("my_histo", 22.22, ['histo' => 'gram']);
 \DDTrace\dogstatsd_distribution("my_disti", 22.22, ['distri' => 'bution']);
+\DDTrace\dogstatsd_histogram("my_histo", 22.22, ['histo' => 'gram']);
 \DDTrace\dogstatsd_set("set", 7, ['set' => '7']);
 
-$server->dump();
+$server->dump(5);
 $server->close();
 
 ?>
 --EXPECT--
-simple-counter:42|c|#foo:bar,bar:true
+counter-simple:42|c|#foo:bar,bar:true
 gogogadget:21.4|g
-my_histo:22.22|h|#histo:gram
 my_disti:22.22|d|#distri:bution
+my_histo:22.22|h|#histo:gram
 set:7|s|#set:7

--- a/tests/ext/includes/request_replayer.inc
+++ b/tests/ext/includes/request_replayer.inc
@@ -30,6 +30,18 @@ class RequestReplayer
         usleep($this->flushInterval * 2 * 1000);
     }
 
+    public function waitForDataAndReplay()
+    {
+        $i = 0;
+        do {
+            if ($i++ == 100) {
+                throw new Exception("wait for replay timeout");
+            }
+            usleep($this->flushInterval * 1000);
+        } while (empty($data = $this->replayRequest()));
+        return $data;
+    }
+
     public function replayRequest()
     {
         // Request replayer now returns as many requests as were sent during a session.
@@ -40,7 +52,7 @@ class RequestReplayer
 
     public function replayHeaders($showOnly = [])
     {
-        $request = $this->replayRequest();
+        $request = $this->waitForDataAndReplay();
         if (!isset($request['headers'])) {
             return [];
         }

--- a/tests/ext/telemetry/config.phpt
+++ b/tests/ext/telemetry/config.phpt
@@ -33,7 +33,7 @@ for ($i = 0; $i < 100; ++$i) {
                 if ($json["request_type"] == "app-started") {
                     $cfg = $json["payload"]["configuration"];
                     print_r(array_values(array_filter($cfg, function($c) {
-                        return $c["origin"] == "EnvVar" && $c["name"] != "trace.sources_path";
+                        return $c["origin"] == "EnvVar" && $c["name"] != "trace.sources_path" && $c["name"] != "trace.sidecar_trace_sender";
                     })));
                     var_dump(count(array_filter($cfg, function($c) {
                         return $c["origin"] == "Default";


### PR DESCRIPTION
Also, initial stack size is a low number. Also the wrong number, generally. Instead, we'll flush the traces in the sidecar when a significant percentage of the max payload size is reached.