### PR TITLE
feat(profiling): `thread id` label on every sample

### DIFF
--- a/profiling/src/bindings/mod.rs
+++ b/profiling/src/bindings/mod.rs
@@ -548,6 +548,12 @@ impl<'a> From<&'a str> for ZaiStr<'a> {
     }
 }
 
+impl<'a> Default for ZaiStr<'a> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl<'a> ZaiStr<'a> {
     pub const fn new() -> ZaiStr<'a> {
         const NULL: &[u8] = b"\0";

--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -679,7 +679,6 @@ impl Profiler {
 
     /// Collect a stack sample with elapsed wall time. Collects CPU time if
     /// it's enabled and available.
-    #[inline]
     pub fn collect_time(&self, execute_data: *mut zend_execute_data, interrupt_count: u32) {
         // todo: should probably exclude the wall and CPU time used by collecting the sample.
         let interrupt_count = interrupt_count as i64;
@@ -729,7 +728,6 @@ impl Profiler {
 
     /// Collect a stack sample with memory allocations.
     #[cfg(feature = "allocation_profiling")]
-    #[inline]
     pub fn collect_allocations(
         &self,
         execute_data: *mut zend_execute_data,
@@ -769,7 +767,6 @@ impl Profiler {
 
     /// Collect a stack sample with exception.
     #[cfg(feature = "exception_profiling")]
-    #[inline]
     pub fn collect_exception(
         &self,
         execute_data: *mut zend_execute_data,
@@ -826,7 +823,6 @@ impl Profiler {
     }];
 
     #[cfg(feature = "timeline")]
-    #[inline]
     pub fn collect_compile_string(&self, now: i64, duration: i64, filename: String, line: u32) {
         let mut labels = Profiler::common_labels(Self::TIMELINE_COMPILE_FILE_LABELS.len());
         labels.extend_from_slice(Self::TIMELINE_COMPILE_FILE_LABELS);
@@ -857,7 +853,6 @@ impl Profiler {
     }
 
     #[cfg(feature = "timeline")]
-    #[inline]
     pub fn collect_compile_file(
         &self,
         now: i64,
@@ -900,7 +895,6 @@ impl Profiler {
 
     /// This function can be called to collect any kind of inactivity that is happening
     #[cfg(feature = "timeline")]
-    #[inline(never)]
     pub fn collect_idle(&self, now: i64, duration: i64, reason: &'static str) {
         let mut labels = Profiler::common_labels(1);
 
@@ -936,7 +930,6 @@ impl Profiler {
     /// collect a stack frame for garbage collection.
     /// as we do not know about the overhead currently, we only collect a fake frame.
     #[cfg(feature = "timeline")]
-    #[inline]
     pub fn collect_garbage_collection(
         &self,
         now: i64,
@@ -994,7 +987,6 @@ impl Profiler {
     ///
     /// * `n_extra_labels` - Reserve room for extra labels, such as when the
     ///                      caller adds gc or exception labels.
-    #[inline(never)]
     fn common_labels(n_extra_labels: usize) -> Vec<Label> {
         let mut labels = Vec::with_capacity(4 + n_extra_labels);
         labels.push(Label {
@@ -1041,7 +1033,6 @@ impl Profiler {
         labels
     }
 
-    #[inline(never)]
     fn prepare_and_send_message(
         &self,
         frames: Vec<ZendFrame>,
@@ -1055,7 +1046,6 @@ impl Profiler {
             .map_err(Box::new)
     }
 
-    #[inline(always)]
     fn prepare_sample_message(
         &self,
         frames: Vec<ZendFrame>,

--- a/profiling/src/profiling/stack_walking.rs
+++ b/profiling/src/profiling/stack_walking.rs
@@ -121,6 +121,7 @@ mod detail {
         });
     }
 
+    #[inline(never)]
     pub fn collect_stack_sample(
         top_execute_data: *mut zend_execute_data,
     ) -> Result<Vec<ZendFrame>, Utf8Error> {
@@ -278,6 +279,7 @@ mod detail {
     #[inline]
     pub fn rshutdown() {}
 
+    #[inline(never)]
     pub fn collect_stack_sample(
         top_execute_data: *mut zend_execute_data,
     ) -> Result<Vec<ZendFrame>, Utf8Error> {

--- a/profiling/tests/correctness/allocations.json
+++ b/profiling/tests/correctness/allocations.json
@@ -1,39 +1,37 @@
 {
-    "test_name":"php_allocations",
+    "test_name": "php_allocations",
     "stacks": [
-      {
-        "profile-type": "alloc-size",
-        "stack-content":
-        [
-          {
-            "regular_expression":"<?php;main;a;standard\\|str_repeat$",
-            "percent": 66,
-            "value": 1248240336,
-            "error_margin": 5
-          },
-          {
-            "regular_expression":"<?php;main;b;standard\\|str_repeat$",
-            "percent": 33,
-            "value": 613620616,
-            "error_margin": 5
-          }
-        ]
-      }, {
-        "profile-type": "alloc-samples",
-        "stack-content":
-        [
-          {
-            "regular_expression":"<?php;main;a;standard\\|str_repeat$",
-            "percent": 50,
-            "error_margin": 5
-          },
-          {
-            "regular_expression":"<?php;main;b;standard\\|str_repeat$",
-            "percent": 50,
-            "error_margin": 5
-          }
-        ]
-      }
+        {
+            "profile-type": "alloc-size",
+            "stack-content": [
+                {
+                    "regular_expression": "<?php;main;a;standard\\|str_repeat$",
+                    "percent": 66,
+                    "value": 1248240336,
+                    "error_margin": 5
+                },
+                {
+                    "regular_expression": "<?php;main;b;standard\\|str_repeat$",
+                    "percent": 33,
+                    "value": 613620616,
+                    "error_margin": 5
+                }
+            ]
+        },
+        {
+            "profile-type": "alloc-samples",
+            "stack-content": [
+                {
+                    "regular_expression": "<?php;main;a;standard\\|str_repeat$",
+                    "percent": 50,
+                    "error_margin": 5
+                },
+                {
+                    "regular_expression": "<?php;main;b;standard\\|str_repeat$",
+                    "percent": 50,
+                    "error_margin": 5
+                }
+            ]
+        }
     ]
-  }
-
+}

--- a/profiling/tests/correctness/exceptions.json
+++ b/profiling/tests/correctness/exceptions.json
@@ -15,12 +15,7 @@
                                 "FooBar\\Exception"
                             ]
                         },
-                        {
-                            "key": "thread name",
-                            "values": [
-                                "Main"
-                            ]
-                        }
+                        { "key": "thread id" }
                     ]
                 }
             ]

--- a/profiling/tests/correctness/exceptions.json
+++ b/profiling/tests/correctness/exceptions.json
@@ -14,7 +14,8 @@
                             "values": [
                                 "FooBar\\Exception"
                             ]
-                        }, {
+                        },
+                        {
                             "key": "thread name",
                             "values": [
                                 "Main"

--- a/profiling/tests/correctness/exceptions.json
+++ b/profiling/tests/correctness/exceptions.json
@@ -7,7 +7,6 @@
                 {
                     "regular_expression": "<\\?php;FooBar\\\\throwAndCatch",
                     "percent": 100,
-                    "error_margin": 100,
                     "labels": [
                         {
                             "key": "exception type",
@@ -17,7 +16,7 @@
                         },
                         {
                             "key": "thread id",
-                            "values_regex": "[0-9]+"
+                            "values_regex": "^[0-9]+$"
                         }
                     ]
                 }

--- a/profiling/tests/correctness/exceptions.json
+++ b/profiling/tests/correctness/exceptions.json
@@ -14,6 +14,11 @@
                             "values": [
                                 "FooBar\\Exception"
                             ]
+                        }, {
+                            "key": "thread name",
+                            "values": [
+                                "Main"
+                            ]
                         }
                     ]
                 }

--- a/profiling/tests/correctness/exceptions.json
+++ b/profiling/tests/correctness/exceptions.json
@@ -15,7 +15,10 @@
                                 "FooBar\\Exception"
                             ]
                         },
-                        { "key": "thread id" }
+                        {
+                            "key": "thread id",
+                            "values_regex": "[0-9]+"
+                        }
                     ]
                 }
             ]

--- a/profiling/tests/correctness/exceptions_zts.json
+++ b/profiling/tests/correctness/exceptions_zts.json
@@ -19,7 +19,10 @@
                             "key": "exception message",
                             "values_regex": "Exception from (worker [0-9]|main thread)"
                         },
-                        { "key": "thread id" }
+                        {
+                            "key": "thread id",
+                            "values_regex": "[0-9]+"
+                        }
                     ]
                 }
             ]

--- a/profiling/tests/correctness/exceptions_zts.json
+++ b/profiling/tests/correctness/exceptions_zts.json
@@ -17,6 +17,11 @@
                         }, {
                             "key": "exception message",
                             "values_regex": "Exception from (worker [0-9]|main thread)"
+                        }, {
+                            "key": "thread name",
+                            "values": [
+                                "Main"
+                            ]
                         }
                     ]
                 }

