### PR TITLE
Add config to disable obfuscation in memcached queries

### DIFF
--- a/ext/configuration.h
+++ b/ext/configuration.h
@@ -184,6 +184,7 @@ enum ddtrace_sampling_rules_format {
     CONFIG(STRING, DD_VERSION, "", .ini_change = ddtrace_alter_dd_version,                                     \
            .env_config_fallback = ddtrace_conf_otel_resource_attributes_version)                               \
     CONFIG(STRING, DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP, DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP_DEFAULT) \
+    CONFIG(BOOL, DD_TRACE_MEMCACHED_OBFUSCATION, "true")                                                       \
     CONFIG(BOOL, DD_TRACE_CLIENT_IP_ENABLED, "false")                                                          \
     CONFIG(CUSTOM(STRING), DD_TRACE_CLIENT_IP_HEADER, "", .parser = ddtrace_parse_client_ip_header_config)     \
     CONFIG(BOOL, DD_TRACE_FORKED_PROCESS, "true")                                                              \

--- a/src/DDTrace/Integrations/Memcache/MemcacheIntegration.php
+++ b/src/DDTrace/Integrations/Memcache/MemcacheIntegration.php
@@ -97,7 +97,9 @@ class MemcacheIntegration extends Integration
             }
             if (!is_array($args[0])) {
                 $integration->setServerTags($span, $this);
-                $span->meta['memcache.query'] = $command . ' ' . Obfuscation::toObfuscatedString($args[0]);
+                $queryParams = dd_trace_env_config("DD_TRACE_MEMCACHED_OBFUSCATION") ?
+                    Obfuscation::toObfuscatedString($args[0]) : $args[0];
+                $span->meta['memcache.query'] = $command . ' ' . $queryParams;
             }
             $span->peerServiceSources = DatabaseIntegrationHelper::PEER_SERVICE_SOURCES;
             $integration->markForTraceAnalytics($span, $command);

--- a/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php
+++ b/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php
@@ -125,9 +125,7 @@ class MemcachedIntegration extends Integration
                 }
                 if (!is_array($args[0])) {
                     $integration->setServerTags($span, $this);
-                    $queryParams = dd_trace_env_config("DD_TRACE_MEMCACHED_OBFUSCATION") ?
-                        Obfuscation::toObfuscatedString($args[0]) : $args[0];
-                    $span->meta['memcached.query'] = $command . ' ' . $queryParams;
+                    $span->meta['memcached.query'] = $command . ' ' . $integration->obfuscateIfNeeded($args[0]);
                 }
                 $span->peerServiceSources = DatabaseIntegrationHelper::PEER_SERVICE_SOURCES;
 
@@ -149,9 +147,7 @@ class MemcachedIntegration extends Integration
                 }
                 if (!is_array($args[0])) {
                     $integration->setServerTags($span, $this);
-                    $queryParams = dd_trace_env_config("DD_TRACE_MEMCACHED_OBFUSCATION") ?
-                        Obfuscation::toObfuscatedString($args[0]) : $args[0];
-                    $span->meta['memcached.query'] = $command . ' ' . $queryParams;
+                    $span->meta['memcached.query'] = $command . ' ' . $integration->obfuscateIfNeeded($args[0]);
                     $span->meta['memcached.server_key'] = $args[0];
                 }
                 $span->peerServiceSources = DatabaseIntegrationHelper::PEER_SERVICE_SOURCES;
@@ -173,9 +169,7 @@ class MemcachedIntegration extends Integration
                     $span->metrics[Tag::DB_ROW_COUNT] = isset($retval) ? (is_array($retval) ? count($retval) : 1) : 0;
                 }
                 $integration->setServerTags($span, $this);
-                $queryParams = dd_trace_env_config("DD_TRACE_MEMCACHED_OBFUSCATION") ?
-                    Obfuscation::toObfuscatedString($args[0], ',') : implode(',', $args[0]);
-                $span->meta['memcached.query'] = $command . ' ' . $queryParams;
+                $span->meta['memcached.query'] = $command . ' ' . $integration->obfuscateIfNeeded($args[0], ',');
                 $span->peerServiceSources = DatabaseIntegrationHelper::PEER_SERVICE_SOURCES;
                 $integration->markForTraceAnalytics($span, $command);
             }
