### PR TITLE
Simplify appsec tracer tests

### DIFF
--- a/tests/Appsec/Mock.php
+++ b/tests/Appsec/Mock.php
@@ -63,7 +63,7 @@ if (!class_exists('datadog\appsec\AppsecStatus')) {
             $this->getDbPdo()->exec(sprintf("INSERT INTO appsec_events VALUES ('%s')", json_encode($event)));
         }
 
-        public function getEvents()
+        public function getEvents(array $names = [], array $addresses = [])
         {
             $result = [];
 
@@ -74,7 +74,11 @@ if (!class_exists('datadog\appsec\AppsecStatus')) {
             $events = $this->getDbPdo()->query("SELECT * FROM appsec_events")->fetchAll();
 
             foreach ($events as $event) {
-                $result[] = json_decode($event['event'], true);
+                $new = json_decode($event['event'], true);
+                if (empty($names) || in_array($new['eventName'], $names) &&
+                    (empty($addresses) || !empty(array_intersect($addresses, array_keys($new))))) {
+                    $result[] = $new;
+                }
             }
 
             return $result;

--- a/tests/Frameworks/Symfony/Version_4_4/src/Security/LoginFormAuthenticator.php
+++ b/tests/Frameworks/Symfony/Version_4_4/src/Security/LoginFormAuthenticator.php
@@ -49,8 +49,8 @@ class LoginFormAuthenticator extends AbstractFormLoginAuthenticator implements P
     public function getCredentials(Request $request)
     {
         $credentials = [
-            'email' => $request->request->get('email'),
-            'password' => $request->request->get('password'),
+            'email' => $request->request->get('_username'),
+            'password' => $request->request->get('_password'),
         ];
         $request->getSession()->set(
             Security::LAST_USERNAME,

--- a/tests/Frameworks/Symfony/Version_4_4/templates/security/login.html.twig
+++ b/tests/Frameworks/Symfony/Version_4_4/templates/security/login.html.twig
@@ -16,9 +16,9 @@
 
     <h1 class="h3 mb-3 font-weight-normal">Please sign in</h1>
     <label for="inputEmail">Email</label>
-    <input type="email" value="{{ last_username }}" name="email" id="inputEmail" class="form-control" autocomplete="email" required autofocus>
+    <input type="email" value="{{ last_username }}" name="_username" id="_username" class="form-control" autocomplete="email" required autofocus>
     <label for="inputPassword">Password</label>
-    <input type="password" name="password" id="inputPassword" class="form-control" autocomplete="current-password" required>
+    <input type="password" name="_password" id="inputPassword" class="form-control" autocomplete="current-password" required>
 
     <input type="hidden" name="_csrf_token"
            value="{{ csrf_token('authenticate') }}"

--- a/tests/Frameworks/WordPress/Version_4_8/wp_2019-10-01.sql
+++ b/tests/Frameworks/WordPress/Version_4_8/wp_2019-10-01.sql
@@ -126,7 +126,7 @@ VALUES
 	(3,'blogname','Datadog','yes'),
 	(4,'blogdescription','Just another WordPress site','yes'),
 	(5,'users_can_register','1','yes'),
-	(6,'admin_email','sammyk@datadoghq.com','yes'),
+	(6,'admin_email','test@datadoghq.com','yes'),
 	(7,'start_of_week','1','yes'),
 	(8,'use_balanceTags','0','yes'),
 	(9,'use_smilies','1','yes'),
@@ -460,7 +460,7 @@ LOCK TABLES `wp_usermeta` WRITE;
 
 INSERT INTO `wp_usermeta` (`umeta_id`, `user_id`, `meta_key`, `meta_value`)
 VALUES
-	(1,1,'nickname','SammyK'),
+	(1,1,'nickname','test'),
 	(2,1,'first_name',''),
 	(3,1,'last_name',''),
 	(4,1,'description',''),
@@ -509,7 +509,7 @@ LOCK TABLES `wp_users` WRITE;
 
 INSERT INTO `wp_users` (`ID`, `user_login`, `user_pass`, `user_nicename`, `user_email`, `user_url`, `user_registered`, `user_activation_key`, `user_status`, `display_name`)
 VALUES
-	(1,'SammyK','$P$BbkLmKT86fImcoVbK.fbWh0K5PTh/9.','sammyk','sammyk@datadoghq.com','','2019-09-16 21:10:55','',0,'Datadog');
+	(1,'test','$P$BbkLmKT86fImcoVbK.fbWh0K5PTh/9.','test','test@datadoghq.com','','2019-09-16 21:10:55','',0,'Datadog');
 
 /*!40000 ALTER TABLE `wp_users` ENABLE KEYS */;
 UNLOCK TABLES;

--- a/tests/Integrations/Laravel/AutomatedLoginEventsTestSuite.php
+++ b/tests/Integrations/Laravel/AutomatedLoginEventsTestSuite.php
@@ -1,0 +1,103 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Laravel;
+
+use DDTrace\Tests\Common\AppsecTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
+use datadog\appsec\AppsecStatus;
+
+class AutomatedLoginEventsTestSuite extends AppsecTestCase
+{
+    protected static function getAppIndexScript()
+    {
+        return __DIR__ . '/../../../Frameworks/Laravel/Version_8_x/public/index.php';
+    }
+
+    protected function ddSetUp()
+    {
+        parent::ddSetUp();
+        $this->connection()->exec("DELETE from users where email LIKE 'test-user%'");
+        AppsecStatus::getInstance()->setDefaults();
+    }
+
+    protected function login($email)
+    {
+        $this->call(
+            GetSpec::create('Login success event', '/login/auth?email='.$email)
+        );
+    }
+
+    protected function createUser($id, $name, $email) {
+        //Password is password
+        $this->connection()->exec("insert into users (id, name, email, password) VALUES (".$id.", '".$name."', '".$email."', '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi')");
+    }
+
+    public function testUserLoginSuccessEvent()
+    {
+        $id = 1234;
+        $name = 'someName';
+        $email = 'test-user@email.com';
+        $this->createUser($id, $name, $email);
+
+        $this->login($email);
+
+        $events = AppsecStatus::getInstance()->getEvents(['track_user_login_success_event']);
+        $this->assertEquals(1, count($events));
+        $this->assertEquals($id, $events[0]['userId']);
+        $this->assertEquals($name, $events[0]['metadata']['name']);
+        $this->assertEquals($email, $events[0]['metadata']['email']);
+        $this->assertTrue($events[0]['automated']);
+    }
+
+    public function testUserLoginFailureEvent()
+    {
+        $email = 'test-user-non-existing@email.com';
+
+        $this->login($email);
+
+        $events = AppsecStatus::getInstance()->getEvents(['track_user_login_failure_event']);
+        $this->assertEquals(1, count($events));
+        $this->assertTrue($events[0]['automated']);
+    }
+
+    public function testUserSignUp()
+    {
+        $email = 'test-user-new@email.com';
+        $name = 'somename';
+        $password = 'somepassword';
+
+       $this->call(
+           GetSpec::create('Signup', sprintf('/login/signup?email=%s&name=%s&password=%s',$email, $email, $password))
+       );
+
+       $users = $this->connection()->query("SELECT * FROM users where email='".$email."'")->fetchAll();
+
+        $this->assertEquals(1, count($users));
+
+        $signUpEvent = AppsecStatus::getInstance()->getEvents(['track_user_signup_event']);
+
+        $this->assertTrue($signUpEvent[0]['automated']);
+        $this->assertEquals($users[0]['id'], $signUpEvent[0]['userId']);
+    }
+
+    public function testLoggedInCalls()
+    {
+        $this->enableSession();
+        $id = 1234;
+        $name = 'someName';
+        $email = 'test-user@email.com';
+        $this->createUser($id, $name, $email);
+
+        //First log in
+        $this->login($email);
+
+        //Now we are logged in lets do another call
+        AppsecStatus::getInstance()->setDefaults(); //Remove all events
+        $this->call(GetSpec::create('Behind auth', '/behind_auth'));
+
+        $events = AppsecStatus::getInstance()->getEvents([
+            'track_user_login_success_event','track_user_login_failure_event', 'track_user_signup_event']);
+        $this->assertEquals(0, count($events)); //Auth does not generate appsec events
+        $this->disableSession();
+    }
+}

--- a/tests/Integrations/Laravel/PathParamsTestSuite.php
+++ b/tests/Integrations/Laravel/PathParamsTestSuite.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Laravel;
+
+use DDTrace\Tests\Common\AppsecTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
+use datadog\appsec\AppsecStatus;
+
+class PathParamsTestSuite extends AppsecTestCase
+{
+    public function testDynamicRouteWithAllParametersGiven()
+    {
+        $param01 = 'first_param';
+        $param02 = 'second_param';
+        $this->call(
+            GetSpec::create('Call to dynamic route', "/dynamic_route/$param01/static/$param02")
+        );
+        $events = AppsecStatus::getInstance()->getEvents(['push_address'], ['server.request.path_params']);
+        $this->assertEquals(1, count($events));
+        $this->assertEquals($param01, $events[0]["server.request.path_params"]['param01']);
+        $this->assertEquals($param02, $events[0]["server.request.path_params"]['param02']);
+    }
+
+    public function testDynamicRouteWithOptionalParametersNotGiven()
+    {
+        $param01 = 'first_param';
+        $this->call(
+            GetSpec::create('Call to dynamic route', "/dynamic_route/$param01/static")
+        );
+        $events = AppsecStatus::getInstance()->getEvents(['push_address'], ['server.request.path_params']);
+        $this->assertEquals(1, count($events));
+        $this->assertCount(1, $events[0]["server.request.path_params"]);
+        $this->assertEquals($param01, $events[0]["server.request.path_params"]['param01']);
+    }
+
+    public function testStaticRouteDoesNotGenerateEvent()
+    {
+        $this->call(
+            GetSpec::create('Call to static route', "/simple")
+        );
+        $events = AppsecStatus::getInstance()->getEvents(['push_address'], ['server.request.path_params']);
+        $this->assertEquals(0, count($events));
+    }
+}

--- a/tests/Integrations/Laravel/V10_x/AutomatedLoginEventsTest.php
+++ b/tests/Integrations/Laravel/V10_x/AutomatedLoginEventsTest.php
@@ -2,11 +2,12 @@
 
 namespace DDTrace\Tests\Integrations\Laravel\V10_x;
 
-use DDTrace\Tests\Common\AppsecTestCase;
-use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
-use datadog\appsec\AppsecStatus;
+use DDTrace\Tests\Integrations\Laravel\AutomatedLoginEventsTestSuite;
 
-class AutomatedLoginEventsTest extends AppsecTestCase
+/**
+ * @group appsec
+ */
+class AutomatedLoginEventsTest extends AutomatedLoginEventsTestSuite
 {
     protected static function getAppIndexScript()
     {
@@ -19,98 +20,5 @@ class AutomatedLoginEventsTest extends AppsecTestCase
             'APP_NAME' => 'laravel_test_app',
             'DD_SERVICE' => 'my_service'
         ]);
-    }
-
-    protected function ddSetUp()
-    {
-        parent::ddSetUp();
-        $this->connection()->exec("DELETE from users where email LIKE 'test-user%'");
-        AppsecStatus::getInstance()->setDefaults();
-    }
-
-    protected function login($email)
-    {
-        return $this->call(GetSpec::create('Login success event', '/login/auth?email='.$email));
-    }
-
-    protected function createUser($id, $name, $email) {
-        //Password is password
-        $this->connection()->exec("insert into users (id, name, email, password) VALUES (".$id.", '".$name."', '".$email."', '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi')");
-    }
-
-    public function testUserLoginSuccessEvent()
-    {
-        $id = 1234;
-        $name = 'someName';
-        $email = 'test-user@email.com';
-        $this->createUser($id, $name, $email);
-
-        $traces = $this->tracesFromWebRequest(function () use ($email) { $this->login($email); });
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals($id, $events[0]['userId']);
-        $this->assertEquals($name, $events[0]['metadata']['name']);
-        $this->assertEquals($email, $events[0]['metadata']['email']);
-        $this->assertTrue($events[0]['automated']);
-        $this->assertEquals('track_user_login_success_event', $events[0]['eventName']);
-    }
-
-    public function testLoggedInCalls()
-    {
-        $this->enableSession();
-        $id = 1234;
-        $name = 'someName';
-        $email = 'test-user@email.com';
-        $this->createUser($id, $name, $email);
-
-        //First log in
-        $this->login($email);
-
-        //Now we are logged in lets do another call
-        AppsecStatus::getInstance()->setDefaults(); //Remove all events
-        $this->call(GetSpec::create('Behind auth', '/behind_auth'));
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(0, count($events)); //Auth does not generate appsec events
-        $this->disableSession();
-    }
-
-    public function testUserLoginFailureEvent()
-    {
-        $email = 'test-user-non-existing@email.com';
-
-        $this->login($email);
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertTrue($events[0]['automated']);
-        $this->assertEquals('track_user_login_failure_event', $events[0]['eventName']);
-    }
-
-    public function testUserSignUp()
-    {
-        $email = 'test-user-new@email.com';
-        $name = 'somename';
-        $password = 'somepassword';
-
-       $this->call(
-           GetSpec::create('Signup', sprintf('/login/signup?email=%s&name=%s&password=%s',$email, $email, $password))
-       );
-
-       $users = $this->connection()->query("SELECT * FROM users where email='".$email."'")->fetchAll();
-
-        $this->assertEquals(1, count($users));
-
-        $signUpEvent = null;
-        foreach(AppsecStatus::getInstance()->getEvents() as $event)
-        {
-            if ($event['eventName'] == 'track_user_signup_event') {
-                $signUpEvent = $event;
-            }
-        }
-
-        $this->assertTrue($signUpEvent['automated']);
-        $this->assertEquals($users[0]['id'], $signUpEvent['userId']);
     }
 }

--- a/tests/Integrations/Laravel/V4/AutomatedLoginEventsTest.php
+++ b/tests/Integrations/Laravel/V4/AutomatedLoginEventsTest.php
@@ -2,112 +2,15 @@
 
 namespace DDTrace\Tests\Integrations\Laravel\V4;
 
-use DDTrace\Tests\Common\AppsecTestCase;
-use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
-use datadog\appsec\AppsecStatus;
+use DDTrace\Tests\Integrations\Laravel\AutomatedLoginEventsTestSuite;
 
 /**
  * @group appsec
  */
-class AutomatedLoginEventsTest extends AppsecTestCase
+class AutomatedLoginEventsTest extends AutomatedLoginEventsTestSuite
 {
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Laravel/Version_4_2/public/index.php';
-    }
-
-    protected function ddSetUp()
-    {
-        parent::ddSetUp();
-        $this->connection()->exec("DELETE from users where email LIKE 'test-user%'");
-        AppsecStatus::getInstance()->setDefaults();
-    }
-
-    protected function login($email)
-    {
-        $this->call(
-            GetSpec::create('Login success event', '/login/auth?email='.$email)
-        );
-    }
-
-    protected function createUser($id, $name, $email) {
-        //Password is password
-        $this->connection()->exec("insert into users (id, name, email, password) VALUES (".$id.", '".$name."', '".$email."', '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi')");
-    }
-
-    public function testUserLoginSuccessEvent()
-    {
-        $id = 1234;
-        $name = 'someName';
-        $email = 'test-user@email.com';
-        $this->createUser($id, $name, $email);
-
-        $this->login($email);
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals($id, $events[0]['userId']);
-        $this->assertEquals($name, $events[0]['metadata']['name']);
-        $this->assertEquals($email, $events[0]['metadata']['email']);
-        $this->assertTrue($events[0]['automated']);
-        $this->assertEquals('track_user_login_success_event', $events[0]['eventName']);
-    }
-
-    public function testUserLoginFailureEvent()
-    {
-        $email = 'test-user-non-existing@email.com';
-
-        $this->login($email);
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertTrue($events[0]['automated']);
-        $this->assertEquals('track_user_login_failure_event', $events[0]['eventName']);
-    }
-
-    public function testUserSignUp()
-    {
-        $email = 'test-user-new@email.com';
-        $name = 'somename';
-        $password = 'somepassword';
-
-       $this->call(
-           GetSpec::create('Signup', sprintf('/login/signup?email=%s&name=%s&password=%s',$email, $email, $password))
-       );
-
-       $users = $this->connection()->query("SELECT * FROM users where email='".$email."'")->fetchAll();
-
-        $this->assertEquals(1, count($users));
-
-        $signUpEvent = null;
-        foreach(AppsecStatus::getInstance()->getEvents() as $event)
-        {
-            if ($event['eventName'] == 'track_user_signup_event') {
-                $signUpEvent = $event;
-            }
-        }
-
-        $this->assertTrue($signUpEvent['automated']);
-        $this->assertEquals($users[0]['id'], $signUpEvent['userId']);
-    }
-
-    public function testLoggedInCalls()
-    {
-        $this->enableSession();
-        $id = 1234;
-        $name = 'someName';
-        $email = 'test-user@email.com';
-        $this->createUser($id, $name, $email);
-
-        //First log in
-        $this->login($email);
-
-        //Now we are logged in lets do another call
-        AppsecStatus::getInstance()->setDefaults(); //Remove all events
-        $this->call(GetSpec::create('Behind auth', '/behind_auth'));
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(0, count($events)); //Auth does not generate appsec events
-        $this->disableSession();
     }
 }

--- a/tests/Integrations/Laravel/V4/PathParamsTest.php
+++ b/tests/Integrations/Laravel/V4/PathParamsTest.php
@@ -2,53 +2,15 @@
 
 namespace DDTrace\Tests\Integrations\Laravel\V4;
 
-use DDTrace\Tests\Common\AppsecTestCase;
-use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
-use datadog\appsec\AppsecStatus;
+use DDTrace\Tests\Integrations\Laravel\PathParamsTestSuite;
 
 /**
  * @group appsec
  */
-class PathParamsTest extends AppsecTestCase
+class PathParamsTest extends PathParamsTestSuite
 {
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Laravel/Version_4_2/public/index.php';
-    }
-
-    public function testDynamicRouteWithAllParametersGiven()
-    {
-        $param01 = 'first_param';
-        $param02 = 'second_param';
-        $this->call(
-            GetSpec::create('Call to dynamic route', "/dynamic_route/$param01/static/$param02")
-        );
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals($param01, $events[0]["server.request.path_params"]['param01']);
-        $this->assertEquals($param02, $events[0]["server.request.path_params"]['param02']);
-        $this->assertEquals('push_address', $events[0]['eventName']);
-    }
-
-    public function testDynamicRouteWithOptionalParametersNotGiven()
-    {
-        $param01 = 'first_param';
-        $this->call(
-            GetSpec::create('Call to dynamic route', "/dynamic_route/$param01/static")
-        );
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertCount(1, $events[0]["server.request.path_params"]);
-        $this->assertEquals($param01, $events[0]["server.request.path_params"]['param01']);
-        $this->assertEquals('push_address', $events[0]['eventName']);
-    }
-
-    public function testStaticRouteDoesNotGenerateEvent()
-    {
-        $this->call(
-            GetSpec::create('Call to static route', "/simple")
-        );
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(0, count($events));
     }
 }

