### PR TITLE
Switch system-tests to python 3.12

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -3553,8 +3553,7 @@ jobs:
 
   system_tests:
     machine:
-      # https://support.circleci.com/hc/en-us/articles/360007324514-How-can-I-use-Docker-volume-mounting-on-CircleCI-
-      image: cimg/python:3.12.4
+      image: ubuntu-2404:2024.05.1
     parameters:
       build:
         type: string
@@ -3569,11 +3568,11 @@ jobs:
       - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
 
-      # - run:
-      #     name: Install python 3.12
-      #     command: |
-      #       sudo apt-get update
-      #       sudo apt-get install python3.12-venv
+      - run:
+          name: Install python 3.12
+          command: |
+            sudo apt-get update
+            sudo apt-get install -y python3.12-full python3.12-dev python3.12-venv
 
       - run:
           name: versions

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -3554,7 +3554,7 @@ jobs:
   system_tests:
     machine:
       # https://support.circleci.com/hc/en-us/articles/360007324514-How-can-I-use-Docker-volume-mounting-on-CircleCI-
-      image: ubuntu-2004:current
+      image: cimg/python:3.12.4
     parameters:
       build:
         type: string
@@ -3569,11 +3569,11 @@ jobs:
       - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
 
-      - run:
-          name: Install python 3.12
-          command: |
-            sudo apt-get update
-            sudo apt-get install python3.12-venv
+      # - run:
+      #     name: Install python 3.12
+      #     command: |
+      #       sudo apt-get update
+      #       sudo apt-get install python3.12-venv
 
       - run:
           name: versions

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -3570,10 +3570,10 @@ jobs:
       - <<: *STEP_ATTACH_WORKSPACE
 
       - run:
-          name: Install python 3.9
+          name: Install python 3.12
           command: |
             sudo apt-get update
-            sudo apt-get install python3.9-venv
+            sudo apt-get install python3.12-venv
 
       - run:
           name: versions


### PR DESCRIPTION
### Description

System tests now use a python 3.12.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
