### PR TITLE
fix(swoole): Multiple Workers in SWOOLE_BASE mode

### DIFF
--- a/src/DDTrace/Integrations/Swoole/SwooleIntegration.php
+++ b/src/DDTrace/Integrations/Swoole/SwooleIntegration.php
@@ -4,7 +4,6 @@ namespace DDTrace\Integrations\Swoole;
 
 use DDTrace\HookData;
 use DDTrace\Integrations\Integration;
-use DDTrace\Log\Logger;
 use DDTrace\SpanStack;
 use DDTrace\Tag;
 use DDTrace\Type;
@@ -35,8 +34,6 @@ class SwooleIntegration extends Integration
         \DDTrace\install_hook(
             $callback,
             function (HookData $hook) use ($integration, $server, $scheme) {
-                Logger::get()->debug('Request start');
-                Logger::get()->debug(json_encode($server));
                 $rootSpan = $hook->span(new SpanStack());
                 $rootSpan->name = "web.request";
                 $rootSpan->service = \ddtrace_config_app_name('swoole');
@@ -114,9 +111,6 @@ class SwooleIntegration extends Integration
         \DDTrace\install_hook(
             $callback,
             function (HookData $hook) use ($integration, $server) {
-                Logger::get()->debug('Worker start');
-                Logger::get()->debug(json_encode($server));
-                handle_fork();
             }
         );
     }

--- a/src/DDTrace/Integrations/Swoole/SwooleIntegration.php
+++ b/src/DDTrace/Integrations/Swoole/SwooleIntegration.php
@@ -111,6 +111,7 @@ class SwooleIntegration extends Integration
         \DDTrace\install_hook(
             $callback,
             function (HookData $hook) use ($integration, $server) {
+                handle_fork();
             }
         );
     }

--- a/src/DDTrace/Integrations/Swoole/SwooleIntegration.php
+++ b/src/DDTrace/Integrations/Swoole/SwooleIntegration.php
@@ -108,29 +108,26 @@ class SwooleIntegration extends Integration
 
     public function instrumentWorkerStart(callable $callback, SwooleIntegration $integration, Server $server)
     {
-        if ($server->mode === SWOOLE_BASE) {
-            return;
-        }
-
         \DDTrace\install_hook(
             $callback,
             function (HookData $hook) use ($integration, $server) {
-                handle_fork();
+                if ($server->worker_pid !== $server->master_pid) {
+                    handle_fork();
+                }
             }
         );
     }
 
     public function instrumentWorkerStop(callable $callback, SwooleIntegration $integration, Server $server)
     {
-        if ($server->mode === SWOOLE_BASE) {
-            return;
-        }
 
         \DDTrace\install_hook(
             $callback,
             null,
             function (HookData $hook) use ($integration, $server) {
-                handle_fork();
+                if ($server->worker_pid !== $server->master_pid) {
+                    handle_fork();
+                }
             }
         );
     }

--- a/src/DDTrace/Integrations/Swoole/SwooleIntegration.php
+++ b/src/DDTrace/Integrations/Swoole/SwooleIntegration.php
@@ -4,6 +4,7 @@ namespace DDTrace\Integrations\Swoole;
 
 use DDTrace\HookData;
 use DDTrace\Integrations\Integration;
+use DDTrace\Log\Logger;
 use DDTrace\SpanStack;
 use DDTrace\Tag;
 use DDTrace\Type;
