### PR TITLE
New SSI package merging glibc/musl

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -3012,10 +3012,10 @@ jobs:
             ./configure
             make clean
             make -j all ECHO_ARG="-e" CFLAGS="-std=gnu11 -O2 -g -Wall -Wextra -Werror"
-            cp modules/dd_library_loader.so modules/dd_library_loader-$(uname -m)-<< parameters.os >>.so
+            cp modules/dd_library_loader.so ../dd_library_loader-$(uname -m)-<< parameters.os >>.so
       - persist_to_workspace:
           root: '.'
-          paths: [ './loader/modules/dd_library_loader-*.so' ]
+          paths: [ './dd_library_loader-*.so' ]
       - store_artifacts:
           path: ./loader/modules/dd_library_loader.so
 
@@ -3050,13 +3050,14 @@ jobs:
             set -xeuo pipefail
 
             arch=$(uname -m)
-            package=$(find ./build/packages -maxdepth 1 -name "dd-library-php-*-${arch}-linux-gnu.tar.gz")
-            rm -rf dd-library-php
+            package=$(find ./build/packages -maxdepth 1 -name "dd-library-php-ssi-*-${arch}-linux.tar.gz")
+            rm -rf dd-library-php-ssi
             tar -xzf ${package}
-            export DD_LOADER_PACKAGE_PATH=${PWD}/dd-library-php
+            export DD_LOADER_PACKAGE_PATH=${PWD}/dd-library-php-ssi
 
             cd loader
-            cp modules/dd_library_loader-$(uname -m)-linux-gnu.so modules/dd_library_loader.so
+            mkdir -p modules
+            cp ../dd-library-php-ssi/linux-gnu/loader/dd_library_loader.so modules/
             ./bin/test.sh
 
   "test_loader_alpine":
@@ -3088,13 +3089,14 @@ jobs:
             apk add --no-cache curl-dev << parameters.alpine_packages >>
 
             arch=$(uname -m)
-            package=$(find ./build/packages -maxdepth 1 -name "dd-library-php-*-${arch}-linux-musl.tar.gz")
-            rm -rf dd-library-php
+            package=$(find ./build/packages -maxdepth 1 -name "dd-library-php-ssi-*-${arch}-linux.tar.gz")
+            rm -rf dd-library-php-ssi
             tar -xzf ${package}
-            export DD_LOADER_PACKAGE_PATH=${PWD}/dd-library-php
+            export DD_LOADER_PACKAGE_PATH=${PWD}/dd-library-php-ssi
 
             cd loader
-            cp modules/dd_library_loader-$(uname -m)-linux-musl.so modules/dd_library_loader.so
+            mkdir -p modules
+            cp ../dd-library-php-ssi/linux-musl/loader/dd_library_loader.so modules/
             ./bin/test.sh
 
   compile_rust_centos:
@@ -4240,6 +4242,11 @@ workflows:
             - "Profiler PHP v8.2 - aarch64-unknown-linux-gnu"
             - "Profiler PHP v8.3 - aarch64-unknown-linux-gnu"
 
+            - "Compile Loader Linux x86_64"
+            - "Compile Loader Linux aarch64"
+            - "Compile Loader Alpine x86_64"
+            - "Compile Loader Alpine aarch64"
+
             - compile_appsec_extension_centos
             - compile_appsec_extension_alpine
             - compile_appsec_helper
@@ -4747,7 +4754,6 @@ workflows:
       - "test_loader_linux":
           requires:
             - "package extension"
-            - "Compile Loader Linux x86_64"
           name: "[Linux/x86_64] Loader PHP << matrix.php_major_minor >>-<< matrix.switch_php_version >>"
           docker_image: "datadog/dd-trace-ci:php-<< matrix.php_major_minor >>_buster"
           resource_class: "medium"
@@ -4766,7 +4772,6 @@ workflows:
       - "test_loader_linux":
           requires:
             - "package extension"
-            - "Compile Loader Linux x86_64"
           name: "[Linux/x86_64] Loader PHP << matrix.php_major_minor >>-<< matrix.switch_php_version >>"
           docker_image: "datadog/dd-trace-ci:php-<< matrix.php_major_minor >>_buster"
           resource_class: "medium"
@@ -4786,7 +4791,6 @@ workflows:
       - "test_loader_linux":
           requires:
             - "package extension"
