### PR TITLE
ci(profiling) fix `PHP_ZTS` test for PHP 8.4

### DIFF
--- a/profiling/tests/phpt/zts_01.phpt
+++ b/profiling/tests/phpt/zts_01.phpt
@@ -14,9 +14,9 @@ datadog.profiling.log_level=debug
 --FILE--
 <?php
 usleep(10000);
-var_dump(PHP_ZTS);
+var_dump((bool)PHP_ZTS);
 ?>
 --EXPECTREGEX--
 .*Started with an upload period of 67 seconds and approximate wall-time period of 10 milliseconds.
-.*int\(1\)
+.*bool\(true\)
 .*


### PR DESCRIPTION
### Description

In PHP 8.4 the `PHP_ZTS` constant got changed to type bool in https://github.com/php/php-src/pull/13079

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
