### PR TITLE
refactor(profiling): less unsafe code

### DIFF
--- a/profiling/src/allocation.rs
+++ b/profiling/src/allocation.rs
@@ -9,7 +9,8 @@ use log::{debug, error, trace, warn};
 use rand::rngs::ThreadRng;
 use rand_distr::{Distribution, Poisson};
 use std::cell::{RefCell, UnsafeCell};
-use std::sync::atomic::{AtomicU64, Ordering::SeqCst};
+use std::sync::atomic::AtomicU64;
+use std::sync::atomic::Ordering::{Relaxed, SeqCst};
 use std::{ffi, ptr};
 
 static mut GC_MEM_CACHES_HANDLER: zend::InternalFunctionHandler = None;
@@ -154,7 +155,7 @@ pub fn alloc_prof_minit() {
 
 pub fn first_rinit_should_disable_due_to_jit() -> bool {
     if NEEDS_RUN_TIME_CHECK_FOR_ENABLED_JIT
-        && alloc_prof_needs_disabled_for_jit(unsafe { crate::RUNTIME_PHP_VERSION_ID })
+        && alloc_prof_needs_disabled_for_jit(crate::RUNTIME_PHP_VERSION_ID.load(Relaxed))
         && *JIT_ENABLED
     {
         error!("Memory allocation profiling will be disabled as long as JIT is active. To enable allocation profiling disable JIT or upgrade PHP to at least version 8.1.21 or 8.2.8. See https://github.com/DataDog/dd-trace-php/pull/2088");

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -420,8 +420,8 @@ extern "C" fn rinit(_type: c_int, _module_number: c_int) -> ZendResult {
 
     unsafe { bindings::zai_config_rinit() };
 
-    // Safety: We are after first rinit and before config mshutdown.
-    let system_settings = unsafe { SystemSettings::get() };
+    // SAFETY: We are after first rinit and before config mshutdown.
+    let mut system_settings = unsafe { SystemSettings::get() };
 
     // initialize the thread local storage and cache some items
     REQUEST_LOCALS.with(|cell| {
@@ -450,7 +450,7 @@ extern "C" fn rinit(_type: c_int, _module_number: c_int) -> ZendResult {
     });
 
     // SAFETY: still safe to access in rinit after first_rinit.
-    let system_settings = unsafe { system_settings.as_ref() };
+    let system_settings = unsafe { system_settings.as_mut() };
 
     // SAFETY: the once control is not mutable during request.
     let once = unsafe { &*ptr::addr_of!(RINIT_ONCE) };


### PR DESCRIPTION
### Description

This reduces unsafe:

1. `RUNTIME_PHP_VERSION_ID` is atomic. The reads and writes are `Relaxed` because the only write happens in module init where no other threads exist.
2. Use `AtomicPtr` for `Profiler.system_settings`, which removes the need for manually derived unsafe `Sync` and `Send`.

### Motivation

I have been reviewing past work to remove the `Mutex` in the `PROFILER` global. The increased scrutiny lead me to change these things.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
