### PR TITLE
Init OCI packaging for SSI

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,8 +1,12 @@
 stages:
   - build
+  - package
+  - internal-publish
   - deploy
   - benchmarks
   - ci-build
+  - test
+  - external-publish
 
 variables:
   LATEST_LIBRARY_x86_64_LINUX_GNU:
@@ -14,6 +18,7 @@ variables:
 
 include:
   - remote: https://gitlab-templates.ddbuild.io/libdatadog/include/ci_authenticated_job.yml
+  - remote: https://gitlab-templates.ddbuild.io/libdatadog/include-wip/one-pipeline.yml
   - local: .gitlab/benchmarks.yml
   - local: .gitlab/ci-images.yml
 
@@ -40,6 +45,36 @@ build:
     paths:
       - 'upstream.env'
       - 'datadog-setup-x86_64-linux-gnu.tar'
+
+# FIXME: trigger only on master?
+download_artifacts:
+  extends: .ci_authenticated_job
+  stage: build
+  image: registry.ddbuild.io/images/ci_docker_base
+  tags: [ "runner:main", "size:large" ]
+  script:
+    - |
+      source .gitlab/download-circleci_artifact.sh
+
+      download_circleci_artifact "gh/DataDog/dd-trace-php" "build_packages" "Compile Loader Linux x86_64" "loader/modules/dd_library_loader.so" "dd_library_loader-x86_64-linux-gnu.so"
+      download_circleci_artifact "gh/DataDog/dd-trace-php" "build_packages" "Compile Loader Linux aarch64" "loader/modules/dd_library_loader.so" "dd_library_loader-aarch64-linux-gnu.so"
+      download_circleci_artifact "gh/DataDog/dd-trace-php" "build_packages" "Compile Loader Alpine x86_64" "loader/modules/dd_library_loader.so" "dd_library_loader-x86_64-linux-musl.so"
+      download_circleci_artifact "gh/DataDog/dd-trace-php" "build_packages" "Compile Loader Alpine aarch64" "loader/modules/dd_library_loader.so" "dd_library_loader-aarch64-linux-musl.so"
+
+      download_circleci_artifact "gh/DataDog/dd-trace-php" "build_packages" "package extension" "dd-library-php-.*-x86_64-linux-gnu.tar.gz" "dd-library-php-x86_64-linux-gnu.tar.gz"
+      download_circleci_artifact "gh/DataDog/dd-trace-php" "build_packages" "package extension" "dd-library-php-.*-aarch64-linux-gnu.tar.gz" "dd-library-php-aarch64-linux-gnu.tar.gz"
+      download_circleci_artifact "gh/DataDog/dd-trace-php" "build_packages" "package extension" "dd-library-php-.*-x86_64-linux-musl.tar.gz" "dd-library-php-x86_64-linux-musl.tar.gz"
+      download_circleci_artifact "gh/DataDog/dd-trace-php" "build_packages" "package extension" "dd-library-php-.*-aarch64-linux-musl.tar.gz" "dd-library-php-aarch64-linux-musl.tar.gz"
+  artifacts:
+    paths:
+      - 'dd_library_loader-x86_64-linux-gnu.so'
+      - 'dd_library_loader-aarch64-linux-gnu.so'
+      - 'dd_library_loader-x86_64-linux-musl.so'
+      - 'dd_library_loader-aarch64-linux-musl.so'
+      - 'dd-library-php-x86_64-linux-gnu.tar.gz'
+      - 'dd-library-php-aarch64-linux-gnu.tar.gz'
+      - 'dd-library-php-x86_64-linux-musl.tar.gz'
+      - 'dd-library-php-aarch64-linux-musl.tar.gz'
 
 deploy_to_reliability_env:
   stage: deploy

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,12 +1,9 @@
 stages:
   - build
-  - package
-  - internal-publish
+  - shared-pipeline # OCI packaging
   - deploy
   - benchmarks
   - ci-build
-  - test
-  - external-publish
 
 variables:
   LATEST_LIBRARY_x86_64_LINUX_GNU:
@@ -78,6 +75,7 @@ download_artifacts:
 
 deploy_to_reliability_env:
   stage: deploy
+  needs: [ build ]
   rules:
     - if: $CI_PIPELINE_SOURCE == "schedule" && $NIGHTLY
       when: always