@@ -195,9 +189,7 @@ class MemcachedIntegration extends Integration
                 }
                 $span->meta['memcached.server_key'] = $args[0];
                 $integration->setServerTags($span, $this);
-                $queryParams = dd_trace_env_config("DD_TRACE_MEMCACHED_OBFUSCATION") ?
-                    Obfuscation::toObfuscatedString($args[1], ',') : implode(',', $args[1]);
-                $query = "$command " . $queryParams;
+                $query = "$command " . $integration->obfuscateIfNeeded($args[1], ',');
                 $span->meta['memcached.query'] = $query;
                 $span->peerServiceSources = DatabaseIntegrationHelper::PEER_SERVICE_SOURCES;
                 $integration->markForTraceAnalytics($span, $command);
@@ -269,6 +261,20 @@ class MemcachedIntegration extends Integration
 
         if (in_array($command, $commandsForAnalytics)) {
             $this->addTraceAnalyticsIfEnabled($span);
+        }
+    }
+
+    /*
+     * Return either the obfuscated params or the params themselves, depending on the env var.
+     */
+    public function obfuscateIfNeeded($params, $glue = ' ')
+    {
+        if (dd_trace_env_config("DD_TRACE_MEMCACHED_OBFUSCATION")) {
+            return Obfuscation::toObfuscatedString($params, $glue);
+        } elseif (is_array($params)) {
+            return implode($glue, $params);
+        } else {
+            return $params;
         }
     }
 }

--- a/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php
+++ b/src/DDTrace/Integrations/Memcached/MemcachedIntegration.php
@@ -125,7 +125,9 @@ class MemcachedIntegration extends Integration
                 }
                 if (!is_array($args[0])) {
                     $integration->setServerTags($span, $this);
-                    $span->meta['memcached.query'] = $command . ' ' . Obfuscation::toObfuscatedString($args[0]);
+                    $queryParams = dd_trace_env_config("DD_TRACE_MEMCACHED_OBFUSCATION") ?
+                        Obfuscation::toObfuscatedString($args[0]) : $args[0];
+                    $span->meta['memcached.query'] = $command . ' ' . $queryParams;
                 }
                 $span->peerServiceSources = DatabaseIntegrationHelper::PEER_SERVICE_SOURCES;
 
@@ -147,7 +149,9 @@ class MemcachedIntegration extends Integration
                 }
                 if (!is_array($args[0])) {
                     $integration->setServerTags($span, $this);
-                    $span->meta['memcached.query'] = $command . ' ' . Obfuscation::toObfuscatedString($args[0]);
+                    $queryParams = dd_trace_env_config("DD_TRACE_MEMCACHED_OBFUSCATION") ?
+                        Obfuscation::toObfuscatedString($args[0]) : $args[0];
+                    $span->meta['memcached.query'] = $command . ' ' . $queryParams;
                     $span->meta['memcached.server_key'] = $args[0];
                 }
                 $span->peerServiceSources = DatabaseIntegrationHelper::PEER_SERVICE_SOURCES;
@@ -169,7 +173,9 @@ class MemcachedIntegration extends Integration
                     $span->metrics[Tag::DB_ROW_COUNT] = isset($retval) ? (is_array($retval) ? count($retval) : 1) : 0;
                 }
                 $integration->setServerTags($span, $this);
-                $span->meta['memcached.query'] = $command . ' ' . Obfuscation::toObfuscatedString($args[0], ',');
+                $queryParams = dd_trace_env_config("DD_TRACE_MEMCACHED_OBFUSCATION") ?
+                    Obfuscation::toObfuscatedString($args[0], ',') : implode(',', $args[0]);
+                $span->meta['memcached.query'] = $command . ' ' . $queryParams;
                 $span->peerServiceSources = DatabaseIntegrationHelper::PEER_SERVICE_SOURCES;
                 $integration->markForTraceAnalytics($span, $command);
             }
@@ -189,7 +195,9 @@ class MemcachedIntegration extends Integration
                 }
                 $span->meta['memcached.server_key'] = $args[0];
                 $integration->setServerTags($span, $this);
