### PR TITLE
Fix post bailout hook execution in 8.3 unoptimized builds

### DIFF
--- a/zend_abstract_interface/interceptor/php8/interceptor.c
+++ b/zend_abstract_interface/interceptor/php8/interceptor.c
@@ -63,7 +63,11 @@ static void zai_hook_safe_finish(zend_execute_data *execute_data, zval *retval, 
     const size_t stack_top_offset = 0x400;
     void *volatile stack = malloc(stack_size);
     if (SETJMP(target) == 0) {
-        void *stacktop = stack + stack_size, *stacktarget = stacktop - stack_top_offset;
+        void *stacktop = stack + stack_size;
+#if PHP_VERSION_ID >= 80300
+        register
+#endif
+        void *stacktarget = stacktop - stack_top_offset;
 
 #ifdef __SANITIZE_ADDRESS__
         void *volatile fake_stack;


### PR DESCRIPTION
When optimized, all is fine; however, in unoptimized builds the compiler will write stacktarget back to the stack and read it later from there, even though the stack address has moved. (i.e. only affects development builds.)

Adding register keyword to avoid this.

### Description

<!---
Any description you feel is relevant and gives more background to this PR, if necessary.
-->

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
