### PR TITLE
ci(profiling): cleanup correctness tests

### DIFF
--- a/profiling/tests/correctness/allocations.json
+++ b/profiling/tests/correctness/allocations.json
@@ -1,37 +1,37 @@
 {
-    "test_name": "php_allocations",
-    "stacks": [
+  "test_name": "php_allocations",
+  "stacks": [
+    {
+      "profile-type": "alloc-size",
+      "stack-content": [
         {
-            "profile-type": "alloc-size",
-            "stack-content": [
-                {
-                    "regular_expression": "<?php;main;a;standard\\|str_repeat$",
-                    "percent": 66,
-                    "value": 1248240336,
-                    "error_margin": 5
-                },
-                {
-                    "regular_expression": "<?php;main;b;standard\\|str_repeat$",
-                    "percent": 33,
-                    "value": 613620616,
-                    "error_margin": 5
-                }
-            ]
+          "regular_expression": "<?php;main;a;standard\\|str_repeat$",
+          "percent": 66,
+          "value": 1248240336,
+          "error_margin": 5
         },
         {
-            "profile-type": "alloc-samples",
-            "stack-content": [
-                {
-                    "regular_expression": "<?php;main;a;standard\\|str_repeat$",
-                    "percent": 50,
-                    "error_margin": 5
-                },
-                {
-                    "regular_expression": "<?php;main;b;standard\\|str_repeat$",
-                    "percent": 50,
-                    "error_margin": 5
-                }
-            ]
+          "regular_expression": "<?php;main;b;standard\\|str_repeat$",
+          "percent": 33,
+          "value": 613620616,
+          "error_margin": 5
         }
-    ]
+      ]
+    },
+    {
+      "profile-type": "alloc-samples",
+      "stack-content": [
+        {
+          "regular_expression": "<?php;main;a;standard\\|str_repeat$",
+          "percent": 50,
+          "error_margin": 5
+        },
+        {
+          "regular_expression": "<?php;main;b;standard\\|str_repeat$",
+          "percent": 50,
+          "error_margin": 5
+        }
+      ]
+    }
+  ]
 }

--- a/profiling/tests/correctness/exceptions.json
+++ b/profiling/tests/correctness/exceptions.json
@@ -1,26 +1,26 @@
 {
-    "test_name": "php_exception",
-    "stacks": [
+  "test_name": "php_exception",
+  "stacks": [
+    {
+      "profile-type": "exception-samples",
+      "stack-content": [
         {
-            "profile-type": "exception-samples",
-            "stack-content": [
-                {
-                    "regular_expression": "<\\?php;FooBar\\\\throwAndCatch",
-                    "percent": 100,
-                    "labels": [
-                        {
-                            "key": "exception type",
-                            "values": [
-                                "FooBar\\Exception"
-                            ]
-                        },
-                        {
-                            "key": "thread id",
-                            "values_regex": "^[0-9]+$"
-                        }
-                    ]
-                }
-            ]
+          "regular_expression": "<\\?php;FooBar\\\\throwAndCatch",
+          "percent": 100,
+          "labels": [
+            {
+              "key": "exception type",
+              "values": [
+                "FooBar\\Exception"
+              ]
+            },
+            {
+              "key": "thread id",
+              "values_regex": "^[0-9]+$"
+            }
+          ]
         }
-    ]
+      ]
+    }
+  ]
 }