-            - "Compile Loader Linux aarch64"
           name: "[Linux/aarch64] Loader PHP << matrix.php_major_minor >>-<< matrix.switch_php_version >>"
           docker_image: "datadog/dd-trace-ci:php-<< matrix.php_major_minor >>_buster"
           resource_class: "arm.medium"
@@ -4804,7 +4808,6 @@ workflows:
       - "test_loader_linux":
           requires:
             - "package extension"
-            - "Compile Loader Linux aarch64"
           name: "[Linux/aarch64] Loader PHP << matrix.php_major_minor >>-<< matrix.switch_php_version >>"
           docker_image: "datadog/dd-trace-ci:php-<< matrix.php_major_minor >>_buster"
           resource_class: "arm.medium"
@@ -4824,7 +4827,6 @@ workflows:
       - "test_loader_alpine":
           requires:
             - "package extension"
-            - "Compile Loader Alpine x86_64"
           name: "[Alpine/x86_64] Loader PHP Alpine << matrix.alpine_version >>"
           docker_image: "alpine:<< matrix.alpine_version >>"
           resource_class: "medium"
@@ -4839,7 +4841,6 @@ workflows:
       - "test_loader_alpine":
           requires:
             - "package extension"
-            - "Compile Loader Alpine aarch64"
           name: "[Alpine/aarch64] Loader PHP Alpine << matrix.alpine_version >>"
           docker_image: "alpine:<< matrix.alpine_version >>"
           resource_class: "arm.medium"

--- a/Makefile
+++ b/Makefile
@@ -446,6 +446,9 @@ bundle.tar.gz: $(PACKAGES_BUILD_DIR)
 	bash ./tooling/bin/generate-installers.sh \
 		$(VERSION) \
 		$(PACKAGES_BUILD_DIR)
+	bash ./tooling/bin/generate-ssi-package.sh \
+		$(VERSION) \
+		$(PACKAGES_BUILD_DIR)
 
 build_pecl_package:
 	BUILD_DIR='$(BUILD_DIR)/'; \
@@ -456,7 +459,7 @@ dbgsym.tar.gz:
 	$(if $(DDTRACE_MAKE_PACKAGES_ASAN), , tar zcf $(PACKAGES_BUILD_DIR)/dd-library-php-$(VERSION)_windows_debugsymbols.tar.gz ./extensions_windows_x86_64_debugsymbols --owner=0 --group=0)
 
 packages: .apk.x86_64 .apk.aarch64 .rpm.x86_64 .rpm.aarch64 .deb.x86_64 .deb.arm64 .tar.gz.x86_64 .tar.gz.aarch64 bundle.tar.gz dbgsym.tar.gz
-	tar zcf packages.tar.gz $(PACKAGES_BUILD_DIR) --owner=0 --group=0
+	tar --exclude='dd-library-php-ssi-*' -zcf packages.tar.gz $(PACKAGES_BUILD_DIR) --owner=0 --group=0
 
 # Generates the src/bridge/_generated_*.php files.
 generate:

