### PR TITLE
Compile sidecar and extension separately, to link them together later

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -2713,6 +2713,31 @@ jobs:
       - store_artifacts:
           path: /tmp/artifacts
 
+  compile_rust_alpine:
+    working_directory: ~/datadog
+    parameters:
+      resource_class:
+        type: string
+        default: large
+    <<: *BARE_DOCKER_MACHINE
+    steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
+      - <<: *STEP_ATTACH_WORKSPACE
+      - setup_docker:
+          docker_image: datadog/dd-trace-ci:php-compile-extension-alpine
+      - run:
+          name: Compile sidecar
+          command: |
+            SHARED=1 PROFILE=tracer-release host_os=linux-musl ./compile_rust.sh
+            cp -v ${CARGO_TARGET_DIR:-target}/tracer-release/libddtrace_php.a libddtrace_php_$(uname -m)-alpine.a
+            objcopy --compress-debug-sections ${CARGO_TARGET_DIR:-target}/tracer-release/libddtrace_php.so libddtrace_php_$(uname -m)-alpine.so
+      - persist_to_workspace:
+          root: '.'
+          paths: [ './libddtrace_php_*.*' ]
+
   compile_alpine:
     working_directory: ~/datadog
     parameters:
@@ -2731,29 +2756,28 @@ jobs:
       - <<: *STEP_ATTACH_WORKSPACE
       - setup_docker:
           docker_image: datadog/dd-trace-ci:php-compile-extension-alpine-<< parameters.php_major_minor >>
+      - run: mkdir -p extensions_$(uname -m) standalone_$(uname -m)
       - run:
           name: Build nts extension
           command: |
-            build-dd-trace-php
+            make -j static CFLAGS="-std=gnu11 -O2 -g -Wall -Wextra -Werror -Wno-error=return-local-addr" ECHO_ARG="-e"
+            objcopy --compress-debug-sections tmp/build_extension/modules/ddtrace.so standalone_$(uname -m)/ddtrace-${PHP_API}-alpine.so
+            cp -v tmp/build_extension/modules/ddtrace.a extensions_$(uname -m)/ddtrace-${PHP_API}-alpine.a
+            if [ "<< parameters.php_major_minor >>" = "7.0" ]; then
+              cp -v tmp/build_extension/ddtrace.ldflags ddtrace_$(uname -m)-alpine.ldflags
+            fi
       - run:
           name: Build zts extension
           command: |
             . /root/.bashrc
             switch_php zts
             rm -r tmp/build_extension
-            build-dd-trace-php
-      - run:
-          name: Compress debug info
-          command: |
-            pushd extensions
-            for FILE in $(find . -name "*.so"); do
-                objcopy --compress-debug-sections $FILE
-            done
-            popd
-            mv extensions extensions_$(uname -m)
+            make -j static CFLAGS="-std=gnu11 -O2 -g -Wall -Wextra -Werror -Wno-error=return-local-addr" ECHO_ARG="-e"
+            objcopy --compress-debug-sections tmp/build_extension/modules/ddtrace.so standalone_$(uname -m)/ddtrace-${PHP_API}-alpine-zts.so
+            cp -v tmp/build_extension/modules/ddtrace.a extensions_$(uname -m)/ddtrace-${PHP_API}-alpine-zts.a
       - persist_to_workspace:
           root: '.'
-          paths: ['./extensions_*']
+          paths: [ './extensions_*', './standalone_*', 'ddtrace_*.ldflags' ]
 
   compile_extension_asan:
     working_directory: ~/datadog
@@ -3091,7 +3115,6 @@ jobs:
       - run:
           name: Compile sidecar
           command: |
-            mkdir -p extensions_$(uname -m)
             set +eo pipefail; source scl_source enable devtoolset-7; set -eo pipefail
             SHARED=1 PROFILE=tracer-release host_os=linux-gnu ./compile_rust.sh
             cp -v ${CARGO_TARGET_DIR:-target}/tracer-release/libddtrace_php.a libddtrace_php_$(uname -m).a
@@ -3158,12 +3181,17 @@ jobs:
           root: '.'
           paths: [ './extensions_*', './standalone_*', 'ddtrace_*.ldflags' ]
 
-  link_extension_centos:
+  link_extension:
     working_directory: ~/datadog
     parameters:
       resource_class:
         type: string
         default: xlarge
