### PR TITLE
feat: Remap OTel to DD status code

### DIFF
--- a/ext/serializer.c
+++ b/ext/serializer.c
@@ -1434,6 +1434,13 @@ void ddtrace_serialize_span_to_array(ddtrace_span_data *span, zval *array) {
 
     zend_array *meta = ddtrace_property_array(&span->property_meta);
 
+    // Remap OTel's status code to DD's status code
+    zval *http_response_status_code = zend_hash_str_find(meta, ZEND_STRL("http.response.status_code"));
+    if (http_response_status_code) {
+        zend_hash_str_update(meta, ZEND_STRL("http.status_code"), http_response_status_code);
+        zend_hash_str_del(meta, ZEND_STRL("http.response.status_code"));
+    }
+
     // SpanData::$name defaults to fully qualified called name (set at span close)
     zval *operation_name = zend_hash_str_find(meta, ZEND_STRL("operation.name"));
     zval *prop_name = &span->property_name;

--- a/ext/serializer.c
+++ b/ext/serializer.c
@@ -1438,6 +1438,7 @@ void ddtrace_serialize_span_to_array(ddtrace_span_data *span, zval *array) {
     // Remap OTel's status code (metric, http.response.status_code) to DD's status code (meta, http.status_code
     zval *http_response_status_code = zend_hash_str_find(metrics, ZEND_STRL("http.response.status_code"));
     if (http_response_status_code) {
+        Z_TRY_ADDREF_P(http_response_status_code);
         zend_hash_str_update(meta, ZEND_STRL("http.status_code"), http_response_status_code);
         zend_hash_str_del(metrics, ZEND_STRL("http.response.status_code"));
     }

--- a/ext/serializer.c
+++ b/ext/serializer.c
@@ -1433,12 +1433,13 @@ void ddtrace_serialize_span_to_array(ddtrace_span_data *span, zval *array) {
     add_assoc_long(el, "duration", span->duration);
 
     zend_array *meta = ddtrace_property_array(&span->property_meta);
+    zend_array *metrics = ddtrace_property_array(&span->property_metrics);
 
-    // Remap OTel's status code to DD's status code
-    zval *http_response_status_code = zend_hash_str_find(meta, ZEND_STRL("http.response.status_code"));
+    // Remap OTel's status code (metric, http.response.status_code) to DD's status code (meta, http.status_code
+    zval *http_response_status_code = zend_hash_str_find(metrics, ZEND_STRL("http.response.status_code"));
     if (http_response_status_code) {
         zend_hash_str_update(meta, ZEND_STRL("http.status_code"), http_response_status_code);
-        zend_hash_str_del(meta, ZEND_STRL("http.response.status_code"));
+        zend_hash_str_del(metrics, ZEND_STRL("http.response.status_code"));
     }
 
     // SpanData::$name defaults to fully qualified called name (set at span close)
@@ -1535,12 +1536,10 @@ void ddtrace_serialize_span_to_array(ddtrace_span_data *span, zval *array) {
             double parsed_analytics_event = strconv_parse_bool(Z_STR_P(analytics_event));
             if (parsed_analytics_event >= 0) {
                 ZVAL_DOUBLE(&analytics_event_as_double, parsed_analytics_event);
-                zend_array *metrics = ddtrace_property_array(&span->property_metrics);
                 zend_hash_str_add_new(metrics, ZEND_STRL("_dd1.sr.eausr"), &analytics_event_as_double);
             }
         } else {
             ZVAL_DOUBLE(&analytics_event_as_double, zval_get_double(analytics_event));
-            zend_array *metrics = ddtrace_property_array(&span->property_metrics);
             zend_hash_str_add_new(metrics, ZEND_STRL("_dd1.sr.eausr"), &analytics_event_as_double);
         }
         zend_hash_str_del(meta, ZEND_STRL("analytics.event"));
@@ -1677,8 +1676,6 @@ void ddtrace_serialize_span_to_array(ddtrace_span_data *span, zval *array) {
                 }
             }
 
-            zend_array *metrics = ddtrace_property_array(&span->property_metrics);
-
             zval mechanism;
             ZVAL_LONG(&mechanism, 8);
             zend_hash_str_update(metrics, ZEND_STRL("_dd.span_sampling.mechanism"), &mechanism);
@@ -1705,7 +1702,6 @@ void ddtrace_serialize_span_to_array(ddtrace_span_data *span, zval *array) {
     _serialize_meta(el, span);
 
 
-    zend_array *metrics = ddtrace_property_array(&span->property_metrics);
     zval metrics_zv;
     array_init(&metrics_zv);
     zend_string *str_key;

--- a/tests/ext/otel_http_response_status_code_remapping.phpt
+++ b/tests/ext/otel_http_response_status_code_remapping.phpt
@@ -4,7 +4,7 @@ Remap http.response.status_code to http.status_code
 <?php
 
 $span = \DDTrace\start_span();
-$span->metrics['http.response.status_code'] = 300;
+$span->metrics['http.response.status_code'] = "300";
 \DDTrace\close_span();
 
 var_dump(dd_trace_serialize_closed_spans());

--- a/tests/ext/otel_http_response_status_code_remapping.phpt
+++ b/tests/ext/otel_http_response_status_code_remapping.phpt
@@ -1,0 +1,41 @@
+--TEST--
+Remap http.response.status_code to http.status_code
+--FILE--
+<?php
+
+$span = \DDTrace\start_span();
+$span->meta['http.response.status_code'] = 300;
+\DDTrace\close_span();
+
+var_dump(dd_trace_serialize_closed_spans());
+
+?>
+--EXPECTF--
+array(1) {
+  [0]=>
+  array(10) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["parent_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(0) ""
+    ["resource"]=>
+    string(0) ""
+    ["service"]=>
+    string(44) "otel_http_response_status_code_remapping.php"
+    ["type"]=>
+    string(3) "cli"
+    ["meta"]=>
+    array(1) {
+      ["http.status_code"]=>
+      string(3) "300"
+    }
+  }
+}

--- a/tests/ext/otel_http_response_status_code_remapping.phpt
+++ b/tests/ext/otel_http_response_status_code_remapping.phpt
@@ -4,7 +4,7 @@ Remap http.response.status_code to http.status_code
 <?php
 
 $span = \DDTrace\start_span();
-$span->meta['http.response.status_code'] = 300;
+$span->metrics['http.response.status_code'] = 300;
 \DDTrace\close_span();
 
 var_dump(dd_trace_serialize_closed_spans());

--- a/tests/ext/otel_http_response_status_code_remapping_precedence.phpt
+++ b/tests/ext/otel_http_response_status_code_remapping_precedence.phpt
@@ -1,0 +1,42 @@
+--TEST--
+http.response.status_code takes precedence over http.status_code
+--FILE--
+<?php
+
+$span = \DDTrace\start_span();
+$span->meta['http.response.status_code'] = 300;
+$span->meta['http.status_code'] = 302;
+\DDTrace\close_span();
+
+var_dump(dd_trace_serialize_closed_spans());
+
+?>
+--EXPECTF--
+array(1) {
+  [0]=>
+  array(10) {
+    ["trace_id"]=>
+    string(%d) "%d"
+    ["span_id"]=>
+    string(%d) "%d"
+    ["parent_id"]=>
+    string(%d) "%d"
+    ["start"]=>
+    int(%d)
+    ["duration"]=>
+    int(%d)
+    ["name"]=>
+    string(0) ""
+    ["resource"]=>
+    string(0) ""
+    ["service"]=>
+    string(55) "otel_http_response_status_code_remapping_precedence.php"
+    ["type"]=>
+    string(3) "cli"
+    ["meta"]=>
+    array(1) {
+      ["http.status_code"]=>
+      string(3) "300"
+    }
+  }
+}

--- a/tests/ext/otel_http_response_status_code_remapping_precedence.phpt
+++ b/tests/ext/otel_http_response_status_code_remapping_precedence.phpt
@@ -4,7 +4,7 @@ http.response.status_code takes precedence over http.status_code
 <?php
 
 $span = \DDTrace\start_span();
-$span->meta['http.response.status_code'] = 300;
+$span->metrics['http.response.status_code'] = 300;
 $span->meta['http.status_code'] = 302;
 \DDTrace\close_span();
 


### PR DESCRIPTION
### Description

[GDoc](https://docs.google.com/document/d/19OAW3sfN_HLai91agdZTNjyMuej_1DszJeSZ4WFD7U0/edit)

Remap http.response.status_code to http.status_code, the former taking precedence.

Also, OTel's status code is also an **int**, meaning that when we setAttribute on it in our Span.php shim, it will be redirected to the metrics array.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
