### PR TITLE
Add http.route tag to SymfonyIntegration.php

### DIFF
--- a/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
@@ -300,11 +300,12 @@ class SymfonyIntegration extends Integration
         \DDTrace\trace_method(
             'Symfony\Component\EventDispatcher\EventDispatcher',
             'dispatch',
-            function (DDTrace\SpanData $span, $args) {
+            function (SpanData $span, $args) {
         
                 list($event) = $args;
-        
-                if (!$event instanceof ControllerEvent) {
+
+                $controllerEventClass = '\Symfony\Component\HttpKernel\Event\ControllerEvent';
+                if (!$event instanceof $controllerEventClass) {
                     return;
                 }
                 

--- a/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
@@ -332,7 +332,11 @@ class SymfonyIntegration extends Integration
         
                 // Replace route parameters in URL with placeholders
                 foreach ($parameters as $key => $value) {
-                    $url = str_replace($value, '{' . $key . '}', $url);
+                    $search = '/' . preg_quote($value, '/') . '/';
+                    if (empty($value)) {
+                        continue;
+                    }
+                    $url = preg_replace($search, '{' . $key . '}', $url, 1);
                 }
         
                 $urlWithoutQueryParameters = strtok($url, '?');

--- a/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
@@ -395,6 +395,13 @@ class SymfonyIntegration extends Integration
                     }
                     $rootSpan->meta['symfony.route.name'] = $route;
                 }
+
+                $path = \DDTrace\Util\Normalizer::uriNormalizeIncomingPath($_SERVER['REQUEST_URI']);
+                foreach (array_keys($parameters) as $key) {
+                    $path = preg_replace('/\?/', '{' . $key . '}', $path, 1);
+                }
+                $span->meta[\DDTrace\Tag::HTTP_ROUTE] = $path;
+                
             }
         );
 

--- a/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
@@ -12,6 +12,7 @@ use DDTrace\Util\Normalizer;
 use DDTrace\Util\Versions;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\KernelEvents;
+use Symfony\Component\Routing\RouterInterface;
 use function DDTrace\install_hook;
 
 class SymfonyIntegration extends Integration


### PR DESCRIPTION
Hello, this is draft pull request adds the http.route tag to the Symfony integration.
Noticing that [PR #2477](https://github.com/DataDog/dd-trace-php/pull/2477) was closed, I decided to take the initiative to implement this feature.

Can you please provide your feedback on this proposal/implementation? If approved, I'll proceed with implementing tests to further validate the changes.

Thank you for your review !

<!---
Any description you feel is relevant and gives more background to this PR, if necessary.
-->

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