--- a/profiling/tests/correctness/exceptions_zts.json
+++ b/profiling/tests/correctness/exceptions_zts.json
@@ -1,30 +1,30 @@
 {
-    "test_name": "php_exception_zts",
-    "stacks": [
+  "test_name": "php_exception_zts",
+  "stacks": [
+    {
+      "profile-type": "exception-samples",
+      "stack-content": [
         {
-            "profile-type": "exception-samples",
-            "stack-content": [
-                {
-                    "regular_expression": "<\\?php|{closure}",
-                    "percent": 100,
-                    "labels": [
-                        {
-                            "key": "exception type",
-                            "values": [
-                                "Exception"
-                            ]
-                        },
-                        {
-                            "key": "exception message",
-                            "values_regex": "Exception from (worker [0-9]|main thread)"
-                        },
-                        {
-                            "key": "thread id",
-                            "values_regex": "^[0-9]+$"
-                        }
-                    ]
-                }
-            ]
+          "regular_expression": "<\\?php|{closure}",
+          "percent": 100,
+          "labels": [
+            {
+              "key": "exception type",
+              "values": [
+                "Exception"
+              ]
+            },
+            {
+              "key": "exception message",
+              "values_regex": "Exception from (worker [0-9]|main thread)"
+            },
+            {
+              "key": "thread id",
+              "values_regex": "^[0-9]+$"
+            }
+          ]
         }
-    ]
+      ]
+    }
+  ]
 }

--- a/profiling/tests/correctness/strange_frames.json
+++ b/profiling/tests/correctness/strange_frames.json
@@ -1,15 +1,15 @@
 {
-    "test_name": "php_strange_frames",
-    "stacks": [
+  "test_name": "php_strange_frames",
+  "stacks": [
+    {
+      "profile-type": "sample",
+      "stack-content": [
         {
-            "profile-type": "sample",
-            "stack-content": [
-                {
-                    "regular_expression": "<?php;main;Datadog\\\\Test\\\\Class1::method1;class@anonymous.*::__invoke;Datadog\\\\Test\\\\Class1::Datadog\\\\Test\\\\\\{closure\\};datadog-profiling\\|Datadog\\\\Profiling\\\\trigger_time_sample",
-                    "percent": 100,
-                    "error_margin": 1
-                }
-            ]
+          "regular_expression": "<?php;main;Datadog\\\\Test\\\\Class1::method1;class@anonymous.*::__invoke;Datadog\\\\Test\\\\Class1::Datadog\\\\Test\\\\\\{closure\\};datadog-profiling\\|Datadog\\\\Profiling\\\\trigger_time_sample",
+          "percent": 100,
+          "error_margin": 1
         }
-    ]
+      ]
+    }
+  ]
 }

--- a/profiling/tests/correctness/time.json
+++ b/profiling/tests/correctness/time.json
@@ -1,45 +1,45 @@
 {
-    "test_name": "php_time",
-    "stacks": [
+  "test_name": "php_time",
+  "stacks": [
+    {
+      "profile-type": "wall-time",
+      "stack-content": [
         {
-            "profile-type": "wall-time",
-            "stack-content": [
-                {
-                    "regular_expression": "<?php;main;a$",
-                    "percent": 17,
-                    "error_margin": 10
-                },
-                {
-                    "regular_expression": "<?php;main;b$",
-                    "percent": 33,
-                    "error_margin": 10
-                },
-                {
-                    "regular_expression": "<?php;main;standard\\|sleep$",
-                    "percent": 50,
-                    "error_margin": 10
-                }
-            ]
+          "regular_expression": "<?php;main;a$",
+          "percent": 17,
+          "error_margin": 10
         },
         {
-            "profile-type": "cpu-time",
-            "stack-content": [
-                {
-                    "regular_expression": "<?php;main;a$",
-                    "percent": 33,
-                    "error_margin": 10
-                },
-                {
-                    "regular_expression": "<?php;main;b$",
-                    "percent": 66,
-                    "error_margin": 10
-                },
-                {
-                    "regular_expression": "<?php;main;standard\\|sleep$",
-                    "percent": 1,
-                    "error_margin": 10
-                }
-            ]
+          "regular_expression": "<?php;main;b$",
+          "percent": 33,
+          "error_margin": 10
+        },
+        {
+          "regular_expression": "<?php;main;standard\\|sleep$",
+          "percent": 50,
+          "error_margin": 10
         }
-    ]
+      ]
+    },
+    {
+      "profile-type": "cpu-time",
+      "stack-content": [
+        {
+          "regular_expression": "<?php;main;a$",
+          "percent": 33,
+          "error_margin": 10
+        },
+        {
+          "regular_expression": "<?php;main;b$",
+          "percent": 66,
+          "error_margin": 10
+        },
+        {
+          "regular_expression": "<?php;main;standard\\|sleep$",
+          "percent": 1,
+          "error_margin": 10
+        }
+      ]
+    }
+  ]
 }