+      docker_image:
+        type: string
+      libddtrace_suffix:
+        type: string
+        default: ""
     <<: *BARE_DOCKER_MACHINE
     steps:
       - restore_cache:
@@ -3172,14 +3200,14 @@ jobs:
       - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
       - setup_docker:
-          docker_image: datadog/dd-trace-ci:centos-7
+          docker_image: << parameters.docker_image >>
       - run:
           name: Link sidecar and extension
           command: |
-            sed -i 's/-export-symbols .*\/ddtrace\.sym/-Wl,--retain-symbols-file=ddtrace.sym/g' ddtrace_$(uname -m).ldflags
+            sed -i 's/-export-symbols .*\/ddtrace\.sym/-Wl,--retain-symbols-file=ddtrace.sym/g' ddtrace_$(uname -m)<< parameters.libddtrace_suffix >>.ldflags
             for archive in extensions_$(uname -m)/*.a; do
               (
-                gcc -shared -Wl,-whole-archive $archive -Wl,-no-whole-archive $(cat ddtrace_$(uname -m).ldflags) libddtrace_php_$(uname -m).a -Wl,-soname -Wl,ddtrace.so -o ${archive%.a}.so
+                gcc -shared -Wl,-whole-archive $archive -Wl,-no-whole-archive $(cat ddtrace_$(uname -m)<< parameters.libddtrace_suffix >>.ldflags) libddtrace_php_$(uname -m)<< parameters.libddtrace_suffix >>.a -Wl,-soname -Wl,ddtrace.so -o ${archive%.a}.so
                 objcopy --compress-debug-sections ${archive%.a}.so
               ) &
             done
@@ -3897,9 +3925,63 @@ workflows:
                 - '8.1'
                 - '8.2'
                 - '8.3'
+          resource_class: "medium"
+          name: "Compile alpine x86_64 PHP << matrix.php_major_minor >>"
+      - compile_alpine:
+          requires: [ 'Prepare Code' ]
+          matrix:
+            parameters:
+              php_major_minor:
+                - '7.0'
+                - '7.1'
+                - '7.2'
+                - '7.3'
+                - '7.4'
+                - '8.0'
+                - '8.1'
+                - '8.2'
+                - '8.3'
+          resource_class: "arm.medium"
+          name: "Compile alpine aarch64 PHP << matrix.php_major_minor >>"
+      - compile_rust_alpine:
+          requires: [ 'Prepare Code' ]
+          matrix:
+            parameters:
               resource_class:
                 - "medium"
                 - "arm.medium"
+      - link_extension:
+          requires:
+            - compile_rust_alpine
+            - "Compile alpine x86_64 PHP 7.0"
+            - "Compile alpine x86_64 PHP 7.1"
+            - "Compile alpine x86_64 PHP 7.2"
+            - "Compile alpine x86_64 PHP 7.3"
+            - "Compile alpine x86_64 PHP 7.4"
+            - "Compile alpine x86_64 PHP 8.0"
+            - "Compile alpine x86_64 PHP 8.1"
+            - "Compile alpine x86_64 PHP 8.2"
+            - "Compile alpine x86_64 PHP 8.3"
+          libddtrace_suffix: "-alpine"
+          resource_class: "medium"
+          name: "Link x86_64 alpine"
+          docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine"
+      - link_extension:
+          requires:
+            - compile_rust_alpine
+            - "Compile alpine aarch64 PHP 7.0"
+            - "Compile alpine aarch64 PHP 7.1"
+            - "Compile alpine aarch64 PHP 7.2"
+            - "Compile alpine aarch64 PHP 7.3"
+            - "Compile alpine aarch64 PHP 7.4"
+            - "Compile alpine aarch64 PHP 8.0"
+            - "Compile alpine aarch64 PHP 8.1"
+            - "Compile alpine aarch64 PHP 8.2"
+            - "Compile alpine aarch64 PHP 8.3"
+          libddtrace_suffix: "-alpine"
+          resource_class: "arm.medium"
+          name: "Link aarch64 alpine"
+          docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine"
       - compile_extension_centos:
           requires: [ 'Prepare Code' ]
           name: "Compile x86_64 PHP 70 nts + zts + debug"
@@ -4072,7 +4154,7 @@ workflows:
           name: "Compile aarch64 rust"
           resource_class: "arm.large"
 
-      - link_extension_centos:
+      - link_extension:
           requires:
             - "Compile x86_64 rust"
             - "Compile x86_64 PHP 70 nts + zts + debug"
@@ -4085,7 +4167,8 @@ workflows:
             - "Compile x86_64 PHP 82 nts + zts + debug"
             - "Compile x86_64 PHP 83 nts + zts + debug"
           name: "Link x86_64 PHP"
-      - link_extension_centos:
+          docker_image: "datadog/dd-trace-ci:centos-7"
+      - link_extension:
           requires:
             - "Compile aarch64 rust"
             - "Compile aarch64 PHP 70 nts + zts + debug"
@@ -4098,6 +4181,7 @@ workflows:
             - "Compile aarch64 PHP 82 nts + zts + debug"
             - "Compile aarch64 PHP 83 nts + zts + debug"
           name: "Link aarch64 PHP"
+          docker_image: "datadog/dd-trace-ci:centos-7"
           resource_class: "arm.xlarge"
 
       - pecl_build:
@@ -4106,7 +4190,8 @@ workflows:
 
       - "package extension":
           requires:
-            - compile_alpine
+            - "Link x86_64 alpine"
+            - "Link aarch64 alpine"
             - "Link x86_64 PHP"
             - "Link aarch64 PHP"
 

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -2782,7 +2782,7 @@ jobs:
             set -eo pipefail
             switch-php debug-zts-asan
             make RUST_DEBUG_BUILD=1
-            cp -v tmp/build_extension/.libs/ddtrace.so extensions_$(uname -m)/ddtrace-<< parameters.so_suffix >>-debug-zts.so
+            cp -v tmp/build_extension/modules/ddtrace.so extensions_$(uname -m)/ddtrace-<< parameters.so_suffix >>-debug-zts.so
       - run:
           name: Compress debug info
           command: |
@@ -3073,6 +3073,33 @@ jobs:
             cp modules/dd_library_loader-$(uname -m)-linux-musl.so modules/dd_library_loader.so
             ./bin/test.sh
 
+  compile_rust_centos:
+    working_directory: ~/datadog
+    parameters:
+      resource_class:
+        type: string
+        default: large
+    <<: *BARE_DOCKER_MACHINE
+    steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
+      - <<: *STEP_ATTACH_WORKSPACE
+      - setup_docker:
+          docker_image: datadog/dd-trace-ci:centos-7
+      - run:
+          name: Compile sidecar
+          command: |
+            mkdir -p extensions_$(uname -m)
+            set +eo pipefail; source scl_source enable devtoolset-7; set -eo pipefail
+            SHARED=1 PROFILE=tracer-release host_os=linux-gnu ./compile_rust.sh
+            cp -v ${CARGO_TARGET_DIR:-target}/tracer-release/libddtrace_php.a libddtrace_php_$(uname -m).a
+            objcopy --compress-debug-sections ${CARGO_TARGET_DIR:-target}/tracer-release/libddtrace_php.so libddtrace_php_$(uname -m).so
+      - persist_to_workspace:
+          root: '.'
+          paths: [ './libddtrace_php_*.*' ]
+
   compile_extension_centos:
     working_directory: ~/datadog
     parameters:
@@ -3089,6 +3116,9 @@ jobs:
         default: true
       php_version:
         type: string
+      persist_ldflags:
+        type: boolean
+        default: false
     <<: *BARE_DOCKER_MACHINE
     steps:
       - restore_cache:
@@ -3098,35 +3128,62 @@ jobs:
       - <<: *STEP_ATTACH_WORKSPACE
       - setup_docker:
           docker_image: << parameters.docker_image >>
-      - run: mkdir -p extensions_$(uname -m)
+      - run: mkdir -p extensions_$(uname -m) standalone_$(uname -m)
       - run:
           name: Build ndebug, nts configuration
           command: |
             set +eo pipefail; source scl_source enable devtoolset-7; set -eo pipefail
             switch-php << parameters.php_version >>
-            make clean && make -j all ECHO_ARG="-e" CFLAGS="-std=gnu11 -O2 -g -Wall -Wextra <<# parameters.catch_warnings >> -Werror <</ parameters.catch_warnings >>"
-            cp -v tmp/build_extension/.libs/ddtrace.so extensions_$(uname -m)/ddtrace-<< parameters.so_suffix >>.so
+            make clean && make -j static ECHO_ARG="-e" CFLAGS="-std=gnu11 -O2 -g -Wall -Wextra <<# parameters.catch_warnings >> -Werror <</ parameters.catch_warnings >>"
+            objcopy --compress-debug-sections tmp/build_extension/modules/ddtrace.so standalone_$(uname -m)/ddtrace-<< parameters.so_suffix >>.so
+            cp -v tmp/build_extension/modules/ddtrace.a extensions_$(uname -m)/ddtrace-<< parameters.so_suffix >>.a
+            <<# parameters.persist_ldflags >> cp -v tmp/build_extension/ddtrace.ldflags ddtrace_$(uname -m).ldflags <</ parameters.persist_ldflags >>
       - run:
           name: Build debug, nts configuration
           command: |
             set +eo pipefail; source scl_source enable devtoolset-7; set -eo pipefail
             switch-php << parameters.php_version >>-debug
-            make clean && make -j all ECHO_ARG="-e" CFLAGS="-std=gnu11 -O0 -g -Wall -Wextra <<# parameters.catch_warnings >> -Werror <</ parameters.catch_warnings >>"
-            cp -v tmp/build_extension/.libs/ddtrace.so extensions_$(uname -m)/ddtrace-<< parameters.so_suffix >>-debug.so
+            make clean && make -j static ECHO_ARG="-e" CFLAGS="-std=gnu11 -O0 -g -Wall -Wextra <<# parameters.catch_warnings >> -Werror <</ parameters.catch_warnings >>"
+            objcopy --compress-debug-sections tmp/build_extension/modules/ddtrace.so standalone_$(uname -m)/ddtrace-<< parameters.so_suffix >>-debug.so
+            cp -v tmp/build_extension/modules/ddtrace.a extensions_$(uname -m)/ddtrace-<< parameters.so_suffix >>-debug.a
       - run:
           name: Build zts configuration
           command: |
             set +eo pipefail; source scl_source enable devtoolset-7; set -eo pipefail
             switch-php << parameters.php_version >>-zts
-            make clean && make -j all ECHO_ARG="-e" CFLAGS="-std=gnu11 -O2 -g -Wall -Wextra <<# parameters.catch_warnings >> -Werror <</ parameters.catch_warnings >>"
-            cp -v tmp/build_extension/.libs/ddtrace.so extensions_$(uname -m)/ddtrace-<< parameters.so_suffix >>-zts.so
+            make clean && make -j static ECHO_ARG="-e" CFLAGS="-std=gnu11 -O2 -g -Wall -Wextra <<# parameters.catch_warnings >> -Werror <</ parameters.catch_warnings >>"
+            objcopy --compress-debug-sections tmp/build_extension/modules/ddtrace.so standalone_$(uname -m)/ddtrace-<< parameters.so_suffix >>-zts.so
+            cp -v tmp/build_extension/modules/ddtrace.a extensions_$(uname -m)/ddtrace-<< parameters.so_suffix >>-zts.a
+      - persist_to_workspace:
+          root: '.'
+          paths: [ './extensions_*', './standalone_*', 'ddtrace_*.ldflags' ]
+
+  link_extension_centos:
+    working_directory: ~/datadog
+    parameters:
+      resource_class:
+        type: string
+        default: xlarge
+    <<: *BARE_DOCKER_MACHINE
+    steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - <<: *STEP_CHECKOUT
+      - <<: *STEP_ATTACH_WORKSPACE
+      - setup_docker:
+          docker_image: datadog/dd-trace-ci:centos-7
       - run:
-          name: Compress debug info
+          name: Link sidecar and extension
           command: |
-            cd extensions_$(uname -m)
-            for FILE in $(find . -name "*.so"); do
-                objcopy --compress-debug-sections $FILE
+            sed -i 's/-export-symbols .*\/ddtrace\.sym/-Wl,--retain-symbols-file=ddtrace.sym/g' ddtrace_$(uname -m).ldflags
+            for archive in extensions_$(uname -m)/*.a; do
+              (
+                gcc -shared -Wl,-whole-archive $archive -Wl,-no-whole-archive $(cat ddtrace_$(uname -m).ldflags) libddtrace_php_$(uname -m).a -Wl,-soname -Wl,ddtrace.so -o ${archive%.a}.so
+                objcopy --compress-debug-sections ${archive%.a}.so
+              ) &
             done
+            wait
       - persist_to_workspace:
           root: '.'
           paths: [ './extensions_*' ]
@@ -3849,12 +3906,14 @@ workflows:
           php_version: "7.0"
           docker_image: "datadog/dd-trace-ci:php-7.0_centos-7"
           so_suffix: "20151012"
+          persist_ldflags: true
       - compile_extension_centos:
           requires: [ 'Prepare Code' ]
           name: "Compile aarch64 PHP 70 nts + zts + debug"
           php_version: "7.0"
           docker_image: "datadog/dd-trace-ci:php-7.0_centos-7"
           so_suffix: "20151012"
+          persist_ldflags: true
           resource_class: "arm.medium"
       - compile_extension_centos:
           requires: [ 'Prepare Code' ]
@@ -4004,6 +4063,43 @@ workflows:
           docker_image: "datadog/dd-trace-ci:php-8.3_windows"
           php_version: "8.3"
           so_suffix: "20230831"
+
+      - compile_rust_centos:
+          requires: [ 'Prepare Code' ]
+          name: "Compile x86_64 rust"
+      - compile_rust_centos:
+          requires: [ 'Prepare Code' ]
+          name: "Compile aarch64 rust"
+          resource_class: "arm.large"
+
+      - link_extension_centos:
+          requires:
+            - "Compile x86_64 rust"
+            - "Compile x86_64 PHP 70 nts + zts + debug"
+            - "Compile x86_64 PHP 71 nts + zts + debug"
+            - "Compile x86_64 PHP 72 nts + zts + debug"
+            - "Compile x86_64 PHP 73 nts + zts + debug"
+            - "Compile x86_64 PHP 74 nts + zts + debug"
+            - "Compile x86_64 PHP 80 nts + zts + debug"
+            - "Compile x86_64 PHP 81 nts + zts + debug"
+            - "Compile x86_64 PHP 82 nts + zts + debug"
+            - "Compile x86_64 PHP 83 nts + zts + debug"
+          name: "Link x86_64 PHP"
+      - link_extension_centos:
+          requires:
+            - "Compile aarch64 rust"
+            - "Compile aarch64 PHP 70 nts + zts + debug"
+            - "Compile aarch64 PHP 71 nts + zts + debug"
+            - "Compile aarch64 PHP 72 nts + zts + debug"
+            - "Compile aarch64 PHP 73 nts + zts + debug"
+            - "Compile aarch64 PHP 74 nts + zts + debug"
+            - "Compile aarch64 PHP 80 nts + zts + debug"
+            - "Compile aarch64 PHP 81 nts + zts + debug"
+            - "Compile aarch64 PHP 82 nts + zts + debug"
+            - "Compile aarch64 PHP 83 nts + zts + debug"
+          name: "Link aarch64 PHP"
+          resource_class: "arm.xlarge"
+
       - pecl_build:
           requires: [ 'Prepare Code' ]
           name: "Build PECL"
@@ -4011,24 +4107,9 @@ workflows:
       - "package extension":
           requires:
             - compile_alpine
-            - "Compile x86_64 PHP 70 nts + zts + debug"
-            - "Compile aarch64 PHP 70 nts + zts + debug"
-            - "Compile x86_64 PHP 71 nts + zts + debug"
-            - "Compile aarch64 PHP 71 nts + zts + debug"
-            - "Compile x86_64 PHP 72 nts + zts + debug"
-            - "Compile aarch64 PHP 72 nts + zts + debug"
-            - "Compile x86_64 PHP 73 nts + zts + debug"
-            - "Compile aarch64 PHP 73 nts + zts + debug"
-            - "Compile x86_64 PHP 74 nts + zts + debug"
-            - "Compile aarch64 PHP 74 nts + zts + debug"
-            - "Compile x86_64 PHP 80 nts + zts + debug"
-            - "Compile aarch64 PHP 80 nts + zts + debug"
-            - "Compile x86_64 PHP 81 nts + zts + debug"
-            - "Compile aarch64 PHP 81 nts + zts + debug"
-            - "Compile x86_64 PHP 82 nts + zts + debug"
-            - "Compile aarch64 PHP 82 nts + zts + debug"
-            - "Compile x86_64 PHP 83 nts + zts + debug"
-            - "Compile aarch64 PHP 83 nts + zts + debug"
+            - "Link x86_64 PHP"
+            - "Link aarch64 PHP"
+
             - "Compile Windows PHP 72 nts + zts"
             - "Compile Windows PHP 73 nts + zts"
             - "Compile Windows PHP 74 nts + zts"

--- a/.gitlab/ci-images.yml
+++ b/.gitlab/ci-images.yml
@@ -45,6 +45,7 @@ Alpine Compile Extension:
   parallel:
     matrix:
       - PHP_VERSION:
+        - base-alpine
         - 8.3-alpine
         - 8.2-alpine
         - 8.1-alpine

--- a/components-rs/lib.rs
+++ b/components-rs/lib.rs
@@ -1,5 +1,6 @@
 #![feature(allow_internal_unstable)]
 #![feature(local_key_cell_methods)]
+#![feature(linkage)]
 
 pub mod log;
 pub mod sidecar;

--- a/config.m4
+++ b/config.m4
@@ -340,5 +340,5 @@ EOT
     PHP_GLOBAL_OBJS="$ddtrace_rust_lib $PHP_GLOBAL_OBJS"
   fi
 
-  echo "$EXTRA_LDFLAGS" > ddtrace.ldflags
+  echo "$EXTRA_LDFLAGS $EXTRA_CFLAGS" > ddtrace.ldflags
 fi

--- a/config.m4
+++ b/config.m4
@@ -4,7 +4,7 @@ PHP_ARG_ENABLE(ddtrace, whether to enable Datadog tracing support,
 PHP_ARG_WITH(ddtrace-sanitize, whether to enable AddressSanitizer for ddtrace,
   [  --with-ddtrace-sanitize Build Datadog tracing with AddressSanitizer support], no, no)
 
-PHP_ARG_WITH(ddtrace-rust-library, the rust libary is located; i.e. to compile without cargo,
+PHP_ARG_WITH(ddtrace-rust-library, the rust library is located; i.e. to compile without cargo,
   [  --with-ddtrace-rust-library Location to rust library for linking against], -, will be compiled)
 
 PHP_ARG_WITH(ddtrace-sidecar-mockgen, binary to generate mock_php.c,
@@ -15,6 +15,9 @@ PHP_ARG_WITH(ddtrace-cargo, where cargo is located for rust code compilation,
 
 PHP_ARG_ENABLE(ddtrace-rust-debug, whether to compile rust in debug mode,
   [  --enable-ddtrace-rust-debug Build rust code in debug mode (significantly slower)], [[$($GREP -q "ZEND_DEBUG 1" $("$PHP_CONFIG" --include-dir)/main/php_config.h && echo yes || echo no)]], [no])
+
+PHP_ARG_ENABLE(ddtrace-rust-library-split, whether to not link the rust library against the extension at compile time,
+  [  --enable-ddtrace-rust-library-split Do not build nor link against the rust code], no, no)
 
 if test "$PHP_DDTRACE" != "no"; then
   AC_CHECK_SIZEOF([long])
@@ -293,7 +296,14 @@ EOT
   PHP_ADD_BUILD_DIR([$ext_builddir/ext/integrations])
   PHP_ADD_INCLUDE([$ext_builddir/ext/integrations])
 
-  if test "$PHP_DDTRACE_RUST_LIBRARY" != "-"; then
+  cat <<'EOT' >> Makefile.fragments
+./modules/ddtrace.a: $(shared_objects_ddtrace) $(DDTRACE_SHARED_DEPENDENCIES)
+	$(LIBTOOL) --mode=link $(CC) -static $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS) $(LDFLAGS)  -o $@ -avoid-version -prefer-pic -module $(shared_objects_ddtrace)
+EOT
+
+  if test "$PHP_DDTRACE_RUST_LIBRARY_SPLIT" != "no"; then
+    ddtrace_rust_lib=""
+  elif test "$PHP_DDTRACE_RUST_LIBRARY" != "-"; then
     ddtrace_rust_lib="$PHP_DDTRACE_RUST_LIBRARY"
   else
     dnl consider it debug if -g is specified (but not -g0)
@@ -329,4 +339,6 @@ EOT
   else
     PHP_GLOBAL_OBJS="$ddtrace_rust_lib $PHP_GLOBAL_OBJS"
   fi
+
+  echo "$EXTRA_LDFLAGS" > ddtrace.ldflags
 fi

--- a/dockerfiles/ci/alpine_compile_extension/Dockerfile
+++ b/dockerfiles/ci/alpine_compile_extension/Dockerfile
@@ -1,33 +1,4 @@
-FROM alpine:3.18 as base
-
-RUN mkdir -p /app
-WORKDIR /app
-
-# Break the dependencies into multiple layers to reduce individual layer size.
-# This is just to avoid an upload issue I was hitting with large layers.
-RUN set -eux; \
-    apk add --no-cache \
-        bash \
-        build-base \
-        curl-dev \
-        libedit-dev \
-        libffi-dev \
-        libmcrypt-dev \
-        libsodium-dev \
-        libxml2-dev \
-        gnu-libiconv-dev \
-        oniguruma-dev
-
-# Profiling deps
-# Minimum: libclang. Nice-to-have: full toolchain including linker to play
-# with cross-language link-time optimization. Needs to match rustc -Vv's llvm
-# version.
-RUN apk add --no-cache llvm16-libs clang16-dev lld llvm16
-RUN apk add --no-cache rust-stdlib
-RUN apk add --no-cache cargo
-RUN apk add --no-cache clang git protoc unzip
-
-FROM base
+FROM datadog/dd-trace-ci:php-compile-extension-alpine
 
 ADD ./docker-php-source /usr/bin/docker-php-source
 ADD ./install-php /usr/bin/install-php
@@ -48,8 +19,6 @@ ENV PHP_INSTALL_DIR=/usr/local/php-${php_version}
 
 RUN install-php
 ENV PATH ${PATH}:${PHP_INSTALL_DIR}/bin
-
-ADD ./build-dd-trace-php /usr/bin/build-dd-trace-php
 
 ADD ./env-init /root/.bashrc
 ENV ENV=/root/.bashrc

--- a/dockerfiles/ci/alpine_compile_extension/base.Dockerfile
+++ b/dockerfiles/ci/alpine_compile_extension/base.Dockerfile
@@ -1,0 +1,35 @@
+FROM alpine:3.18
+
+RUN mkdir -p /app
+WORKDIR /app
+
+# Break the dependencies into multiple layers to reduce individual layer size.
+# This is just to avoid an upload issue I was hitting with large layers.
+RUN set -eux; \
+    apk add --no-cache \
+        bash \
+        autoconf \
+        coreutils \
+        g++ \
+        gcc \
+        make \
+        build-base \
+        curl-dev \
+        libedit-dev \
+        libffi-dev \
+        libmcrypt-dev \
+        libsodium-dev \
+        libxml2-dev \
+        gnu-libiconv-dev \
+        oniguruma-dev
+
+# Profiling deps
+# Minimum: libclang. Nice-to-have: full toolchain including linker to play
+# with cross-language link-time optimization. Needs to match rustc -Vv's llvm
+# version.
+RUN apk add --no-cache llvm16-libs clang16-dev lld llvm16
+RUN apk add --no-cache rust-stdlib
+RUN apk add --no-cache cargo
+RUN apk add --no-cache clang git protoc unzip
+
+CMD ["bash"]

--- a/dockerfiles/ci/alpine_compile_extension/docker-compose.yml
+++ b/dockerfiles/ci/alpine_compile_extension/docker-compose.yml
@@ -2,19 +2,27 @@ version: '3.7'
 
 services:
 
-  7.0-alpine:
-    image: datadog/dd-trace-ci:php-compile-extension-alpine-7.0
+  base-alpine:
+    image: datadog/dd-trace-ci:php-compile-extension-alpine
     build:
       context: .
+      dockerfile: base.Dockerfile
       x-bake: &bake
         platforms:
           - linux/arm64
           - linux/amd64
+    volumes:
+        - ../../:/app
+
+  7.0-alpine:
+    image: datadog/dd-trace-ci:php-compile-extension-alpine-7.0
+    build:
+      context: .
+      x-bake: *bake
       args:
         php_version: 7.0.33
         php_sha: d71a6ecb6b13dc53fed7532a7f8f949c4044806f067502f8fb6f9facbb40452a
         php_api: 20151012
-    command: build-dd-trace-php
     volumes:
         - ../../:/app
 
@@ -27,7 +35,6 @@ services:
         php_version: 7.1.33
         php_sha: 0055f368ffefe51d5a4483755bd17475e88e74302c08b727952831c5b2682ea2
         php_api: 20160303
-    command: build-dd-trace-php
     volumes:
         - ../../:/app
 
@@ -40,7 +47,6 @@ services:
         php_version: 7.2.34
         php_sha: 8b2777c741e83f188d3ca6d8e98ece7264acafee86787298fae57e05d0dddc78
         php_api: 20170718
-    command: build-dd-trace-php
     volumes:
         - ../../:/app
 
@@ -53,7 +59,6 @@ services:
         php_version: 7.3.33
         php_sha: 9a369c32c6f52036b0a890f290327f148a1904ee66aa56e2c9a7546da6525ec8
         php_api: 20180731
-    command: build-dd-trace-php
     volumes:
         - ../../:/app
 
@@ -66,7 +71,6 @@ services:
         php_version: 7.4.33
         php_sha: 5a2337996f07c8a097e03d46263b5c98d2c8e355227756351421003bea8f463e
         php_api: 20190902
-    command: build-dd-trace-php
     volumes:
         - ../../:/app
 
@@ -79,7 +83,6 @@ services:
         php_version: 8.0.30
         php_sha: 449d2048fcb20a314d8c218097c6d1047a9f1c5bb72aa54d5d3eba0a27a4c80c
         php_api: 20200930
-    command: build-dd-trace-php
     volumes:
       - ../../:/app
 
@@ -92,7 +95,6 @@ services:
         php_version: 8.1.26
         php_sha: d954cecfc3d294c2fccbe2b1a6bef784ce0d6c5d44a9e28f8a527e092825f2cb
         php_api: 20210902
-    command: build-dd-trace-php
     volumes:
       - ../../:/app
 
@@ -105,7 +107,6 @@ services:
         php_version: 8.2.13
         php_sha: 6a194038f5a9e46d8f70a9d59c072c3b08d6edbdd8e304096e24ccf2225bcf1b
         php_api: 20220829
-    command: build-dd-trace-php
     volumes:
       - ../../:/app
 
@@ -119,6 +120,5 @@ services:
         php_url: https://www.php.net/distributions/php-8.3.0.tar.gz
         php_sha: "557ae14650f1d1984d3213e3fcd8d93a5f11418b3f8026d3a2d5022251163951"
         php_api: 20230831
-    command: build-dd-trace-php
     volumes:
       - ../../:/app

--- a/loader/php_dd_library_loader.h
+++ b/loader/php_dd_library_loader.h
@@ -27,9 +27,9 @@ typedef enum {
 
 #define TELEMETRY(reason, format, ...) ddloader_telemetryf(reason, format, ##__VA_ARGS__);
 
-#define DECLARE_INJECTED_EXT(name, dir, hook, deps)                                                                                                 \
+#define DECLARE_INJECTED_EXT(name, dir, _pre_load_hook, _pre_minit_hook, deps)                                                                                                 \
     {                                                                                                                                               \
-        .ext_name = name, .ext_dir = dir, .tmp_name = name "_injected", .tmp_deps = deps, .pre_minit_hook = hook, .orig_module_startup_func = NULL, \
+        .ext_name = name, .ext_dir = dir, .tmp_name = name "_injected", .tmp_deps = deps, .pre_load_hook = _pre_load_hook, .pre_minit_hook = _pre_minit_hook, .orig_module_startup_func = NULL, \
         .orig_module_deps = NULL, .orig_module_functions = NULL, .module_number = -1, .version = NULL                                               \
     }
 
@@ -39,6 +39,7 @@ typedef struct _injected_ext {
 
     const char *tmp_name;
     const zend_module_dep *tmp_deps;
+    char *(*pre_load_hook)(void);
     void (*pre_minit_hook)(void);
 
     zend_result (*orig_module_startup_func)(INIT_FUNC_ARGS);


### PR DESCRIPTION
This also allows using the `.so` shared libraries to be used individually, to reduce size.