### PR TITLE
Disable sidecar tracing on PHP 8.3 again

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1005,7 +1005,7 @@ define run_composer_with_retry
 endef
 
 define run_tests_without_coverage
-	$(TEST_EXTRA_ENV) $(ENV_OVERRIDE) php $(TEST_EXTRA_INI) -d datadog.instrumentation_telemetry_enabled=$(shell (test $(TELEMETRY_ENABLED) && echo 1) || (test $(PHP_MAJOR_MINOR) -ge 83 && echo 1) || echo 0) -d datadog.trace.sidecar_trace_sender=$(shell test $(PHP_MAJOR_MINOR) -ge 83 && echo 1 || echo 0) $(TRACER_SOURCES_INI) $(PHPUNIT) $(1) --filter=$(FILTER)
+	$(TEST_EXTRA_ENV) $(ENV_OVERRIDE) php $(TEST_EXTRA_INI) -d datadog.instrumentation_telemetry_enabled=$(shell (test $(TELEMETRY_ENABLED) && echo 1) || (test $(PHP_MAJOR_MINOR) -ge 84 && echo 1) || echo 0) -d datadog.trace.sidecar_trace_sender=$(shell test $(PHP_MAJOR_MINOR) -ge 84 && echo 1 || echo 0) $(TRACER_SOURCES_INI) $(PHPUNIT) $(1) --filter=$(FILTER)
 endef
 
 define run_tests_with_coverage

--- a/ext/configuration.h
+++ b/ext/configuration.h
@@ -53,7 +53,7 @@ enum ddtrace_sampling_rules_format {
 #define DD_INTEGRATION_ANALYTICS_ENABLED_DEFAULT false
 #define DD_INTEGRATION_ANALYTICS_SAMPLE_RATE_DEFAULT 1
 
-#if PHP_VERSION_ID >= 80300 || defined(_WIN32)
+#if PHP_VERSION_ID >= 80400 || defined(_WIN32)
 #define DD_SIDECAR_TRACE_SENDER_DEFAULT true
 #else
 #define DD_SIDECAR_TRACE_SENDER_DEFAULT false

--- a/tests/ext/background-sender/sidecar_fallback.phpt
+++ b/tests/ext/background-sender/sidecar_fallback.phpt
@@ -2,7 +2,7 @@
 Send telemetry about the sidecar being disabled
 --SKIPIF--
 <?php include __DIR__ . '/../includes/skipif_no_dev_env.inc'; ?>
-<?php if (PHP_VERSION_ID < 80300) die('skip: Sidecar fallback exists only on PHP 8.3'); ?>
+<?php if (PHP_VERSION_ID < 80400) die('skip: Sidecar fallback exists only on PHP 8.4'); ?>
 <?php if (strncasecmp(PHP_OS, "WIN", 3) == 0) die('skip: There is no background sender on Windows'); ?>
 <?php if (getenv('USE_ZEND_ALLOC') === '0' && !getenv("SKIP_ASAN")) die('skip: valgrind reports sendmsg(msg.msg_control) points to uninitialised byte(s), but it is unproblematic and outside our control in rust code'); ?>
 <?php include __DIR__ . '/../includes/request_replayer.inc'; $rr = new RequestReplayer; usleep(5000); $rr->replayRequest(); /* avoid cross-pollination */ ?>

--- a/tests/ext/sidecar_disabled_when_telemetry_disabled.phpt
+++ b/tests/ext/sidecar_disabled_when_telemetry_disabled.phpt
@@ -6,7 +6,7 @@ Sidecar should be disabled when telemetry is disabled
 <?php
 include_once 'startup_logging.inc';
 
-// IN PHP 8.3, the sidecar is enabled
+// IN PHP 8.4, the sidecar is enabled
 // In all other versions the sidecar is disabled.
 // But we disable in all cases if telemetry is disabled.
 // So in this test, the sidecar should be disabled all the time

--- a/tests/ext/sidecar_enabled.phpt
+++ b/tests/ext/sidecar_enabled.phpt
@@ -1,12 +1,12 @@
 --TEST--
-Sidecar should be enabled by default on PHP 8.3
+Sidecar should be enabled by default on PHP 8.4
 --SKIPIF--
 <?php include 'startup_logging_skipif_unix_83.inc'; ?>
 --FILE--
 <?php
 include_once 'startup_logging.inc';
 
-// IN PHP 8.3, the sidecar is enabled by default, let's test this here
+// IN PHP 8.4, the sidecar is enabled by default, let's test this here
 // In all other versions the sidecar is disabled but this is tested by sidecar_disabled_when_telemetry_disabled.phpt
 $logs = dd_get_startup_logs([], [
     'DD_TRACE_DEBUG' => '1',

--- a/tests/ext/startup_logging_skipif_unix_83.inc
+++ b/tests/ext/startup_logging_skipif_unix_83.inc
@@ -3,4 +3,4 @@
 include_once 'startup_logging.inc';
 if (!dd_get_php_cgi()) die('skip: php-cgi SAPI required');
 if (strncasecmp(PHP_OS, "WIN", 3) == 0) die('skip: There is no background sender on Windows');
-if (version_compare(PHP_VERSION, '8.3.0', '<')) die('skip: This tests is only for PHP 8.3');
+if (version_compare(PHP_VERSION, '8.4.0', '<')) die('skip: This tests is only for PHP 8.4');


### PR DESCRIPTION
Mainly for 1.2 release; will be reverted soon, probably.