--- a/profiling/tests/correctness/timeline.json
+++ b/profiling/tests/correctness/timeline.json
@@ -20,58 +20,86 @@
                             "values": [
                                 "gc"
                             ]
+                        },
+                        {
+                            "key": "end_timestamp_ns",
+                            "values_regex": "^[0-9]+$"
+                        },
+                        {
+                            "key": "gc collected",
+                            "values_regex": "^[0-9]+$"
+                        },
+                        {
+                            "key": "gc runs",
+                            "values_regex": "^[0-9]+$"
                         }
                     ]
                 },
                 {
                     "regular_expression": "^\\[require\\]$",
                     "percent": 100,
-                    "error_margin": 100,
+                    "error_margin": 99,
                     "labels": [
                         {
                             "key": "event",
                             "values": [
                                 "compilation"
                             ]
+                        },
+                        {
+                            "key": "end_timestamp_ns",
+                            "values_regex": "^[0-9]+$"
                         }
                     ]
                 },
                 {
                     "regular_expression": "^\\[include\\]$",
                     "percent": 100,
-                    "error_margin": 100,
+                    "error_margin": 99,
                     "labels": [
                         {
                             "key": "event",
                             "values": [
                                 "compilation"
                             ]
+                        },
+                        {
+                            "key": "end_timestamp_ns",
+                            "values_regex": "^[0-9]+$"
                         }
                     ]
                 },
                 {
                     "regular_expression": "^\\[eval\\]$",
                     "percent": 100,
-                    "error_margin": 100,
+                    "error_margin": 99,
                     "labels": [
                         {
                             "key": "event",
                             "values": [
                                 "compilation"
                             ]
+                        },
+                        {
+                            "key": "end_timestamp_ns",
+                            "values_regex": "^[0-9]+$"
                         }
                     ]
                 },
                 {
                     "regular_expression": "^\\[idle\\]$",
                     "percent": 100,
-                    "error_margin": 100,
+                    "error_margin": 99,
                     "labels": [
                         {
                             "key": "event",
                             "values": [
                                 "sleeping"
                             ]
+                        },
+                        {
+                            "key": "end_timestamp_ns",
+                            "values_regex": "^[0-9]+$"
                         }
                     ]
                 }

