### PR TITLE
[loader] Add a libc check at runtime

### DIFF
--- a/loader/dd_library_loader.c
+++ b/loader/dd_library_loader.c
@@ -488,7 +488,6 @@ static bool ddloader_libc_check() {
     const char *error = dlerror();
     // gnu_get_libc_version is available since glibc 2.1
     char *(*get_libc_version)(void) = dlsym(RTLD_DEFAULT, "gnu_get_libc_version");
-    const char* lib_path;
     error = dlerror();
     if (error == NULL && get_libc_version != NULL) {
         is_musl = false;

--- a/loader/dd_library_loader.c
+++ b/loader/dd_library_loader.c
@@ -483,7 +483,37 @@ static inline void ddloader_configure() {
     package_path = getenv("DD_LOADER_PACKAGE_PATH");
 }
 
+static bool ddloader_libc_check() {
+    bool is_musl;
+    const char *error = dlerror();
+    // gnu_get_libc_version is available since glibc 2.1
+    char *(*get_libc_version)(void) = dlsym(RTLD_DEFAULT, "gnu_get_libc_version");
+    const char* lib_path;
+    error = dlerror();
+    if (error == NULL && get_libc_version != NULL) {
+        is_musl = false;
+    } else {
+        is_musl = true;
+    }
+
+#if defined(__MUSL__)
+    if (!is_musl) {
+        return false;
+    }
+#else
+    if (is_musl) {
+        return false;
+    }
+#endif
+
+    return true;
+}
+
 static int ddloader_api_no_check(int api_no) {
+    if (!ddloader_libc_check()) {
+        return SUCCESS;
+    }
+
     ddloader_configure();
 
     switch (api_no) {
@@ -541,7 +571,7 @@ static int ddloader_api_no_check(int api_no) {
 
 static int ddloader_build_id_check(const char *build_id) {
     // Guardrail
-    if (!php_api_no) {
+    if (!ddloader_libc_check() || !php_api_no) {
         return SUCCESS;
     }
 

--- a/loader/dd_library_loader.c
+++ b/loader/dd_library_loader.c
@@ -517,6 +517,18 @@ static int ddloader_api_no_check(int api_no) {
     ddloader_configure();
 
     switch (api_no) {
+        case 220040412:
+            runtime_version = "5.0";
+            break;
+        case 220051025:
+            runtime_version = "5.1";
+            break;
+        case 220060519:
+            runtime_version = "5.2";
+            break;
+        case 220090626:
+            runtime_version = "5.3";
+            break;
         case 220100525:
             runtime_version = "5.4";
             break;


### PR DESCRIPTION
### Description

Avoid trying to load an incompatible lib if we know it will fail.

Check code taken from https://github.com/DataDog/auto_inject/pull/266/files#diff-612d425717135d74863f5b8ef8a0c02d214976ad4a5d8b1690ee4bf2297459f0R47-R60

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