--- a/profiling/tests/correctness/exceptions_zts.json
+++ b/profiling/tests/correctness/exceptions_zts.json
@@ -14,10 +14,12 @@
                             "values": [
                                 "Exception"
                             ]
-                        }, {
+                        },
+                        {
                             "key": "exception message",
                             "values_regex": "Exception from (worker [0-9]|main thread)"
-                        }, {
+                        },
+                        {
                             "key": "thread name",
                             "values": [
                                 "Main"

--- a/profiling/tests/correctness/exceptions_zts.json
+++ b/profiling/tests/correctness/exceptions_zts.json
@@ -19,12 +19,7 @@
                             "key": "exception message",
                             "values_regex": "Exception from (worker [0-9]|main thread)"
                         },
-                        {
-                            "key": "thread name",
-                            "values": [
-                                "Main"
-                            ]
-                        }
+                        { "key": "thread id" }
                     ]
                 }
             ]

--- a/profiling/tests/correctness/exceptions_zts.json
+++ b/profiling/tests/correctness/exceptions_zts.json
@@ -7,7 +7,6 @@
                 {
                     "regular_expression": "<\\?php|{closure}",
                     "percent": 100,
-                    "error_margin": 99,
                     "labels": [
                         {
                             "key": "exception type",
@@ -21,7 +20,7 @@
                         },
                         {
                             "key": "thread id",
-                            "values_regex": "[0-9]+"
+                            "values_regex": "^[0-9]+$"
                         }
                     ]
                 }

