### PR TITLE
Implement LFI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1214,6 +1214,8 @@ test_integrations_amqp35: global_test_run_dependencies tests/Integrations/AMQP/V
 	$(call run_tests_debug,tests/Integrations/AMQP/V3_5)
 test_integrations_deferred_loading: global_test_run_dependencies tests/Integrations/DeferredLoading/composer.lock-php$(PHP_MAJOR_MINOR)
 	$(call run_tests_debug,tests/Integrations/DeferredLoading)
+test_integrations_filesystem: global_test_run_dependencies
+	$(call run_tests_debug,tests/Integrations/Filesystem)
 test_integrations_curl: global_test_run_dependencies
 	$(call run_tests_debug,tests/Integrations/Curl)
 test_integrations_elasticsearch1: global_test_run_dependencies tests/Integrations/Elasticsearch/V1/composer.lock-php$(PHP_MAJOR_MINOR)

--- a/appsec/src/extension/backtrace.c
+++ b/appsec/src/extension/backtrace.c
@@ -6,6 +6,7 @@
 #include "backtrace.h"
 #include "compatibility.h"
 #include "configuration.h"
+#include "ddappsec.h"
 #include "ddtrace.h"
 #include "logging.h"
 #include "php_compat.h"
@@ -246,13 +247,11 @@ bool dd_report_exploit_backtrace(zend_string *nullable id)
     zval *dd_stack = zend_hash_find(Z_ARR_P(meta_struct), _dd_stack_key);
     zval *exploit = NULL;
     if (!dd_stack || Z_TYPE_P(dd_stack) == IS_NULL) {
-        zval new_dd_stack;
-        zval new_exploit;
         dd_stack = zend_hash_add_new(
-            Z_ARR_P(meta_struct), _dd_stack_key, &new_dd_stack);
+            Z_ARR_P(meta_struct), _dd_stack_key, &EG(uninitialized_zval));
         array_init(dd_stack);
-        exploit =
-            zend_hash_add_new(Z_ARR_P(dd_stack), _exploit_key, &new_exploit);
+        exploit = zend_hash_add_new(
+            Z_ARR_P(dd_stack), _exploit_key, &EG(uninitialized_zval));
         array_init(exploit);
     } else if (Z_TYPE_P(dd_stack) != IS_ARRAY) {
         return false;

--- a/appsec/src/extension/commands/request_exec.c
+++ b/appsec/src/extension/commands/request_exec.c
@@ -14,6 +14,7 @@
 
 struct ctx {
     struct req_info req_info; // dd_command_proc_resp_verd_span_data expect it
+    bool rasp;
     zval *nonnull data;
 };
 
@@ -22,13 +23,13 @@ static dd_result _pack_command(mpack_writer_t *nonnull w, void *nonnull ctx);
 static const dd_command_spec _spec = {
     .name = "request_exec",
     .name_len = sizeof("request_exec") - 1,
-    .num_args = 1, // a single map
+    .num_args = 2,
     .outgoing_cb = _pack_command,
     .incoming_cb = dd_command_proc_resp_verd_span_data,
     .config_features_cb = dd_command_process_config_features_unexpected,
 };
 
-dd_result dd_request_exec(dd_conn *nonnull conn, zval *nonnull data)
+dd_result dd_request_exec(dd_conn *nonnull conn, zval *nonnull data, bool rasp)
 {
     if (Z_TYPE_P(data) != IS_ARRAY) {
         mlog(dd_log_debug, "Invalid data provided to command request_exec, "
@@ -36,7 +37,7 @@ dd_result dd_request_exec(dd_conn *nonnull conn, zval *nonnull data)
         return dd_error;
     }
 
-    struct ctx ctx = {.data = data};
+    struct ctx ctx = {.rasp = rasp, .data = data};
 
     return dd_command_exec_req_info(conn, &_spec, &ctx.req_info);
 }
@@ -46,6 +47,7 @@ static dd_result _pack_command(mpack_writer_t *nonnull w, void *nonnull _ctx)
     assert(_ctx != NULL);
     struct ctx *ctx = _ctx;
 
+    mpack_write(w, ctx->rasp);
     dd_mpack_write_zval(w, ctx->data);
 
     return dd_success;

--- a/appsec/src/extension/commands/request_exec.h
+++ b/appsec/src/extension/commands/request_exec.h
@@ -9,4 +9,4 @@
 #include <SAPI.h>
 #include <php.h>
 
-dd_result dd_request_exec(dd_conn *nonnull conn, zval *nonnull data);
+dd_result dd_request_exec(dd_conn *nonnull conn, zval *nonnull data, bool rasp);

--- a/appsec/src/extension/configuration.h
+++ b/appsec/src/extension/configuration.h
@@ -46,7 +46,7 @@ extern bool runtime_config_first_init;
     SYSCFG(BOOL, DD_APPSEC_HELPER_LAUNCH, "true")                                                                                     \
     CONFIG(STRING, DD_APPSEC_HELPER_PATH, DD_BASE("bin/libddappsec-helper.so"))                                                       \
     SYSCFG(BOOL, DD_APPSEC_STACK_TRACE_ENABLED, "true")                                                                               \
-    SYSCFG(BOOL, DD_APPSEC_RASP_ENABLED , "true")                                                                                     \
+    SYSCFG(BOOL, DD_APPSEC_RASP_ENABLED , "false")                                                                                    \
     SYSCFG(INT, DD_APPSEC_MAX_STACK_TRACE_DEPTH, "32")                                                                                \
     SYSCFG(INT, DD_APPSEC_MAX_STACK_TRACES, "2")                                                                                      \
     CONFIG(STRING, DD_APPSEC_HELPER_RUNTIME_PATH, "/tmp", .ini_change = dd_on_runtime_path_update)                                    \

--- a/appsec/src/extension/configuration.h
+++ b/appsec/src/extension/configuration.h
@@ -46,6 +46,7 @@ extern bool runtime_config_first_init;
     SYSCFG(BOOL, DD_APPSEC_HELPER_LAUNCH, "true")                                                                                     \
     CONFIG(STRING, DD_APPSEC_HELPER_PATH, DD_BASE("bin/libddappsec-helper.so"))                                                       \
     SYSCFG(BOOL, DD_APPSEC_STACK_TRACE_ENABLED, "true")                                                                               \
+    SYSCFG(BOOL, DD_APPSEC_RASP_ENABLED , "true")                                                                                     \
     SYSCFG(INT, DD_APPSEC_MAX_STACK_TRACE_DEPTH, "32")                                                                                \
     SYSCFG(INT, DD_APPSEC_MAX_STACK_TRACES, "2")                                                                                      \
     CONFIG(STRING, DD_APPSEC_HELPER_RUNTIME_PATH, "/tmp", .ini_change = dd_on_runtime_path_update)                                    \

--- a/appsec/src/extension/ddappsec.c
+++ b/appsec/src/extension/ddappsec.c
@@ -467,7 +467,7 @@ static PHP_FUNCTION(datadog_appsec_testing_request_exec)
         RETURN_FALSE;
     }
 
-    if (dd_request_exec(conn, data) != dd_success) {
+    if (dd_request_exec(conn, data, false) != dd_success) {
         RETURN_FALSE;
     }
 
@@ -485,7 +485,9 @@ static PHP_FUNCTION(datadog_appsec_push_address)
 
     zend_string *key = NULL;
     zval *value = NULL;
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "Sz", &key, &value) == FAILURE) {
+    bool rasp = false;
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "Sz|b", &key, &value, &rasp) ==
+        FAILURE) {
         RETURN_FALSE;
     }
 
@@ -502,7 +504,7 @@ static PHP_FUNCTION(datadog_appsec_push_address)
         return;
     }
 
