### PR TITLE
Properly handle make clean

### DIFF
--- a/config.m4
+++ b/config.m4
@@ -302,7 +302,7 @@ EOT
     pushdef([PHP_GEN_GLOBAL_MAKEFILE], [
       popdef([PHP_GEN_GLOBAL_MAKEFILE])
       PHP_GEN_GLOBAL_MAKEFILE
-      sed -i $([[ "$(uname)" != "Darwin" ]] || echo "''") -e '/^distclean:/a\'$'\n\t''rm -rf target/' -e '/.*\.a /{s/| xargs rm -f/! -path ".\/target\/*" | xargs rm -f/'$'\n}' Makefile
+      sed -i $({ sed --version 2>&1 || echo ''; } | grep GNU >/dev/null || echo "''") -e '/^distclean:/a\'$'\n\t''rm -rf target/' -e '/.*\.a /{s/| xargs rm -f/! -path ".\/target\/*" | xargs rm -f/'$'\n}' Makefile
       DDTRACE_GEN_GLOBAL_MAKEFILE_WRAP
     ])
   ])

--- a/config.m4
+++ b/config.m4
@@ -296,6 +296,18 @@ EOT
   PHP_ADD_BUILD_DIR([$ext_builddir/ext/integrations])
   PHP_ADD_INCLUDE([$ext_builddir/ext/integrations])
 
+  dnl Avoid cleaning rust artifacts with make clean (cargo is really good at detecting changes - and rust files are not dependent on php environment).
+  dnl However, for users who really want to clean, there's always make distclean, which will flatly remove the whole target/ directory.
+  AC_DEFUN([DDTRACE_GEN_GLOBAL_MAKEFILE_WRAP], [
+    pushdef([PHP_GEN_GLOBAL_MAKEFILE], [
+      popdef([PHP_GEN_GLOBAL_MAKEFILE])
+      PHP_GEN_GLOBAL_MAKEFILE
+      sed -i $([[ "$(uname)" != "Darwin" ]] || echo "''") -e '/^distclean:/a\'$'\n\t''rm -rf target/' -e '/.*\.a /{s/| xargs rm -f/! -path ".\/target\/*" | xargs rm -f/'$'\n}' Makefile
+      DDTRACE_GEN_GLOBAL_MAKEFILE_WRAP
+    ])
+  ])
+  DDTRACE_GEN_GLOBAL_MAKEFILE_WRAP
+
   cat <<'EOT' >> Makefile.fragments
 ./modules/ddtrace.a: $(shared_objects_ddtrace) $(DDTRACE_SHARED_DEPENDENCIES)
 	$(LIBTOOL) --mode=link $(CC) -static $(COMMON_FLAGS) $(CFLAGS_CLEAN) $(EXTRA_CFLAGS) $(LDFLAGS)  -o $@ -avoid-version -prefer-pic -module $(shared_objects_ddtrace)


### PR DESCRIPTION
Currently a make clean would remove intermediate archives in rust target/ directory, like "./target/debug/build/aws-lc-sys-ca1986c45891d6ab/out/libaws_lc_0_19_0_crypto.a" These intermediate files would not be recreated on their own after a make clean, letting the build fail after a make clean (until one manually removed more files).

This will keep these intermediate rust files, relying on cargo to detect changes, but make distclean will remove the whole target/ directory.