### PR TITLE
Respect the active service/env/version for metric tags

### DIFF
--- a/ext/serializer.c
+++ b/ext/serializer.c
@@ -852,6 +852,18 @@ zend_string *ddtrace_default_service_name(void) {
     }
 }
 
+zend_string *ddtrace_active_service_name(void) {
+    ddtrace_span_data *span = ddtrace_active_span();
+    if (span) {
+        return ddtrace_convert_to_str(&span->property_service);
+    }
+    zend_string *ini_service = get_DD_SERVICE();
+    if (ZSTR_LEN(ini_service)) {
+        return zend_string_copy(ini_service);
+    }
+    return ddtrace_default_service_name();
+}
+
 void ddtrace_set_root_span_properties(ddtrace_root_span_data *span) {
     ddtrace_update_root_id_properties(span);
 

--- a/ext/serializer.h
+++ b/ext/serializer.h
@@ -14,6 +14,7 @@ void ddtrace_set_root_span_properties(ddtrace_root_span_data *span);
 void ddtrace_update_root_id_properties(ddtrace_root_span_data *span);
 void ddtrace_inherit_span_properties(ddtrace_span_data *span, ddtrace_span_data *parent);
 zend_string *ddtrace_default_service_name(void);
+zend_string *ddtrace_active_service_name(void);
 
 void ddtrace_initialize_span_sampling_limiter(void);
 void ddtrace_shutdown_span_sampling_limiter(void);

--- a/tests/ext/dogstatsd/metrics_over_udp.phpt
+++ b/tests/ext/dogstatsd/metrics_over_udp.phpt
@@ -57,8 +57,8 @@ $server->close();
 
 ?>
 --EXPECT--
-counter-simple:42|c|#foo:bar,bar:true
-gogogadget:21.4|g
-my_disti:22.22|d|#distri:bution
-my_histo:22.22|h|#histo:gram
-set:7|s|#set:7
+counter-simple:42|c|#service:metrics_over_udp.php,foo:bar,bar:true
+gogogadget:21.4|g|#service:metrics_over_udp.php
+my_disti:22.22|d|#service:metrics_over_udp.php,distri:bution
+my_histo:22.22|h|#service:metrics_over_udp.php,histo:gram
+set:7|s|#service:metrics_over_udp.php,set:7


### PR DESCRIPTION
I just noticed that while testing live-debugger metrics - the actual service still ought to be reported.
It's just php-dogstatsd which isn't aware of ddtrace state.