--- a/tests/Integrations/Laravel/V5_7/AutomatedLoginEventsTest.php
+++ b/tests/Integrations/Laravel/V5_7/AutomatedLoginEventsTest.php
@@ -2,112 +2,15 @@
 
 namespace DDTrace\Tests\Integrations\Laravel\V5_7;
 
-use DDTrace\Tests\Common\AppsecTestCase;
-use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
-use datadog\appsec\AppsecStatus;
+use DDTrace\Tests\Integrations\Laravel\AutomatedLoginEventsTestSuite;
 
 /**
  * @group appsec
  */
-class AutomatedLoginEventsTest extends AppsecTestCase
+class AutomatedLoginEventsTest extends AutomatedLoginEventsTestSuite
 {
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Laravel/Version_5_7/public/index.php';
-    }
-
-    protected function ddSetUp()
-    {
-        parent::ddSetUp();
-        $this->connection()->exec("DELETE from users where email LIKE 'test-user%'");
-        AppsecStatus::getInstance()->setDefaults();
-    }
-
-    protected function login($email)
-    {
-        $this->call(
-            GetSpec::create('Login success event', '/login/auth?email='.$email)
-        );
-    }
-
-    public function testUserLoginSuccessEvent()
-    {
-        $id = 1234;
-        $name = 'someName';
-        $email = 'test-user@email.com';
-        $this->createUser($id, $name, $email);
-
-        $this->login($email);
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals($id, $events[0]['userId']);
-        $this->assertEquals($name, $events[0]['metadata']['name']);
-        $this->assertEquals($email, $events[0]['metadata']['email']);
-        $this->assertTrue($events[0]['automated']);
-        $this->assertEquals('track_user_login_success_event', $events[0]['eventName']);
-    }
-
-    public function testUserLoginFailureEvent()
-    {
-        $email = 'test-user-non-existing@email.com';
-
-        $this->login($email);
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertTrue($events[0]['automated']);
-        $this->assertEquals('track_user_login_failure_event', $events[0]['eventName']);
-    }
-
-    public function testUserSignUp()
-    {
-        $email = 'test-user-new@email.com';
-        $name = 'somename';
-        $password = 'somepassword';
-
-       $this->call(
-           GetSpec::create('Signup', sprintf('/login/signup?email=%s&name=%s&password=%s',$email, $email, $password))
-       );
-
-       $users = $this->connection()->query("SELECT * FROM users where email='".$email."'")->fetchAll();
-
-        $this->assertEquals(1, count($users));
-
-        $signUpEvent = null;
-        foreach(AppsecStatus::getInstance()->getEvents() as $event)
-        {
-            if ($event['eventName'] == 'track_user_signup_event') {
-                $signUpEvent = $event;
-            }
-        }
-
-        $this->assertTrue($signUpEvent['automated']);
-        $this->assertEquals($users[0]['id'], $signUpEvent['userId']);
-    }
-
-    protected function createUser($id, $name, $email) {
-        //Password is password
-        $this->connection()->exec("insert into users (id, name, email, password) VALUES (".$id.", '".$name."', '".$email."', '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi')");
-    }
-
-    public function testLoggedInCalls()
-    {
-        $this->enableSession();
-        $id = 1234;
-        $name = 'someName';
-        $email = 'test-user@email.com';
-        $this->createUser($id, $name, $email);
-
-        //First log in
-        $this->login($email);
-
-        //Now we are logged in lets do another call
-        AppsecStatus::getInstance()->setDefaults(); //Remove all events
-        $this->call(GetSpec::create('Behind auth', '/behind_auth'));
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(0, count($events)); //Auth does not generate appsec events
-        $this->disableSession();
     }
 }

--- a/tests/Integrations/Laravel/V5_7/PathParamsTest.php
+++ b/tests/Integrations/Laravel/V5_7/PathParamsTest.php
@@ -2,53 +2,15 @@
 
 namespace DDTrace\Tests\Integrations\Laravel\V5_7;
 
-use DDTrace\Tests\Common\AppsecTestCase;
-use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
-use datadog\appsec\AppsecStatus;
+use DDTrace\Tests\Integrations\Laravel\PathParamsTestSuite;
 
 /**
  * @group appsec
  */
-class PathParamsTest extends AppsecTestCase
+class PathParamsTest extends PathParamsTestSuite
 {
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Laravel/Version_5_7/public/index.php';
-    }
-
-    public function testDynamicRouteWithAllParametersGiven()
-    {
-        $param01 = 'first_param';
-        $param02 = 'second_param';
-        $this->call(
-            GetSpec::create('Call to dynamic route', "/dynamic_route/$param01/static/$param02")
-        );
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals($param01, $events[0]["server.request.path_params"]['param01']);
-        $this->assertEquals($param02, $events[0]["server.request.path_params"]['param02']);
-        $this->assertEquals('push_address', $events[0]['eventName']);
-    }
-
-    public function testDynamicRouteWithOptionalParametersNotGiven()
-    {
-        $param01 = 'first_param';
-        $this->call(
-            GetSpec::create('Call to dynamic route', "/dynamic_route/$param01/static")
-        );
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertCount(1, $events[0]["server.request.path_params"]);
-        $this->assertEquals($param01, $events[0]["server.request.path_params"]['param01']);
-        $this->assertEquals('push_address', $events[0]['eventName']);
-    }
-
-    public function testStaticRouteDoesNotGenerateEvent()
-    {
-        $this->call(
-            GetSpec::create('Call to static route', "/simple")
-        );
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(0, count($events));
     }
 }

--- a/tests/Integrations/Laravel/V5_8/AutomatedLoginEventsTest.php
+++ b/tests/Integrations/Laravel/V5_8/AutomatedLoginEventsTest.php
@@ -2,112 +2,15 @@
 
 namespace DDTrace\Tests\Integrations\Laravel\V5_8;
 
-use DDTrace\Tests\Common\AppsecTestCase;
-use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
-use datadog\appsec\AppsecStatus;
+use DDTrace\Tests\Integrations\Laravel\AutomatedLoginEventsTestSuite;
 
 /**
  * @group appsec
  */