--- a/profiling/tests/correctness/strange_frames.json
+++ b/profiling/tests/correctness/strange_frames.json
@@ -1,17 +1,15 @@
 {
-    "test_name":"php_strange_frames",
+    "test_name": "php_strange_frames",
     "stacks": [
-      {
-        "profile-type": "sample",
-        "stack-content":
-        [
-          {
-            "regular_expression": "<?php;main;Datadog\\\\Test\\\\Class1::method1;class@anonymous.*::__invoke;Datadog\\\\Test\\\\Class1::Datadog\\\\Test\\\\\\{closure\\};datadog-profiling\\|Datadog\\\\Profiling\\\\trigger_time_sample",
-            "percent": 100,
-            "error_margin": 1
-          }
-        ]
-      }
+        {
+            "profile-type": "sample",
+            "stack-content": [
+                {
+                    "regular_expression": "<?php;main;Datadog\\\\Test\\\\Class1::method1;class@anonymous.*::__invoke;Datadog\\\\Test\\\\Class1::Datadog\\\\Test\\\\\\{closure\\};datadog-profiling\\|Datadog\\\\Profiling\\\\trigger_time_sample",
+                    "percent": 100,
+                    "error_margin": 1
+                }
+            ]
+        }
     ]
-  }
-
+}

--- a/profiling/tests/correctness/time.json
+++ b/profiling/tests/correctness/time.json
@@ -1,47 +1,45 @@
 {
-    "test_name":"php_time",
+    "test_name": "php_time",
     "stacks": [
-      {
-        "profile-type": "wall-time",
-        "stack-content":
-        [
-          {
-            "regular_expression":"<?php;main;a$",
-            "percent": 17,
-            "error_margin": 10
-          },
-          {
-            "regular_expression":"<?php;main;b$",
-            "percent": 33,
-            "error_margin": 10
-          },
-          {
-            "regular_expression":"<?php;main;standard\\|sleep$",
-            "percent": 50,
-            "error_margin": 10
-          }
-        ]
-      }, {
-        "profile-type": "cpu-time",
-        "stack-content":
-        [
-          {
-            "regular_expression":"<?php;main;a$",
-            "percent": 33,
-            "error_margin": 10
-          },
-          {
-            "regular_expression":"<?php;main;b$",
-            "percent": 66,
-            "error_margin": 10
-          },
-          {
-            "regular_expression":"<?php;main;standard\\|sleep$",
-            "percent": 1,
-            "error_margin": 10
-          }
-        ]
-      }
+        {
+            "profile-type": "wall-time",
+            "stack-content": [
+                {
+                    "regular_expression": "<?php;main;a$",
+                    "percent": 17,
+                    "error_margin": 10
+                },
+                {
+                    "regular_expression": "<?php;main;b$",
+                    "percent": 33,
+                    "error_margin": 10
+                },
+                {
+                    "regular_expression": "<?php;main;standard\\|sleep$",
+                    "percent": 50,
+                    "error_margin": 10
+                }
+            ]
+        },
+        {
+            "profile-type": "cpu-time",
+            "stack-content": [
+                {
+                    "regular_expression": "<?php;main;a$",
+                    "percent": 33,
+                    "error_margin": 10
+                },
+                {
+                    "regular_expression": "<?php;main;b$",
+                    "percent": 66,
+                    "error_margin": 10
+                },
+                {
+                    "regular_expression": "<?php;main;standard\\|sleep$",
+                    "percent": 1,
+                    "error_margin": 10
+                }
+            ]
+        }
     ]
-  }
-
+}