@@ -103,17 +101,18 @@ tracer-base-image:
     - if: '$CI_PIPELINE_SOURCE == "schedule"'
       when: always
   stage: deploy
+  needs: [ build ]
   script:
     - echo $GH_TOKEN|docker login ghcr.io/datadog -u uploader --password-stdin
 
     #Dev X86
     - rm -rf ./tooling/ci/binaries
-    - ./tooling/ci/download-binary-php.sh dev   
+    - ./tooling/ci/download-binary-php.sh dev
     - docker buildx build --load --progress=plain --platform linux/amd64 -f ./tooling/ci/Dockerfile -t ghcr.io/datadog/dd-trace-php/dd-library-php:latest_snapshot .
     - docker push ghcr.io/datadog/dd-trace-php/dd-library-php:latest_snapshot
- 
+
     #Prod X86
     - rm -rf ./tooling/ci/binaries
-    - ./tooling/ci/download-binary-php.sh prod   
+    - ./tooling/ci/download-binary-php.sh prod
     - docker buildx build --load --progress=plain --platform linux/amd64 -f ./tooling/ci/Dockerfile -t ghcr.io/datadog/dd-trace-php/dd-library-php:latest .
     - docker push ghcr.io/datadog/dd-trace-php/dd-library-php:latest

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -43,7 +43,6 @@ build:
       - 'upstream.env'
       - 'datadog-setup-x86_64-linux-gnu.tar'
 
-# FIXME: trigger only on master?
 download_artifacts:
   extends: .ci_authenticated_job
   stage: build
@@ -53,25 +52,12 @@ download_artifacts:
     - |
       source .gitlab/download-circleci_artifact.sh
 
-      download_circleci_artifact "gh/DataDog/dd-trace-php" "build_packages" "Compile Loader Linux x86_64" "loader/modules/dd_library_loader.so" "dd_library_loader-x86_64-linux-gnu.so"
-      download_circleci_artifact "gh/DataDog/dd-trace-php" "build_packages" "Compile Loader Linux aarch64" "loader/modules/dd_library_loader.so" "dd_library_loader-aarch64-linux-gnu.so"
-      download_circleci_artifact "gh/DataDog/dd-trace-php" "build_packages" "Compile Loader Alpine x86_64" "loader/modules/dd_library_loader.so" "dd_library_loader-x86_64-linux-musl.so"
-      download_circleci_artifact "gh/DataDog/dd-trace-php" "build_packages" "Compile Loader Alpine aarch64" "loader/modules/dd_library_loader.so" "dd_library_loader-aarch64-linux-musl.so"
-
-      download_circleci_artifact "gh/DataDog/dd-trace-php" "build_packages" "package extension" "dd-library-php-.*-x86_64-linux-gnu.tar.gz" "dd-library-php-x86_64-linux-gnu.tar.gz"
-      download_circleci_artifact "gh/DataDog/dd-trace-php" "build_packages" "package extension" "dd-library-php-.*-aarch64-linux-gnu.tar.gz" "dd-library-php-aarch64-linux-gnu.tar.gz"
-      download_circleci_artifact "gh/DataDog/dd-trace-php" "build_packages" "package extension" "dd-library-php-.*-x86_64-linux-musl.tar.gz" "dd-library-php-x86_64-linux-musl.tar.gz"
-      download_circleci_artifact "gh/DataDog/dd-trace-php" "build_packages" "package extension" "dd-library-php-.*-aarch64-linux-musl.tar.gz" "dd-library-php-aarch64-linux-musl.tar.gz"
+      download_circleci_artifact "gh/DataDog/dd-trace-php" "build_packages" "package extension" "dd-library-php-ssi-.*-x86_64-linux.tar.gz" "dd-library-php-ssi-x86_64-linux.tar.gz"
+      download_circleci_artifact "gh/DataDog/dd-trace-php" "build_packages" "package extension" "dd-library-php-ssi-.*-aarch64-linux.tar.gz" "dd-library-php-ssi-aarch64-linux.tar.gz"
   artifacts:
     paths:
