### PR TITLE
Use valgrind suppressions instead of disabling valgrind

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -154,6 +154,7 @@ test_with_init_hook: $(SO_FILE) $(INIT_HOOK_TEST_FILES)
 test_extension_ci: $(SO_FILE) $(TEST_FILES) $(TEST_STUB_FILES)
 	( \
 	set -xe; \
+	export PATH="$(PROJECT_ROOT)/tests/ext/valgrind:$$PATH"; \
 	export DD_TRACE_CLI_ENABLED=1; \
 	export TEST_PHP_JUNIT=$(JUNIT_RESULTS_DIR)/normal-extension-test.xml; \
 	$(MAKE) -C $(BUILD_DIR) CFLAGS="-g" clean all; \
@@ -161,7 +162,6 @@ test_extension_ci: $(SO_FILE) $(TEST_FILES) $(TEST_STUB_FILES)
 	\
 	export TEST_PHP_JUNIT=$(JUNIT_RESULTS_DIR)/valgrind-extension-test.xml; \
 	export TEST_PHP_OUTPUT=$(JUNIT_RESULTS_DIR)/valgrind-run-tests.out; \
-	export DD_TRACE_SIDECAR_TRACE_SENDER=0; \
 	$(RUN_TESTS_CMD) -d extension=$(SO_FILE) -m -s $$TEST_PHP_OUTPUT $(BUILD_DIR)/$(TESTS) && ! grep -e 'LEAKED TEST SUMMARY' $$TEST_PHP_OUTPUT; \
 	)
 

--- a/tests/ext/background-sender/agent_sampling_sidecar.phpt
+++ b/tests/ext/background-sender/agent_sampling_sidecar.phpt
@@ -2,7 +2,6 @@
 The sidecar trace flusher sender informs about changes to the agent sample rate
 --SKIPIF--
 <?php include __DIR__ . '/../includes/skipif_no_dev_env.inc'; ?>
-<?php if ((getenv('USE_ZEND_ALLOC') === '0' && !getenv("SKIP_ASAN")) || getenv("TEST_PHP_JUNIT")) die('skip: valgrind reports sendmsg(msg.msg_control) points to uninitialised byte(s), but it is unproblematic and outside our control in rust code'); ?>
 --ENV--
 DD_TRACE_LOG_LEVEL=info,startup=off
 DD_AGENT_HOST=request-replayer

--- a/tests/ext/valgrind/suppressions.txt
+++ b/tests/ext/valgrind/suppressions.txt
@@ -1,0 +1,7 @@
+{
+   <sendmsg in rust has unitialized bytes>
+   Memcheck:Param
+   sendmsg(msg.msg_control)
+   fun:sendmsg
+   fun:*send_with_fd*
+}

--- a/tests/ext/valgrind/valgrind
+++ b/tests/ext/valgrind/valgrind
@@ -1,0 +1,4 @@
+#!/bin/bash
+DIR=$(dirname "$0")
+export PATH=${PATH/${DIR//\//\\\/}:/}
+exec valgrind "--suppressions=$DIR/suppressions.txt" "$@"


### PR DESCRIPTION
Redirect valgrind executions to our custom valgrind-invoking script, to apply suppressions.