### PR TITLE
refactor(profiling): extract func is_internal()

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -455,17 +455,17 @@ dependencies = [
 
 [[package]]
 name = "bindgen"
-version = "0.66.1"
+version = "0.69.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2b84e06fc203107bfbad243f4aba2af864eb7db3b1cf46ea0a023b0b433d2a7"
+checksum = "a00dc851838a2120612785d195287475a3ac45514741da670b735818822129a0"
 dependencies = [
  "bitflags 2.4.2",
  "cexpr",
  "clang-sys",
+ "itertools 0.11.0",
  "lazy_static",
  "lazycell",
  "log",
- "peeking_take_while",
  "prettyplease 0.2.16",
  "proc-macro2",
  "quote",
@@ -1191,6 +1191,8 @@ dependencies = [
  "protoc-bin-vendored",
  "serde",
  "serde_bytes",
+ "serde_json",
+ "tokio",
 ]
 
 [[package]]
@@ -2785,12 +2787,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "de3145af08024dea9fa9914f381a17b8fc6034dfb00f3a84013f7ff43f29ed4c"
 
 [[package]]
-name = "peeking_take_while"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
-
-[[package]]
 name = "percent-encoding"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3671,9 +3667,9 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.113"
+version = "1.0.118"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69801b70b1c3dac963ecb03a364ba0ceda9cf60c71cfe475e99864759c8b8a79"
+checksum = "d947f6b3163d8857ea16c4fa0dd4840d52f3041039a85decd46867eb1abef2e4"
 dependencies = [
  "itoa",
  "ryu",

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -57,7 +57,7 @@ stack_walking_tests = []
 trigger_time_sample = []
 
 [build-dependencies]
-bindgen = { version = "0.66.1" }
+bindgen = { version = "0.69.4" }
 cc = { version = "1.0" }
 
 # profiling release options in root Cargo.toml

--- a/profiling/build.rs
+++ b/profiling/build.rs
@@ -181,6 +181,8 @@ impl bindgen::callbacks::ParseCallbacks for IgnoreMacros {
             | "IS_STRING" | "IS_ARRAY" | "IS_OBJECT" | "IS_RESOURCE" | "IS_REFERENCE"
             | "_IS_BOOL" => Some(IntKind::U8),
 
+            "ZEND_INTERNAL_FUNCTION" | "ZEND_USER_FUNCTION" => Some(IntKind::U8),
+
             // None means whatever it would have been without this hook
             // (likely u32).
             _ => None,
@@ -248,7 +250,7 @@ fn generate_bindings(php_config_includes: &str, fibers: bool) {
         .rustified_enum("zai_config_type")
         .parse_callbacks(Box::new(ignored_macros))
         .clang_args(php_config_includes.split(' '))
-        .parse_callbacks(Box::new(bindgen::CargoCallbacks))
+        .parse_callbacks(Box::new(bindgen::CargoCallbacks::new()))
         .layout_tests(false)
         // this prevents bindgen from copying C comments to Rust, as otherwise
         // rustdoc would look for tests and currently fail as it assumes

--- a/profiling/src/bindings/mod.rs
+++ b/profiling/src/bindings/mod.rs
@@ -126,10 +126,9 @@ impl _zend_function {
 
     /// Returns the module name, if there is one. May return Some(b"\0").
     pub fn module_name(&self) -> Option<&[u8]> {
-        // Safety: the function's type field is always safe to access.
-        if unsafe { self.type_ } == ZEND_INTERNAL_FUNCTION as u8 {
-            // Safety: union access is guarded by ZEND_INTERNAL_FUNCTION, and
-            // assume its module is valid.
+        if self.is_internal() {
+            // Safety: union access is guarded by is_internal(), and assume
+            // its module is valid.
             unsafe { self.internal_function.module.as_ref() }
                 .filter(|module| !module.name.is_null())
                 // Safety: assume module.name has a valid c string.
@@ -137,6 +136,12 @@ impl _zend_function {
         } else {
             None
         }
+    }
+
+    #[inline]
+    pub fn is_internal(&self) -> bool {
+        // Safety: the function's type field is always safe to access.
+        unsafe { self.type_ == ZEND_INTERNAL_FUNCTION }
     }
 }
 


### PR DESCRIPTION
### Description

Adds `_zend_function.is_internal()` and uses it in a few places.  Also bumps bindgen version and fixes a deprecated warning.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