-class AutomatedLoginEventsTest extends AppsecTestCase
+class AutomatedLoginEventsTest extends AutomatedLoginEventsTestSuite
 {
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Laravel/Version_5_8/public/index.php';
-    }
-
-    protected function ddSetUp()
-    {
-        parent::ddSetUp();
-        $this->connection()->exec("DELETE from users where email LIKE 'test-user%'");
-        AppsecStatus::getInstance()->setDefaults();
-    }
-
-    protected function login($email)
-    {
-        $this->call(
-            GetSpec::create('Login success event', '/login/auth?email='.$email)
-        );
-    }
-
-    protected function createUser($id, $name, $email) {
-        //Password is password
-        $this->connection()->exec("insert into users (id, name, email, password) VALUES (".$id.", '".$name."', '".$email."', '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi')");
-    }
-
-    public function testUserLoginSuccessEvent()
-    {
-        $id = 1234;
-        $name = 'someName';
-        $email = 'test-user@email.com';
-        $this->createUser($id, $name, $email);
-
-        $this->login($email);
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals($id, $events[0]['userId']);
-        $this->assertEquals($name, $events[0]['metadata']['name']);
-        $this->assertEquals($email, $events[0]['metadata']['email']);
-        $this->assertTrue($events[0]['automated']);
-        $this->assertEquals('track_user_login_success_event', $events[0]['eventName']);
-    }
-
-    public function testUserLoginFailureEvent()
-    {
-        $email = 'test-user-non-existing@email.com';
-
-        $this->login($email);
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertTrue($events[0]['automated']);
-        $this->assertEquals('track_user_login_failure_event', $events[0]['eventName']);
-    }
-
-    public function testUserSignUp()
-    {
-        $email = 'test-user-new@email.com';
-        $name = 'somename';
-        $password = 'somepassword';
-
-       $this->call(
-           GetSpec::create('Signup', sprintf('/login/signup?email=%s&name=%s&password=%s',$email, $email, $password))
-       );
-
-       $users = $this->connection()->query("SELECT * FROM users where email='".$email."'")->fetchAll();
-
-        $this->assertEquals(1, count($users));
-
-        $signUpEvent = null;
-        foreach(AppsecStatus::getInstance()->getEvents() as $event)
-        {
-            if ($event['eventName'] == 'track_user_signup_event') {
-                $signUpEvent = $event;
-            }
-        }
-
-        $this->assertTrue($signUpEvent['automated']);
-        $this->assertEquals($users[0]['id'], $signUpEvent['userId']);
-    }
-
-    public function testLoggedInCalls()
-    {
-        $this->enableSession();
-        $id = 1234;
-        $name = 'someName';
-        $email = 'test-user@email.com';
-        $this->createUser($id, $name, $email);
-
-        //First log in
-        $this->login($email);
-
-        //Now we are logged in lets do another call
-        AppsecStatus::getInstance()->setDefaults(); //Remove all events
-        $this->call(GetSpec::create('Behind auth', '/behind_auth'));
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(0, count($events)); //Auth does not generate appsec events
-        $this->disableSession();
     }
 }

--- a/tests/Integrations/Laravel/V5_8/PathParamsTest.php
+++ b/tests/Integrations/Laravel/V5_8/PathParamsTest.php
@@ -2,53 +2,15 @@
 
 namespace DDTrace\Tests\Integrations\Laravel\V5_8;
 
-use DDTrace\Tests\Common\AppsecTestCase;
-use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
-use datadog\appsec\AppsecStatus;
+use DDTrace\Tests\Integrations\Laravel\PathParamsTestSuite;
 
 /**
  * @group appsec
  */
-class PathParamsTest extends AppsecTestCase
+class PathParamsTest extends PathParamsTestSuite
 {
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Laravel/Version_5_8/public/index.php';
-    }
-
-    public function testDynamicRouteWithAllParametersGiven()
-    {
-        $param01 = 'first_param';
-        $param02 = 'second_param';
-        $this->call(
-            GetSpec::create('Call to dynamic route', "/dynamic_route/$param01/static/$param02")
-        );
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals($param01, $events[0]["server.request.path_params"]['param01']);
-        $this->assertEquals($param02, $events[0]["server.request.path_params"]['param02']);
-        $this->assertEquals('push_address', $events[0]['eventName']);
-    }
-
-    public function testDynamicRouteWithOptionalParametersNotGiven()
-    {
-        $param01 = 'first_param';
-        $this->call(
-            GetSpec::create('Call to dynamic route', "/dynamic_route/$param01/static")
-        );
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertCount(1, $events[0]["server.request.path_params"]);
-        $this->assertEquals($param01, $events[0]["server.request.path_params"]['param01']);
-        $this->assertEquals('push_address', $events[0]['eventName']);
-    }
-
-    public function testStaticRouteDoesNotGenerateEvent()
-    {
-        $this->call(
-            GetSpec::create('Call to static route', "/simple")
-        );
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(0, count($events));
     }
 }

--- a/tests/Integrations/Laravel/V8_x/AutomatedLoginEventsTest.php
+++ b/tests/Integrations/Laravel/V8_x/AutomatedLoginEventsTest.php
@@ -2,112 +2,15 @@
 
 namespace DDTrace\Tests\Integrations\Laravel\V8_x;
 
-use DDTrace\Tests\Common\AppsecTestCase;
-use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
-use datadog\appsec\AppsecStatus;
+use DDTrace\Tests\Integrations\Laravel\AutomatedLoginEventsTestSuite;
 
 /**
  * @group appsec
  */
-class AutomatedLoginEventsTest extends AppsecTestCase
+class AutomatedLoginEventsTest extends AutomatedLoginEventsTestSuite
 {
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Laravel/Version_8_x/public/index.php';
-    }
-
-    protected function ddSetUp()
-    {
-        parent::ddSetUp();
-        $this->connection()->exec("DELETE from users where email LIKE 'test-user%'");
-        AppsecStatus::getInstance()->setDefaults();
-    }
-
-    protected function login($email)
-    {
-        $this->call(
-            GetSpec::create('Login success event', '/login/auth?email='.$email)
-        );
-    }
-
-    protected function createUser($id, $name, $email) {
-        //Password is password
-        $this->connection()->exec("insert into users (id, name, email, password) VALUES (".$id.", '".$name."', '".$email."', '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi')");
-    }
-
-    public function testUserLoginSuccessEvent()
-    {
-        $id = 1234;
-        $name = 'someName';
-        $email = 'test-user@email.com';
-        $this->createUser($id, $name, $email);
-
-        $this->login($email);
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals($id, $events[0]['userId']);
-        $this->assertEquals($name, $events[0]['metadata']['name']);
-        $this->assertEquals($email, $events[0]['metadata']['email']);
-        $this->assertTrue($events[0]['automated']);
-        $this->assertEquals('track_user_login_success_event', $events[0]['eventName']);
-    }
-
-    public function testUserLoginFailureEvent()
-    {
-        $email = 'test-user-non-existing@email.com';
-
-        $this->login($email);
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertTrue($events[0]['automated']);
-        $this->assertEquals('track_user_login_failure_event', $events[0]['eventName']);
-    }
-
-    public function testUserSignUp()
-    {
-        $email = 'test-user-new@email.com';
-        $name = 'somename';
-        $password = 'somepassword';
-
-       $this->call(
-           GetSpec::create('Signup', sprintf('/login/signup?email=%s&name=%s&password=%s',$email, $email, $password))
-       );
-
-       $users = $this->connection()->query("SELECT * FROM users where email='".$email."'")->fetchAll();
-
-        $this->assertEquals(1, count($users));
-
-        $signUpEvent = null;
-        foreach(AppsecStatus::getInstance()->getEvents() as $event)
-        {
-            if ($event['eventName'] == 'track_user_signup_event') {
-                $signUpEvent = $event;
-            }
-        }
-
-        $this->assertTrue($signUpEvent['automated']);
-        $this->assertEquals($users[0]['id'], $signUpEvent['userId']);
-    }
-
-    public function testLoggedInCalls()
-    {
-        $this->enableSession();
-        $id = 1234;
-        $name = 'someName';
-        $email = 'test-user@email.com';
-        $this->createUser($id, $name, $email);
-
-        //First log in
-        $this->login($email);
-
-        //Now we are logged in lets do another call
-        AppsecStatus::getInstance()->setDefaults(); //Remove all events
-        $this->call(GetSpec::create('Behind auth', '/behind_auth'));
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(0, count($events)); //Auth does not generate appsec events
-        $this->disableSession();
     }
 }

--- a/tests/Integrations/Laravel/V8_x/PathParamsTest.php
+++ b/tests/Integrations/Laravel/V8_x/PathParamsTest.php
@@ -2,53 +2,15 @@
 
 namespace DDTrace\Tests\Integrations\Laravel\V8_x;
 
-use DDTrace\Tests\Common\AppsecTestCase;
-use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
-use datadog\appsec\AppsecStatus;
+use DDTrace\Tests\Integrations\Laravel\PathParamsTestSuite;
 
 /**
  * @group appsec
  */
-class PathParamsTest extends AppsecTestCase
+class PathParamsTest extends PathParamsTestSuite
 {
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Laravel/Version_8_x/public/index.php';
-    }
-
-    public function testDynamicRouteWithAllParametersGiven()
-    {
-        $param01 = 'first_param';
-        $param02 = 'second_param';
-        $this->call(
-            GetSpec::create('Call to dynamic route', "/dynamic_route/$param01/static/$param02")
-        );
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals($param01, $events[0]["server.request.path_params"]['param01']);
-        $this->assertEquals($param02, $events[0]["server.request.path_params"]['param02']);
-        $this->assertEquals('push_address', $events[0]['eventName']);
-    }
-
-    public function testDynamicRouteWithOptionalParametersNotGiven()
-    {
-        $param01 = 'first_param';
-        $this->call(
-            GetSpec::create('Call to dynamic route', "/dynamic_route/$param01/static")
-        );
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertCount(1, $events[0]["server.request.path_params"]);
-        $this->assertEquals($param01, $events[0]["server.request.path_params"]['param01']);
-        $this->assertEquals('push_address', $events[0]['eventName']);
-    }
-
-    public function testStaticRouteDoesNotGenerateEvent()
-    {
-        $this->call(
-            GetSpec::create('Call to static route', "/simple")
-        );
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(0, count($events));
     }
 }

--- a/tests/Integrations/Laravel/V9_x/AutomatedLoginEventsTest.php
+++ b/tests/Integrations/Laravel/V9_x/AutomatedLoginEventsTest.php
@@ -2,11 +2,12 @@
 
 namespace DDTrace\Tests\Integrations\Laravel\V9_x;
 
-use DDTrace\Tests\Common\AppsecTestCase;
-use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
-use datadog\appsec\AppsecStatus;
+use DDTrace\Tests\Integrations\Laravel\AutomatedLoginEventsTestSuite;
 
-class AutomatedLoginEventsTest extends AppsecTestCase
+/**
+ * @group appsec
+ */
+class AutomatedLoginEventsTest extends AutomatedLoginEventsTestSuite
 {
     protected static function getAppIndexScript()
     {
@@ -19,98 +20,5 @@ class AutomatedLoginEventsTest extends AppsecTestCase
             'APP_NAME' => 'laravel_test_app',
             'DD_SERVICE' => 'my_service'
         ]);
-    }
-
-    protected function ddSetUp()
-    {
-        parent::ddSetUp();
-        $this->connection()->exec("DELETE from users where email LIKE 'test-user%'");
-        AppsecStatus::getInstance()->setDefaults();
-    }
-
-    protected function login($email)
-    {
-        return $this->call(GetSpec::create('Login success event', '/login/auth?email='.$email));
-    }
-
-    protected function createUser($id, $name, $email) {
-        //Password is password
-        $this->connection()->exec("insert into users (id, name, email, password) VALUES (".$id.", '".$name."', '".$email."', '$2y$10$92IXUNpkjO0rOQ5byMi.Ye4oKoEa3Ro9llC/.og/at2.uheWG/igi')");
-    }
-
-    public function testUserLoginSuccessEvent()
-    {
-        $id = 1234;
-        $name = 'someName';
-        $email = 'test-user@email.com';
-        $this->createUser($id, $name, $email);
-
-        $traces = $this->tracesFromWebRequest(function () use ($email) { $this->login($email); });
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals($id, $events[0]['userId']);
-        $this->assertEquals($name, $events[0]['metadata']['name']);
-        $this->assertEquals($email, $events[0]['metadata']['email']);
-        $this->assertTrue($events[0]['automated']);
-        $this->assertEquals('track_user_login_success_event', $events[0]['eventName']);
-    }
-
-    public function testLoggedInCalls()
-    {
-        $this->enableSession();
-        $id = 1234;
-        $name = 'someName';
-        $email = 'test-user@email.com';
-        $this->createUser($id, $name, $email);
-
-        //First log in
-        $this->login($email);
-
-        //Now we are logged in lets do another call
-        AppsecStatus::getInstance()->setDefaults(); //Remove all events
-        $this->call(GetSpec::create('Behind auth', '/behind_auth'));
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(0, count($events)); //Auth does not generate appsec events
-        $this->disableSession();
-    }
-
-    public function testUserLoginFailureEvent()
-    {
-        $email = 'test-user-non-existing@email.com';
-
-        $this->login($email);
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertTrue($events[0]['automated']);
-        $this->assertEquals('track_user_login_failure_event', $events[0]['eventName']);
-    }
-
-    public function testUserSignUp()
-    {
-        $email = 'test-user-new@email.com';
-        $name = 'somename';
-        $password = 'somepassword';
-
-       $this->call(
-           GetSpec::create('Signup', sprintf('/login/signup?email=%s&name=%s&password=%s',$email, $email, $password))
-       );
-
-       $users = $this->connection()->query("SELECT * FROM users where email='".$email."'")->fetchAll();
-
-        $this->assertEquals(1, count($users));
-
-        $signUpEvent = null;
-        foreach(AppsecStatus::getInstance()->getEvents() as $event)
-        {
-            if ($event['eventName'] == 'track_user_signup_event') {
-                $signUpEvent = $event;
-            }
-        }
-
-        $this->assertTrue($signUpEvent['automated']);
-        $this->assertEquals($users[0]['id'], $signUpEvent['userId']);
     }
 }

