### PR TITLE
build: shrink size of Rust artifacts

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,10 @@ license = "Apache-2.0"
 debug = 2 # full debug info
 
 [profile.release]
-debug = 1
-lto = "thin"
+codegen-units = 1
+debug = "line-tables-only"
 incremental = false
+lto = "fat"
 
 [profile.tracer-release]
 debug = 1 # line tables only


### PR DESCRIPTION
### Description

This is an attempt to shrink artifacts, but unlike #2601,  this does not do `panic=abort`. For `panic=abort` to be really effective, you also need to rebuild std from source. That means rebuilding images and also installing Rust from rustup (because the packages we are using do not include std sources). We had issues with CI last time we tried it. We played whack-a-mole for a while, but since the issues just kept going and we wanted to release 1.0.0beta1, we decide to revert back.

But this PR without `panic=abort` will still shrink the size a fair bit, so it's worth splitting out. I wouldn't go so far as saying that it will fix the size issue reported in PR #2599, but it helps.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