-    dd_result res = dd_request_exec(conn, &parameters_zv);
+    dd_result res = dd_request_exec(conn, &parameters_zv, rasp);
     zval_ptr_dtor(&parameters_zv);
 
     if (dd_req_is_user_req()) {
@@ -529,6 +531,7 @@ ZEND_END_ARG_INFO()
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(push_address_arginfo, 0, 0, IS_VOID, 1)
 ZEND_ARG_INFO(0, key)
 ZEND_ARG_INFO(0, value)
+ZEND_ARG_INFO(0, rasp)
 ZEND_END_ARG_INFO()
 
 // clang-format off

--- a/appsec/src/extension/ddappsec.c
+++ b/appsec/src/extension/ddappsec.c
@@ -513,6 +513,13 @@ static PHP_FUNCTION(datadog_appsec_push_address)
     dd_result res = dd_request_exec(conn, &parameters_zv, rasp);
     zval_ptr_dtor(&parameters_zv);
 
+    if (rasp && (res == dd_should_block || res == dd_should_redirect)) {
+        gettimeofday(&end, NULL);
+        int elapsed = ((end.tv_sec - start.tv_sec) * 1000000) +
+                      (end.tv_usec - start.tv_usec);
+        dd_tags_add_rasp_duration_ext(dd_trace_get_active_root_span(), elapsed);
+    }
+
     if (dd_req_is_user_req()) {
         if (res == dd_should_block || res == dd_should_redirect) {
             dd_req_call_blocking_function(res);

--- a/appsec/src/extension/ddappsec.c
+++ b/appsec/src/extension/ddappsec.c
@@ -478,6 +478,7 @@ static PHP_FUNCTION(datadog_appsec_push_address)
 {
     struct timeval start, end;
     gettimeofday(&start, NULL);
+    int elapsed = 0;
     UNUSED(return_value);
     if (!DDAPPSEC_G(active)) {
         mlog(dd_log_debug, "Trying to access to push_address "
@@ -515,8 +516,8 @@ static PHP_FUNCTION(datadog_appsec_push_address)
 
     if (rasp && (res == dd_should_block || res == dd_should_redirect)) {
         gettimeofday(&end, NULL);
-        int elapsed = ((end.tv_sec - start.tv_sec) * 1000000) +
-                      (end.tv_usec - start.tv_usec);
+        elapsed = ((end.tv_sec - start.tv_sec) * 1000000) +
+                  (end.tv_usec - start.tv_usec);
         dd_tags_add_rasp_duration_ext(dd_trace_get_active_root_span(), elapsed);
     }
 
@@ -532,10 +533,10 @@ static PHP_FUNCTION(datadog_appsec_push_address)
         }
     }
 
-    if (rasp) {
+    if (rasp && elapsed == 0) {
         gettimeofday(&end, NULL);
-        int elapsed = ((end.tv_sec - start.tv_sec) * 1000000) +
-                      (end.tv_usec - start.tv_usec);
+        elapsed = ((end.tv_sec - start.tv_sec) * 1000000) +
+                  (end.tv_usec - start.tv_usec);
         dd_tags_add_rasp_duration_ext(dd_trace_get_active_root_span(), elapsed);
     }
 }

--- a/appsec/src/extension/ddappsec.c
+++ b/appsec/src/extension/ddappsec.c
@@ -491,6 +491,10 @@ static PHP_FUNCTION(datadog_appsec_push_address)
         RETURN_FALSE;
     }
 
+    if (rasp && !get_global_DD_APPSEC_RASP_ENABLED()) {
+        return;
+    }
+
     zval parameters_zv;
     zend_array *parameters_arr = zend_new_array(1);
     ZVAL_ARR(&parameters_zv, parameters_arr);

--- a/appsec/src/extension/ddappsec.c
+++ b/appsec/src/extension/ddappsec.c
@@ -476,9 +476,10 @@ static PHP_FUNCTION(datadog_appsec_testing_request_exec)
 
 static PHP_FUNCTION(datadog_appsec_push_address)
 {
-    struct timeval start, end;
+    struct timeval start;
+    struct timeval end;
     gettimeofday(&start, NULL);
-    int elapsed = 0;
+    long elapsed = 0;
     UNUSED(return_value);
     if (!DDAPPSEC_G(active)) {
         mlog(dd_log_debug, "Trying to access to push_address "
@@ -516,9 +517,13 @@ static PHP_FUNCTION(datadog_appsec_push_address)
 
     if (rasp && (res == dd_should_block || res == dd_should_redirect)) {
         gettimeofday(&end, NULL);
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
         elapsed = ((end.tv_sec - start.tv_sec) * 1000000) +
                   (end.tv_usec - start.tv_usec);
-        dd_tags_add_rasp_duration_ext(dd_trace_get_active_root_span(), elapsed);
+        zend_object *span = dd_trace_get_active_root_span();
+        if (span) {
+            dd_tags_add_rasp_duration_ext(span, elapsed);
+        }
     }
 
     if (dd_req_is_user_req()) {
@@ -535,9 +540,13 @@ static PHP_FUNCTION(datadog_appsec_push_address)
 
     if (rasp && elapsed == 0) {
         gettimeofday(&end, NULL);
+        // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
         elapsed = ((end.tv_sec - start.tv_sec) * 1000000) +
                   (end.tv_usec - start.tv_usec);
-        dd_tags_add_rasp_duration_ext(dd_trace_get_active_root_span(), elapsed);
+        zend_object *span = dd_trace_get_active_root_span();
+        if (span) {
+            dd_tags_add_rasp_duration_ext(span, elapsed);
+        }
     }
 }
 

--- a/appsec/src/extension/ddappsec.c
+++ b/appsec/src/extension/ddappsec.c
@@ -515,7 +515,7 @@ static PHP_FUNCTION(datadog_appsec_push_address)
     dd_result res = dd_request_exec(conn, &parameters_zv, rasp);
     zval_ptr_dtor(&parameters_zv);
 
-    if (rasp && (res == dd_should_block || res == dd_should_redirect)) {
+    if (rasp) {
         clock_gettime(CLOCK_MONOTONIC_RAW, &end);
         elapsed =
             ((int64_t)end.tv_sec - (int64_t)start.tv_sec) *
@@ -537,19 +537,6 @@ static PHP_FUNCTION(datadog_appsec_push_address)
             dd_request_abort_static_page();
         } else if (res == dd_should_redirect) {
             dd_request_abort_redirect();
-        }
-    }
-
-    if (rasp && elapsed == 0) {
-        clock_gettime(CLOCK_MONOTONIC_RAW, &end);
-        elapsed =
-            ((int64_t)end.tv_sec - (int64_t)start.tv_sec) *
-                // NOLINTNEXTLINE(cppcoreguidelines-avoid-magic-numbers,readability-magic-numbers)
-                (int64_t)1000000000 +
-            ((int64_t)end.tv_nsec - (int64_t)start.tv_nsec);
-        zend_object *span = dd_trace_get_active_root_span();
-        if (span) {
-            dd_tags_add_rasp_duration_ext(span, elapsed);
         }
     }
 }

--- a/appsec/src/extension/ddappsec.c
+++ b/appsec/src/extension/ddappsec.c
@@ -476,6 +476,8 @@ static PHP_FUNCTION(datadog_appsec_testing_request_exec)
 
 static PHP_FUNCTION(datadog_appsec_push_address)
 {
+    struct timeval start, end;
+    gettimeofday(&start, NULL);
     UNUSED(return_value);
     if (!DDAPPSEC_G(active)) {
         mlog(dd_log_debug, "Trying to access to push_address "
@@ -521,6 +523,13 @@ static PHP_FUNCTION(datadog_appsec_push_address)
         } else if (res == dd_should_redirect) {
             dd_request_abort_redirect();
         }
+    }
+
+    if (rasp) {
+        gettimeofday(&end, NULL);
+        int elapsed = ((end.tv_sec - start.tv_sec) * 1000000) +
+                      (end.tv_usec - start.tv_usec);
+        dd_tags_add_rasp_duration_ext(dd_trace_get_active_root_span(), elapsed);
     }
 }
 

--- a/appsec/src/extension/tags.c
+++ b/appsec/src/extension/tags.c
@@ -303,7 +303,7 @@ void dd_tags_set_event_user_id(zend_string *nonnull zstr)
     _event_user_id = zend_string_copy(zstr);
 }
 
-void dd_tags_add_rasp_duration_ext(zend_object *nonnull span, int duration)
+void dd_tags_add_rasp_duration_ext(zend_object *nonnull span, long duration)
 {
     zval *metrics_zv = dd_trace_span_get_metrics(span);
     if (!metrics_zv) {

--- a/appsec/src/extension/tags.c
+++ b/appsec/src/extension/tags.c
@@ -303,7 +303,8 @@ void dd_tags_set_event_user_id(zend_string *nonnull zstr)
     _event_user_id = zend_string_copy(zstr);
 }
 
-void dd_tags_add_rasp_duration_ext(zend_object *nonnull span, long duration)
+void dd_tags_add_rasp_duration_ext(
+    zend_object *nonnull span, zend_long duration)
 {
     zval *metrics_zv = dd_trace_span_get_metrics(span);
     if (!metrics_zv) {

--- a/appsec/src/extension/tags.c
+++ b/appsec/src/extension/tags.c
@@ -60,6 +60,7 @@
     "_dd.appsec.events.users.login.success.sdk"
 #define DD_EVENTS_USER_LOGIN_FAILURE_SDK                                       \
     "_dd.appsec.events.users.login.failure.sdk"
+#define DD_EVENTS_RASP_DURATION_EXT "_dd.appsec.rasp.duration_ext"
 
 static zend_string *_dd_tag_data_zstr;
 static zend_string *_dd_tag_event_zstr;
@@ -78,6 +79,7 @@ static zend_string *_dd_tag_rh_content_encoding; // response
 static zend_string *_dd_tag_rh_content_language; // response
 static zend_string *_dd_tag_user_id;
 static zend_string *_dd_metric_enabled;
+static zend_string *_dd_rasp_duration_ext;
 static zend_string *_dd_signup_event;
 static zend_string *_dd_login_success_event;
 static zend_string *_dd_login_failure_event;
@@ -172,6 +174,9 @@ void dd_tags_startup()
     _key_https_zstr = zend_string_init_interned(LSTRARG("HTTPS"), 1);
     _key_remote_addr_zstr =
         zend_string_init_interned(LSTRARG("REMOTE_ADDR"), 1);
+
+    _dd_rasp_duration_ext =
+        zend_string_init_interned(LSTRARG(DD_EVENTS_RASP_DURATION_EXT), 1);
 
     // Event related strings
     _track_zstr =
@@ -296,6 +301,17 @@ void dd_tags_add_appsec_json_frag(zend_string *nonnull zstr)
 void dd_tags_set_event_user_id(zend_string *nonnull zstr)
 {
     _event_user_id = zend_string_copy(zstr);
+}
+
+void dd_tags_add_rasp_duration_ext(zend_object *nonnull span, int duration)
+{
+    zval *metrics_zv = dd_trace_span_get_metrics(span);
+    if (!metrics_zv) {
+        return;
+    }
+    zval zv;
+    ZVAL_LONG(&zv, duration);
+    zend_hash_add(Z_ARRVAL_P(metrics_zv), _dd_rasp_duration_ext, &zv);
 }
 
 void dd_tags_rshutdown()

--- a/appsec/src/extension/tags.h
+++ b/appsec/src/extension/tags.h
@@ -28,4 +28,5 @@ void dd_tags_set_event_user_id(zend_string *nonnull zstr);
 // does not increase the refcount on zstr
 void dd_tags_add_appsec_json_frag(zend_string *nonnull zstr);
 
-void dd_tags_add_rasp_duration_ext(zend_object *nonnull span, long duration);
+void dd_tags_add_rasp_duration_ext(
+    zend_object *nonnull span, zend_long duration);

--- a/appsec/src/extension/tags.h
+++ b/appsec/src/extension/tags.h
@@ -28,4 +28,4 @@ void dd_tags_set_event_user_id(zend_string *nonnull zstr);
 // does not increase the refcount on zstr
 void dd_tags_add_appsec_json_frag(zend_string *nonnull zstr);
 
-void dd_tags_add_rasp_duration_ext(zend_object *nonnull span, int duration);
+void dd_tags_add_rasp_duration_ext(zend_object *nonnull span, long duration);

--- a/appsec/src/extension/tags.h
+++ b/appsec/src/extension/tags.h
@@ -28,4 +28,4 @@ void dd_tags_set_event_user_id(zend_string *nonnull zstr);
 // does not increase the refcount on zstr
 void dd_tags_add_appsec_json_frag(zend_string *nonnull zstr);
 
-
+void dd_tags_add_rasp_duration_ext(zend_object *nonnull span, int duration);

--- a/appsec/src/extension/user_tracking.c
+++ b/appsec/src/extension/user_tracking.c
@@ -131,7 +131,7 @@ void dd_find_and_apply_verdict_for_user(zend_string *nonnull user_id)
     zend_hash_str_add_new(
         Z_ARRVAL(data_zv), "usr.id", sizeof("usr.id") - 1, &user_id_zv);
 
-    dd_result res = dd_request_exec(conn, &data_zv);
+    dd_result res = dd_request_exec(conn, &data_zv, false);
     zval_ptr_dtor(&data_zv);
 
     dd_tags_set_event_user_id(user_id);

--- a/appsec/src/helper/client.cpp
+++ b/appsec/src/helper/client.cpp
@@ -226,14 +226,14 @@ template <typename T> bool client::service_guard()
 
 template <typename T>
 std::shared_ptr<typename T::response> client::publish(
-    typename T::request &command)
+    typename T::request &command, bool rasp)
 {
     SPDLOG_DEBUG("received command {}", T::name);
 
     auto response = std::make_shared<typename T::response>();
     try {
         // NOLINTNEXTLINE(bugprone-unchecked-optional-access)
-        auto res = context_->publish(std::move(command.data));
+        auto res = context_->publish(std::move(command.data), rasp);
         if (res) {
             for (auto &act : res->actions) {
                 dds::network::action_struct new_action;
@@ -316,7 +316,7 @@ bool client::handle_command(network::request_exec::request &command)
         context_.emplace(*service_->get_engine());
     }
 
-    auto response = publish<network::request_exec>(command);
+    auto response = publish<network::request_exec>(command, command.rasp);
     return send_message<network::request_exec>(response);
 }
 

--- a/appsec/src/helper/client.hpp
+++ b/appsec/src/helper/client.hpp
@@ -65,7 +65,8 @@ public:
 
 protected:
     template <typename T>
-    std::shared_ptr<typename T::response> publish(typename T::request &command);
+    std::shared_ptr<typename T::response> publish(
+        typename T::request &command, bool rasp = false);
     template <typename T> bool service_guard();
     template <typename T, bool actions = true>
     bool send_message(const std::shared_ptr<typename T::response> &message);

--- a/appsec/src/helper/engine.cpp
+++ b/appsec/src/helper/engine.cpp
@@ -51,7 +51,8 @@ void engine::update(
     std::atomic_store_explicit(&common_, new_common, std::memory_order_release);
 }
 
-std::optional<engine::result> engine::context::publish(parameter &&param)
+std::optional<engine::result> engine::context::publish(
+    parameter &&param, bool rasp)
 {
     // Once the parameter reaches this function, it is guaranteed to be
     // owned by the engine.
@@ -82,7 +83,7 @@ std::optional<engine::result> engine::context::publish(parameter &&param)
         }
         try {
             const auto &listener = it->second;
-            listener->call(data, event_);
+            listener->call(data, event_, rasp);
         } catch (std::exception &e) {
             SPDLOG_ERROR("subscriber failed: {}", e.what());
         }

--- a/appsec/src/helper/engine.hpp
+++ b/appsec/src/helper/engine.hpp
@@ -66,7 +66,7 @@ public:
         context &operator=(context &&) = delete;
         ~context() = default;
 
-        std::optional<result> publish(parameter &&param);
+        std::optional<result> publish(parameter &&param, bool rasp = false);
         // NOLINTNEXTLINE(google-runtime-references)
         void get_metrics(metrics::telemetry_submitter &msubmitter);
 

--- a/appsec/src/helper/metrics.hpp
+++ b/appsec/src/helper/metrics.hpp
@@ -98,6 +98,11 @@ constexpr std::string_view event_rules_version =
 constexpr std::string_view waf_version = "_dd.appsec.waf.version";
 constexpr std::string_view waf_duration = "_dd.appsec.waf.duration";
 
+// rasp
+constexpr std::string_view rasp_duration = "_dd.appsec.rasp.duration";
+constexpr std::string_view rasp_rule_eval = "_dd.appsec.rasp.rule.eval";
+constexpr std::string_view rasp_timeout = "_dd.appsec.rasp.timeout";
+
 } // namespace dds::metrics
 
 template <>

--- a/appsec/src/helper/network/proto.hpp
+++ b/appsec/src/helper/network/proto.hpp
@@ -187,6 +187,7 @@ struct request_exec {
         static constexpr const char *name = request_exec::name;
         static constexpr request_id id = request_id::request_exec;
 
+        bool rasp = false;
         dds::parameter data;
 
         request() = default;
@@ -196,7 +197,7 @@ struct request_exec {
         request &operator=(request &&) = default;
         ~request() override = default;
 
-        MSGPACK_DEFINE(data)
+        MSGPACK_DEFINE(rasp, data)
     };
 
     struct response : base_response_generic<response> {

--- a/appsec/src/helper/remote_config/listeners/engine_listener.hpp
+++ b/appsec/src/helper/remote_config/listeners/engine_listener.hpp
@@ -34,7 +34,7 @@ public:
     [[nodiscard]] std::unordered_set<product> get_supported_products() override
     {
         return {known_products::ASM, known_products::ASM_DD,
-            known_products::ASM_DATA};
+            known_products::ASM_DATA, known_products::ASM_RASP_LFI};
     }
 
 protected:

--- a/appsec/src/helper/remote_config/product.hpp
+++ b/appsec/src/helper/remote_config/product.hpp
@@ -29,6 +29,8 @@ struct known_products {
     static inline constexpr product ASM_DATA{std::string_view{"ASM_DATA"}};
     static inline constexpr product ASM_FEATURES{
         std::string_view{"ASM_FEATURES"}};
+    static inline constexpr product ASM_RASP_LFI{
+        std::string_view{"ASM_RASP_LFI"}};
     static inline constexpr product UNKNOWN{std::string_view{"UNKOWN"}};
 
     static product for_name(std::string_view name)
@@ -44,6 +46,9 @@ struct known_products {
         }
         if (name == ASM_FEATURES.name()) {
             return ASM_FEATURES;
+        }
+        if (name == ASM_RASP_LFI.name()) {
+            return ASM_RASP_LFI;
         }
 
         return UNKNOWN;

--- a/appsec/src/helper/subscriber/base.hpp
+++ b/appsec/src/helper/subscriber/base.hpp
@@ -28,7 +28,8 @@ public:
 
         virtual ~listener() = default;
         // NOLINTNEXTLINE(google-runtime-references)
-        virtual void call(parameter_view &data, event &event) = 0;
+        virtual void call(
+            parameter_view &data, event &event, bool rasp = false) = 0;
 
         // NOLINTNEXTLINE(google-runtime-references)
         virtual void submit_metrics(

--- a/appsec/src/helper/subscriber/waf.cpp
+++ b/appsec/src/helper/subscriber/waf.cpp
@@ -413,10 +413,11 @@ void instance::listener::submit_metrics(
     msubmitter.submit_span_metric(metrics::waf_duration, total_runtime_);
 
     if (rasp_calls_ > 0) {
-        metrics[tag::rasp_duration] = rasp_runtime_;
-        metrics[tag::rasp_rule_eval] = rasp_calls_;
+        msubmitter.submit_span_metric(metrics::rasp_duration, rasp_runtime_);
+        msubmitter.submit_span_metric(metrics::rasp_rule_eval, rasp_calls_);
         if (rasp_timeouts_ > 0) {
-            metrics[tag::rasp_timeout] = rasp_timeouts_;
+            msubmitter.submit_span_metric(
+                metrics::rasp_timeout, rasp_timeouts_);
         }
     }
 

--- a/appsec/src/helper/subscriber/waf.cpp
+++ b/appsec/src/helper/subscriber/waf.cpp
@@ -347,6 +347,7 @@ void instance::listener::call(
         }
     }
     if (rasp) {
+        // NOLINTNEXTLINE
         rasp_runtime_ += res.total_runtime / 1000.0;
         rasp_calls_++;
         if (res.timeout) {

--- a/appsec/src/helper/subscriber/waf.hpp
+++ b/appsec/src/helper/subscriber/waf.hpp
@@ -36,7 +36,8 @@ public:
         listener &operator=(listener &&) noexcept;
         ~listener() override;
 
-        void call(dds::parameter_view &data, event &event) override;
+        void call(dds::parameter_view &data, event &event,
+            bool rasp = false) override;
 
         // NOLINTNEXTLINE(google-runtime-references)
         void submit_metrics(metrics::telemetry_submitter &msubmitter) override;
@@ -46,6 +47,8 @@ public:
         std::chrono::microseconds waf_timeout_;
         double total_runtime_{0.0};
         std::string ruleset_version_;
+        bool rasp_request_ = false;
+        double rasp_runtime_{0.0};
         std::map<std::string, std::string> derivatives_;
         metrics::telemetry_tags base_tags_;
         bool rule_triggered_{};

--- a/appsec/src/helper/subscriber/waf.hpp
+++ b/appsec/src/helper/subscriber/waf.hpp
@@ -36,8 +36,7 @@ public:
         listener &operator=(listener &&) noexcept;
         ~listener() override;
 
-        void call(dds::parameter_view &data, event &event,
-            bool rasp = false) override;
+        void call(dds::parameter_view &data, event &event, bool rasp) override;
 
         // NOLINTNEXTLINE(google-runtime-references)
         void submit_metrics(metrics::telemetry_submitter &msubmitter) override;

--- a/appsec/src/helper/subscriber/waf.hpp
+++ b/appsec/src/helper/subscriber/waf.hpp
@@ -49,6 +49,8 @@ public:
         std::string ruleset_version_;
         bool rasp_request_ = false;
         double rasp_runtime_{0.0};
+        unsigned rasp_calls_{0};
+        unsigned rasp_timeouts_{0};
         std::map<std::string, std::string> derivatives_;
         metrics::telemetry_tags base_tags_;
         bool rule_triggered_{};

--- a/appsec/src/helper/tags.hpp
+++ b/appsec/src/helper/tags.hpp
@@ -19,5 +19,6 @@ constexpr std::string_view event_rules_version =
 
 constexpr std::string_view waf_version = "_dd.appsec.waf.version";
 constexpr std::string_view waf_duration = "_dd.appsec.waf.duration";
+constexpr std::string_view rasp_duration = "_dd.appsec.rasp.duration";
 
 } // namespace dds::tag

--- a/appsec/src/helper/tags.hpp
+++ b/appsec/src/helper/tags.hpp
@@ -20,5 +20,7 @@ constexpr std::string_view event_rules_version =
 constexpr std::string_view waf_version = "_dd.appsec.waf.version";
 constexpr std::string_view waf_duration = "_dd.appsec.waf.duration";
 constexpr std::string_view rasp_duration = "_dd.appsec.rasp.duration";
+constexpr std::string_view rasp_rule_eval = "_dd.appsec.rasp.rule.eval";
+constexpr std::string_view rasp_timeout = "_dd.appsec.rasp.timeout";
 
 } // namespace dds::tag

--- a/appsec/src/helper/tags.hpp
+++ b/appsec/src/helper/tags.hpp
@@ -19,8 +19,5 @@ constexpr std::string_view event_rules_version =
 
 constexpr std::string_view waf_version = "_dd.appsec.waf.version";
 constexpr std::string_view waf_duration = "_dd.appsec.waf.duration";
-constexpr std::string_view rasp_duration = "_dd.appsec.rasp.duration";
-constexpr std::string_view rasp_rule_eval = "_dd.appsec.rasp.rule.eval";
-constexpr std::string_view rasp_timeout = "_dd.appsec.rasp.timeout";
 
 } // namespace dds::tag

--- a/appsec/tests/extension/actions_handling_01.phpt
+++ b/appsec/tests/extension/actions_handling_01.phpt
@@ -30,8 +30,10 @@ array(2) {
   [0]=>
   string(12) "request_exec"
   [1]=>
-  array(1) {
+  array(2) {
     [0]=>
+    bool(false)
+    [1]=>
     array(1) {
       ["server.request.path_params"]=>
       array(2) {

--- a/appsec/tests/extension/push_params_ok_01.phpt
+++ b/appsec/tests/extension/push_params_ok_01.phpt
@@ -30,8 +30,10 @@ array(2) {
   [0]=>
   string(12) "request_exec"
   [1]=>
-  array(1) {
+  array(2) {
     [0]=>
+    bool(false)
+    [1]=>
     array(1) {
       ["server.request.path_params"]=>
       array(2) {

--- a/appsec/tests/extension/push_params_ok_02.phpt
+++ b/appsec/tests/extension/push_params_ok_02.phpt
@@ -30,8 +30,10 @@ array(2) {
   [0]=>
   string(12) "request_exec"
   [1]=>
-  array(1) {
+  array(2) {
     [0]=>
+    bool(false)
+    [1]=>
     array(1) {
       ["server.request.path_params"]=>
       string(11) "some string"

--- a/appsec/tests/extension/push_params_ok_03.phpt
+++ b/appsec/tests/extension/push_params_ok_03.phpt
@@ -30,8 +30,10 @@ array(2) {
   [0]=>
   string(12) "request_exec"
   [1]=>
-  array(1) {
+  array(2) {
     [0]=>
+    bool(false)
+    [1]=>
     array(1) {
       ["server.request.path_params"]=>
       int(1234)

--- a/appsec/tests/extension/push_params_ok_04.phpt
+++ b/appsec/tests/extension/push_params_ok_04.phpt
@@ -5,7 +5,7 @@ extension=ddtrace.so
 datadog.appsec.enabled=1
 --FILE--
 <?php
-use function datadog\appsec\testing\{rinit,rshutdown};
+use function datadog\appsec\testing\{rinit,rshutdown, root_span_get_metrics};
 use function datadog\appsec\push_address;
 
 include __DIR__ . '/inc/mock_helper.php';
@@ -20,6 +20,7 @@ var_dump(rinit());
 $is_rasp = true;
 push_address("server.request.path_params", 1234, $is_rasp);
 var_dump(rshutdown());
+print_r(root_span_get_metrics());
 
 var_dump($helper->get_command("request_exec"));
 
@@ -27,6 +28,12 @@ var_dump($helper->get_command("request_exec"));
 --EXPECTF--
 bool(true)
 bool(true)
+Array
+(
+    [process_id] => %d
+    [_dd.appsec.rasp.duration_ext] => %d
+    [_dd.appsec.enabled] => %d
+)
 array(2) {
   [0]=>
   string(12) "request_exec"

--- a/appsec/tests/extension/push_params_ok_04.phpt
+++ b/appsec/tests/extension/push_params_ok_04.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Some addresses are rasp requests
+--INI--
+extension=ddtrace.so
+datadog.appsec.enabled=1
+--FILE--
+<?php
+use function datadog\appsec\testing\{rinit,rshutdown};
+use function datadog\appsec\push_address;
+
+include __DIR__ . '/inc/mock_helper.php';
+
+$helper = Helper::createInitedRun([
+    response_list(response_request_init([[['ok', []]]])),
+    response_list(response_request_exec([[['ok', []]], [], [], [], false])),
+    response_list(response_request_shutdown([[['ok', []]], new ArrayObject(), new ArrayObject()]))
+]);
+
+var_dump(rinit());
+$is_rasp = true;
+push_address("server.request.path_params", 1234, $is_rasp);
+var_dump(rshutdown());
+
+var_dump($helper->get_command("request_exec"));
+
+?>
+--EXPECTF--
+bool(true)
+bool(true)
+array(2) {
+  [0]=>
+  string(12) "request_exec"
+  [1]=>
+  array(2) {
+    [0]=>
+    bool(true)
+    [1]=>
+    array(1) {
+      ["server.request.path_params"]=>
+      int(1234)
+    }
+  }
+}

--- a/appsec/tests/extension/push_params_ok_05.phpt
+++ b/appsec/tests/extension/push_params_ok_05.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Rasp addresses are not sent to the helper if RASP disabled
+--INI--
+extension=ddtrace.so
+datadog.appsec.enabled=1
+--ENV--
+DD_APPSEC_RASP_ENABLED=false
+--FILE--
+<?php
+use function datadog\appsec\testing\{rinit,rshutdown};
+use function datadog\appsec\push_address;
+
+include __DIR__ . '/inc/mock_helper.php';
+
+$helper = Helper::createInitedRun([
+    response_list(response_request_init([[['ok', []]]])),
+    response_list(response_request_shutdown([[['ok', []]], new ArrayObject(), new ArrayObject()]))
+]);
+
+var_dump(rinit());
+$is_rasp = true;
+push_address("server.request.path_params", 1234, $is_rasp);
+var_dump(rshutdown());
+
+var_dump($helper->get_command("request_exec"));
+
+?>
+--EXPECTF--
+bool(true)
+bool(true)
+array(0) {
+}

--- a/appsec/tests/extension/push_params_ok_05.phpt
+++ b/appsec/tests/extension/push_params_ok_05.phpt
@@ -7,7 +7,7 @@ datadog.appsec.enabled=1
 DD_APPSEC_RASP_ENABLED=false
 --FILE--
 <?php
-use function datadog\appsec\testing\{rinit,rshutdown};
+use function datadog\appsec\testing\{rinit,rshutdown,root_span_get_metrics};
 use function datadog\appsec\push_address;
 
 include __DIR__ . '/inc/mock_helper.php';
@@ -21,6 +21,7 @@ var_dump(rinit());
 $is_rasp = true;
 push_address("server.request.path_params", 1234, $is_rasp);
 var_dump(rshutdown());
+print_r(root_span_get_metrics());
 
 var_dump($helper->get_command("request_exec"));
 
@@ -28,5 +29,10 @@ var_dump($helper->get_command("request_exec"));
 --EXPECTF--
 bool(true)
 bool(true)
+Array
+(
+    [process_id] => %d
+    [_dd.appsec.enabled] => %d
+)
 array(0) {
 }

--- a/appsec/tests/extension/push_params_ok_06.phpt
+++ b/appsec/tests/extension/push_params_ok_06.phpt
@@ -1,19 +1,17 @@
 --TEST--
-Some addresses are rasp requests when rasp enabled
+Rasp addresses are not sent to the helper if RASP disabled. Rasp disabled by default
 --INI--
 extension=ddtrace.so
 datadog.appsec.enabled=1
-datadog.appsec.rasp_enabled=1
 --FILE--
 <?php
-use function datadog\appsec\testing\{rinit,rshutdown, root_span_get_metrics};
+use function datadog\appsec\testing\{rinit,rshutdown,root_span_get_metrics};
 use function datadog\appsec\push_address;
 
 include __DIR__ . '/inc/mock_helper.php';
 
 $helper = Helper::createInitedRun([
     response_list(response_request_init([[['ok', []]]])),
-    response_list(response_request_exec([[['ok', []]], [], [], [], false])),
     response_list(response_request_shutdown([[['ok', []]], new ArrayObject(), new ArrayObject()]))
 ]);
 
@@ -32,20 +30,7 @@ bool(true)
 Array
 (
     [process_id] => %d
-    [_dd.appsec.rasp.duration_ext] => %d
     [_dd.appsec.enabled] => %d
 )
-array(2) {
-  [0]=>
-  string(12) "request_exec"
-  [1]=>
-  array(2) {
-    [0]=>
-    bool(true)
-    [1]=>
-    array(1) {
-      ["server.request.path_params"]=>
-      int(1234)
-    }
-  }
+array(0) {
 }

--- a/appsec/tests/extension/request_exec.phpt
+++ b/appsec/tests/extension/request_exec.phpt
@@ -45,8 +45,10 @@ array(2) {
   [0]=>
   string(12) "request_exec"
   [1]=>
-  array(1) {
+  array(2) {
     [0]=>
+    bool(false)
+    [1]=>
     array(3) {
       ["key 01"]=>
       string(10) "some value"

--- a/appsec/tests/extension/user_tracking_do_nothing_from_login_success.phpt
+++ b/appsec/tests/extension/user_tracking_do_nothing_from_login_success.phpt
@@ -32,7 +32,7 @@ track_user_login_success_event("Admin",
 
 $c = $helper->get_commands();
 echo "usr.id:\n";
-var_dump($c[0][1][0]['usr.id']);
+var_dump($c[0][1][1]['usr.id']);
 
 echo "root_span_get_meta():\n";
 print_r(root_span_get_meta());

--- a/appsec/tests/extension/user_tracking_do_nothing_from_set_user.phpt
+++ b/appsec/tests/extension/user_tracking_do_nothing_from_set_user.phpt
@@ -30,7 +30,7 @@ DDTrace\set_user("Admin",
 
 $c = $helper->get_commands();
 echo "usr.id:\n";
-var_dump($c[0][1][0]['usr.id']);
+var_dump($c[0][1][1]['usr.id']);
 
 echo "root_span_get_meta():\n";
 print_r(root_span_get_meta());

--- a/appsec/tests/helper/client_test.cpp
+++ b/appsec/tests/helper/client_test.cpp
@@ -2687,7 +2687,7 @@ TEST(ClientTest, SchemasOverTheLimitAreCompressed)
     }
 }
 
-TEST(ClientTest, RaspDuration)
+TEST(ClientTest, RaspCalls)
 {
     auto smanager = std::make_shared<service_manager>();
     auto broker = new mock::broker();
@@ -2759,9 +2759,10 @@ TEST(ClientTest, RaspDuration)
         auto msg_res =
             dynamic_cast<network::request_shutdown::response *>(res.get());
 
-        EXPECT_EQ(msg_res->metrics.size(), 2);
+        EXPECT_EQ(msg_res->metrics.size(), 3);
         EXPECT_GT(msg_res->metrics[tag::waf_duration], 0.0);
-        EXPECT_GT(msg_res->metrics[tag::rasp_duration], 0.0);
+        EXPECT_EQ(msg_res->metrics[tag::rasp_rule_eval], 1);
+        EXPECT_GE(msg_res->metrics[tag::rasp_duration], 0.0);
     }
 }
 

--- a/appsec/tests/helper/client_test.cpp
+++ b/appsec/tests/helper/client_test.cpp
@@ -2717,7 +2717,7 @@ TEST(ClientTest, RaspCalls)
             dynamic_cast<network::request_shutdown::response *>(res.get());
 
         EXPECT_EQ(msg_res->metrics.size(), 1);
-        EXPECT_GT(msg_res->metrics[tag::waf_duration], 0.0);
+        EXPECT_GT(msg_res->metrics[metrics::waf_duration], 0.0);
     }
 
     // Rasp during request
@@ -2760,9 +2760,9 @@ TEST(ClientTest, RaspCalls)
             dynamic_cast<network::request_shutdown::response *>(res.get());
 
         EXPECT_EQ(msg_res->metrics.size(), 3);
-        EXPECT_GT(msg_res->metrics[tag::waf_duration], 0.0);
-        EXPECT_EQ(msg_res->metrics[tag::rasp_rule_eval], 1);
-        EXPECT_GE(msg_res->metrics[tag::rasp_duration], 0.0);
+        EXPECT_GT(msg_res->metrics[metrics::waf_duration], 0.0);
+        EXPECT_EQ(msg_res->metrics[metrics::rasp_rule_eval], 1);
+        EXPECT_GE(msg_res->metrics[metrics::rasp_duration], 0.0);
     }
 }
 

--- a/appsec/tests/helper/client_test.cpp
+++ b/appsec/tests/helper/client_test.cpp
@@ -2687,4 +2687,82 @@ TEST(ClientTest, SchemasOverTheLimitAreCompressed)
     }
 }
 
+TEST(ClientTest, RaspDuration)
+{
+    auto smanager = std::make_shared<service_manager>();
+    auto broker = new mock::broker();
+
+    client c(smanager, std::unique_ptr<mock::broker>(broker));
+
+    set_extension_configuration_to(broker, c, EXTENSION_CONFIGURATION_ENABLED);
+
+    // No Rasp during request
+    {
+        request_init(broker, c);
+        network::request_shutdown::request msg;
+        msg.data = parameter::map();
+        msg.data.add("server.response.code", parameter::string("1991"sv));
+
+        network::request req(std::move(msg));
+
+        std::shared_ptr<network::base_response> res;
+        EXPECT_CALL(*broker, recv(_)).WillOnce(Return(req));
+        EXPECT_CALL(*broker,
+            send(
+                testing::An<const std::shared_ptr<network::base_response> &>()))
+            .WillOnce(DoAll(testing::SaveArg<0>(&res), Return(true)));
+
+        EXPECT_TRUE(c.run_request());
+        auto msg_res =
+            dynamic_cast<network::request_shutdown::response *>(res.get());
+
+        EXPECT_EQ(msg_res->metrics.size(), 1);
+        EXPECT_GT(msg_res->metrics[tag::waf_duration], 0.0);
+    }
+
+    // Rasp during request
+    {
+        request_init(broker, c);
+
+        // Request Execution
+        {
+            network::request_exec::request msg;
+
+            msg.rasp = true;
+            msg.data = parameter::map();
+
+            network::request req(std::move(msg));
+
+            std::shared_ptr<network::base_response> res;
+            EXPECT_CALL(*broker, recv(_)).WillOnce(Return(req));
+            EXPECT_CALL(*broker,
+                send(testing::An<
+                    const std::shared_ptr<network::base_response> &>()))
+                .WillOnce(DoAll(Return(true)));
+
+            EXPECT_TRUE(c.run_request());
+        }
+
+        network::request_shutdown::request msg;
+        msg.data = parameter::map();
+
+        network::request req(std::move(msg));
+
+        std::shared_ptr<network::base_response> res;
+        EXPECT_CALL(*broker, recv(_)).WillOnce(Return(req));
+        EXPECT_CALL(*broker,
+            send(
+                testing::An<const std::shared_ptr<network::base_response> &>()))
+            .WillOnce(DoAll(testing::SaveArg<0>(&res), Return(true)));
+
+        EXPECT_TRUE(c.run_request());
+        auto msg_res =
+            dynamic_cast<network::request_shutdown::response *>(res.get());
+
+        EXPECT_EQ(msg_res->metrics.size(), 2);
+        EXPECT_GT(msg_res->metrics[tag::waf_duration], 0.0);
+        EXPECT_GT(msg_res->metrics[tag::rasp_duration], 0.0);
+    }
+}
+
 } // namespace dds

--- a/appsec/tests/helper/engine_test.cpp
+++ b/appsec/tests/helper/engine_test.cpp
@@ -72,10 +72,10 @@ TEST(EngineTest, SingleSubscriptor)
     EXPECT_CALL(*sub, get_listener()).WillRepeatedly(Invoke([]() {
         auto listener = std::make_unique<mock::listener>();
         EXPECT_CALL(*listener, call(_, _, _))
-            .WillRepeatedly(Invoke(
-                [](dds::parameter_view &data, dds::event &event_, bool rasp) -> void {
-                    event_.actions.push_back({dds::action_type::block, {}});
-                }));
+            .WillRepeatedly(Invoke([](dds::parameter_view &data,
+                                       dds::event &event_, bool rasp) -> void {
+                event_.actions.push_back({dds::action_type::block, {}});
+            }));
         return listener;
     }));
 
@@ -104,24 +104,24 @@ TEST(EngineTest, MultipleSubscriptors)
 
     auto blocker = std::make_unique<mock::listener>();
     EXPECT_CALL(*blocker, call(_, _, _))
-        .WillRepeatedly(
-            Invoke([](dds::parameter_view &data, dds::event &event_, bool rasp) -> void {
-                std::unordered_set<std::string_view> subs{"a", "b", "e", "f"};
-                if (subs.find(data[0].parameterName) != subs.end()) {
-                    event_.data.push_back("some event");
-                    event_.actions.push_back({dds::action_type::block, {}});
-                }
-            }));
+        .WillRepeatedly(Invoke([](dds::parameter_view &data, dds::event &event_,
+                                   bool rasp) -> void {
+            std::unordered_set<std::string_view> subs{"a", "b", "e", "f"};
+            if (subs.find(data[0].parameterName) != subs.end()) {
+                event_.data.push_back("some event");
+                event_.actions.push_back({dds::action_type::block, {}});
+            }
+        }));
 
     auto recorder = std::make_unique<mock::listener>();
     EXPECT_CALL(*recorder, call(_, _, _))
-        .WillRepeatedly(
-            Invoke([](dds::parameter_view &data, dds::event &event_, bool rasp) -> void {
-                std::unordered_set<std::string_view> subs{"c", "d", "e", "g"};
-                if (subs.find(data[0].parameterName) != subs.end()) {
-                    event_.data.push_back("some event");
-                }
-            }));
+        .WillRepeatedly(Invoke([](dds::parameter_view &data, dds::event &event_,
+                                   bool rasp) -> void {
+            std::unordered_set<std::string_view> subs{"c", "d", "e", "g"};
+            if (subs.find(data[0].parameterName) != subs.end()) {
+                event_.data.push_back("some event");
+            }
+        }));
 
     std::unique_ptr<mock::listener> ignorer =
         std::unique_ptr<mock::listener>(new mock::listener());
@@ -280,8 +280,8 @@ TEST(EngineTest, WafDefaultActions)
 
     auto listener = std::make_unique<mock::listener>();
     EXPECT_CALL(*listener, call(_, _, _))
-        .WillRepeatedly(Invoke([](dds::parameter_view &data,
-                                   dds::event &event_, bool rasp) -> void {
+        .WillRepeatedly(Invoke([](dds::parameter_view &data, dds::event &event_,
+                                   bool rasp) -> void {
             event_.actions.push_back({dds::action_type::redirect, {}});
             event_.actions.push_back({dds::action_type::block, {}});
             event_.actions.push_back({dds::action_type::stack_trace, {}});
@@ -324,11 +324,11 @@ TEST(EngineTest, InvalidActionsAreDiscarded)
 
     auto listener = std::make_unique<mock::listener>();
     EXPECT_CALL(*listener, call(_, _, _))
-        .WillRepeatedly(
-            Invoke([](dds::parameter_view &data, dds::event &event_, bool rasp) -> void {
-                event_.actions.push_back({dds::action_type::invalid, {}});
-                event_.actions.push_back({dds::action_type::block, {}});
-            }));
+        .WillRepeatedly(Invoke([](dds::parameter_view &data, dds::event &event_,
+                                   bool rasp) -> void {
+            event_.actions.push_back({dds::action_type::invalid, {}});
+            event_.actions.push_back({dds::action_type::block, {}});
+        }));
 
     auto sub = std::make_unique<mock::subscriber>();
     EXPECT_CALL(*sub, get_listener()).WillOnce(Invoke([&]() {
@@ -935,10 +935,10 @@ TEST(EngineTest, RateLimiterForceKeep)
 
     auto listener = std::make_unique<mock::listener>();
     EXPECT_CALL(*listener, call(_, _, _))
-        .WillRepeatedly(
-            Invoke([](dds::parameter_view &data, dds::event &event_, bool rasp) -> void {
-                event_.actions.push_back({dds::action_type::redirect, {}});
-            }));
+        .WillRepeatedly(Invoke([](dds::parameter_view &data, dds::event &event_,
+                                   bool rasp) -> void {
+            event_.actions.push_back({dds::action_type::redirect, {}});
+        }));
 
     auto sub = std::make_unique<mock::subscriber>();
     EXPECT_CALL(*sub, get_listener()).WillOnce(Invoke([&]() {
@@ -963,10 +963,10 @@ TEST(EngineTest, RateLimiterDoNotForceKeep)
     EXPECT_CALL(*sub, get_listener()).WillRepeatedly(Invoke([&]() {
         auto listener = std::make_unique<mock::listener>();
         EXPECT_CALL(*listener, call(_, _, _))
-            .WillOnce(Invoke(
-                [](dds::parameter_view &data, dds::event &event_, bool rasp) -> void {
-                    event_.actions.push_back({dds::action_type::redirect, {}});
-                }));
+            .WillOnce(Invoke([](dds::parameter_view &data, dds::event &event_,
+                                 bool rasp) -> void {
+                event_.actions.push_back({dds::action_type::redirect, {}});
+            }));
         return listener;
     }));
 

--- a/appsec/tests/helper/engine_test.cpp
+++ b/appsec/tests/helper/engine_test.cpp
@@ -24,8 +24,11 @@ namespace dds {
 namespace mock {
 class listener : public dds::subscriber::listener {
 public:
-    MOCK_METHOD2(call, void(dds::parameter_view &, dds::event &));
     MOCK_METHOD1(submit_metrics, void(metrics::telemetry_submitter &));
+    MOCK_METHOD3(call, void(dds::parameter_view &, dds::event &, bool));
+    MOCK_METHOD2(
+        get_meta_and_metrics, void(std::map<std::string, std::string> &,
+                                  std::map<std::string_view, double> &));
 };
 
 class subscriber : public dds::subscriber {
@@ -68,9 +71,9 @@ TEST(EngineTest, SingleSubscriptor)
     auto sub = std::make_unique<mock::subscriber>();
     EXPECT_CALL(*sub, get_listener()).WillRepeatedly(Invoke([]() {
         auto listener = std::make_unique<mock::listener>();
-        EXPECT_CALL(*listener, call(_, _))
+        EXPECT_CALL(*listener, call(_, _, _))
             .WillRepeatedly(Invoke(
-                [](dds::parameter_view &data, dds::event &event_) -> void {
+                [](dds::parameter_view &data, dds::event &event_, bool rasp) -> void {
                     event_.actions.push_back({dds::action_type::block, {}});
                 }));
         return listener;
@@ -100,9 +103,9 @@ TEST(EngineTest, MultipleSubscriptors)
     auto e{engine::create()};
 
     auto blocker = std::make_unique<mock::listener>();
-    EXPECT_CALL(*blocker, call(_, _))
+    EXPECT_CALL(*blocker, call(_, _, _))
         .WillRepeatedly(
-            Invoke([](dds::parameter_view &data, dds::event &event_) -> void {
+            Invoke([](dds::parameter_view &data, dds::event &event_, bool rasp) -> void {
                 std::unordered_set<std::string_view> subs{"a", "b", "e", "f"};
                 if (subs.find(data[0].parameterName) != subs.end()) {
                     event_.data.push_back("some event");
@@ -111,9 +114,9 @@ TEST(EngineTest, MultipleSubscriptors)
             }));
 
     auto recorder = std::make_unique<mock::listener>();
-    EXPECT_CALL(*recorder, call(_, _))
+    EXPECT_CALL(*recorder, call(_, _, _))
         .WillRepeatedly(
-            Invoke([](dds::parameter_view &data, dds::event &event_) -> void {
+            Invoke([](dds::parameter_view &data, dds::event &event_, bool rasp) -> void {
                 std::unordered_set<std::string_view> subs{"c", "d", "e", "g"};
                 if (subs.find(data[0].parameterName) != subs.end()) {
                     event_.data.push_back("some event");
@@ -122,7 +125,7 @@ TEST(EngineTest, MultipleSubscriptors)
 
     std::unique_ptr<mock::listener> ignorer =
         std::unique_ptr<mock::listener>(new mock::listener());
-    EXPECT_CALL(*ignorer, call(_, _)).Times(testing::AnyNumber());
+    EXPECT_CALL(*ignorer, call(_, _, _)).Times(testing::AnyNumber());
 
     std::unique_ptr<mock::subscriber> sub1 =
         std::unique_ptr<mock::subscriber>(new mock::subscriber());
@@ -220,10 +223,10 @@ TEST(EngineTest, StatefulSubscriptor)
     auto sub = std::make_unique<mock::subscriber>();
     EXPECT_CALL(*sub, get_listener()).WillRepeatedly(Invoke([&]() {
         auto listener = std::make_unique<mock::listener>();
-        EXPECT_CALL(*listener, call(_, _))
+        EXPECT_CALL(*listener, call(_, _, _))
             .Times(3)
             .WillRepeatedly(Invoke([&attempt](dds::parameter_view &data,
-                                       dds::event &event_) -> void {
+                                       dds::event &event_, bool rasp) -> void {
                 if (attempt == 2 || attempt == 5) {
                     event_.actions.push_back({dds::action_type::block, {}});
                 }
@@ -276,9 +279,9 @@ TEST(EngineTest, WafDefaultActions)
     auto e{engine::create(engine_settings::default_trace_rate_limit)};
 
     auto listener = std::make_unique<mock::listener>();
-    EXPECT_CALL(*listener, call(_, _))
+    EXPECT_CALL(*listener, call(_, _, _))
         .WillRepeatedly(Invoke([](dds::parameter_view &data,
-                                   dds::event &event_) -> void {
+                                   dds::event &event_, bool rasp) -> void {
             event_.actions.push_back({dds::action_type::redirect, {}});
             event_.actions.push_back({dds::action_type::block, {}});
             event_.actions.push_back({dds::action_type::stack_trace, {}});
@@ -320,9 +323,9 @@ TEST(EngineTest, InvalidActionsAreDiscarded)
     auto e{engine::create(engine_settings::default_trace_rate_limit)};
 
     auto listener = std::make_unique<mock::listener>();
-    EXPECT_CALL(*listener, call(_, _))
+    EXPECT_CALL(*listener, call(_, _, _))
         .WillRepeatedly(
-            Invoke([](dds::parameter_view &data, dds::event &event_) -> void {
+            Invoke([](dds::parameter_view &data, dds::event &event_, bool rasp) -> void {
                 event_.actions.push_back({dds::action_type::invalid, {}});
                 event_.actions.push_back({dds::action_type::block, {}});
             }));
@@ -429,7 +432,7 @@ TEST(EngineTest, MockSubscriptorsUpdateRuleData)
 
     auto ignorer = []() {
         auto listener = std::make_unique<mock::listener>();
-        EXPECT_CALL(*listener, call(_, _)).Times(testing::AnyNumber());
+        EXPECT_CALL(*listener, call(_, _, _)).Times(testing::AnyNumber());
         return listener;
     };
 
@@ -479,7 +482,7 @@ TEST(EngineTest, MockSubscriptorsInvalidRuleData)
 
     auto ignorer = []() {
         auto listener = std::make_unique<mock::listener>();
-        EXPECT_CALL(*listener, call(_, _)).Times(testing::AnyNumber());
+        EXPECT_CALL(*listener, call(_, _, _)).Times(testing::AnyNumber());
         return listener;
     };
 
@@ -931,9 +934,9 @@ TEST(EngineTest, RateLimiterForceKeep)
     auto e{engine::create(rate_limit)};
 
     auto listener = std::make_unique<mock::listener>();
-    EXPECT_CALL(*listener, call(_, _))
+    EXPECT_CALL(*listener, call(_, _, _))
         .WillRepeatedly(
-            Invoke([](dds::parameter_view &data, dds::event &event_) -> void {
+            Invoke([](dds::parameter_view &data, dds::event &event_, bool rasp) -> void {
                 event_.actions.push_back({dds::action_type::redirect, {}});
             }));
 
@@ -959,9 +962,9 @@ TEST(EngineTest, RateLimiterDoNotForceKeep)
     auto sub = std::make_unique<mock::subscriber>();
     EXPECT_CALL(*sub, get_listener()).WillRepeatedly(Invoke([&]() {
         auto listener = std::make_unique<mock::listener>();
-        EXPECT_CALL(*listener, call(_, _))
+        EXPECT_CALL(*listener, call(_, _, _))
             .WillOnce(Invoke(
-                [](dds::parameter_view &data, dds::event &event_) -> void {
+                [](dds::parameter_view &data, dds::event &event_, bool rasp) -> void {
                     event_.actions.push_back({dds::action_type::redirect, {}});
                 }));
         return listener;

--- a/appsec/tests/helper/waf_test.cpp
+++ b/appsec/tests/helper/waf_test.cpp
@@ -112,7 +112,7 @@ TEST(WafTest, RunWithTimeout)
         std::map<std::string, std::string> meta;
         std::map<std::string_view, double> metrics;
 
-        subscriber::ptr wi(
+        std::shared_ptr<subscriber> wi(
             waf::instance::from_string(waf_rule, meta, metrics, 0));
         auto ctx = wi->get_listener();
 

--- a/appsec/tests/integration/build.gradle
+++ b/appsec/tests/integration/build.gradle
@@ -30,8 +30,9 @@ dependencies {
 
     implementation platform('org.testcontainers:testcontainers-bom:1.19.8')
     implementation "org.testcontainers:junit-jupiter"
-    implementation 'org.junit.jupiter:junit-jupiter-engine:5.10.2'
     implementation 'com.flipkart.zjsonpatch:zjsonpatch:0.4.16'
+    implementation 'org.junit.jupiter:junit-jupiter-engine:5.10.2'
+    implementation 'org.junit.jupiter:junit-jupiter-params:5.9.2'
 }
 
 test {

--- a/appsec/tests/integration/src/test/bin/enable_extensions.sh
+++ b/appsec/tests/integration/src/test/bin/enable_extensions.sh
@@ -28,6 +28,7 @@ if [[ -f /appsec/ddappsec.so && -d /project ]]; then
     echo datadog.appsec.rules=/etc/recommended.json
     echo datadog.appsec.log_file=/tmp/logs/appsec.log
     echo datadog.appsec.log_level=debug
+    echo datadog.appsec.rasp_enabled=1
   } >> /etc/php/php.ini
 fi
 

--- a/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/CommonTests.groovy
+++ b/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/CommonTests.groovy
@@ -218,8 +218,6 @@ trait CommonTests {
                     Arguments.of("readfile", "/tmp/dummy", 15),
                     Arguments.of("file_get_contents", "/tmp/dummy", 15),
                     Arguments.of("fopen", "/tmp/dummy", 12),
-                    Arguments.of("stat", "/tmp/dummy", 15),
-                    Arguments.of("lstat", "/tmp/dummy", 15),
             });
      }
 

--- a/appsec/tests/integration/src/test/waf/recommended.json
+++ b/appsec/tests/integration/src/test/waf/recommended.json
@@ -56,6 +56,36 @@
       ]
     },
     {
+      "id": "rasp-001-001",
+      "name": "Path traversal attack",
+      "tags": {
+        "type": "lfi",
+        "category": "vulnerability_trigger",
+        "module": "rasp"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "params": [
+              {
+                "address": "server.request.query"
+              }
+            ],
+            "resource": [
+              {
+                "address": "server.io.fs.file"
+              }
+            ]
+          },
+          "operator": "lfi_detector"
+        }
+      ],
+      "transformers": [],
+      "on_match": [
+        "stack_trace"
+      ]
+    },
+    {
       "id": "blk-001-003",
       "name": "Block User Addresses",
       "tags": {

--- a/appsec/tests/integration/src/test/www/base/public/filesystem.php
+++ b/appsec/tests/integration/src/test/www/base/public/filesystem.php
@@ -1,0 +1,31 @@
+<?php
+
+function one() {
+    $function = $_GET['function'];
+    $path = $_GET['path'];
+
+    switch ($function) {
+        case 'file_put_contents':
+                file_put_contents($path, 'some content');
+                break;
+        case 'fopen':
+                fopen($path, 'r');
+                break;
+        default:
+            $function($path);
+            break;
+    }
+}
+
+function two() {
+    one();
+}
+
+function three() {
+    two();
+}
+
+three();
+
+
+echo "OK";

--- a/ext/configuration.h
+++ b/ext/configuration.h
@@ -142,6 +142,7 @@ enum ddtrace_sampling_rules_format {
     CONFIG(BOOL, DD_TRACE_SYMFONY_MESSENGER_MIDDLEWARES, "false")                                              \
     CONFIG(BOOL, DD_TRACE_REMOVE_ROOT_SPAN_LARAVEL_QUEUE, "true")                                              \
     CONFIG(BOOL, DD_TRACE_REMOVE_ROOT_SPAN_SYMFONY_MESSENGER, "true")                                          \
+    CONFIG(BOOL, DD_APPSEC_RASP_ENABLED , "false")                                                             \
     CONFIG(BOOL, DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS, "false")                                         \
     CONFIG(SET, DD_TRACE_RESOURCE_URI_FRAGMENT_REGEX, "")                                                      \
     CONFIG(SET, DD_TRACE_RESOURCE_URI_MAPPING_INCOMING, "")                                                    \

--- a/ext/integrations/integrations.c
+++ b/ext/integrations/integrations.c
@@ -245,6 +245,15 @@ void ddtrace_integrations_minit(void) {
     DD_SET_UP_DEFERRED_LOADING_BY_FUNCTION(DDTRACE_INTEGRATION_EXEC, "proc_open",
                                          "DDTrace\\Integrations\\Exec\\ExecIntegration");
 
+    DD_SET_UP_DEFERRED_LOADING_BY_FUNCTION(DDTRACE_INTEGRATION_FILESYSTEM, "file_get_contents",
+                                           "DDTrace\\Integrations\\Filesystem\\FilesystemIntegration");
+    DD_SET_UP_DEFERRED_LOADING_BY_FUNCTION(DDTRACE_INTEGRATION_FILESYSTEM, "file_put_contents",
+                                           "DDTrace\\Integrations\\Filesystem\\FilesystemIntegration");
+    DD_SET_UP_DEFERRED_LOADING_BY_FUNCTION(DDTRACE_INTEGRATION_FILESYSTEM, "fopen", "DDTrace\\Integrations\\Filesystem\\FilesystemIntegration");
+    DD_SET_UP_DEFERRED_LOADING_BY_FUNCTION(DDTRACE_INTEGRATION_FILESYSTEM, "readfile", "DDTrace\\Integrations\\Filesystem\\FilesystemIntegration");
+    DD_SET_UP_DEFERRED_LOADING_BY_FUNCTION(DDTRACE_INTEGRATION_FILESYSTEM, "stat", "DDTrace\\Integrations\\Filesystem\\FilesystemIntegration");
+    DD_SET_UP_DEFERRED_LOADING_BY_FUNCTION(DDTRACE_INTEGRATION_FILESYSTEM, "lstat", "DDTrace\\Integrations\\Filesystem\\FilesystemIntegration");
+
     DD_SET_UP_DEFERRED_LOADING_BY_FUNCTION(DDTRACE_INTEGRATION_CURL, "curl_exec",
                                            "DDTrace\\Integrations\\Curl\\CurlIntegration");
     DD_SET_UP_DEFERRED_LOADING_BY_FUNCTION(DDTRACE_INTEGRATION_CURL, "curl_multi_exec",

--- a/ext/integrations/integrations.c
+++ b/ext/integrations/integrations.c
@@ -251,8 +251,6 @@ void ddtrace_integrations_minit(void) {
                                            "DDTrace\\Integrations\\Filesystem\\FilesystemIntegration");
     DD_SET_UP_DEFERRED_LOADING_BY_FUNCTION(DDTRACE_INTEGRATION_FILESYSTEM, "fopen", "DDTrace\\Integrations\\Filesystem\\FilesystemIntegration");
     DD_SET_UP_DEFERRED_LOADING_BY_FUNCTION(DDTRACE_INTEGRATION_FILESYSTEM, "readfile", "DDTrace\\Integrations\\Filesystem\\FilesystemIntegration");
-    DD_SET_UP_DEFERRED_LOADING_BY_FUNCTION(DDTRACE_INTEGRATION_FILESYSTEM, "stat", "DDTrace\\Integrations\\Filesystem\\FilesystemIntegration");
-    DD_SET_UP_DEFERRED_LOADING_BY_FUNCTION(DDTRACE_INTEGRATION_FILESYSTEM, "lstat", "DDTrace\\Integrations\\Filesystem\\FilesystemIntegration");
 
     DD_SET_UP_DEFERRED_LOADING_BY_FUNCTION(DDTRACE_INTEGRATION_CURL, "curl_exec",
                                            "DDTrace\\Integrations\\Curl\\CurlIntegration");

--- a/ext/integrations/integrations.c
+++ b/ext/integrations/integrations.c
@@ -7,6 +7,9 @@
 #include <hook/hook.h>
 #include <sandbox/sandbox.h>
 #undef INTEGRATION
+#undef INTEGRATION_CUSTOM_ENABLED
+
+static bool is_filesystem_enabled() { return get_DD_TRACE_FILESYSTEM_ENABLED() && get_DD_APPSEC_RASP_ENABLED(); }
 
 #define DDTRACE_DEFERRED_INTEGRATION_LOADER(class, fname, integration_name)             \
     dd_hook_method_and_unhook_on_first_call((zai_str)ZAI_STRL(class), (zai_str)ZAI_STRL(fname), \
@@ -24,13 +27,15 @@
     dd_set_up_deferred_loading_by_method(name, (zai_str)ZAI_STR_EMPTY, (zai_str)ZAI_STRL(fname), \
                                          (zai_str)ZAI_STRL(integration), false)
 
-#define INTEGRATION(id, lcname, ...)                                    \
+#define INTEGRATION(id, lcname, ...) INTEGRATION_AUX(id, lcname, get_DD_TRACE_##id##_ENABLED)
+#define INTEGRATION_CUSTOM_ENABLED(id, lcname, is_enabled_func, ...) INTEGRATION_AUX(id, lcname, is_enabled_func)
+#define INTEGRATION_AUX(id, lcname, is_enabled_func)                   \
     {                                                                  \
         .name = DDTRACE_INTEGRATION_##id,                              \
         .name_ucase = #id,                                             \
         .name_lcase = (lcname),                                        \
         .name_len = sizeof(lcname) - 1,                                \
-        .is_enabled = get_DD_TRACE_##id##_ENABLED,              \
+        .is_enabled = is_enabled_func,                                 \
         .is_analytics_enabled = get_DD_TRACE_##id##_ANALYTICS_ENABLED, \
         .get_sample_rate = get_DD_TRACE_##id##_ANALYTICS_SAMPLE_RATE,  \
         .aux = {0},                                                    \

--- a/ext/integrations/integrations.h
+++ b/ext/integrations/integrations.h
@@ -20,7 +20,7 @@
     INTEGRATION(DRUPAL, "drupal")                                                                                        \
     INTEGRATION(ELASTICSEARCH, "elasticsearch")                                                                          \
     INTEGRATION(ELOQUENT, "eloquent")                                                                                    \
-    INTEGRATION(FILESYSTEM, "filesystem")                                                                                \
+    INTEGRATION_CUSTOM_ENABLED(FILESYSTEM, "filesystem", is_filesystem_enabled)                                          \
     INTEGRATION(FRANKENPHP, "frankenphp")                                                                                \
     INTEGRATION(GOOGLESPANNER, "googlespanner")                                                                          \
     INTEGRATION(GUZZLE, "guzzle")                                                                                        \
@@ -54,6 +54,7 @@
     INTEGRATION(ZENDFRAMEWORK, "zendframework")
 
 #define INTEGRATION(id, ...) DDTRACE_INTEGRATION_##id,
+#define INTEGRATION_CUSTOM_ENABLED(id, ...) INTEGRATION(id)
 typedef enum { DD_INTEGRATIONS } ddtrace_integration_name;
 #undef INTEGRATION
 

--- a/ext/integrations/integrations.h
+++ b/ext/integrations/integrations.h
@@ -20,6 +20,7 @@
     INTEGRATION(DRUPAL, "drupal")                                                                                        \
     INTEGRATION(ELASTICSEARCH, "elasticsearch")                                                                          \
     INTEGRATION(ELOQUENT, "eloquent")                                                                                    \
+    INTEGRATION(FILESYSTEM, "filesystem")                                                                                \
     INTEGRATION(FRANKENPHP, "frankenphp")                                                                                \
     INTEGRATION(GOOGLESPANNER, "googlespanner")                                                                          \
     INTEGRATION(GUZZLE, "guzzle")                                                                                        \

--- a/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
+++ b/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
@@ -41,7 +41,6 @@ class FilesystemIntegration extends Integration
             null
         );
 
-
         \DDTrace\install_hook(
             'lstat',
             self::preHook('lstat'),

--- a/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
+++ b/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
@@ -1,0 +1,68 @@
+<?php
+
+namespace DDTrace\Integrations\Filesystem;
+
+use DDTrace\HookData;
+use DDTrace\Integrations\Integration;
+
+class FilesystemIntegration extends Integration
+{
+    const NAME = "filesystem";
+
+    public function init(): int
+    {
+        \DDTrace\install_hook(
+            'file_get_contents',
+            self::preHook('file_get_contents'),
+            null
+        );
+
+        \DDTrace\install_hook(
+            'file_put_contents',
+            self::preHook('file_put_contents'),
+            null
+        );
+
+        \DDTrace\install_hook(
+            'fopen',
+            self::preHook('fopen'),
+            null
+        );
+
+        \DDTrace\install_hook(
+            'readfile',
+            self::preHook('readfile'),
+            null
+        );
+
+        \DDTrace\install_hook(
+            'stat',
+            self::preHook('stat'),
+            null
+        );
+
+
+        \DDTrace\install_hook(
+            'lstat',
+            self::preHook('lstat'),
+            null
+        );
+
+        return Integration::LOADED;
+    }
+
+    private static function preHook($variant)
+    {
+        return static function (HookData $hook) use ($variant) {
+            if (count($hook->args) == 0 || !is_string($hook->args[0])) {
+                return;
+            }
+
+            $filename = $hook->args[0];
+            if (function_exists('\datadog\appsec\push_address')) {
+                \datadog\appsec\push_address("server.io.fs.file", $filename);
+            }
+        };
+    }
+
+}

--- a/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
+++ b/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
@@ -59,7 +59,7 @@ class FilesystemIntegration extends Integration
 
             $filename = $hook->args[0];
             if (function_exists('\datadog\appsec\push_address')) {
-                \datadog\appsec\push_address("server.io.fs.file", $filename);
+                \datadog\appsec\push_address("server.io.fs.file", $filename, true);
             }
         };
     }

--- a/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
+++ b/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
@@ -16,7 +16,7 @@ class FilesystemIntegration extends Integration
             return Integration::LOADED;
         }
 
-        if (!function_exists('\datadog\appsec\push_address')) {
+        if (!function_exists('datadog\appsec\push_address')) {
             //Dont load Appsec wrappers is not available
             return Integration::LOADED;
         }

--- a/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
+++ b/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
@@ -12,6 +12,10 @@ class FilesystemIntegration extends Integration
 
     public function init(): int
     {
+        if (!\dd_trace_env_config("DD_APPSEC_RASP_ENABLED")) {
+            return Integration::LOADED;
+        }
+
         if (!function_exists('\datadog\appsec\push_address')) {
             //Dont load Appsec wrappers is not available
             return Integration::LOADED;
@@ -60,6 +64,15 @@ class FilesystemIntegration extends Integration
     {
         return static function (HookData $hook) use ($variant) {
             if (count($hook->args) == 0 || !is_string($hook->args[0])) {
+                return;
+            }
+
+            $protocol = [];
+            if (
+                preg_match('/^[a-z]+\:\/\//', $hook->args[0], $protocol) &&
+                isset($protocol[0]) &&
+                $protocol[0] !== 'file')
+            {
                 return;
             }
 

--- a/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
+++ b/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
@@ -13,12 +13,12 @@ class FilesystemIntegration extends Integration
     public function init(): int
     {
         if (!\dd_trace_env_config("DD_APPSEC_RASP_ENABLED")) {
-            return Integration::LOADED;
+            return Integration::NOT_LOADED;
         }
 
         if (!function_exists('datadog\appsec\push_address')) {
             //Dont load Appsec wrappers is not available
-            return Integration::LOADED;
+            return Integration::NOT_LOADED;
         }
 
         \DDTrace\install_hook(

--- a/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
+++ b/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
@@ -54,7 +54,6 @@ class FilesystemIntegration extends Integration
     private static function preHook($variant)
     {
         return static function (HookData $hook) use ($variant) {
-            $time_start = microtime(true);
             if (count($hook->args) == 0 || !is_string($hook->args[0])) {
                 return;
             }
@@ -67,8 +66,6 @@ class FilesystemIntegration extends Integration
             $filename = $hook->args[0];
             if (function_exists('\datadog\appsec\push_address')) {
                 \datadog\appsec\push_address("server.io.fs.file", $filename, true);
-                $time_end = microtime(true);
-                $span->metrics[Tag::APPSEC_RASP_DURATION_EXT] = $time_end - $time_start;
             }
         };
     }

--- a/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
+++ b/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
@@ -13,7 +13,7 @@ class FilesystemIntegration extends Integration
     public function init(): int
     {
         if (!function_exists('\datadog\appsec\push_address')) {
-            //There is no point on adding all this wrappers without that function available when appsec is not loaded
+            //Dont load Appsec wrappers is not available
             return Integration::LOADED;
         }
 

--- a/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
+++ b/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
@@ -45,18 +45,6 @@ class FilesystemIntegration extends Integration
             null
         );
 
-        \DDTrace\install_hook(
-            'stat',
-            self::preHook('stat'),
-            null
-        );
-
-        \DDTrace\install_hook(
-            'lstat',
-            self::preHook('lstat'),
-            null
-        );
-
         return Integration::LOADED;
     }
 

--- a/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
+++ b/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
@@ -67,9 +67,9 @@ class FilesystemIntegration extends Integration
             $filename = $hook->args[0];
             if (function_exists('\datadog\appsec\push_address')) {
                 \datadog\appsec\push_address("server.io.fs.file", $filename, true);
+                $time_end = microtime(true);
+                $span->metrics[Tag::APPSEC_RASP_DURATION_EXT] = $time_end - $time_start;
             }
-            $time_end = microtime(true);
-            $span->metrics[Tag::APPSEC_RASP_DURATION_EXT] = $time_end - $time_start;
         };
     }
 

--- a/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
+++ b/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
@@ -63,13 +63,7 @@ class FilesystemIntegration extends Integration
                 return;
             }
 
-            if (!$hook->span()->parent) {
-                return;
-            }
-            $span = $hook->span()->parent;
-
-            $filename = $hook->args[0];
-            \datadog\appsec\push_address("server.io.fs.file", $filename, true);
+            \datadog\appsec\push_address("server.io.fs.file", $hook->args[0], true);
         };
     }
 

--- a/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
+++ b/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
@@ -12,6 +12,11 @@ class FilesystemIntegration extends Integration
 
     public function init(): int
     {
+        if (!function_exists('\datadog\appsec\push_address')) {
+            //There is no point on adding all this wrappers without that function available when appsec is not loaded
+            return Integration::LOADED;
+        }
+
         \DDTrace\install_hook(
             'file_get_contents',
             self::preHook('file_get_contents'),
@@ -64,9 +69,7 @@ class FilesystemIntegration extends Integration
             $span = $hook->span()->parent;
 
             $filename = $hook->args[0];
-            if (function_exists('\datadog\appsec\push_address')) {
-                \datadog\appsec\push_address("server.io.fs.file", $filename, true);
-            }
+            \datadog\appsec\push_address("server.io.fs.file", $filename, true);
         };
     }
 

--- a/src/api/Tag.php
+++ b/src/api/Tag.php
@@ -105,4 +105,7 @@ class Tag
     const EXEC_CMDLINE_SHELL = 'cmd.shell';
     const EXEC_TRUNCATED = 'cmd.truncated';
     const EXEC_EXIT_CODE = 'cmd.exit_code';
+
+    // Appsec
+    const APPSEC_RASP_DURATION_EXT = '_dd.appsec.rasp.duration_ext';
 }

--- a/src/api/Tag.php
+++ b/src/api/Tag.php
@@ -105,7 +105,4 @@ class Tag
     const EXEC_CMDLINE_SHELL = 'cmd.shell';
     const EXEC_TRUNCATED = 'cmd.truncated';
     const EXEC_EXIT_CODE = 'cmd.exit_code';
-
-    // Appsec
-    const APPSEC_RASP_DURATION_EXT = '_dd.appsec.rasp.duration_ext';
 }

--- a/tests/Appsec/Mock.php
+++ b/tests/Appsec/Mock.php
@@ -152,10 +152,10 @@ if (!function_exists('datadog\appsec\push_address')) {
      * This function is exposed by appsec but here we are mocking it for tests
      * @param array $params
      */
-    function push_address($key, $value) {
+    function push_address($key, $value, $rasp = false) {
         if(!appsecMockEnabled()) {
            return;
         }
-        AppsecStatus::getInstance()->addEvent([$key => $value], 'push_address');
+        AppsecStatus::getInstance()->addEvent(['rasp' => $rasp, $key => $value], 'push_address');
     }
 }

--- a/tests/Integrations/Custom/Autoloaded/InstrumentationTest.php
+++ b/tests/Integrations/Custom/Autoloaded/InstrumentationTest.php
@@ -129,6 +129,13 @@ final class InstrumentationTest extends WebFrameworkTestCase
                 'auto_enabled' => null,
             ],
             [
+                "name" => "filesystem",
+                "enabled" => false,
+                "version" => "",
+                'compatible' => null,
+                'auto_enabled' => null,
+            ],
+            [
                 "name" => "logs",
                 "enabled" => false,
                 "version" => "",

--- a/tests/Integrations/Filesystem/.gitignore
+++ b/tests/Integrations/Filesystem/.gitignore
@@ -1,0 +1,1 @@
+somefile

--- a/tests/Integrations/Filesystem/FilesystemTest.php
+++ b/tests/Integrations/Filesystem/FilesystemTest.php
@@ -1,0 +1,80 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\DeferredLoading;
+
+use DDTrace\Tests\Common\SpanAssertion;
+use DDTrace\Tests\Common\AppsecTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
+use PHPUnit\Framework\TestCase;
+use datadog\appsec\AppsecStatus;
+
+final class FilesystemTest extends AppsecTestCase
+{
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/index.php';
+    }
+
+    protected function assertEvent(string $value)
+    {
+       $events = AppsecStatus::getInstance()->getEvents();
+       $this->assertEquals(1, count($events));
+       $this->assertEquals($value, $events[0]["server.io.fs.file"]);
+       $this->assertEquals('push_address', $events[0]['eventName']);
+    }
+
+    public function testFileGetContents()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $response = $this->call(GetSpec::create('Root', '/?function=file_get_contents&path=./index.php'));
+            TestCase::assertSame('OK', $response);
+        });
+
+        $this->assertEvent('./index.php');
+    }
+
+    public function testFilePutContents()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $response = $this->call(GetSpec::create('Root', '/?function=file_put_contents&path=./somefile'));
+            TestCase::assertSame('OK', $response);
+        });
+       $this->assertEvent('./somefile');
+    }
+
+    public function testFopen()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $response = $this->call(GetSpec::create('Root', '/?function=fopen&path=./index.php'));
+            TestCase::assertSame('OK', $response);
+        });
+        $this->assertEvent('./index.php');
+    }
+
+    public function testReadFile()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $response = $this->call(GetSpec::create('Root', '/?function=readfile&path=./dummy'));
+            TestCase::assertSame("Dummy file content\nOK", $response);
+        });
+        $this->assertEvent('./dummy');
+    }
+
+    public function testStat()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $response = $this->call(GetSpec::create('Root', '/?function=stat&path=./dummy'));
+            TestCase::assertSame("OK", $response);
+        });
+        $this->assertEvent('./dummy');
+    }
+
+    public function testLstat()
+    {
+        $traces = $this->tracesFromWebRequest(function () {
+            $response = $this->call(GetSpec::create('Root', '/?function=lstat&path=./dummy'));
+            TestCase::assertSame("OK", $response);
+        });
+        $this->assertEvent('./dummy');
+    }
+}

--- a/tests/Integrations/Filesystem/FilesystemTest.php
+++ b/tests/Integrations/Filesystem/FilesystemTest.php
@@ -21,6 +21,7 @@ final class FilesystemTest extends AppsecTestCase
        $this->assertEquals(1, count($events));
        $this->assertEquals($value, $events[0]["server.io.fs.file"]);
        $this->assertEquals('push_address', $events[0]['eventName']);
+       $this->assertTrue($events[0]['rasp']);
     }
 
     public function testFileGetContents()

--- a/tests/Integrations/Filesystem/FilesystemTest.php
+++ b/tests/Integrations/Filesystem/FilesystemTest.php
@@ -61,22 +61,4 @@ final class FilesystemTest extends AppsecTestCase
         });
         $this->assertEvent('./dummy', $traces);
     }
-
-    public function testStat()
-    {
-        $traces = $this->tracesFromWebRequest(function () {
-            $response = $this->call(GetSpec::create('Root', '/?function=stat&path=./dummy'));
-            TestCase::assertSame("OK", $response);
-        });
-        $this->assertEvent('./dummy', $traces);
-    }
-
-    public function testLstat()
-    {
-        $traces = $this->tracesFromWebRequest(function () {
-            $response = $this->call(GetSpec::create('Root', '/?function=lstat&path=./dummy'));
-            TestCase::assertSame("OK", $response);
-        });
-        $this->assertEvent('./dummy', $traces);
-    }
 }

--- a/tests/Integrations/Filesystem/FilesystemTest.php
+++ b/tests/Integrations/Filesystem/FilesystemTest.php
@@ -15,13 +15,14 @@ final class FilesystemTest extends AppsecTestCase
         return __DIR__ . '/index.php';
     }
 
-    protected function assertEvent(string $value)
+    protected function assertEvent(string $value, $traces)
     {
        $events = AppsecStatus::getInstance()->getEvents();
        $this->assertEquals(1, count($events));
        $this->assertEquals($value, $events[0]["server.io.fs.file"]);
        $this->assertEquals('push_address', $events[0]['eventName']);
        $this->assertTrue($events[0]['rasp']);
+       $this->assertGreaterThanOrEqual(0.0, $traces[0][0]['metrics']['_dd.appsec.rasp.duration_ext']);
     }
 
     public function testFileGetContents()
@@ -31,7 +32,7 @@ final class FilesystemTest extends AppsecTestCase
             TestCase::assertSame('OK', $response);
         });
 
-        $this->assertEvent('./index.php');
+        $this->assertEvent('./index.php', $traces);
     }
 
     public function testFilePutContents()
@@ -40,7 +41,7 @@ final class FilesystemTest extends AppsecTestCase
             $response = $this->call(GetSpec::create('Root', '/?function=file_put_contents&path=./somefile'));
             TestCase::assertSame('OK', $response);
         });
-       $this->assertEvent('./somefile');
+       $this->assertEvent('./somefile', $traces);
     }
 
     public function testFopen()
@@ -49,7 +50,7 @@ final class FilesystemTest extends AppsecTestCase
             $response = $this->call(GetSpec::create('Root', '/?function=fopen&path=./index.php'));
             TestCase::assertSame('OK', $response);
         });
-        $this->assertEvent('./index.php');
+        $this->assertEvent('./index.php', $traces);
     }
 
     public function testReadFile()
@@ -58,7 +59,7 @@ final class FilesystemTest extends AppsecTestCase
             $response = $this->call(GetSpec::create('Root', '/?function=readfile&path=./dummy'));
             TestCase::assertSame("Dummy file content\nOK", $response);
         });
-        $this->assertEvent('./dummy');
+        $this->assertEvent('./dummy', $traces);
     }
 
     public function testStat()
@@ -67,7 +68,7 @@ final class FilesystemTest extends AppsecTestCase
             $response = $this->call(GetSpec::create('Root', '/?function=stat&path=./dummy'));
             TestCase::assertSame("OK", $response);
         });
-        $this->assertEvent('./dummy');
+        $this->assertEvent('./dummy', $traces);
     }
 
     public function testLstat()
@@ -76,6 +77,6 @@ final class FilesystemTest extends AppsecTestCase
             $response = $this->call(GetSpec::create('Root', '/?function=lstat&path=./dummy'));
             TestCase::assertSame("OK", $response);
         });
-        $this->assertEvent('./dummy');
+        $this->assertEvent('./dummy', $traces);
     }
 }

--- a/tests/Integrations/Filesystem/dummy
+++ b/tests/Integrations/Filesystem/dummy
@@ -1,0 +1,1 @@
+Dummy file content

--- a/tests/Integrations/Filesystem/index.php
+++ b/tests/Integrations/Filesystem/index.php
@@ -1,0 +1,20 @@
+<?php
+
+require __DIR__ . '/../../vendor/autoload.php';
+
+$function = $_GET['function'];
+$path = $_GET['path'];
+
+switch ($function) {
+    case 'file_put_contents':
+            file_put_contents($path, 'some content');
+            break;
+    case 'fopen':
+            fopen($path, 'r');
+            break;
+    default:
+        $function($path);
+        break;
+}
+
+echo "OK";

--- a/tests/ext/includes/dummy_filesystem_integration.inc
+++ b/tests/ext/includes/dummy_filesystem_integration.inc
@@ -1,0 +1,11 @@
+<?php
+
+namespace DDTrace\Integrations\Filesystem {
+    class FilesystemIntegration implements \DDTrace\Integration
+    {
+        function init(): int
+        {
+            return self::LOADED;
+        }
+    }
+}

--- a/tests/ext/includes/request_replayer.inc
+++ b/tests/ext/includes/request_replayer.inc
@@ -1,5 +1,7 @@
 <?php
 
+include __DIR__ . '/dummy_filesystem_integration.inc'; //This file uses wrapped function file_get_contents
+
 class RequestReplayer
 {
     /**

--- a/tests/ext/telemetry/integration_filesystem.phpt
+++ b/tests/ext/telemetry/integration_filesystem.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Signal integration telemetry
+Filesystem integration depends on RASP. If RASP enabled, integration is enabled
 --SKIPIF--
 <?php
 if (getenv('PHP_PEAR_RUNTESTS') === '1') die("skip: pecl run-tests does not support {PWD}");
@@ -11,6 +11,7 @@ require __DIR__ . '/../includes/clear_skipif_telemetry.inc'
 DD_TRACE_GENERATE_ROOT_SPAN=0
 _DD_LOAD_TEST_INTEGRATIONS=1
 DD_INSTRUMENTATION_TELEMETRY_ENABLED=1
+DD_APPSEC_RASP_ENABLED=1
 --INI--
 datadog.trace.agent_url="file://{PWD}/integration-telemetry.out"
 --FILE--
@@ -69,7 +70,7 @@ PUBLIC STATIC METHOD
 test_access hook
 array(1) {
   ["integrations"]=>
-  array(3) {
+  array(2) {
     [0]=>
     array(5) {
       ["name"]=>
@@ -84,19 +85,6 @@ array(1) {
       NULL
     }
     [1]=>
-    array(5) {
-      ["name"]=>
-      string(10) "filesystem"
-      ["enabled"]=>
-      bool(false)
-      ["version"]=>
-      string(0) ""
-      ["compatible"]=>
-      NULL
-      ["auto_enabled"]=>
-      NULL
-    }
-    [2]=>
     array(5) {
       ["name"]=>
       string(4) "logs"

--- a/tests/ext/telemetry/integration_filesystem_01.phpt
+++ b/tests/ext/telemetry/integration_filesystem_01.phpt
@@ -1,0 +1,77 @@
+--TEST--
+Filesystem integration depends on RASP. If RASP is not enabled, integration is disabled
+--SKIPIF--
+<?php
+if (getenv('PHP_PEAR_RUNTESTS') === '1') die("skip: pecl run-tests does not support {PWD}");
+if (PHP_OS === "WINNT" && PHP_VERSION_ID < 70400) die("skip: Windows on PHP 7.2 and 7.3 have permission issues with synchronous access to telemetry");
+if (getenv('USE_ZEND_ALLOC') === '0' && !getenv("SKIP_ASAN")) die('skip timing sensitive test - valgrind is too slow');
+require __DIR__ . '/../includes/clear_skipif_telemetry.inc'
+?>
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
+_DD_LOAD_TEST_INTEGRATIONS=1
+DD_INSTRUMENTATION_TELEMETRY_ENABLED=1
+--INI--
+datadog.trace.agent_url="file://{PWD}/integration-telemetry.out"
+--FILE--
+<?php
+namespace
+{
+    dd_trace_internal_fn("finalize_telemetry");
+
+    for ($i = 0; $i < 100; ++$i) {
+        usleep(100000);
+        if (file_exists(__DIR__ . '/integration-telemetry.out')) {
+            foreach (file(__DIR__ . '/integration-telemetry.out') as $l) {
+                if ($l) {
+                    $json = json_decode($l, true);
+                    $batch = $json["request_type"] == "message-batch" ? $json["payload"] : [$json];
+                    foreach ($batch as $json) {
+                        if ($json["request_type"] == "app-integrations-change") {
+                            var_dump($json["payload"]);
+                            break 3;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+?>
+--EXPECT--
+array(1) {
+  ["integrations"]=>
+  array(2) {
+    [0]=>
+    array(5) {
+      ["name"]=>
+      string(10) "filesystem"
+      ["enabled"]=>
+      bool(false)
+      ["version"]=>
+      string(0) ""
+      ["compatible"]=>
+      NULL
+      ["auto_enabled"]=>
+      NULL
+    }
+    [1]=>
+    array(5) {
+      ["name"]=>
+      string(4) "logs"
+      ["enabled"]=>
+      bool(false)
+      ["version"]=>
+      string(0) ""
+      ["compatible"]=>
+      NULL
+      ["auto_enabled"]=>
+      NULL
+    }
+  }
+}
+--CLEAN--
+<?php
+
+@unlink(__DIR__ . '/integration-telemetry.out');

--- a/tests/ext/telemetry/integration_filesystem_02.phpt
+++ b/tests/ext/telemetry/integration_filesystem_02.phpt
@@ -1,0 +1,65 @@
+--TEST--
+Filesystem integration depends on RASP. If RASP is enabled but wrapped functions are not used, it is not enabled
+--SKIPIF--
+<?php
+if (getenv('PHP_PEAR_RUNTESTS') === '1') die("skip: pecl run-tests does not support {PWD}");
+if (PHP_OS === "WINNT" && PHP_VERSION_ID < 70400) die("skip: Windows on PHP 7.2 and 7.3 have permission issues with synchronous access to telemetry");
+if (getenv('USE_ZEND_ALLOC') === '0' && !getenv("SKIP_ASAN")) die('skip timing sensitive test - valgrind is too slow');
+require __DIR__ . '/../includes/clear_skipif_telemetry.inc'
+?>
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
+_DD_LOAD_TEST_INTEGRATIONS=1
+DD_INSTRUMENTATION_TELEMETRY_ENABLED=1
+DD_APPSEC_RASP_ENABLED=1
+--INI--
+datadog.trace.agent_url="file://{PWD}/integration-telemetry.out"
+--FILE--
+<?php
+namespace
+{
+    dd_trace_internal_fn("finalize_telemetry");
+
+    for ($i = 0; $i < 100; ++$i) {
+        usleep(100000);
+        if (file_exists(__DIR__ . '/integration-telemetry.out')) {
+            foreach (file(__DIR__ . '/integration-telemetry.out') as $l) {
+                if ($l) {
+                    $json = json_decode($l, true);
+                    $batch = $json["request_type"] == "message-batch" ? $json["payload"] : [$json];
+                    foreach ($batch as $json) {
+                        if ($json["request_type"] == "app-integrations-change") {
+                            var_dump($json["payload"]);
+                            break 3;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+?>
+--EXPECT--
+array(1) {
+  ["integrations"]=>
+  array(1) {
+    [0]=>
+    array(5) {
+      ["name"]=>
+      string(4) "logs"
+      ["enabled"]=>
+      bool(false)
+      ["version"]=>
+      string(0) ""
+      ["compatible"]=>
+      NULL
+      ["auto_enabled"]=>
+      NULL
+    }
+  }
+}
+--CLEAN--
+<?php
+
+@unlink(__DIR__ . '/integration-telemetry.out');

--- a/tests/ext/telemetry/integration_filesystem_03.phpt
+++ b/tests/ext/telemetry/integration_filesystem_03.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Filesystem integration depends on RASP. If RASP enabled, integration is enabled
+Filesystem integration depends on RASP. If RASP is enabled and wrapped function are used, then it is enabled
 --SKIPIF--
 <?php
 if (getenv('PHP_PEAR_RUNTESTS') === '1') die("skip: pecl run-tests does not support {PWD}");
@@ -16,32 +16,10 @@ DD_APPSEC_RASP_ENABLED=1
 datadog.trace.agent_url="file://{PWD}/integration-telemetry.out"
 --FILE--
 <?php
-
-namespace DDTrace\Test
-{
-    class TestSandboxedIntegration implements \DDTrace\Integration
-    {
-        function init(): int
-        {
-            dd_trace_method("Test", "public_static_method", function() {
-                echo "test_access hook" . PHP_EOL;
-            });
-            return self::LOADED;
-        }
-    }
-}
-
 namespace
 {
-    class Test
-    {
-        public static function public_static_method()
-        {
-            echo "PUBLIC STATIC METHOD\n";
-        }
-    }
-
-    Test::public_static_method();
+    //Here we use one wrapped function
+    file_put_contents('/tmp/dummy', 'foo');
 
     dd_trace_internal_fn("finalize_telemetry");
 
@@ -66,15 +44,13 @@ namespace
 
 ?>
 --EXPECT--
-PUBLIC STATIC METHOD
-test_access hook
 array(1) {
   ["integrations"]=>
   array(2) {
     [0]=>
     array(5) {
       ["name"]=>
-      string(37) "ddtrace\test\testsandboxedintegration"
+      string(10) "filesystem"
       ["enabled"]=>
       bool(true)
       ["version"]=>

--- a/tests/ext/telemetry/integration_filesystem_04.phpt
+++ b/tests/ext/telemetry/integration_filesystem_04.phpt
@@ -1,0 +1,82 @@
+--TEST--
+Filesystem integration can also be disabled with default integrations flag
+--SKIPIF--
+<?php
+if (getenv('PHP_PEAR_RUNTESTS') === '1') die("skip: pecl run-tests does not support {PWD}");
+if (PHP_OS === "WINNT" && PHP_VERSION_ID < 70400) die("skip: Windows on PHP 7.2 and 7.3 have permission issues with synchronous access to telemetry");
+if (getenv('USE_ZEND_ALLOC') === '0' && !getenv("SKIP_ASAN")) die('skip timing sensitive test - valgrind is too slow');
+require __DIR__ . '/../includes/clear_skipif_telemetry.inc'
+?>
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
+_DD_LOAD_TEST_INTEGRATIONS=1
+DD_INSTRUMENTATION_TELEMETRY_ENABLED=1
+DD_APPSEC_RASP_ENABLED=1
+DD_TRACE_FILESYSTEM_ENABLED=0
+--INI--
+datadog.trace.agent_url="file://{PWD}/integration-telemetry.out"
+--FILE--
+<?php
+namespace
+{
+    //Here we use one wrapped function
+    file_put_contents('/tmp/dummy', 'foo');
+
+    dd_trace_internal_fn("finalize_telemetry");
+
+    for ($i = 0; $i < 100; ++$i) {
+        usleep(100000);
+        if (file_exists(__DIR__ . '/integration-telemetry.out')) {
+            foreach (file(__DIR__ . '/integration-telemetry.out') as $l) {
+                if ($l) {
+                    $json = json_decode($l, true);
+                    $batch = $json["request_type"] == "message-batch" ? $json["payload"] : [$json];
+                    foreach ($batch as $json) {
+                        if ($json["request_type"] == "app-integrations-change") {
+                            var_dump($json["payload"]);
+                            break 3;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+?>
+--EXPECT--
+array(1) {
+  ["integrations"]=>
+  array(2) {
+    [0]=>
+    array(5) {
+      ["name"]=>
+      string(10) "filesystem"
+      ["enabled"]=>
+      bool(false)
+      ["version"]=>
+      string(0) ""
+      ["compatible"]=>
+      NULL
+      ["auto_enabled"]=>
+      NULL
+    }
+    [1]=>
+    array(5) {
+      ["name"]=>
+      string(4) "logs"
+      ["enabled"]=>
+      bool(false)
+      ["version"]=>
+      string(0) ""
+      ["compatible"]=>
+      NULL
+      ["auto_enabled"]=>
+      NULL
+    }
+  }
+}
+--CLEAN--
+<?php
+
+@unlink(__DIR__ . '/integration-telemetry.out');


### PR DESCRIPTION
### Description
First exploit prevention capability in PHP AppSec. This PR lays the foundation for the entire RASP architecture — not just LFI detection, but the full pipeline for reporting exploits, wiring into Remote Config, and emitting the right metrics.

Concretely:
- Wraps `file_get_contents`, `file_put_contents`, `fopen`, and `readfile` to
  push addresses to the WAF on each call
- Introduces exploit prevention metrics and the RASP span tags
  (`rasp.duration`, `rasp.duration_ext`)
- Adds the LFI capability to Remote Config so it can be toggled without a redeploy
- Adds `DD_APPSEC_RASP_ENABLED` config flag (disabled by default)
- Sets up the integration in a way that makes adding new attack types straightforward — new capabilities plug into the same architecture without touching the lower layers

Related Jiras: [APPSEC-52929], [APPSEC-53812], [APPSEC-53813]



[APPSEC-52929]: https://datadoghq.atlassian.net/browse/APPSEC-52929?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APPSEC-53812]: https://datadoghq.atlassian.net/browse/APPSEC-53812?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[APPSEC-53813]: https://datadoghq.atlassian.net/browse/APPSEC-53813?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