-                $query = "$command " . Obfuscation::toObfuscatedString($args[1], ',');
+                $queryParams = dd_trace_env_config("DD_TRACE_MEMCACHED_OBFUSCATION") ?
+                    Obfuscation::toObfuscatedString($args[1], ',') : implode(',', $args[1]);
+                $query = "$command " . $queryParams;
                 $span->meta['memcached.query'] = $query;
                 $span->peerServiceSources = DatabaseIntegrationHelper::PEER_SERVICE_SOURCES;
                 $integration->markForTraceAnalytics($span, $command);

--- a/tests/Integrations/Memcache/MemcacheTest.php
+++ b/tests/Integrations/Memcache/MemcacheTest.php
@@ -37,6 +37,7 @@ final class MemcacheTest extends IntegrationTestCase
             'DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED',
             'DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED',
             'DD_SERVICE',
+            'DD_TRACE_MEMCACHED_OBFUSCATION',
         ];
     }
 
@@ -49,6 +50,22 @@ final class MemcacheTest extends IntegrationTestCase
             SpanAssertion::build('Memcache.add', 'memcache', 'memcached', 'add')
                 ->withExactTags(array_merge(self::baseTags(), [
                     'memcache.query' => 'add ' . Obfuscation::toObfuscatedString('key'),
+                    'memcache.command' => 'add',
+                    Tag::SPAN_KIND => 'client',
+                ]))
+        ]);
+    }
+
+    public function testAddNoObfuscation()
+    {
+        $this->putEnvAndReloadConfig(['DD_TRACE_MEMCACHED_OBFUSCATION=false']);
+        $traces = $this->isolateTracer(function () {
+            $this->client->add('key', 'value');
+        });
+        $this->assertSpans($traces, [
+            SpanAssertion::build('Memcache.add', 'memcache', 'memcached', 'add')
+                ->withExactTags(array_merge(self::baseTags(), [
+                    'memcache.query' => 'add ' . 'key',
                     'memcache.command' => 'add',
                     Tag::SPAN_KIND => 'client',
                 ]))

--- a/tests/Integrations/Memcached/MemcachedTest.php
+++ b/tests/Integrations/Memcached/MemcachedTest.php
@@ -36,6 +36,7 @@ final class MemcachedTest extends IntegrationTestCase
             'DD_TRACE_PEER_SERVICE_DEFAULTS_ENABLED',
             'DD_TRACE_REMOVE_INTEGRATION_SERVICE_NAMES_ENABLED',
             'DD_SERVICE',
+            'DD_TRACE_MEMCACHED_OBFUSCATION',
         ];
     }
 
@@ -521,6 +522,30 @@ final class MemcachedTest extends IntegrationTestCase
             SpanAssertion::build('Memcached.getMulti', 'memcached', 'memcached', 'getMulti')
                 ->withExactTags(array_merge($this->baseTags(), [
                     'memcached.query' => 'getMulti ' . Obfuscation::toObfuscatedString(['key1', 'key2'], ','),
+                    'memcached.command' => 'getMulti',
+                ]))->withExactMetrics([
+                    Tag::DB_ROW_COUNT => 2,
+                    '_dd.agent_psr' => 1.0,
+                    '_sampling_priority_v1' => 1.0,
+                ]),
+        ]);
+    }
+
+    public function testGetMultiNoObfuscation()
+    {
+        $this->putEnvAndReloadConfig(['DD_TRACE_MEMCACHED_OBFUSCATION=false']);
+        $traces = $this->isolateTracer(function () {
+            $this->client->add('key1', 'value1');
+            $this->client->add('key2', 'value2');
+
+            $this->assertEquals(['key1' => 'value1', 'key2' => 'value2'], $this->client->getMulti(['key1', 'key2']));
+        });
+        $this->assertSpans($traces, [
+            SpanAssertion::exists('Memcached.add'),
+            SpanAssertion::exists('Memcached.add'),
+            SpanAssertion::build('Memcached.getMulti', 'memcached', 'memcached', 'getMulti')
+                ->withExactTags(array_merge($this->baseTags(), [
+                    'memcached.query' => 'getMulti key1,key2',
                     'memcached.command' => 'getMulti',
                 ]))->withExactMetrics([
                     Tag::DB_ROW_COUNT => 2,


### PR DESCRIPTION
### Description

Add config to disable obfuscation in memcached queries. Keeps old behavior by default. Added on both memcache and memcached. Tests for memached cover only one path, but I didn't want to duplicate the number of integration tests.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