--- a/profiling/tests/correctness/timeline.json
+++ b/profiling/tests/correctness/timeline.json
@@ -1,109 +1,109 @@
 {
-    "test_name": "php_timeline",
-    "stacks": [
+  "test_name": "php_timeline",
+  "stacks": [
+    {
+      "profile-type": "timeline",
+      "stack-content": [
         {
-            "profile-type": "timeline",
-            "stack-content": [
-                {
-                    "regular_expression": "^\\[gc\\]$",
-                    "percent": 100,
-                    "error_margin": 100,
-                    "labels": [
-                        {
-                            "key": "gc reason",
-                            "values": [
-                                "induced"
-                            ]
-                        },
-                        {
-                            "key": "event",
-                            "values": [
-                                "gc"
-                            ]
-                        },
-                        {
-                            "key": "end_timestamp_ns",
-                            "values_regex": "^[0-9]+$"
-                        },
-                        {
-                            "key": "gc collected",
-                            "values_regex": "^[0-9]+$"
-                        },
-                        {
-                            "key": "gc runs",
-                            "values_regex": "^[0-9]+$"
-                        }
-                    ]
-                },
-                {
-                    "regular_expression": "^\\[require\\]$",
-                    "percent": 100,
-                    "error_margin": 99,
-                    "labels": [
-                        {
-                            "key": "event",
-                            "values": [
-                                "compilation"
-                            ]
-                        },
-                        {
-                            "key": "end_timestamp_ns",
-                            "values_regex": "^[0-9]+$"
-                        }
-                    ]
-                },
-                {
-                    "regular_expression": "^\\[include\\]$",
-                    "percent": 100,
-                    "error_margin": 99,
-                    "labels": [
-                        {
-                            "key": "event",
-                            "values": [
-                                "compilation"
-                            ]
-                        },
-                        {
-                            "key": "end_timestamp_ns",
-                            "values_regex": "^[0-9]+$"
-                        }
-                    ]
-                },
-                {
-                    "regular_expression": "^\\[eval\\]$",
-                    "percent": 100,
-                    "error_margin": 99,
-                    "labels": [
-                        {
-                            "key": "event",
-                            "values": [
-                                "compilation"
-                            ]
-                        },
-                        {
-                            "key": "end_timestamp_ns",
-                            "values_regex": "^[0-9]+$"
-                        }
-                    ]
-                },
-                {
-                    "regular_expression": "^\\[idle\\]$",
-                    "percent": 100,
-                    "error_margin": 99,
-                    "labels": [
-                        {
-                            "key": "event",
-                            "values": [
-                                "sleeping"
-                            ]
-                        },
-                        {
-                            "key": "end_timestamp_ns",
-                            "values_regex": "^[0-9]+$"
-                        }
-                    ]
-                }
-            ]
+          "regular_expression": "^\\[gc\\]$",
+          "percent": 100,
+          "error_margin": 100,
+          "labels": [
+            {
+              "key": "gc reason",
+              "values": [
+                "induced"
+              ]
+            },
+            {
+              "key": "event",
+              "values": [
+                "gc"
+              ]
+            },
+            {
+              "key": "end_timestamp_ns",
+              "values_regex": "^[0-9]+$"
+            },
+            {
+              "key": "gc collected",
+              "values_regex": "^[0-9]+$"
+            },
+            {
+              "key": "gc runs",
+              "values_regex": "^[0-9]+$"
+            }
+          ]
+        },
+        {
+          "regular_expression": "^\\[require\\]$",
+          "percent": 100,
+          "error_margin": 99,
+          "labels": [
+            {
+              "key": "event",
+              "values": [
+                "compilation"
+              ]
+            },
+            {
+              "key": "end_timestamp_ns",
+              "values_regex": "^[0-9]+$"
+            }
+          ]
+        },
+        {
+          "regular_expression": "^\\[include\\]$",
+          "percent": 100,
+          "error_margin": 99,
+          "labels": [
+            {
+              "key": "event",
+              "values": [
+                "compilation"
+              ]
+            },
+            {
+              "key": "end_timestamp_ns",
+              "values_regex": "^[0-9]+$"
+            }
+          ]
+        },
+        {
+          "regular_expression": "^\\[eval\\]$",
+          "percent": 100,
+          "error_margin": 99,
+          "labels": [
+            {
+              "key": "event",
+              "values": [
+                "compilation"
+              ]
+            },
+            {
+              "key": "end_timestamp_ns",
+              "values_regex": "^[0-9]+$"
+            }
+          ]
+        },
+        {
+          "regular_expression": "^\\[idle\\]$",
+          "percent": 100,
+          "error_margin": 99,
+          "labels": [
+            {
+              "key": "event",
+              "values": [
+                "sleeping"
+              ]
+            },
+            {
+              "key": "end_timestamp_ns",
+              "values_regex": "^[0-9]+$"
+            }
+          ]
         }
-    ]
+      ]
+    }
+  ]
 }


### PR DESCRIPTION
### Description

This PR adds a check for the timeline feature for missing labels (mostly `end_timestamp_ns`) and also cleans up the JSON files using `jq`.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