--- a/tests/Integrations/Symfony/AutomatedLoginEventsTestSuite.php
+++ b/tests/Integrations/Symfony/AutomatedLoginEventsTestSuite.php
@@ -1,0 +1,75 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Symfony;
+
+use DDTrace\Tests\Common\AppsecTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\PostSpec;
+use datadog\appsec\AppsecStatus;
+
+class AutomatedLoginEventsTestSuite extends AppsecTestCase
+{
+    protected function ddSetUp()
+    {
+        parent::ddSetUp();
+        $this->connection()->exec("DELETE from user where email LIKE 'test-user%'");
+        AppsecStatus::getInstance()->setDefaults();
+    }
+
+    public function testUserLoginSuccessEvent()
+    {
+        $email = 'test-user@email.com';
+        $password = 'test';
+        //Password is password
+        $this->connection()->exec('insert into user (roles, email, password) VALUES ("", "'.$email.'", "$2y$13$WNnAxSuifzgXGx9kYfFr.eMaXzE50MmrMnXxmrlZqxSa21oiMyy0i")');
+
+         $spec = PostSpec::create('request', '/login', [
+                        'Content-Type: application/x-www-form-urlencoded'
+                    ], "_username=$email&_password=$password");
+
+         $this->call($spec, [ CURLOPT_FOLLOWLOCATION => false ]);
+
+         $events = AppsecStatus::getInstance()->getEvents(['track_user_login_success_event']);
+
+         $this->assertEquals(1, count($events));
+         $this->assertEquals($email, $events[0]['userId']);
+         $this->assertEmpty($events[0]['metadata']);
+         $this->assertTrue($events[0]['automated']);
+    }
+
+    public function testUserLoginFailureEvent()
+    {
+        $email = 'non-existing@email.com';
+        $password = 'some password';
+        $spec = PostSpec::create('request', '/login', [
+                        'Content-Type: application/x-www-form-urlencoded'
+                    ], "_username=$email&_password=$password");
+
+         $this->call($spec, [ CURLOPT_FOLLOWLOCATION => false ]);
+
+         $events = AppsecStatus::getInstance()->getEvents(['track_user_login_failure_event']);
+         $this->assertEquals(1, count($events));
+         $this->assertEmpty($events[0]['userId']);
+         $this->assertEmpty($events[0]['metadata']);
+         $this->assertTrue($events[0]['automated']);
+    }
+
+    public function testUserSignUp()
+    {
+       $email = 'test-user@email.com';
+       $password = 'some password';
+       $spec = PostSpec::create('Signup', '/register', [
+                       'Content-Type: application/x-www-form-urlencoded'
+                   ], "registration_form[email]=$email&registration_form[plainPassword]=$password&registration_form[agreeTerms]=1");
+
+       $this->call($spec, [ CURLOPT_FOLLOWLOCATION => false ]);
+
+       $users = $this->connection()->query("SELECT * FROM user where email='".$email."'")->fetchAll();
+
+        $this->assertEquals(1, count($users));
+
+        $signUpEvent = AppsecStatus::getInstance()->getEvents(['track_user_signup_event']);
+
+        $this->assertTrue($signUpEvent[0]['automated']);
+        $this->assertEquals($email, $signUpEvent[0]['userId']);
+    }
+}

--- a/tests/Integrations/Symfony/PathParamsTestSuite.php
+++ b/tests/Integrations/Symfony/PathParamsTestSuite.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Symfony;
+
+use DDTrace\Tests\Common\AppsecTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\PostSpec;
+use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
+use datadog\appsec\AppsecStatus;
+
+/**
+ * @group appsec
+ */
+class PathParamsTestSuite extends AppsecTestCase
+{
+    public function testDynamicRouteWithOptionalsFilled()
+    {
+        $param01 = 'first_param';
+        $param02 = 'second_param';
+        $this->call(GetSpec::create('dynamic', "/dynamic_route/$param01/$param02"));
+        $events = AppsecStatus::getInstance()->getEvents(['push_address'], ['server.request.path_params']);
+        $this->assertEquals(1, count($events));
+        $this->assertEquals($param01, $events[0]["server.request.path_params"]['param01']);
+        $this->assertEquals($param02, $events[0]["server.request.path_params"]['param02']);
+    }
+
+    public function testDynamicRouteWithOptionalsNotFilled()
+    {
+        $param01 = 'first_param';
+        $this->call(GetSpec::create('dynamic', "/dynamic_route/$param01"));
+        $events = AppsecStatus::getInstance()->getEvents(['push_address'], ['server.request.path_params']);
+        $this->assertEquals(1, count($events));
+        $this->assertEquals($param01, $events[0]["server.request.path_params"]['param01']);
+        $this->assertEmpty($events[0]["server.request.path_params"]['param02']);
+    }
+
+    public function testStaticRoute()
+    {
+        $this->call(GetSpec::create('static', "/simple"));
+        $events = AppsecStatus::getInstance()->getEvents(['push_address'], ['server.request.path_params']);
+        $this->assertEquals(0, count($events));
+    }
+}

--- a/tests/Integrations/Symfony/V3_3/AutomatedLoginEventsTest.php
+++ b/tests/Integrations/Symfony/V3_3/AutomatedLoginEventsTest.php
@@ -2,91 +2,15 @@
 
 namespace DDTrace\Tests\Integrations\Symfony\V3_3;
 
-use DDTrace\Tests\Common\AppsecTestCase;
-use DDTrace\Tests\Frameworks\Util\Request\PostSpec;
-use datadog\appsec\AppsecStatus;
+use DDTrace\Tests\Integrations\Symfony\AutomatedLoginEventsTestSuite;
 
 /**
  * @group appsec
  */
-class AutomatedLoginEventsTest extends AppsecTestCase
+class AutomatedLoginEventsTest extends AutomatedLoginEventsTestSuite
 {
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Symfony/Version_3_3/web/index.php';
     }
-
-    protected function ddSetUp()
-    {
-        parent::ddSetUp();
-        $this->connection()->exec("DELETE from app_users where email LIKE 'test-user%'");
-        AppsecStatus::getInstance()->setDefaults();
-    }
-
-    public function testUserLoginSuccessEvent()
-    {
-        $email = 'test-user@email.com';
-        $password = 'test';
-        //Password is password
-        $query = 'insert into app_users (email, username, password, is_active) VALUES ("'.$email.'", "'.$email.'", "$2y$13$WNnAxSuifzgXGx9kYfFr.eMaXzE50MmrMnXxmrlZqxSa21oiMyy0i", 1)';
-        $this->connection()->exec($query);
-
-         $spec = PostSpec::create('request', '/login', [
-                        'Content-Type: application/x-www-form-urlencoded'
-                    ], "_username=$email&_password=$password");
-
-         $this->call($spec, [ CURLOPT_FOLLOWLOCATION => false ]);
-
-         $events = AppsecStatus::getInstance()->getEvents();
-         $this->assertEquals(1, count($events));
-         $this->assertEquals($email, $events[0]['userId']);
-         $this->assertEmpty($events[0]['metadata']);
-         $this->assertTrue($events[0]['automated']);
-         $this->assertEquals('track_user_login_success_event', $events[0]['eventName']);
-    }
-
-    public function testUserLoginFailureEvent()
-    {
-        $email = 'non-existing@email.com';
-        $password = 'some password';
-        $spec = PostSpec::create('request', '/login', [
-                        'Content-Type: application/x-www-form-urlencoded'
-                    ], "_username=$email&_password=$password");
-
-         $this->call($spec, [ CURLOPT_FOLLOWLOCATION => false ]);
-
-         $events = AppsecStatus::getInstance()->getEvents();
-         $this->assertEquals(1, count($events));
-         $this->assertEmpty($events[0]['userId']);
-         $this->assertEmpty($events[0]['metadata']);
-         $this->assertTrue($events[0]['automated']);
-         $this->assertEquals('track_user_login_failure_event', $events[0]['eventName']);
-    }
-
-    public function testUserSignUp()
-    {
-       $email = 'test-user@email.com';
-       $password = 'some password';
-       $spec = PostSpec::create('Signup', '/register', [
-                       'Content-Type: application/x-www-form-urlencoded'
-                   ], "user[email]=$email&user[username]=$email&user[plainPassword][first]=$password&user[plainPassword][second]=$password");
-
-       $this->call($spec, [ CURLOPT_FOLLOWLOCATION => false ]);
-
-       $users = $this->connection()->query("SELECT * FROM app_users where email='".$email."'")->fetchAll();
-
-        $this->assertEquals(1, count($users));
-
-        $signUpEvent = null;
-        foreach(AppsecStatus::getInstance()->getEvents() as $event)
-        {
-            if ($event['eventName'] == 'track_user_signup_event') {
-                $signUpEvent = $event;
-            }
-        }
-
-        $this->assertTrue($signUpEvent['automated']);
-        $this->assertEquals($email, $signUpEvent['userId']);
-    }
-
 }

--- a/tests/Integrations/Symfony/V3_3/AutomatedLoginEventsTest.php
+++ b/tests/Integrations/Symfony/V3_3/AutomatedLoginEventsTest.php
@@ -13,4 +13,22 @@ class AutomatedLoginEventsTest extends AutomatedLoginEventsTestSuite
     {
         return __DIR__ . '/../../../Frameworks/Symfony/Version_3_3/web/index.php';
     }
+
+    public function deleteUsers()
+    {
+        $this->connection()->exec("DELETE from app_users where email LIKE 'test-user%'");
+    }
+
+    public function getUser($email)
+    {
+        return $this->connection()->query("SELECT * FROM app_users where email='".$email."'")->fetchAll();
+    }
+
+    public function createUser($email) {
+         $this->connection()->exec('insert into app_users (email, username, password, is_active) VALUES ("'.$email.'", "'.$email.'", "$2y$13$WNnAxSuifzgXGx9kYfFr.eMaXzE50MmrMnXxmrlZqxSa21oiMyy0i", 1)');
+    }
+
+    public function getSignUpPayload($email, $password) {
+        return "user[email]=$email&user[username]=$email&user[plainPassword][first]=$password&user[plainPassword][second]=$password";
+    }
 }

--- a/tests/Integrations/Symfony/V3_3/PathParamsTest.php
+++ b/tests/Integrations/Symfony/V3_3/PathParamsTest.php
@@ -2,37 +2,15 @@
 
 namespace DDTrace\Tests\Integrations\Symfony\V3_3;
 
-use DDTrace\Tests\Common\AppsecTestCase;
-use DDTrace\Tests\Frameworks\Util\Request\PostSpec;
-use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
-use datadog\appsec\AppsecStatus;
+use DDTrace\Tests\Integrations\Symfony\PathParamsTestSuite;
 
 /**
  * @group appsec
  */
-class PathParamsTest extends AppsecTestCase
+class PathParamsTest extends PathParamsTestSuite
 {
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Symfony/Version_3_3/web/index.php';
-    }
-
-    public function testDynamicRouteWithOptionalsFilled()
-    {
-        $param01 = 'first_param';
-        $param02 = 'second_param';
-        $this->call(GetSpec::create('dynamic', "/dynamic_route/$param01/$param02"));
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals($param01, $events[0]["server.request.path_params"]['param01']);
-        $this->assertEquals($param02, $events[0]["server.request.path_params"]['param02']);
-        $this->assertEquals('push_address', $events[0]['eventName']);
-    }
-
-    public function testStaticRoute()
-    {
-        $this->call(GetSpec::create('static', "/simple"));
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(0, count($events));
     }
 }

--- a/tests/Integrations/Symfony/V3_3/PathParamsTest.php
+++ b/tests/Integrations/Symfony/V3_3/PathParamsTest.php
@@ -13,4 +13,9 @@ class PathParamsTest extends PathParamsTestSuite
     {
         return __DIR__ . '/../../../Frameworks/Symfony/Version_3_3/web/index.php';
     }
+
+    public function testDynamicRouteWithOptionalsNotFilled()
+    {
+        $this->markTestSkipped("Not working on this version");
+    }
 }

--- a/tests/Integrations/Symfony/V4_4/AutomatedLoginEventsTest.php
+++ b/tests/Integrations/Symfony/V4_4/AutomatedLoginEventsTest.php
@@ -2,89 +2,15 @@
 
 namespace DDTrace\Tests\Integrations\Symfony\V4_4;
 
-use DDTrace\Tests\Common\AppsecTestCase;
-use DDTrace\Tests\Frameworks\Util\Request\PostSpec;
-use datadog\appsec\AppsecStatus;
+use DDTrace\Tests\Integrations\Symfony\AutomatedLoginEventsTestSuite;
 
 /**
  * @group appsec
  */