--- a/profiling/tests/phpt/exceptions_01.phpt
+++ b/profiling/tests/phpt/exceptions_01.phpt
@@ -27,6 +27,7 @@ DD_PROFILING_LOG_LEVEL=trace
 function generateExceptions() {
     for ($i = 0; $i <= 100; $i++) {
         try {
+            // two labels: "thread_id" and "exception type"
             throw new \RuntimeException();
         } catch (\RuntimeException $e) {
             # I don't care :-P
@@ -41,6 +42,6 @@ echo 'Done.';
 ?>
 --EXPECTREGEX--
 .* Exception profiling initialized with sampling distance: 20
-.* Sent stack sample of 2 frames, 3 labels with Exception RuntimeException to profiler.
-.*Done..*
+.* Sent stack sample of 2 frames, 2 labels with Exception RuntimeException to profiler.
+.*Done\..*
 .*

--- a/profiling/tests/phpt/exceptions_01.phpt
+++ b/profiling/tests/phpt/exceptions_01.phpt
@@ -41,6 +41,6 @@ echo 'Done.';
 ?>
 --EXPECTREGEX--
 .* Exception profiling initialized with sampling distance: 20
-.* Sent stack sample of 2 frames, 1 labels with Exception RuntimeException to profiler.
+.* Sent stack sample of 2 frames, 3 labels with Exception RuntimeException to profiler.
 .*Done..*
 .*

--- a/profiling/tests/phpt/exceptions_fibers_throw.phpt
+++ b/profiling/tests/phpt/exceptions_fibers_throw.phpt
@@ -1,0 +1,47 @@
+--TEST--
+[profiling] test exceptions being sampled in throwing fibers
+--SKIPIF--
+<?php
+if (!extension_loaded('datadog-profiling'))
+    echo "skip: test requires Datadog Continuous Profiler\n";
+ob_start();
+phpinfo(INFO_MODULES);
+$info = ob_get_clean();
+if (strpos($info, 'Exception Profiling Enabled') === false)
+    echo "skip: datadog profiler is compiled without exception profiling support\n";
+?>
+--ENV--
+DD_PROFILING_ENABLED=yes
+DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED=no
+DD_PROFILING_EXPERIMENTAL_TIMELINE_ENABLED=no
+DD_PROFILING_EXPERIMENTAL_EXCEPTION_ENABLED=yes
+DD_PROFILING_EXPERIMENTAL_EXCEPTION_SAMPLING_DISTANCE=1
+DD_PROFILING_ALLOCATION_ENABLED=no
+--FILE--
+<?php
+
+// Must not crash
+for ($i = 0; $i < 100; ++$i) {
+    try {
+        $fiber = new Fiber(
+            function() {
+                try {
+                    Fiber::suspend(1);
+                } catch(Throwable $e) {
+                }
+            }
+        );
+
+        $fiber->start();
+
+        $fiber->throw(new Error);
+    } catch (Throwable $e) {
+        # I care even less than in the other test
+    }
+}
+
+echo 'Done.';
+
+?>
+--EXPECT--
+Done.

--- a/profiling/tests/phpt/exceptions_zts_01.phpt
+++ b/profiling/tests/phpt/exceptions_zts_01.phpt
@@ -51,7 +51,7 @@ echo 'Done.';
 ?>
 --EXPECTREGEX--
 .* Exception profiling initialized with sampling distance: 20
-.* Sent stack sample of 1 frames, 1 labels with Exception RuntimeException to profiler.
+.* Sent stack sample of 1 frames, 2 labels with Exception RuntimeException to profiler.
 .*Worker [0-9] exited
 .*Done..*
 .*


### PR DESCRIPTION
### Description

Turns out the profiling-backend assumes that all pprof based profiles emit a `thread id` and `thread name` label with every sample, so this PR aims to do this. Edit: profiling-backend was updated to not require the thread name, but we should add at least `thread id` anyway. Since thread names are uncommon (we don't know of a single PHP program/library which names threads), we omit `thread name` for now.

Took this as an opportunity to clean up a few things:

- `message_labels` was renamed to `common_labels` and now sets the "fiber" tag (was in `prepare_message` before). It also accepts a parameter for how much extra space to allocate in the `Vec`, so callers can avoid reallocations.
- Avoided `lazy_static` labels, and removed un-necessary `vec!` usages to reduce allocations.
- We always call `send_message(prepare_message(...))`, so I made a helper for this called `prepare_and_send_message`.

PROF-9887

### Reviewer checklist
- [ ] Test coverage seems ok.
- [x] Appropriate labels assigned.