--- a/components-rs/sidecar.rs
+++ b/components-rs/sidecar.rs
@@ -22,7 +22,7 @@ extern "C" {
 
 #[cfg(php_shared_build)]
 fn run_sidecar(mut cfg: config::Config) -> anyhow::Result<SidecarTransport> {
-    if unsafe { *DDTRACE_MOCK_PHP_SIZE } > 0 {
+    if !unsafe { DDTRACE_MOCK_PHP_SIZE }.is_null() {
         let mock = unsafe { std::slice::from_raw_parts(DDTRACE_MOCK_PHP, *DDTRACE_MOCK_PHP_SIZE) };
         cfg.library_dependencies
             .push(LibDependency::Binary(mock));

--- a/loader/config.m4
+++ b/loader/config.m4
@@ -4,6 +4,16 @@ PHP_ARG_ENABLE([dd_library_loader],
     [Enable dd_library_loader support])],
   [no])
 
+dnl Detect musl libc
+AC_MSG_CHECKING([whether we are using musl libc])
+if command -v ldd >/dev/null && ldd --version 2>&1 | grep -q ^musl
+then
+  AC_MSG_RESULT(yes)
+  AC_DEFINE([__MUSL__], [1], [Define when using musl libc])
+else
+  AC_MSG_RESULT(no)
+fi
+
 if test "$PHP_DD_LIBRARY_LOADER" != "no"; then
   dnl In case of no dependencies
   AC_DEFINE(HAVE_DD_LIBRARY_LOADER, 1, [ Have dd_library_loader support ])

--- a/tooling/bin/generate-ssi-package.sh
+++ b/tooling/bin/generate-ssi-package.sh
@@ -1,0 +1,68 @@
+#!/usr/bin/env bash
+
+set -xeuo pipefail
+IFS=$'\n\t'
+
+release_version=$1
+packages_build_dir=$2
+
+tmp_folder=/tmp/bundle
+tmp_folder_final=$tmp_folder/final
+
+architectures=(x86_64 aarch64)
+
+if [[ -n ${DDTRACE_MAKE_PACKAGES_ASAN:-} ]]; then
+    exit 0
+fi
+
+for architecture in "${architectures[@]}"; do
+    root=$tmp_folder_final/$architecture/dd-library-php-ssi
+    gnu=$root/linux-gnu
+    musl=$root/linux-musl
+    trace=$root/trace
+
+    # Starting from a clean folder
+    rm -rf ${tmp_folder}
+    mkdir -p ${gnu}/loader ${musl}/loader ${trace}
+
+    ########################
+    # Loader
+    ########################
+    cp libddtrace_php_${architecture}.so ${gnu}/loader/libddtrace_php.so
+    cp libddtrace_php_${architecture}-alpine.so ${musl}/loader/libddtrace_php.so
+
+    cp dd_library_loader-${architecture}-linux-gnu.so ${gnu}/loader/dd_library_loader.so
+    cp dd_library_loader-${architecture}-linux-musl.so ${musl}/loader/dd_library_loader.so
+
+    echo 'zend_extension=${DD_LOADER_PACKAGE_PATH}/linux-gnu/loader/dd_library_loader.so' > ${gnu}/loader/dd_library_loader.ini
+    echo 'zend_extension=${DD_LOADER_PACKAGE_PATH}/linux-musl/loader/dd_library_loader.so' > ${musl}/loader/dd_library_loader.ini
+
+    ########################
+    # Trace
+    ########################
+
+    php_apis=(20151012 20160303 20170718 20180731 20190902 20200930 20210902 20220829 20230831)
+    for php_api in "${php_apis[@]}"; do
+        mkdir -p ${gnu}/trace/ext/$php_api ${musl}/trace/ext/$php_api
+        # gnu
+        cp ./standalone_${architecture}/ddtrace-$php_api.so ${gnu}/trace/ext/$php_api/ddtrace.so
+        cp ./standalone_${architecture}/ddtrace-$php_api-zts.so ${gnu}/trace/ext/$php_api/ddtrace-zts.so
+        cp ./standalone_${architecture}/ddtrace-$php_api-debug.so ${gnu}/trace/ext/$php_api/ddtrace-debug.so
+
+        # musl
+        cp ./standalone_${architecture}/ddtrace-$php_api-alpine.so ${musl}/trace/ext/$php_api/ddtrace.so
+        if [[ ${php_api} -ge 20151012 ]]; then # zts on alpine starting 7.0
+            cp ./standalone_${architecture}/ddtrace-$php_api-alpine-zts.so ${musl}/trace/ext/$php_api/ddtrace-zts.so
+        fi
+    done;
+
+    cp -r ./src ${trace}/
+    echo "$release_version" > ${root}/VERSION
+
+    ########################
+    # Final archives
+    ########################
+    tar -czv \
+        -f ${packages_build_dir}/dd-library-php-ssi-${release_version}-$architecture-linux.tar.gz \
+        -C $tmp_folder_final/$architecture . --owner=0 --group=0
+done

--- a/tooling/bin/generate-ssi-package.sh
+++ b/tooling/bin/generate-ssi-package.sh
@@ -57,7 +57,7 @@ for architecture in "${architectures[@]}"; do
     done;
 
     cp -r ./src ${trace}/
-    echo "$release_version" > ${root}/VERSION
+    echo "$release_version" > ${root}/version
 
     ########################
     # Final archives


### PR DESCRIPTION
### Description

Package structure is like
```
/
    version

    trace/
        src/

    linux-gnu/
        loader/
            libddtrace_php.so
            dd_library_loader.ini  <-- zend_extension=${DD_LOADER_PACKAGE_PATH}/linux-gnu/loader/dd_library_loader.so
            dd_library_loader.so
        trace/
            ext/
                ...

    linux-musl/
        loader
            libddtrace_php.so
            dd_library_loader.ini  <-- zend_extension=${DD_LOADER_PACKAGE_PATH}/linux-musl/loader/dd_library_loader.so
            dd_library_loader.so
        trace/
            ext/
                ...
``` 

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
