### PR TITLE
Improve sampler

### DIFF
--- a/appsec/src/helper/client.cpp
+++ b/appsec/src/helper/client.cpp
@@ -416,7 +416,7 @@ bool client::handle_command(network::request_shutdown::request &command)
     auto free_ctx = defer([this]() { this->context_.reset(); });
 
     auto sampler = service_->get_schema_sampler();
-    if (sampler && sampler->get()) {
+    if (sampler && sampler->picked()) {
         parameter context_processor = parameter::map();
         context_processor.add("extract-schema", parameter::as_boolean(true));
         command.data.add("waf.context.processor", std::move(context_processor));

--- a/appsec/tests/helper/sampler_test.cpp
+++ b/appsec/tests/helper/sampler_test.cpp
@@ -15,7 +15,7 @@ class sampler : public dds::sampler {
 public:
     sampler(double sample_rate) : dds::sampler(sample_rate) {}
     void set_request(unsigned int i) { request_ = i; }
-    auto get_request() { return request_; }
+    unsigned int get_request() { return request_; }
 };
 
 } // namespace mock
@@ -25,7 +25,7 @@ std::atomic<int> picked = 0;
 void count_picked(dds::sampler &sampler, int iterations)
 {
     for (int i = 0; i < iterations; i++) {
-        if (sampler.get()) {
+        if (sampler.picked()) {
             picked++;
         }
     }
@@ -197,7 +197,7 @@ TEST(SamplerTest, TestOverflow)
 {
     mock::sampler s(0);
     s.set_request(UINT_MAX);
-    s.get();
-    EXPECT_EQ(1, s.get_request());
+    s.picked();
+    EXPECT_EQ(0, s.get_request());
 }
 } // namespace dds

--- a/appsec/tests/helper/service_test.cpp
+++ b/appsec/tests/helper/service_test.cpp
@@ -57,7 +57,7 @@ TEST(ServiceTest, ServicePickSchemaExtractionSamples)
         auto s = service(
             engine, service_config, nullptr, {true, all_requests_are_picked});
 
-        EXPECT_TRUE(s.get_schema_sampler()->get());
+        EXPECT_TRUE(s.get_schema_sampler()->picked());
     }
 
     { // Constructor. It does not pick based on rate
@@ -65,7 +65,7 @@ TEST(ServiceTest, ServicePickSchemaExtractionSamples)
         auto s = service(
             engine, service_config, nullptr, {true, no_request_is_picked});
 
-        EXPECT_FALSE(s.get_schema_sampler()->get());
+        EXPECT_FALSE(s.get_schema_sampler()->picked());
     }
 
     { // Constructor. It does not pick if disabled
@@ -74,7 +74,7 @@ TEST(ServiceTest, ServicePickSchemaExtractionSamples)
         auto s = service(engine, service_config, nullptr,
             {schema_extraction_disabled, all_requests_are_picked});
 
-        EXPECT_FALSE(s.get_schema_sampler()->get());
+        EXPECT_FALSE(s.get_schema_sampler()->picked());
     }
 
     { // Static constructor. It picks based on rate
@@ -83,7 +83,7 @@ TEST(ServiceTest, ServicePickSchemaExtractionSamples)
         auto service = service::from_settings(
             service_identifier(sid), engine_settings, {}, meta, metrics, false);
 
-        EXPECT_TRUE(service->get_schema_sampler()->get());
+        EXPECT_TRUE(service->get_schema_sampler()->picked());
     }
 
     { // Static constructor.  It does not pick based on rate
@@ -92,7 +92,7 @@ TEST(ServiceTest, ServicePickSchemaExtractionSamples)
         auto service = service::from_settings(
             service_identifier(sid), engine_settings, {}, meta, metrics, false);
 
-        EXPECT_FALSE(service->get_schema_sampler()->get());
+        EXPECT_FALSE(service->get_schema_sampler()->picked());
     }
 
     { // Static constructor. It does not pick if disabled
@@ -101,7 +101,7 @@ TEST(ServiceTest, ServicePickSchemaExtractionSamples)
         auto service = service::from_settings(
             service_identifier(sid), engine_settings, {}, meta, metrics, false);
 
-        EXPECT_FALSE(service->get_schema_sampler()->get());
+        EXPECT_FALSE(service->get_schema_sampler()->picked());
     }
 }
 


### PR DESCRIPTION
### Description

There have been error when more than one request was running on parallel due to the sampler not managing it properly. This PR refactor the sampler to stop these errors.

APPSEC-53993

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
