### PR TITLE
fix: Crash in OpenTelemetry Span::getCurrent() when accessing span link

### DIFF
--- a/src/DDTrace/OpenTelemetry/Context.php
+++ b/src/DDTrace/OpenTelemetry/Context.php
@@ -186,7 +186,7 @@ final class Context implements ContextInterface
                 API\TraceFlags::DEFAULT,
                 new API\TraceState($spanLink->traceState ?? null),
             );
-            $links[] = new SDK\Link($linkSpanContext, Attributes::create($spanLink->attributes));
+            $links[] = new SDK\Link($linkSpanContext, Attributes::create($spanLink->attributes ?? []));
         }
 
         $OTelCurrentSpan = SDK\Span::startSpan(

--- a/tests/OpenTelemetry/Integration/InteroperabilityTest.php
+++ b/tests/OpenTelemetry/Integration/InteroperabilityTest.php
@@ -942,6 +942,32 @@ final class InteroperabilityTest extends BaseTestCase
         $this->assertSame("[{\"trace_id\":\"ff0000000000051791e0000000000041\",\"span_id\":\"ff00000000000517\",\"trace_state\":\"dd=t.dm:-0\",\"attributes\":{\"arg1\":\"value1\",\"arg2\":\"value2\"}}]", $traces[0][0]['meta']['_dd.span_links']);
     }
 
+    public function testBasicSpanLinksFromDatadog()
+    {
+        $traces = $this->isolateTracer(function () {
+            $span = start_span();
+            $span->name = "dd.span";
+
+            $spanLink = new SpanLink();
+            $spanLink->traceId = "ff0000000000051791e0000000000041";
+            $spanLink->spanId = "ff00000000000517";
+            $span->links[] = $spanLink;
+
+            /** @var \OpenTelemetry\SDK\Trace\Span $OTelSpan */
+            $OTelSpan = Span::getCurrent();
+            $OTelSpanLink = $OTelSpan->toSpanData()->getLinks()[0];
+            $OTelSpanLinkContext = $OTelSpanLink->getSpanContext();
+
+            $this->assertSame('ff0000000000051791e0000000000041', $OTelSpanLinkContext->getTraceId());
+            $this->assertSame('ff00000000000517', $OTelSpanLinkContext->getSpanId());
+
+            close_span();
+        });
+
+        $this->assertCount(1, $traces[0]);
+        $this->assertSame("[{\"trace_id\":\"ff0000000000051791e0000000000041\",\"span_id\":\"ff00000000000517\"}]", $traces[0][0]['meta']['_dd.span_links']);
+    }
+
     public function testSpanLinksInteroperabilityFromOpenTelemetrySpan()
     {
         $sampledSpanContext = SpanContext::create(


### PR DESCRIPTION
### Description

Fix #2765

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