-      - 'dd_library_loader-x86_64-linux-gnu.so'
-      - 'dd_library_loader-aarch64-linux-gnu.so'
-      - 'dd_library_loader-x86_64-linux-musl.so'
-      - 'dd_library_loader-aarch64-linux-musl.so'
-      - 'dd-library-php-x86_64-linux-gnu.tar.gz'
-      - 'dd-library-php-aarch64-linux-gnu.tar.gz'
-      - 'dd-library-php-x86_64-linux-musl.tar.gz'
-      - 'dd-library-php-aarch64-linux-musl.tar.gz'
+      - 'dd-library-php-ssi-x86_64-linux.tar.gz'
+      - 'dd-library-php-ssi-aarch64-linux.tar.gz'
 
 deploy_to_reliability_env:
   stage: deploy

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -69,6 +69,7 @@ benchmarks-tracer:
 
 download_circle_ci_release:
   stage: benchmarks
+  needs: []
   rules:
     - if: ($NIGHTLY_BENCHMARKS || $CI_PIPELINE_SOURCE != "schedule") && $CI_COMMIT_REF_NAME == "master"
       when: always

--- a/.gitlab/download-circleci_artifact.sh
+++ b/.gitlab/download-circleci_artifact.sh
@@ -1,0 +1,90 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+echoerr() {
+    echo "${1}" >&2
+}
+
+call_api() {
+    URL="${1}"
+    echoerr "[API] ${URL}"
+    curl --retry 5 --fail --silent --show-error "${URL}" -H "Circle-Token: ${CIRCLECI_TOKEN}" || exit 1
+}
+
+json_extract() {
+    JSON="${1}"
+    QUERY="${2}"
+    echo "${JSON}" | jq -r "${QUERY}"
+}
+
+download_circleci_artifact() {
+    SLUG=$1                 # "gh/DataDog/dd-trace-php"
+    WORKFLOW_NAME=$2        # "build_packages"
+    JOB_NAME=$3             # "Compile Loader Linux x86_64"
+    ARTIFACT_PATTERN=$4     # "loader/modules/dd_library_loader.so"
+    ARTIFACT_NAME=$5        # "dd_library_loader-x86_64-linux-gnu.so"
+
+    BRANCH=${CI_COMMIT_BRANCH}  # Set by Gilab CI
+    COMMIT_SHA=${CI_COMMIT_SHA} # Set by Gilab CI
+
+    PIPELINES=$(call_api "https://circleci.com/api/v2/project/${SLUG}/pipeline?branch=${BRANCH}")
+
+    # Ensure it's the same GIT commit
+    REVISION=$(json_extract "${PIPELINES}" ".items[0].vcs.revision")
+    if [[ "${COMMIT_SHA}" != "${REVISION}" ]]; then
+        echo "The git commit hash (${CI_COMMIT_SHA}) does not match the one in the CircleCI pipeline (${REVISION})"
+        exit 1
+    fi
+
+    PIPELINE_ID=$(json_extract "${PIPELINES}" ".items[0].id")
+    PIPELINE_NUMBER=$(json_extract "${PIPELINES}" ".items[0].number")
+
+    WORKFLOWS=$(call_api "https://circleci.com/api/v2/pipeline/${PIPELINE_ID}/workflow")
+    WORKFLOW_ID=$(json_extract "${WORKFLOWS}" ".items[] | select(.name == \"${WORKFLOW_NAME}\") | .id")
+
+    JOB_NUMBER=""
+    for i in {0..120}; do
+        JOBS=$(call_api https://circleci.com/api/v2/workflow/${WORKFLOW_ID}/job)
+        JOB=$(json_extract "${JOBS}" ".items[] | select(.name == \"${JOB_NAME}\")")
+
+        JOB_STATUS=$(json_extract "${JOB}" ".status")
+        if [[ "${JOB_STATUS}" == "running" || "${JOB_STATUS}" == "blocked" || "${JOB_STATUS}" == "not_running" ]]; then
+            echo "Job is still waiting or running. Will try again in 30 seconds..."
+            sleep 30s
+            continue
+        fi
+
+        if [[ "${JOB_STATUS}" != "success" ]]; then
+            printf "CircleCI job is not successful:\n ${JOB}\n"
+            exit 1
+        fi
+
+        JOB_NUMBER=$(json_extract "${JOB}" ".job_number")
+        break
+    done
+
+    if [[ "${JOB_NUMBER}" == "" ]]; then
+        echo "Timeout. Is CircleCI job still running?"
+        exit 1
+    fi
+
+    ARTIFACTS=$(call_api "https://circleci.com/api/v2/project/${SLUG}/${JOB_NUMBER}/artifacts")
+    QUERY=".items[] | select(.path | test(\"$ARTIFACT_PATTERN\"))"
+    ARTIFACT_URL=$(json_extract "${ARTIFACTS}" ".items[] | select(.path | test(\"$ARTIFACT_PATTERN\")) | .url")
+
+    if [ -z "${ARTIFACT_URL}" ]; then
+        echo "Oooops, I did not found any artifact that satisfy this pattern: ${ARTIFACT_PATTERN}. Here is the list:"
+        echo $(json_extract "${ARTIFACTS}" ".items[] | .path")
+        exit 1
+    fi
+
+    echo "Artifact URL: ${ARTIFACT_URL}"
+    echo "Artifact name: ${ARTIFACT_NAME}"
+    echo "Downloading artifact..."
+
+    curl --silent -L "${ARTIFACT_URL}" --output "${ARTIFACT_NAME}"
+}
+
+if [[ -f ".env" ]]; then
+    source .env
+fi

--- a/.gitlab/prepare-oci-package.sh
+++ b/.gitlab/prepare-oci-package.sh
@@ -8,15 +8,6 @@ elif [[ "$arch" == "amd64" ]]; then
     arch="x86_64"
 fi
 
-# FIXME: handle Alpine/musl in the same package?
-
-rm -rf dd-library-php
-tar xvzf ../dd-library-php-${arch}-linux-gnu.tar.gz
-
-mkdir -p sources
-
-cp ../dd_library_loader-${arch}-linux-gnu.so sources/dd_library_loader.so
-cp -R dd-library-php/trace sources/
-cp dd-library-php/VERSION sources/version
-
-echo 'zend_extension=${DD_LOADER_PACKAGE_PATH}/dd_library_loader.so' > sources/dd_library_loader.ini
+rm -rf dd-library-php-ssi
+tar xvzf ../dd-library-php-ssi-${arch}-linux.tar.gz
+mv dd-library-php-ssi sources

--- a/.gitlab/prepare-oci-package.sh
+++ b/.gitlab/prepare-oci-package.sh
@@ -1,0 +1,22 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+arch=${ARCH:-$(uname -m)}
+if [[ "$arch" == "arm64" ]]; then
+    arch="aarch64"
+elif [[ "$arch" == "amd64" ]]; then
+    arch="x86_64"
+fi
+
+# FIXME: handle Alpine/musl in the same package?
+
+rm -rf dd-library-php
+tar xvzf ../dd-library-php-${arch}-linux-gnu.tar.gz
+
+mkdir -p sources
+
+cp ../dd_library_loader-${arch}-linux-gnu.so sources/dd_library_loader.so
+cp -R dd-library-php/trace sources/
+cp dd-library-php/VERSION sources/version
+
+echo 'zend_extension=${DD_LOADER_PACKAGE_PATH}/dd_library_loader.so' > sources/dd_library_loader.ini

--- a/tooling/bin/generate-ssi-package.sh
+++ b/tooling/bin/generate-ssi-package.sh
@@ -6,6 +6,10 @@ IFS=$'\n\t'
 release_version=$1
 packages_build_dir=$2
 
+# This string will be used in the OCI tag
+# '+' char is not allowed
+release_version_sanitized=${release_version/+/-}
+
 tmp_folder=/tmp/bundle
 tmp_folder_final=$tmp_folder/final
 
@@ -57,7 +61,7 @@ for architecture in "${architectures[@]}"; do
     done;
 
     cp -r ./src ${trace}/
-    echo "$release_version" > ${root}/version
+    echo "$release_version_sanitized" > ${root}/version
 
     ########################
     # Final archives


### PR DESCRIPTION
### Description

~~Based on https://github.com/DataDog/dd-trace-php/pull/2684~~ ~~Based on https://github.com/DataDog/dd-trace-php/pull/2744~~

Include the pipeline in charge of creating and pushing an OCI package for SSI

~~This pipeline has no support for Alpine/musl yet, but we can implement this later.~~

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