@@ -111,7 +112,10 @@ class SwooleIntegration extends Integration
         \DDTrace\install_hook(
             $callback,
             function (HookData $hook) use ($integration, $server) {
-                if ($server->worker_pid !== $server->master_pid) {
+                Logger::get()->debug('Worker start');
+                Logger::get()->debug(json_encode($server));
+                if ($server->mode !== SWOOLE_BASE || ($server->worker_pid !== $server->master_pid)) {
+                    // While not in base mode, swoole will always perform swoole_fork_exec
                     handle_fork();
                 }
             }
@@ -120,12 +124,14 @@ class SwooleIntegration extends Integration
 
     public function instrumentWorkerStop(callable $callback, SwooleIntegration $integration, Server $server)
     {
-
         \DDTrace\install_hook(
             $callback,
             null,
             function (HookData $hook) use ($integration, $server) {
-                if ($server->worker_pid !== $server->master_pid) {
+                Logger::get()->debug('Worker stop');
+                Logger::get()->debug(json_encode($server));
+                if ($server->mode !== SWOOLE_BASE || ($server->worker_pid !== $server->master_pid)) {
+                    // While not in base mode, swoole will always perform swoole_fork_exec
                     handle_fork();
                 }
             }

--- a/tests/Frameworks/Swoole/index.php
+++ b/tests/Frameworks/Swoole/index.php
@@ -3,7 +3,9 @@
 require __DIR__ . '/../../vendor/autoload.php';
 
 $http = new Swoole\Http\Server("0.0.0.0", 9999);
-
+$http->set([
+    'worker_num' => 2
+]);
 $http->on('request', function ($request, $response) {
     $requestUri = $request->server['request_uri'];
 

--- a/tests/Sapi/SwooleServer/SwooleServer.php
+++ b/tests/Sapi/SwooleServer/SwooleServer.php
@@ -73,7 +73,13 @@ final class SwooleServer implements Sapi
     public function stop()
     {
         error_log("[swoole-server] Stopping...");
-        $this->process->stop(0);
+        $pid = $this->process->getPid();
+        error_log("[swoole-server] PID: $pid");
+        $exitCode = $this->process->stop(0, SIGTERM);
+        $logs = $this->process->getOutput();
+        error_log("[swoole-server] Output: $logs");
+        error_log("[swoole-server] Error output: " . $this->process->getErrorOutput());
+        error_log("[swoole-server] Terminated: " . ($this->process->isTerminated() ? 'yes' : 'no'));
     }
 
     public function isFastCgi()

--- a/tests/Sapi/SwooleServer/SwooleServer.php
+++ b/tests/Sapi/SwooleServer/SwooleServer.php
@@ -73,13 +73,7 @@ final class SwooleServer implements Sapi
     public function stop()
     {
         error_log("[swoole-server] Stopping...");
-        $pid = $this->process->getPid();
-        error_log("[swoole-server] PID: $pid");
-        $exitCode = $this->process->stop(0, SIGTERM);
-        $logs = $this->process->getOutput();
-        error_log("[swoole-server] Output: $logs");
-        error_log("[swoole-server] Error output: " . $this->process->getErrorOutput());
-        error_log("[swoole-server] Terminated: " . ($this->process->isTerminated() ? 'yes' : 'no'));
+        $this->process->stop(0, SIGTERM);
     }
 
     public function isFastCgi()


### PR DESCRIPTION
### Description

<!---
Any description you feel is relevant and gives more background to this PR, if necessary.
-->

A [swoole_fork](https://github.com/swoole/swoole-src/blob/f4299e7d02dec030fd7b26c3d060cbeec41e3304/src/server/process.cc#L106) always happens during Factory::spawn_Event_worker, regardless of the server's mode. Therefore, when multiple workers are used, we have to handle forking.

This wasn't caught before because, considering that we use 1 core in all of our tests, we were, therefore, using 1 worker by default.

Removed the fork handling at worker stop/exit/error, since they aren't necessary.

On my app (Laravel Octane w/ Swoole), I generated some load and it's working as well ([sandbox](https://app.datadoghq.eu/apm/traces?query=%40_trace_root%3A1%20env%3Aprod&agg_m=count&agg_m_source=base&agg_t=count&cols=core_service%2Ccore_resource_name%2Clog_duration%2Clog_http.method%2Clog_http.status_code&fromUser=true&graphType=flamegraph&historicalData=false&messageDisplay=inline&query_translation_version=v0&shouldShowLegend=true&sort=time&spanType=trace-root&view=spans&start=1722332527500&end=1722332640000&paused=true)) - This load was generated under the SWOOLE_BASE mode with four workers. Similar load was generated under SWOOLE_PROCESS a few minutes before the linked time span.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
