### PR TITLE
fix: Handle OTel HTTP semantic conventions < 1.21.0

### DIFF
--- a/tests/ext/otel_http_status_code_remapping.phpt
+++ b/tests/ext/otel_http_status_code_remapping.phpt
@@ -1,10 +1,10 @@
 --TEST--
-Remap http.response.status_code to http.status_code - OTel HTTP Semantic Convention >= 1.21.0
+Remap http.status_code metric to http.status_code meta - OTel HTTP Semantic Convention < 1.21.0
 --FILE--
 <?php
 
 $span = \DDTrace\start_span();
-$span->metrics['http.response.status_code'] = "300";
+$span->metrics['http.status_code'] = "200";
 \DDTrace\close_span();
 
 var_dump(dd_trace_serialize_closed_spans());
@@ -29,13 +29,13 @@ array(1) {
     ["resource"]=>
     string(0) ""
     ["service"]=>
-    string(44) "otel_http_response_status_code_remapping.php"
+    string(35) "otel_http_status_code_remapping.php"
     ["type"]=>
     string(3) "cli"
     ["meta"]=>
     array(1) {
       ["http.status_code"]=>
-      string(3) "300"
+      string(3) "200"
     }
   }
 }


### PR DESCRIPTION
### Description

[AIDM-162](https://datadoghq.atlassian.net/browse/AIDM-162)

The following [system test](https://github.com/DataDog/system-tests/blob/6c78b4029f1c6474115c561783f6ce2c2624958c/tests/parametric/test_otel_span_methods.py#L105-L119) was failing. This is because from OTel pov, doing `setAttribute` sets the status code in the metrics array. 

This PR simply maps (and therefore overrides, if set) the deprecated `http.status_code` metric to the meta array. 

This tag is set in [Otel HTTP semantic versions inferior or equal](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.20.0/specification/trace/semantic_conventions/http.md#common-attributes) than [1.21.0](https://github.com/open-telemetry/opentelemetry-specification/blob/v1.21.0/specification/trace/semantic_conventions/http.md#common-attributes)

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.


[AIDM-162]: https://datadoghq.atlassian.net/browse/AIDM-162?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