### PR TITLE
fix: Add `ddsource` attribute to json-formatted logs

### DIFF
--- a/src/DDTrace/Integrations/Logs/LogsIntegration.php
+++ b/src/DDTrace/Integrations/Logs/LogsIntegration.php
@@ -237,6 +237,17 @@ class LogsIntegration extends Integration
         );
         \DDTrace\remove_hook($hook, NullLogger::class);
 
+        \DDTrace\install_hook(
+            'Monolog\Formatter\JsonFormatter::toJson',
+            function (HookData $hook) {
+                /** @var array $normalized */
+                $normalized = $hook->args[0];
+                $normalized['ddsource'] = 'php';
+                $hook->args[0] = $normalized;
+                $hook->overrideArguments($hook->args);
+            }
+        );
+
         return Integration::LOADED;
     }
 }

--- a/src/DDTrace/Integrations/Logs/LogsIntegration.php
+++ b/src/DDTrace/Integrations/Logs/LogsIntegration.php
@@ -242,7 +242,7 @@ class LogsIntegration extends Integration
             function (HookData $hook) {
                 /** @var array $normalized */
                 $normalized = $hook->args[0];
-                $normalized['ddsource'] = 'php';
+                $normalized['source'] = 'php';
                 $hook->args[0] = $normalized;
                 $hook->overrideArguments($hook->args);
             }

--- a/tests/Integrations/Logs/MonologV2/MonologV2Test.php
+++ b/tests/Integrations/Logs/MonologV2/MonologV2Test.php
@@ -10,7 +10,7 @@ class MonologV2Test extends MonologV1Test
         $this->usingJson(
             'debug',
             $this->getLogger(true),
-            '/^{"message":"A debug message","context":{"dd.trace_id":"\d+","dd.span_id":"\d+","dd.service":"my-service","dd.version":"4.2","dd.env":"my-env"},"level":100,"level_name":"DEBUG","channel":"test","datetime":".*","extra":{}}/'
+            '/^{"message":"A debug message","context":{"dd.trace_id":"\d+","dd.span_id":"\d+","dd.service":"my-service","dd.version":"4.2","dd.env":"my-env"},"level":100,"level_name":"DEBUG","channel":"test","datetime":".*","extra":{},"ddsource":"php"}/'
         );
     }
 
@@ -18,7 +18,7 @@ class MonologV2Test extends MonologV1Test
         $this->usingJson(
             'log',
             $this->getLogger(true),
-            '/^{"message":"A critical message","context":{"dd.trace_id":"\d+","dd.span_id":"\d+","dd.service":"my-service","dd.version":"4.2","dd.env":"my-env"},"level":500,"level_name":"CRITICAL","channel":"test","datetime":".*","extra":{}}/',
+            '/^{"message":"A critical message","context":{"dd.trace_id":"\d+","dd.span_id":"\d+","dd.service":"my-service","dd.version":"4.2","dd.env":"my-env"},"level":500,"level_name":"CRITICAL","channel":"test","datetime":".*","extra":{},"ddsource":"php"}/',
             false,
             'critical'
         );


### PR DESCRIPTION
### Description

**Problem:** The PHP Log pipeline is not automatically used to process PHP logs ==> No Log Correlation by default, despite the trace identifiers being injected.

Two solutions:
1. We inject the trace identifiers outside of `context`
2. We use `ddsource`

Either way, it seems like we should have always been using ddsource + it is more elegant and is the actual way of doing it.

TBD - I gotta double test this on my sandbox. generating the artifact...

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