-class AutomatedLoginEventsTest extends AppsecTestCase
+class AutomatedLoginEventsTest extends AutomatedLoginEventsTestSuite
 {
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Symfony/Version_4_4/public/index.php';
-    }
-
-    protected function ddSetUp()
-    {
-        parent::ddSetUp();
-        $this->connection()->exec("DELETE from user where email LIKE 'test-user%'");
-        AppsecStatus::getInstance()->setDefaults();
-    }
-
-    public function testUserLoginSuccessEvent()
-    {
-        $email = 'test-user@email.com';
-        $password = 'test';
-        //Password is password
-        $this->connection()->exec('insert into user (roles, email, password) VALUES ("", "'.$email.'", "$2y$13$WNnAxSuifzgXGx9kYfFr.eMaXzE50MmrMnXxmrlZqxSa21oiMyy0i")');
-
-         $spec = PostSpec::create('request', '/login', [
-                        'Content-Type: application/x-www-form-urlencoded'
-                    ], "email=$email&password=$password");
-
-         $this->call($spec, [ CURLOPT_FOLLOWLOCATION => false ]);
-
-         $events = AppsecStatus::getInstance()->getEvents();
-         $this->assertEquals(1, count($events));
-         $this->assertEquals($email, $events[0]['userId']);
-         $this->assertEmpty($events[0]['metadata']);
-         $this->assertTrue($events[0]['automated']);
-         $this->assertEquals('track_user_login_success_event', $events[0]['eventName']);
-    }
-
-    public function testUserLoginFailureEvent()
-    {
-        $email = 'non-existing@email.com';
-        $password = 'some password';
-        $spec = PostSpec::create('request', '/login', [
-                        'Content-Type: application/x-www-form-urlencoded'
-                    ], "_username=$email&_password=$password");
-
-         $this->call($spec, [ CURLOPT_FOLLOWLOCATION => false ]);
-
-         $events = AppsecStatus::getInstance()->getEvents();
-         $this->assertEquals(1, count($events));
-         $this->assertEmpty($events[0]['userId']);
-         $this->assertEmpty($events[0]['metadata']);
-         $this->assertTrue($events[0]['automated']);
-         $this->assertEquals('track_user_login_failure_event', $events[0]['eventName']);
-    }
-
-    public function testUserSignUp()
-    {
-       $email = 'test-user@email.com';
-       $password = 'some password';
-       $spec = PostSpec::create('Signup', '/register', [
-                       'Content-Type: application/x-www-form-urlencoded'
-                   ], "registration_form[email]=$email&registration_form[plainPassword]=$password&registration_form[agreeTerms]=1");
-
-       $this->call($spec, [ CURLOPT_FOLLOWLOCATION => false ]);
-
-       $users = $this->connection()->query("SELECT * FROM user where email='".$email."'")->fetchAll();
-
-        $this->assertEquals(1, count($users));
-
-        $signUpEvent = null;
-        foreach(AppsecStatus::getInstance()->getEvents() as $event)
-        {
-            if ($event['eventName'] == 'track_user_signup_event') {
-                $signUpEvent = $event;
-            }
-        }
-
-        $this->assertTrue($signUpEvent['automated']);
-        $this->assertEquals($email, $signUpEvent['userId']);
     }
 }

--- a/tests/Integrations/Symfony/V4_4/PathParamsTest.php
+++ b/tests/Integrations/Symfony/V4_4/PathParamsTest.php
@@ -2,49 +2,15 @@
 
 namespace DDTrace\Tests\Integrations\Symfony\V4_4;
 
-use DDTrace\Tests\Common\AppsecTestCase;
-use DDTrace\Tests\Frameworks\Util\Request\PostSpec;
-use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
-use datadog\appsec\AppsecStatus;
+use DDTrace\Tests\Integrations\Symfony\PathParamsTestSuite;
 
 /**
  * @group appsec
  */
-class PathParamsTest extends AppsecTestCase
+class PathParamsTest extends PathParamsTestSuite
 {
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Symfony/Version_4_4/public/index.php';
-    }
-
-    public function testDynamicRouteWithOptionalsFilled()
-    {
-        $param01 = 'first_param';
-        $param02 = 'second_param';
-        $this->call(GetSpec::create('dynamic', "/dynamic_route/$param01/$param02"));
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals($param01, $events[0]["server.request.path_params"]['param01']);
-        $this->assertEquals($param02, $events[0]["server.request.path_params"]['param02']);
-        $this->assertEquals('push_address', $events[0]['eventName']);
-    }
-
-    public function testDynamicRouteWithOptionalsNotFilled()
-    {
-        $param01 = 'first_param';
-        $this->call(GetSpec::create('dynamic', "/dynamic_route/$param01"));
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals($param01, $events[0]["server.request.path_params"]['param01']);
-        $this->assertEmpty($events[0]["server.request.path_params"]['param02']);
-        $this->assertEquals('push_address', $events[0]['eventName']);
-    }
-
-
-    public function testStaticRoute()
-    {
-        $this->call(GetSpec::create('static', "/simple"));
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(0, count($events));
     }
 }

--- a/tests/Integrations/Symfony/V5_2/AutomatedLoginEventsTest.php
+++ b/tests/Integrations/Symfony/V5_2/AutomatedLoginEventsTest.php
@@ -2,89 +2,15 @@
 
 namespace DDTrace\Tests\Integrations\Symfony\V5_2;
 
-use DDTrace\Tests\Common\AppsecTestCase;
-use DDTrace\Tests\Frameworks\Util\Request\PostSpec;
-use datadog\appsec\AppsecStatus;
+use DDTrace\Tests\Integrations\Symfony\AutomatedLoginEventsTestSuite;
 
 /**
  * @group appsec
  */
-class AutomatedLoginEventsTest extends AppsecTestCase
+class AutomatedLoginEventsTest extends AutomatedLoginEventsTestSuite
 {
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Symfony/Version_5_2/public/index.php';
-    }
-
-    protected function ddSetUp()
-    {
-        parent::ddSetUp();
-        $this->connection()->exec("DELETE from user where email LIKE 'test-user%'");
-        AppsecStatus::getInstance()->setDefaults();
-    }
-
-    public function testUserLoginSuccessEvent()
-    {
-        $email = 'test-user@email.com';
-        $password = 'test';
-        //Password is password
-        $this->connection()->exec('insert into user (roles, email, password) VALUES ("", "'.$email.'", "$2y$13$WNnAxSuifzgXGx9kYfFr.eMaXzE50MmrMnXxmrlZqxSa21oiMyy0i")');
-
-         $spec = PostSpec::create('request', '/login', [
-                        'Content-Type: application/x-www-form-urlencoded'
-                    ], "_username=$email&_password=$password");
-
-         $this->call($spec, [ CURLOPT_FOLLOWLOCATION => false ]);
-
-         $events = AppsecStatus::getInstance()->getEvents();
-         $this->assertEquals(1, count($events));
-         $this->assertEquals($email, $events[0]['userId']);
-         $this->assertEmpty($events[0]['metadata']);
-         $this->assertTrue($events[0]['automated']);
-         $this->assertEquals('track_user_login_success_event', $events[0]['eventName']);
-    }
-
-    public function testUserLoginFailureEvent()
-    {
-        $email = 'non-existing@email.com';
-        $password = 'some password';
-        $spec = PostSpec::create('request', '/login', [
-                        'Content-Type: application/x-www-form-urlencoded'
-                    ], "_username=$email&_password=$password");
-
-         $this->call($spec, [ CURLOPT_FOLLOWLOCATION => false ]);
-
-         $events = AppsecStatus::getInstance()->getEvents();
-         $this->assertEquals(1, count($events));
-         $this->assertEmpty($events[0]['userId']);
-         $this->assertEmpty($events[0]['metadata']);
-         $this->assertTrue($events[0]['automated']);
-         $this->assertEquals('track_user_login_failure_event', $events[0]['eventName']);
-    }
-
-    public function testUserSignUp()
-    {
-       $email = 'test-user@email.com';
-       $password = 'some password';
-       $spec = PostSpec::create('Signup', '/register', [
-                       'Content-Type: application/x-www-form-urlencoded'
-                   ], "registration_form[email]=$email&registration_form[plainPassword]=$password&registration_form[agreeTerms]=1");
-
-       $this->call($spec, [ CURLOPT_FOLLOWLOCATION => false ]);
-
-       $users = $this->connection()->query("SELECT * FROM user where email='".$email."'")->fetchAll();
-
-        $this->assertEquals(1, count($users));
-
-        $signUpEvent = null;
-        foreach(AppsecStatus::getInstance()->getEvents() as $event)
-        {
-            if ($event['eventName'] == 'track_user_signup_event') {
-                $signUpEvent = $event;
-            }
-        }
-
-        $this->assertTrue($signUpEvent['automated']);
-        $this->assertEquals($email, $signUpEvent['userId']);
     }
 }

--- a/tests/Integrations/Symfony/V5_2/PathParamsTest.php
+++ b/tests/Integrations/Symfony/V5_2/PathParamsTest.php
@@ -2,49 +2,15 @@
 
 namespace DDTrace\Tests\Integrations\Symfony\V5_2;
 
-use DDTrace\Tests\Common\AppsecTestCase;
-use DDTrace\Tests\Frameworks\Util\Request\PostSpec;
-use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
-use datadog\appsec\AppsecStatus;
+use DDTrace\Tests\Integrations\Symfony\PathParamsTestSuite;
 
 /**
  * @group appsec
  */
-class PathParamsTest extends AppsecTestCase
+class PathParamsTest extends PathParamsTestSuite
 {
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Symfony/Version_5_2/public/index.php';
-    }
-
-    public function testDynamicRouteWithOptionalsFilled()
-    {
-        $param01 = 'first_param';
-        $param02 = 'second_param';
-        $this->call(GetSpec::create('dynamic', "/dynamic_route/$param01/$param02"));
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals($param01, $events[0]["server.request.path_params"]['param01']);
-        $this->assertEquals($param02, $events[0]["server.request.path_params"]['param02']);
-        $this->assertEquals('push_address', $events[0]['eventName']);
-    }
-
-    public function testDynamicRouteWithOptionalsNotFilled()
-    {
-        $param01 = 'first_param';
-        $this->call(GetSpec::create('dynamic', "/dynamic_route/$param01"));
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals($param01, $events[0]["server.request.path_params"]['param01']);
-        $this->assertEmpty($events[0]["server.request.path_params"]['param02']);
-        $this->assertEquals('push_address', $events[0]['eventName']);
-    }
-
-
-    public function testStaticRoute()
-    {
-        $this->call(GetSpec::create('static', "/simple"));
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(0, count($events));
     }
 }

--- a/tests/Integrations/Symfony/V6_2/AutomatedLoginEventsTest.php
+++ b/tests/Integrations/Symfony/V6_2/AutomatedLoginEventsTest.php
@@ -9,6 +9,12 @@ use DDTrace\Tests\Integrations\Symfony\AutomatedLoginEventsTestSuite;
  */
 class AutomatedLoginEventsTest extends AutomatedLoginEventsTestSuite
 {
+
+    public function createUser($email) {
+         $this->connection()->exec('insert into user (roles, email, password) VALUES ("{}", "'.$email.'", "$2y$13$WNnAxSuifzgXGx9kYfFr.eMaXzE50MmrMnXxmrlZqxSa21oiMyy0i")');
+    }
+
+
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Symfony/Version_6_2/public/index.php';

--- a/tests/Integrations/Symfony/V6_2/AutomatedLoginEventsTest.php
+++ b/tests/Integrations/Symfony/V6_2/AutomatedLoginEventsTest.php
@@ -2,87 +2,15 @@
 
 namespace DDTrace\Tests\Integrations\Symfony\V6_2;
 
-use DDTrace\Tests\Common\AppsecTestCase;
-use DDTrace\Tests\Frameworks\Util\Request\PostSpec;
-use datadog\appsec\AppsecStatus;
+use DDTrace\Tests\Integrations\Symfony\AutomatedLoginEventsTestSuite;
 
 /**
  * @group appsec
  */
-class AutomatedLoginEventsTest extends AppsecTestCase
+class AutomatedLoginEventsTest extends AutomatedLoginEventsTestSuite
 {
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Symfony/Version_6_2/public/index.php';
-    }
-
-    protected function ddSetUp()
-    {
-        parent::ddSetUp();
-        $this->connection()->exec("DELETE from user where email LIKE 'test-user%'");
-        AppsecStatus::getInstance()->setDefaults();
-    }
-
-    public function testUserLoginSuccessEvent()
-    {
-        $email = 'test-user@email.com';
-        $password = 'test';
-        //Password is password
-        $this->connection()->exec('insert into user (roles, email, password) VALUES ("{}", "' . $email . '", "$2y$13$WNnAxSuifzgXGx9kYfFr.eMaXzE50MmrMnXxmrlZqxSa21oiMyy0i")');
-
-        $spec = PostSpec::create('request', '/login', [
-            'Content-Type: application/x-www-form-urlencoded'
-        ], "_username=$email&_password=$password");
-
-        $this->call($spec, [CURLOPT_FOLLOWLOCATION => false]);
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals($email, $events[0]['userId']);
-        $this->assertEmpty($events[0]['metadata']);
-        $this->assertTrue($events[0]['automated']);
-        $this->assertEquals('track_user_login_success_event', $events[0]['eventName']);
-    }
-
-    public function testUserLoginFailureEvent()
-    {
-        $email = 'non-existing@email.com';
-        $password = 'some password';
-        $spec = PostSpec::create('request', '/login', [
-            'Content-Type: application/x-www-form-urlencoded'
-        ], "_username=$email&_password=$password");
-
-        $this->call($spec, [CURLOPT_FOLLOWLOCATION => false]);
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEmpty($events[0]['userId']);
-        $this->assertEmpty($events[0]['metadata']);
-        $this->assertTrue($events[0]['automated']);
-        $this->assertEquals('track_user_login_failure_event', $events[0]['eventName']);
-    }
-
-    public function testUserSignUp()
-    {
-        $email = 'test-user@email.com';
-        $password = 'some password';
-        $spec = PostSpec::create('Signup', '/register', [
-            'Content-Type: application/x-www-form-urlencoded'
-        ], "registration_form[email]=$email&registration_form[plainPassword]=$password&registration_form[agreeTerms]=1");
-
-        $this->call($spec, [CURLOPT_FOLLOWLOCATION => false]);
-
-        $users = $this->connection()->query("SELECT * FROM user where email='" . $email . "'")->fetchAll();
-
-        $this->assertEquals(1, count($users));
-
-        $signUpEvent = null;
-        foreach (AppsecStatus::getInstance()->getEvents() as $event) {
-            if ($event['eventName'] == 'track_user_signup_event') {
-                $signUpEvent = $event;
-            }
-        }
-        $this->assertTrue($signUpEvent['automated']);
-        $this->assertEquals($email, $signUpEvent['userId']);
     }
 }

--- a/tests/Integrations/Symfony/V6_2/PathParamsTest.php
+++ b/tests/Integrations/Symfony/V6_2/PathParamsTest.php
@@ -2,49 +2,15 @@
 
 namespace DDTrace\Tests\Integrations\Symfony\V6_2;
 
-use DDTrace\Tests\Common\AppsecTestCase;
-use DDTrace\Tests\Frameworks\Util\Request\PostSpec;
-use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
-use datadog\appsec\AppsecStatus;
+use DDTrace\Tests\Integrations\Symfony\PathParamsTestSuite;
 
 /**
  * @group appsec
  */
-class PathParamsTest extends AppsecTestCase
+class PathParamsTest extends PathParamsTestSuite
 {
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/Symfony/Version_6_2/public/index.php';
-    }
-
-    public function testDynamicRouteWithOptionalsFilled()
-    {
-        $param01 = 'first_param';
-        $param02 = 'second_param';
-        $this->call(GetSpec::create('dynamic', "/dynamic_route/$param01/$param02"));
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals($param01, $events[0]["server.request.path_params"]['param01']);
-        $this->assertEquals($param02, $events[0]["server.request.path_params"]['param02']);
-        $this->assertEquals('push_address', $events[0]['eventName']);
-    }
-
-    public function testDynamicRouteWithOptionalsNotFilled()
-    {
-        $param01 = 'first_param';
-        $this->call(GetSpec::create('dynamic', "/dynamic_route/$param01"));
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals($param01, $events[0]["server.request.path_params"]['param01']);
-        $this->assertEmpty($events[0]["server.request.path_params"]['param02']);
-        $this->assertEquals('push_address', $events[0]['eventName']);
-    }
-
-
-    public function testStaticRoute()
-    {
-        $this->call(GetSpec::create('static', "/simple"));
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(0, count($events));
     }
 }

--- a/tests/Integrations/Symfony/V7_0/AutomatedLoginEventsTest.php
+++ b/tests/Integrations/Symfony/V7_0/AutomatedLoginEventsTest.php
@@ -13,4 +13,8 @@ class AutomatedLoginEventsTest extends AutomatedLoginEventsTestSuite
     {
         return __DIR__ . '/../../../Frameworks/Symfony/Version_7_0/public/index.php';
     }
+
+    public function createUser($email) {
+         $this->connection()->exec('insert into user (roles, email, password) VALUES ("{}", "'.$email.'", "$2y$13$WNnAxSuifzgXGx9kYfFr.eMaXzE50MmrMnXxmrlZqxSa21oiMyy0i")');
+    }
 }

--- a/tests/Integrations/Symfony/V7_0/AutomatedLoginEventsTest.php
+++ b/tests/Integrations/Symfony/V7_0/AutomatedLoginEventsTest.php
@@ -2,7 +2,12 @@
 
 namespace DDTrace\Tests\Integrations\Symfony\V7_0;
 
-class AutomatedLoginEventsTest extends \DDTrace\Tests\Integrations\Symfony\V6_2\AutomatedLoginEventsTest
+use DDTrace\Tests\Integrations\Symfony\AutomatedLoginEventsTestSuite;
+
+/**
+ * @group appsec
+ */
+class AutomatedLoginEventsTest extends AutomatedLoginEventsTestSuite
 {
     protected static function getAppIndexScript()
     {

--- a/tests/Integrations/WordPress/AutomatedLoginEventsTestSuite.php
+++ b/tests/Integrations/WordPress/AutomatedLoginEventsTestSuite.php
@@ -12,6 +12,7 @@ use datadog\appsec\AppsecStatus;
  */
 class AutomatedLoginEventsTestSuite extends AppsecTestCase
 {
+    protected $users_table = 'wp55_users';
     protected function ddSetUp()
     {
         parent::ddSetUp();
@@ -27,7 +28,7 @@ class AutomatedLoginEventsTestSuite extends AppsecTestCase
         $name = 'some name';
         //Password is test
         $this->connection()->exec(
-            'INSERT INTO wp55_users VALUES ('.$id.',"test","$P$BDzpK1XXL9P2cYWggPMUbN87GQSiI80","test","'.$email.'","","2020-10-22 16:31:15","",0,"'.$name.'")'
+            'INSERT INTO '.$this->users_table.' VALUES ('.$id.',"test","$P$BDzpK1XXL9P2cYWggPMUbN87GQSiI80","test","'.$email.'","","2020-10-22 16:31:15","",0,"'.$name.'")'
         );
 
         $spec = PostSpec::create('request', '/wp-login.php', [
@@ -70,7 +71,7 @@ class AutomatedLoginEventsTestSuite extends AppsecTestCase
         $name = 'some name';
         //Password is test
         $this->connection()->exec(
-            'INSERT INTO wp55_users VALUES ('.$id.',"test","$P$BDzpK1XXL9P2cYWggPMUbN87GQSiI80","test","'.$email.'","","2020-10-22 16:31:15","",0,"'.$name.'")'
+            'INSERT INTO '.$this->users_table.' VALUES ('.$id.',"test","$P$BDzpK1XXL9P2cYWggPMUbN87GQSiI80","test","'.$email.'","","2020-10-22 16:31:15","",0,"'.$name.'")'
         );
 
         $spec = PostSpec::create('request', '/wp-login.php', [
@@ -98,7 +99,7 @@ class AutomatedLoginEventsTestSuite extends AppsecTestCase
            ], "user_login=$username&user_email=$email&wp-submit=Register&redirect_to=")
        );
 
-       $users = $this->connection()->query("SELECT * FROM wp55_users where user_email='".$email."'")->fetchAll();
+       $users = $this->connection()->query("SELECT * FROM ".$this->users_table." where user_email='".$email."'")->fetchAll();
 
        $this->assertEquals(1, count($users));
 

--- a/tests/Integrations/WordPress/AutomatedLoginEventsTestSuite.php
+++ b/tests/Integrations/WordPress/AutomatedLoginEventsTestSuite.php
@@ -1,0 +1,112 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\WordPress;
+
+use DDTrace\Tests\Common\AppsecTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\PostSpec;
+use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
+use datadog\appsec\AppsecStatus;
+
+ /**
+ * @group appsec
+ */
+class AutomatedLoginEventsTestSuite extends AppsecTestCase
+{
+    protected function ddSetUp()
+    {
+        parent::ddSetUp();
+        $this->connection()->exec("DELETE from users where email LIKE 'test-user%'");
+        AppsecStatus::getInstance()->setDefaults();
+    }
+
+    public function testUserLoginSuccessEvent()
+    {
+        $email = 'test-user@email.com';
+        $password = 'test';
+        $id = 123;
+        $name = 'some name';
+        //Password is test
+        $this->connection()->exec(
+            'INSERT INTO wp55_users VALUES ('.$id.',"test","$P$BDzpK1XXL9P2cYWggPMUbN87GQSiI80","test","'.$email.'","","2020-10-22 16:31:15","",0,"'.$name.'")'
+        );
+
+        $spec = PostSpec::create('request', '/wp-login.php', [
+            'Content-Type: application/x-www-form-urlencoded'
+        ], "log=$email&pwd=$password&wp-submit=Log In");
+
+        $this->call($spec, [ CURLOPT_FOLLOWLOCATION => false, CURLOPT_COOKIESESSION => true ]);
+
+        $events = AppsecStatus::getInstance()->getEvents(['track_user_login_success_event']);
+        $this->assertEquals(1, count($events));
+        $this->assertEquals($id, $events[0]['userId']);
+        $this->assertEquals($email, $events[0]['metadata']['email']);
+        $this->assertEquals($name, $events[0]['metadata']['name']);
+        $this->assertTrue($events[0]['automated']);
+    }
+
+    public function testUserLoginFailureEventWhenUserDoesNotExists()
+    {
+        $email = 'non-existing@email.com';
+        $password = 'some password';
+        $spec = PostSpec::create('request', '/wp-login.php', [
+                    'Content-Type: application/x-www-form-urlencoded'
+                ], "log=$email&pwd=$password&wp-submit=Log In");
+
+        $this->call($spec, [ CURLOPT_FOLLOWLOCATION => false, CURLOPT_COOKIESESSION => true ]);
+
+        $events = AppsecStatus::getInstance()->getEvents(['track_user_login_failure_event']);
+        $this->assertEquals(1, count($events));
+        $this->assertEquals($email, $events[0]['userId']);
+        $this->assertFalse($events[0]['exists']);
+        $this->assertEmpty($events[0]['metadata']);
+        $this->assertTrue($events[0]['automated']);
+    }
+
+    public function testUserLoginFailureEventWhenUserDoesExists()
+    {
+        $email = 'test-user-2@email.com';
+        $password = 'test';
+        $id = 333;
+        $name = 'some name';
+        //Password is test
+        $this->connection()->exec(
+            'INSERT INTO wp55_users VALUES ('.$id.',"test","$P$BDzpK1XXL9P2cYWggPMUbN87GQSiI80","test","'.$email.'","","2020-10-22 16:31:15","",0,"'.$name.'")'
+        );
+
+        $spec = PostSpec::create('request', '/wp-login.php', [
+            'Content-Type: application/x-www-form-urlencoded'
+        ], "log=$email&pwd=invalid&wp-submit=Log In");
+
+        $this->call($spec, [ CURLOPT_FOLLOWLOCATION => false, CURLOPT_COOKIESESSION => true ]);
+
+        $events = AppsecStatus::getInstance()->getEvents(['track_user_login_failure_event']);
+        $this->assertEquals(1, count($events));
+        $this->assertEquals($email, $events[0]['userId']);
+        $this->assertTrue($events[0]['exists']);
+        $this->assertEmpty($events[0]['metadata']);
+        $this->assertTrue($events[0]['automated']);
+    }
+
+    public function testUserSignUp()
+    {
+        $email = 'test-user-signup@email.com';
+        $username = 'someusername';
+
+       $this->call(
+           PostSpec::create('request', '/wp-login.php?action=register', [
+               'Content-Type: application/x-www-form-urlencoded'
+           ], "user_login=$username&user_email=$email&wp-submit=Register&redirect_to=")
+       );
+
+       $users = $this->connection()->query("SELECT * FROM wp55_users where user_email='".$email."'")->fetchAll();
+
+       $this->assertEquals(1, count($users));
+
+       $signUpEvent = AppsecStatus::getInstance()->getEvents(['track_user_signup_event']);
+
+       $this->assertTrue($signUpEvent[0]['automated']);
+       $this->assertEquals($users[0]['ID'], $signUpEvent[0]['userId']);
+       $this->assertEquals($users[0]['user_login'], $signUpEvent[0]['metadata']['username']);
+       $this->assertEquals($users[0]['user_email'], $signUpEvent[0]['metadata']['email']);
+    }
+}

--- a/tests/Integrations/WordPress/PathParamsTestSuite.php
+++ b/tests/Integrations/WordPress/PathParamsTestSuite.php
@@ -1,0 +1,65 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\WordPress;
+
+use DDTrace\Tests\Common\AppsecTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
+use datadog\appsec\AppsecStatus;
+
+class PathParamsTestSuite extends AppsecTestCase
+{
+    public function testPost()
+    {
+        $this->call(
+            GetSpec::create(
+                'Post example',
+                '/hello-world'
+            )
+        );
+
+        $events = AppsecStatus::getInstance()->getEvents(['push_address'], ['server.request.path_params']);
+        $this->assertEquals(1, count($events));
+        $this->assertEquals('hello-world', $events[0]["server.request.path_params"]['name']);
+    }
+
+    public function testCategory()
+    {
+        $this->call(
+            GetSpec::create(
+                'Category',
+                '/category/uncategorized'
+            )
+        );
+
+        $events = AppsecStatus::getInstance()->getEvents(['push_address'], ['server.request.path_params']);
+        $this->assertEquals(1, count($events));
+        $this->assertEquals('uncategorized', $events[0]["server.request.path_params"]['category_name']);
+    }
+
+    public function testAuthor()
+    {
+        $this->call(
+            GetSpec::create(
+                'Author',
+                '/author/test'
+            )
+        );
+
+        $events = AppsecStatus::getInstance()->getEvents(['push_address'], ['server.request.path_params']);
+        $this->assertEquals(1, count($events));
+        $this->assertEquals('test', $events[0]["server.request.path_params"]['author_name']);
+    }
+
+    public function testNonExistingPost()
+    {
+       $this->call(
+            GetSpec::create(
+                'Not existing post',
+                '/non-existing-post'
+            )
+        );
+
+        $events = AppsecStatus::getInstance()->getEvents(['push_address'], ['server.request.path_params']);
+        $this->assertEquals(0, count($events));
+    }
+}

--- a/tests/Integrations/WordPress/V4_8/AutomatedLoginEventsTest.php
+++ b/tests/Integrations/WordPress/V4_8/AutomatedLoginEventsTest.php
@@ -2,14 +2,12 @@
 
 namespace DDTrace\Tests\Integrations\WordPress\V4_8;
 
-use DDTrace\Tests\Common\AppsecTestCase;
-use DDTrace\Tests\Frameworks\Util\Request\PostSpec;
-use datadog\appsec\AppsecStatus;
+use DDTrace\Tests\Integrations\WordPress\AutomatedLoginEventsTestSuite;
 
  /**
  * @group appsec
  */
-class AutomatedLoginEventsTest extends AppsecTestCase
+class AutomatedLoginEventsTest extends AutomatedLoginEventsTestSuite
 {
     protected static function getAppIndexScript()
     {
@@ -18,112 +16,5 @@ class AutomatedLoginEventsTest extends AppsecTestCase
 
     protected function databaseDump() {
         return file_get_contents(__DIR__ . '/../../../Frameworks/WordPress/Version_4_8/wp_2019-10-01.sql');
-    }
-
-    protected function ddSetUp()
-    {
-        parent::ddSetUp();
-        $this->connection()->exec("DELETE from users where email LIKE 'test-user%'");
-        AppsecStatus::getInstance()->setDefaults();
-    }
-
-    public function testUserLoginSuccessEvent()
-    {
-        $email = 'test-user@email.com';
-        $password = 'test';
-        $id = 123;
-        $name = 'some name';
-        //Password is test
-        $this->connection()->exec(
-            'INSERT INTO wp_users VALUES ('.$id.',"test","$P$BDzpK1XXL9P2cYWggPMUbN87GQSiI80","test","'.$email.'","","2020-10-22 16:31:15","",0,"'.$name.'")'
-        );
-
-        $spec = PostSpec::create('request', '/wp-login.php', [
-            'Content-Type: application/x-www-form-urlencoded'
-        ], "log=$email&pwd=$password&wp-submit=Log In");
-
-        $this->call($spec, [ CURLOPT_FOLLOWLOCATION => false, CURLOPT_COOKIESESSION => true ]);
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals($id, $events[0]['userId']);
-        $this->assertEquals($email, $events[0]['metadata']['email']);
-        $this->assertEquals($name, $events[0]['metadata']['name']);
-        $this->assertTrue($events[0]['automated']);
-        $this->assertEquals('track_user_login_success_event', $events[0]['eventName']);
-    }
-
-    public function testUserLoginFailureEventWhenUserDoesNotExists()
-    {
-        $email = 'non-existing@email.com';
-        $password = 'some password';
-        $spec = PostSpec::create('request', '/wp-login.php', [
-                    'Content-Type: application/x-www-form-urlencoded'
-                ], "log=$email&pwd=$password&wp-submit=Log In");
-
-        $this->call($spec, [ CURLOPT_FOLLOWLOCATION => false, CURLOPT_COOKIESESSION => true ]);
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals($email, $events[0]['userId']);
-        $this->assertFalse($events[0]['exists']);
-        $this->assertEmpty($events[0]['metadata']);
-        $this->assertTrue($events[0]['automated']);
-        $this->assertEquals('track_user_login_failure_event', $events[0]['eventName']);
-    }
-
-    public function testUserLoginFailureEventWhenUserDoesExists()
-    {
-        $email = 'test-user-2@email.com';
-        $password = 'test';
-        $id = 333;
-        $name = 'some name';
-        //Password is test
-        $this->connection()->exec(
-            'INSERT INTO wp_users VALUES ('.$id.',"test","$P$BDzpK1XXL9P2cYWggPMUbN87GQSiI80","test","'.$email.'","","2020-10-22 16:31:15","",0,"'.$name.'")'
-        );
-
-        $spec = PostSpec::create('request', '/wp-login.php', [
-            'Content-Type: application/x-www-form-urlencoded'
-        ], "log=$email&pwd=invalid&wp-submit=Log In");
-
-        $this->call($spec, [ CURLOPT_FOLLOWLOCATION => false, CURLOPT_COOKIESESSION => true ]);
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals($email, $events[0]['userId']);
-        $this->assertTrue($events[0]['exists']);
-        $this->assertEmpty($events[0]['metadata']);
-        $this->assertTrue($events[0]['automated']);
-        $this->assertEquals('track_user_login_failure_event', $events[0]['eventName']);
-    }
-
-    public function testUserSignUp()
-    {
-        $email = 'test-user-signup@email.com';
-        $username = 'someusername';
-
-       $this->call(
-           PostSpec::create('request', '/wp-login.php?action=register', [
-               'Content-Type: application/x-www-form-urlencoded'
-           ], "user_login=$username&user_email=$email&wp-submit=Register&redirect_to=")
-       );
-
-       $users = $this->connection()->query("SELECT * FROM wp_users where user_email='".$email."'")->fetchAll();
-
-       $this->assertEquals(1, count($users));
-
-       $signUpEvent = null;
-       foreach(AppsecStatus::getInstance()->getEvents() as $event)
-       {
-           if ($event['eventName'] == 'track_user_signup_event') {
-               $signUpEvent = $event;
-           }
-       }
-
-       $this->assertTrue($signUpEvent['automated']);
-       $this->assertEquals($users[0]['ID'], $signUpEvent['userId']);
-       $this->assertEquals($users[0]['user_login'], $signUpEvent['metadata']['username']);
-       $this->assertEquals($users[0]['user_email'], $signUpEvent['metadata']['email']);
     }
 }

--- a/tests/Integrations/WordPress/V4_8/AutomatedLoginEventsTest.php
+++ b/tests/Integrations/WordPress/V4_8/AutomatedLoginEventsTest.php
@@ -9,6 +9,8 @@ use DDTrace\Tests\Integrations\WordPress\AutomatedLoginEventsTestSuite;
  */
 class AutomatedLoginEventsTest extends AutomatedLoginEventsTestSuite
 {
+    protected $users_table = 'wp_users';
+
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/WordPress/Version_4_8/index.php';

--- a/tests/Integrations/WordPress/V4_8/PathParamsTest.php
+++ b/tests/Integrations/WordPress/V4_8/PathParamsTest.php
@@ -2,11 +2,12 @@
 
 namespace DDTrace\Tests\Integrations\WordPress\V4_8;
 
-use DDTrace\Tests\Common\AppsecTestCase;
-use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
-use datadog\appsec\AppsecStatus;
+use DDTrace\Tests\Integrations\WordPress\PathParamsTestSuite;
 
-class PathParamsTest extends AppsecTestCase
+ /**
+ * @group appsec
+ */
+class PathParamsTest extends PathParamsTestSuite
 {
     protected static function getAppIndexScript()
     {
@@ -15,63 +16,5 @@ class PathParamsTest extends AppsecTestCase
 
     protected function databaseDump() {
         return file_get_contents(__DIR__ . '/../../../Frameworks/WordPress/Version_4_8/wp_2019-10-01.sql');
-    }
-
-    public function testPost()
-    {
-        $this->call(
-            GetSpec::create(
-                'Post example',
-                '/hello-world'
-            )
-        );
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals('hello-world', $events[0]["server.request.path_params"]['name']);
-        $this->assertEquals('push_address', $events[0]['eventName']);
-    }
-
-    public function testCategory()
-    {
-        $this->call(
-            GetSpec::create(
-                'Category',
-                '/category/uncategorized'
-            )
-        );
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals('uncategorized', $events[0]["server.request.path_params"]['category_name']);
-        $this->assertEquals('push_address', $events[0]['eventName']);
-    }
-
-    public function testAuthor()
-    {
-        $this->call(
-            GetSpec::create(
-                'Author',
-                '/author/SammyK'
-            )
-        );
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals('SammyK', $events[0]["server.request.path_params"]['author_name']);
-        $this->assertEquals('push_address', $events[0]['eventName']);
-    }
-
-    public function testNonExistingPost()
-    {
-       $this->call(
-            GetSpec::create(
-                'Not existing post',
-                '/non-existing-post'
-            )
-        );
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(0, count($events));
     }
 }

--- a/tests/Integrations/WordPress/V5_5/AutomatedLoginEventsTest.php
+++ b/tests/Integrations/WordPress/V5_5/AutomatedLoginEventsTest.php
@@ -2,14 +2,12 @@
 
 namespace DDTrace\Tests\Integrations\WordPress\V5_5;
 
-use DDTrace\Tests\Common\AppsecTestCase;
-use DDTrace\Tests\Frameworks\Util\Request\PostSpec;
-use datadog\appsec\AppsecStatus;
+use DDTrace\Tests\Integrations\WordPress\AutomatedLoginEventsTestSuite;
 
  /**
  * @group appsec
  */
-class AutomatedLoginEventsTest extends AppsecTestCase
+class AutomatedLoginEventsTest extends AutomatedLoginEventsTestSuite
 {
     protected static function getAppIndexScript()
     {
@@ -18,112 +16,5 @@ class AutomatedLoginEventsTest extends AppsecTestCase
 
     protected function databaseDump() {
         return file_get_contents(__DIR__ . '/../../../Frameworks/WordPress/Version_5_5/wp_2020-10-21.sql');
-    }
-
-    protected function ddSetUp()
-    {
-        parent::ddSetUp();
-        $this->connection()->exec("DELETE from users where email LIKE 'test-user%'");
-        AppsecStatus::getInstance()->setDefaults();
-    }
-
-    public function testUserLoginSuccessEvent()
-    {
-        $email = 'test-user@email.com';
-        $password = 'test';
-        $id = 123;
-        $name = 'some name';
-        //Password is test
-        $this->connection()->exec(
-            'INSERT INTO wp55_users VALUES ('.$id.',"test","$P$BDzpK1XXL9P2cYWggPMUbN87GQSiI80","test","'.$email.'","","2020-10-22 16:31:15","",0,"'.$name.'")'
-        );
-
-        $spec = PostSpec::create('request', '/wp-login.php', [
-            'Content-Type: application/x-www-form-urlencoded'
-        ], "log=$email&pwd=$password&wp-submit=Log In");
-
-        $this->call($spec, [ CURLOPT_FOLLOWLOCATION => false, CURLOPT_COOKIESESSION => true ]);
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals($id, $events[0]['userId']);
-        $this->assertEquals($email, $events[0]['metadata']['email']);
-        $this->assertEquals($name, $events[0]['metadata']['name']);
-        $this->assertTrue($events[0]['automated']);
-        $this->assertEquals('track_user_login_success_event', $events[0]['eventName']);
-    }
-
-    public function testUserLoginFailureEventWhenUserDoesNotExists()
-    {
-        $email = 'non-existing@email.com';
-        $password = 'some password';
-        $spec = PostSpec::create('request', '/wp-login.php', [
-                    'Content-Type: application/x-www-form-urlencoded'
-                ], "log=$email&pwd=$password&wp-submit=Log In");
-
-        $this->call($spec, [ CURLOPT_FOLLOWLOCATION => false, CURLOPT_COOKIESESSION => true ]);
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals($email, $events[0]['userId']);
-        $this->assertFalse($events[0]['exists']);
-        $this->assertEmpty($events[0]['metadata']);
-        $this->assertTrue($events[0]['automated']);
-        $this->assertEquals('track_user_login_failure_event', $events[0]['eventName']);
-    }
-
-    public function testUserLoginFailureEventWhenUserDoesExists()
-    {
-        $email = 'test-user-2@email.com';
-        $password = 'test';
-        $id = 333;
-        $name = 'some name';
-        //Password is test
-        $this->connection()->exec(
-            'INSERT INTO wp55_users VALUES ('.$id.',"test","$P$BDzpK1XXL9P2cYWggPMUbN87GQSiI80","test","'.$email.'","","2020-10-22 16:31:15","",0,"'.$name.'")'
-        );
-
-        $spec = PostSpec::create('request', '/wp-login.php', [
-            'Content-Type: application/x-www-form-urlencoded'
-        ], "log=$email&pwd=invalid&wp-submit=Log In");
-
-        $this->call($spec, [ CURLOPT_FOLLOWLOCATION => false, CURLOPT_COOKIESESSION => true ]);
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals($email, $events[0]['userId']);
-        $this->assertTrue($events[0]['exists']);
-        $this->assertEmpty($events[0]['metadata']);
-        $this->assertTrue($events[0]['automated']);
-        $this->assertEquals('track_user_login_failure_event', $events[0]['eventName']);
-    }
-
-    public function testUserSignUp()
-    {
-        $email = 'test-user-signup@email.com';
-        $username = 'someusername';
-
-       $this->call(
-           PostSpec::create('request', '/wp-login.php?action=register', [
-               'Content-Type: application/x-www-form-urlencoded'
-           ], "user_login=$username&user_email=$email&wp-submit=Register&redirect_to=")
-       );
-
-       $users = $this->connection()->query("SELECT * FROM wp55_users where user_email='".$email."'")->fetchAll();
-
-       $this->assertEquals(1, count($users));
-
-       $signUpEvent = null;
-       foreach(AppsecStatus::getInstance()->getEvents() as $event)
-       {
-           if ($event['eventName'] == 'track_user_signup_event') {
-               $signUpEvent = $event;
-           }
-       }
-
-       $this->assertTrue($signUpEvent['automated']);
-       $this->assertEquals($users[0]['ID'], $signUpEvent['userId']);
-       $this->assertEquals($users[0]['user_login'], $signUpEvent['metadata']['username']);
-       $this->assertEquals($users[0]['user_email'], $signUpEvent['metadata']['email']);
     }
 }

--- a/tests/Integrations/WordPress/V5_5/PathParamsTest.php
+++ b/tests/Integrations/WordPress/V5_5/PathParamsTest.php
@@ -2,11 +2,12 @@
 
 namespace DDTrace\Tests\Integrations\WordPress\V5_5;
 
-use DDTrace\Tests\Common\AppsecTestCase;
-use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
-use datadog\appsec\AppsecStatus;
+use DDTrace\Tests\Integrations\WordPress\PathParamsTestSuite;
 
-class PathParamsTest extends AppsecTestCase
+ /**
+ * @group appsec
+ */
+class PathParamsTest extends PathParamsTestSuite
 {
     protected static function getAppIndexScript()
     {
@@ -16,82 +17,5 @@ class PathParamsTest extends AppsecTestCase
     protected function connection()
     {
         return new \PDO('mysql:host=mysql_integration;dbname=test', 'test', 'test');
-    }
-
-    protected function ddSetUp()
-    {
-        parent::ddSetUp();
-        $this->connection()->exec(file_get_contents(__DIR__ . '/../../../Frameworks/WordPress/Version_5_5/wp_2020-10-21.sql'));
-        AppsecStatus::getInstance()->setDefaults();
-    }
-
-    public static function ddSetUpBeforeClass()
-    {
-        parent::ddSetUpBeforeClass();
-        AppsecStatus::getInstance()->init();
-    }
-
-    public static function ddTearDownAfterClass()
-    {
-        AppsecStatus::getInstance()->destroy();
-        parent::ddTearDownAfterClass();
-    }
-
-    public function testPost()
-    {
-        $this->call(
-            GetSpec::create(
-                'Post example',
-                '/hello-world'
-            )
-        );
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals('hello-world', $events[0]["server.request.path_params"]['name']);
-        $this->assertEquals('push_address', $events[0]['eventName']);
-    }
-
-    public function testCategory()
-    {
-        $this->call(
-            GetSpec::create(
-                'Category',
-                '/category/uncategorized'
-            )
-        );
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals('uncategorized', $events[0]["server.request.path_params"]['category_name']);
-        $this->assertEquals('push_address', $events[0]['eventName']);
-    }
-
-    public function testAuthor()
-    {
-        $this->call(
-            GetSpec::create(
-                'Author',
-                '/author/test'
-            )
-        );
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals('test', $events[0]["server.request.path_params"]['author_name']);
-        $this->assertEquals('push_address', $events[0]['eventName']);
-    }
-
-    public function testNonExistingPost()
-    {
-       $this->call(
-            GetSpec::create(
-                'Not existing post',
-                '/non-existing-post'
-            )
-        );
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(0, count($events));
     }
 }

--- a/tests/Integrations/WordPress/V5_9/AutomatedLoginEventsTest.php
+++ b/tests/Integrations/WordPress/V5_9/AutomatedLoginEventsTest.php
@@ -1,16 +1,13 @@
 <?php
 
-namespace DDTrace\Tests\Integrations\WordPress\V5_8;
+namespace DDTrace\Tests\Integrations\WordPress\V5_9;
 
-use DDTrace\Tests\Common\AppsecTestCase;
-use DDTrace\Tests\Frameworks\Util\Request\PostSpec;
-use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
-use datadog\appsec\AppsecStatus;
+use DDTrace\Tests\Integrations\WordPress\AutomatedLoginEventsTestSuite;
 
  /**
  * @group appsec
  */
-class AutomatedLoginEventsTest extends AppsecTestCase
+class AutomatedLoginEventsTest extends AutomatedLoginEventsTestSuite
 {
     protected static function getAppIndexScript()
     {
@@ -19,112 +16,5 @@ class AutomatedLoginEventsTest extends AppsecTestCase
 
     protected function databaseDump() {
         return file_get_contents(__DIR__ . '/../../../Frameworks/WordPress/Version_5_5/wp_2020-10-21.sql');
-    }
-
-    protected function ddSetUp()
-    {
-        parent::ddSetUp();
-        $this->connection()->exec("DELETE from users where email LIKE 'test-user%'");
-        AppsecStatus::getInstance()->setDefaults();
-    }
-
-    public function testUserLoginSuccessEvent()
-    {
-        $email = 'test-user@email.com';
-        $password = 'test';
-        $id = 123;
-        $name = 'some name';
-        //Password is test
-        $this->connection()->exec(
-            'INSERT INTO wp55_users VALUES ('.$id.',"test","$P$BDzpK1XXL9P2cYWggPMUbN87GQSiI80","test","'.$email.'","","2020-10-22 16:31:15","",0,"'.$name.'")'
-        );
-
-        $spec = PostSpec::create('request', '/wp-login.php', [
-            'Content-Type: application/x-www-form-urlencoded'
-        ], "log=$email&pwd=$password&wp-submit=Log In");
-
-        $this->call($spec, [ CURLOPT_FOLLOWLOCATION => false, CURLOPT_COOKIESESSION => true ]);
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals($id, $events[0]['userId']);
-        $this->assertEquals($email, $events[0]['metadata']['email']);
-        $this->assertEquals($name, $events[0]['metadata']['name']);
-        $this->assertTrue($events[0]['automated']);
-        $this->assertEquals('track_user_login_success_event', $events[0]['eventName']);
-    }
-
-    public function testUserLoginFailureEventWhenUserDoesNotExists()
-    {
-        $email = 'non-existing@email.com';
-        $password = 'some password';
-        $spec = PostSpec::create('request', '/wp-login.php', [
-                    'Content-Type: application/x-www-form-urlencoded'
-                ], "log=$email&pwd=$password&wp-submit=Log In");
-
-        $this->call($spec, [ CURLOPT_FOLLOWLOCATION => false, CURLOPT_COOKIESESSION => true ]);
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals($email, $events[0]['userId']);
-        $this->assertFalse($events[0]['exists']);
-        $this->assertEmpty($events[0]['metadata']);
-        $this->assertTrue($events[0]['automated']);
-        $this->assertEquals('track_user_login_failure_event', $events[0]['eventName']);
-    }
-
-    public function testUserLoginFailureEventWhenUserDoesExists()
-    {
-        $email = 'test-user-2@email.com';
-        $password = 'test';
-        $id = 333;
-        $name = 'some name';
-        //Password is test
-        $this->connection()->exec(
-            'INSERT INTO wp55_users VALUES ('.$id.',"test","$P$BDzpK1XXL9P2cYWggPMUbN87GQSiI80","test","'.$email.'","","2020-10-22 16:31:15","",0,"'.$name.'")'
-        );
-
-        $spec = PostSpec::create('request', '/wp-login.php', [
-            'Content-Type: application/x-www-form-urlencoded'
-        ], "log=$email&pwd=invalid&wp-submit=Log In");
-
-        $this->call($spec, [ CURLOPT_FOLLOWLOCATION => false, CURLOPT_COOKIESESSION => true ]);
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals($email, $events[0]['userId']);
-        $this->assertTrue($events[0]['exists']);
-        $this->assertEmpty($events[0]['metadata']);
-        $this->assertTrue($events[0]['automated']);
-        $this->assertEquals('track_user_login_failure_event', $events[0]['eventName']);
-    }
-
-    public function testUserSignUp()
-    {
-        $email = 'test-user-signup@email.com';
-        $username = 'someusername';
-
-       $this->call(
-           PostSpec::create('request', '/wp-login.php?action=register', [
-               'Content-Type: application/x-www-form-urlencoded'
-           ], "user_login=$username&user_email=$email&wp-submit=Register&redirect_to=")
-       );
-
-       $users = $this->connection()->query("SELECT * FROM wp55_users where user_email='".$email."'")->fetchAll();
-
-       $this->assertEquals(1, count($users));
-
-       $signUpEvent = null;
-       foreach(AppsecStatus::getInstance()->getEvents() as $event)
-       {
-           if ($event['eventName'] == 'track_user_signup_event') {
-               $signUpEvent = $event;
-           }
-       }
-
-       $this->assertTrue($signUpEvent['automated']);
-       $this->assertEquals($users[0]['ID'], $signUpEvent['userId']);
-       $this->assertEquals($users[0]['user_login'], $signUpEvent['metadata']['username']);
-       $this->assertEquals($users[0]['user_email'], $signUpEvent['metadata']['email']);
     }
 }

--- a/tests/Integrations/WordPress/V5_9/PathParamsTest.php
+++ b/tests/Integrations/WordPress/V5_9/PathParamsTest.php
@@ -2,11 +2,12 @@
 
 namespace DDTrace\Tests\Integrations\WordPress\V5_9;
 
-use DDTrace\Tests\Common\AppsecTestCase;
-use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
-use datadog\appsec\AppsecStatus;
+use DDTrace\Tests\Integrations\WordPress\PathParamsTestSuite;
 
-class PathParamsTest extends AppsecTestCase
+ /**
+ * @group appsec
+ */
+class PathParamsTest extends PathParamsTestSuite
 {
     protected static function getAppIndexScript()
     {
@@ -15,63 +16,5 @@ class PathParamsTest extends AppsecTestCase
 
     protected function databaseDump() {
         return file_get_contents(__DIR__ . '/../../../Frameworks/WordPress/Version_5_5/wp_2020-10-21.sql');
-    }
-
-    public function testPost()
-    {
-        $this->call(
-            GetSpec::create(
-                'Post example',
-                '/hello-world'
-            )
-        );
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals('hello-world', $events[0]["server.request.path_params"]['name']);
-        $this->assertEquals('push_address', $events[0]['eventName']);
-    }
-
-    public function testCategory()
-    {
-        $this->call(
-            GetSpec::create(
-                'Category',
-                '/category/uncategorized'
-            )
-        );
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals('uncategorized', $events[0]["server.request.path_params"]['category_name']);
-        $this->assertEquals('push_address', $events[0]['eventName']);
-    }
-
-    public function testAuthor()
-    {
-        $this->call(
-            GetSpec::create(
-                'Author',
-                '/author/test'
-            )
-        );
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals('test', $events[0]["server.request.path_params"]['author_name']);
-        $this->assertEquals('push_address', $events[0]['eventName']);
-    }
-
-    public function testNonExistingPost()
-    {
-       $this->call(
-            GetSpec::create(
-                'Not existing post',
-                '/non-existing-post'
-            )
-        );
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(0, count($events));
     }
 }

--- a/tests/Integrations/WordPress/V6_1/PathParamsTest.php
+++ b/tests/Integrations/WordPress/V6_1/PathParamsTest.php
@@ -2,80 +2,15 @@
 
 namespace DDTrace\Tests\Integrations\WordPress\V6_1;
 
-use DDTrace\Tests\Common\AppsecTestCase;
-use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
-use datadog\appsec\AppsecStatus;
+use DDTrace\Tests\Integrations\WordPress\PathParamsTestSuite;
 
-class PathParamsTest extends AppsecTestCase
+ /**
+ * @group appsec
+ */
+class PathParamsTest extends PathParamsTestSuite
 {
     protected static function getAppIndexScript()
     {
         return __DIR__ . '/../../../Frameworks/WordPress/Version_6_1/index.php';
-    }
-
-    public function ddSetUp()
-    {
-        parent::ddSetUp();
-        $pdo = new \PDO('mysql:host=mysql_integration;dbname=test', 'test', 'test');
-        $pdo->exec(file_get_contents(__DIR__ . '/../../../Frameworks/WordPress/Version_6_1/scripts/wp_initdb.sql'));
-        AppsecStatus::getInstance()->setDefaults();
-    }
-
-    public function testPost()
-    {
-        $this->call(
-            GetSpec::create(
-                'Post example',
-                '/hello-world'
-            )
-        );
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals('hello-world', $events[0]["server.request.path_params"]['name']);
-        $this->assertEquals('push_address', $events[0]['eventName']);
-    }
-
-    public function testCategory()
-    {
-        $this->call(
-            GetSpec::create(
-                'Category',
-                '/category/uncategorized'
-            )
-        );
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals('uncategorized', $events[0]["server.request.path_params"]['category_name']);
-        $this->assertEquals('push_address', $events[0]['eventName']);
-    }
-
-    public function testAuthor()
-    {
-        $this->call(
-            GetSpec::create(
-                'Author',
-                '/author/test'
-            )
-        );
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(1, count($events));
-        $this->assertEquals('test', $events[0]["server.request.path_params"]['author_name']);
-        $this->assertEquals('push_address', $events[0]['eventName']);
-    }
-
-    public function testNonExistingPost()
-    {
-       $this->call(
-            GetSpec::create(
-                'Not existing post',
-                '/non-existing-post'
-            )
-        );
-
-        $events = AppsecStatus::getInstance()->getEvents();
-        $this->assertEquals(0, count($events));
     }
 }


### PR DESCRIPTION
### Description

Reduce duplication on `appsec` integration tests on the tracer suite

Summary:
On appsec we had two main tests `AutomatedLoginEventsTest` and `PathParamsTest` per framework version. This two test files were 99% identical given a framework. This PR extract a parent clase per framework and then each version extends it and when necessary, change implementation

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
