### PR TITLE
Optimize circleci build times

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -244,6 +244,24 @@ aliases:
         # Avoid intermittent DNS hangs: See https://github.com/curl/curl/issues/593#issuecomment-170146252
         echo "options single-request" | sudo tee -a /etc/resolv.conf
 
+  - &STEP_LINK_EXTENSION
+    run:
+      name: Link extension
+      background: true
+      command: |
+        echo $$ > /tmp/link_extension.pid
+        sed -i 's/-export-symbols .*\/ddtrace\.sym/-Wl,--retain-symbols-file=ddtrace.sym/g' ddtrace.ldflags
+        gcc -shared -Wl,-whole-archive ddtrace.a -Wl,-no-whole-archive $(cat ddtrace.ldflags) libddtrace_php.a -Wl,-soname -Wl,ddtrace.so -o ddtrace.so
+        mkdir -p tmp/build_extension/modules
+        mv ddtrace.so tmp/build_extension/modules/
+
+  - &STEP_AWAIT_LINK_EXTENSION
+    run:
+      name: Wait for extension linking
+      command: |
+        tail --pid=$(cat /tmp/link_extension.pid) -f /dev/null || true
+        echo "export DD_TRACE_ASSUME_COMPILED=1" >> $BASH_ENV
+
   - &STEP_STORE_TEST_RESULTS
     store_test_results:
       path: test-results
@@ -405,9 +423,8 @@ commands:
               cp .circleci/valgrind/<< parameters.valgrind_config >>_valgrind.rc /home/circleci/.valgrindrc
               cp .circleci/valgrind/valgrind_<< parameters.valgrind_config >>_suppressions.lib /home/circleci/valgrind_<< parameters.valgrind_config >>_suppressions.lib
             fi
-  prepare_extension_and_composer_with_cache:
+  update_composer_with_cache:
     steps:
-      - <<: *STEP_EXT_INSTALL
       - <<: *STEP_COMPOSER_CACHE_RESTORE
       - <<: *STEP_COMPOSER_UPDATE
       - <<: *STEP_COMPOSER_CACHE_SAVE
@@ -717,9 +734,11 @@ jobs:
             - source-v1-{{ .Branch }}-{{ .Revision }}
       - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
+      - <<: *STEP_LINK_EXTENSION
       - lib_curl_workaround:
           command: sudo apt update; sudo apt -y install libcurl4-nss-dev
-      - prepare_extension_and_composer_with_cache
+      - update_composer_with_cache
+      - <<: *STEP_AWAIT_LINK_EXTENSION
       - run:
           name: Install phpstan
           command: |
@@ -777,9 +796,11 @@ jobs:
             - source-v1-{{ .Branch }}-{{ .Revision }}
       - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
-      - <<: *STEP_EXT_INSTALL
+      - <<: *STEP_LINK_EXTENSION
       - <<: *STEP_EXPORT_CI_ENV
       - <<: *STEP_PREPARE_TEST_RESULTS_DIR
+      - <<: *STEP_AWAIT_LINK_EXTENSION
+      - <<: *STEP_EXT_INSTALL
       - run:
           name: Run xdebug tests
           command: |
@@ -841,13 +862,16 @@ jobs:
           extra: with_httpbin_and_request_replayer
       - switch_php:
           php_version: << parameters.switch_php_version >>
-      - prepare_extension_and_composer_with_cache
+      - <<: *STEP_LINK_EXTENSION
+      - update_composer_with_cache
       - <<: *STEP_COMPOSER_TESTS_UPDATE
       - <<: *STEP_PREPARE_TEST_RESULTS_DIR
       - <<: *STEP_EXPORT_CI_ENV
       - <<: *STEP_WAIT_REQUEST_REPLAYER
       - <<: *STEP_RESOLVE_HTTPBIN_HOSTNAME_TO_IP
       - <<: *STEP_WAIT_TEST_AGENT
+      - <<: *STEP_AWAIT_LINK_EXTENSION
+      - <<: *STEP_EXT_INSTALL
       - run:
           name: Run tests
           command: |
@@ -895,11 +919,14 @@ jobs:
           extra: with_httpbin_and_request_replayer
       - switch_php:
           php_version: << parameters.switch_php_version >>
-      - prepare_extension_and_composer_with_cache
+      - <<: *STEP_LINK_EXTENSION
+      - update_composer_with_cache
       - <<: *STEP_COMPOSER_TESTS_UPDATE
       - <<: *STEP_PREPARE_TEST_RESULTS_DIR
       - <<: *STEP_EXPORT_CI_ENV
       - <<: *STEP_WAIT_REQUEST_REPLAYER
+      - <<: *STEP_AWAIT_LINK_EXTENSION
+      - <<: *STEP_EXT_INSTALL
       - run:
           name: Run tests
           command: |
@@ -943,13 +970,16 @@ jobs:
           extra: with_httpbin_and_request_replayer
       - switch_php:
           php_version: << parameters.switch_php_version >>
-      - prepare_extension_and_composer_with_cache
+      - <<: *STEP_LINK_EXTENSION
+      - update_composer_with_cache
       - <<: *STEP_COMPOSER_TESTS_UPDATE
       - <<: *STEP_PREPARE_TEST_RESULTS_DIR
       - <<: *STEP_EXPORT_CI_ENV
       - <<: *STEP_WAIT_REQUEST_REPLAYER
       - <<: *STEP_RESOLVE_HTTPBIN_HOSTNAME_TO_IP
       - <<: *STEP_WAIT_TEST_AGENT
+      - <<: *STEP_AWAIT_LINK_EXTENSION
+      - <<: *STEP_EXT_INSTALL
       - run:
           name: Run tests
           command: |
@@ -1144,10 +1174,12 @@ jobs:
           extra: with_httpbin_and_request_replayer
       - switch_php:
           php_version: << parameters.switch_php_version >>
+      - <<: *STEP_LINK_EXTENSION
       - <<: *STEP_EXPORT_CI_ENV
       - <<: *STEP_WAIT_REQUEST_REPLAYER
       - <<: *STEP_RESOLVE_HTTPBIN_HOSTNAME_TO_IP
       - <<: *STEP_WAIT_TEST_AGENT
+      - <<: *STEP_AWAIT_LINK_EXTENSION
       - run:
           name: Run tests
           command: |
@@ -1598,7 +1630,6 @@ jobs:
             - run:
                 name: Updating composer to v2
                 command: sudo composer self-update --2 --no-interaction
-      - install_extension
       - <<: *STEP_COMPOSER_CACHE_RESTORE
       - <<: *STEP_COMPOSER_UPDATE
       - <<: *STEP_COMPOSER_TESTS_UPDATE
@@ -1609,6 +1640,8 @@ jobs:
             equal: [ false, << parameters.coverage >> ]
           steps:
             - <<: *STEP_DISABLE_XDEBUG
+      - <<: *STEP_AWAIT_LINK_EXTENSION
+      - install_extension
       - <<: *STEP_WAIT_MYSQL
       - <<: *STEP_WAIT_REQUEST_REPLAYER
       - <<: *STEP_WAIT_TEST_AGENT
@@ -1669,6 +1702,11 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
+      - git_checkout
+      - <<: *STEP_ATTACH_WORKSPACE
+      - switch_php:
+          php_version: << parameters.switch_php_version >>
+      - <<: *STEP_LINK_EXTENSION
       - when:
           condition:
             and:
@@ -1681,11 +1719,6 @@ jobs:
             - run:
                 name: Updating composer to v2
                 command: sudo composer self-update --2 --no-interaction
-      - git_checkout
-      - <<: *STEP_ATTACH_WORKSPACE
-      - switch_php:
-          php_version: << parameters.switch_php_version >>
-      - install_extension
       - <<: *STEP_COMPOSER_CACHE_RESTORE
       - <<: *STEP_COMPOSER_UPDATE
       - <<: *STEP_COMPOSER_TESTS_UPDATE
@@ -1696,6 +1729,8 @@ jobs:
             equal: [ false, << parameters.coverage >> ]
           steps:
             - <<: *STEP_DISABLE_XDEBUG
+      - <<: *STEP_AWAIT_LINK_EXTENSION
+      - install_extension
       - when:
           condition:
             equal: [ "with_integrations", << parameters.with_executor >> ]
@@ -1703,6 +1738,7 @@ jobs:
             - <<: *STEP_WAIT_MYSQL
       - <<: *STEP_WAIT_REQUEST_REPLAYER
       - <<: *STEP_WAIT_TEST_AGENT
+      - <<: *STEP_AWAIT_LINK_EXTENSION
       - run:
           name: Run tests
           command: |
@@ -1745,7 +1781,10 @@ jobs:
             - source-v1-{{ .Branch }}-{{ .Revision }}
       - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
-      - prepare_extension_and_composer_with_cache
+      - <<: *STEP_LINK_EXTENSION
+      - update_composer_with_cache
+      - <<: *STEP_AWAIT_LINK_EXTENSION
+      - <<: *STEP_EXT_INSTALL
       - <<: *STEP_PREPARE_TEST_RESULTS_DIR
       - <<: *STEP_EXPORT_CI_ENV
       - <<: *STEP_WAIT_TEST_AGENT
@@ -1899,6 +1938,7 @@ jobs:
       - <<: *STEP_ATTACH_WORKSPACE
       - switch_php:
           php_version: << parameters.switch_php_version >>
+      - <<: *STEP_LINK_EXTENSION
       - <<: *STEP_PREPARE_TEST_RESULTS_DIR
       - <<: *STEP_EXPORT_CI_ENV
       - <<: *STEP_WAIT_REQUEST_REPLAYER
@@ -1912,6 +1952,7 @@ jobs:
               echo 'ext/<< parameters.ext_name >> is enabled but should not be installed'
               exit 1
             fi
+      - <<: *STEP_AWAIT_LINK_EXTENSION
       - run:
           name: Run << parameters.ext_name >> integration tests with ext/<< parameters.ext_name >> as shared lib + leak detection
           command: |
@@ -2554,6 +2595,61 @@ jobs:
             find $(pecl config-get test_dir) -type f -name '*.diff' -exec cp --parents '{}' /tmp/artifacts \;
           when: on_fail
       - store_artifacts: { path: '/tmp/artifacts' }
+
+  compile_rust_test:
+    working_directory: ~/datadog
+    parameters:
+      resource_class:
+        type: string
+        default: large
+    <<: *BARE_DOCKER_MACHINE
+    steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - git_checkout
+      - append_build_id
+      - setup_docker:
+          docker_image: datadog/dd-trace-ci:buster
+      - run:
+          name: Compile sidecar
+          command: |
+            SHARED=1 host_os=linux-gnu ./compile_rust.sh
+            cp -v ${CARGO_TARGET_DIR:-target}/debug/libddtrace_php.a .
+      - persist_to_workspace:
+          root: '.'
+          paths: [ './libddtrace_php.a' ]
+
+  compile_extension_test:
+    working_directory: ~/datadog
+    parameters:
+      php_major_minor:
+        # Expected in the format: <major>.<minor>, e.g. 8.2
+        type: string
+      resource_class:
+        type: string
+        default: medium
+      switch_php_version:
+        type: string
+    <<: *BARE_DOCKER_MACHINE
+    steps:
+      - restore_cache:
+          keys:
+            - source-v1-{{ .Branch }}-{{ .Revision }}
+      - git_checkout
+      - append_build_id
+      - setup_docker:
+          docker_image: datadog/dd-trace-ci:php-<< parameters.php_major_minor >>_buster
+      - run:
+          name: Build << parameters.switch_php_version >> extension
+          command: |
+            switch-php << parameters.switch_php_version >>
+            make -j static CFLAGS="-std=gnu11 -O2 -g -Wall -Wextra -Werror -Wno-error=return-local-addr" ECHO_ARG="-e"
+            cp -v tmp/build_extension/modules/ddtrace.a ddtrace.a
+            cp -v tmp/build_extension/ddtrace.ldflags ddtrace.ldflags
+      - persist_to_workspace:
+          root: '.'
+          paths: [ './ddtrace.a', 'ddtrace.ldflags' ]
 
   ExtensionComponents:
     working_directory: ~/datadog
@@ -3722,7 +3818,6 @@ jobs:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
       - git_checkout
-      - <<: *STEP_ATTACH_WORKSPACE
       - run:
           name: Install cbindgen
           command: cargo install cbindgen
@@ -5001,8 +5096,49 @@ workflows:
 
       - "Prepare Code"
 
+      - compile_rust_test:
+          name: "<< matrix.resource_class >>: Compile rust code for testing"
+          matrix:
+            parameters:
+              resource_class:
+                - medium
+                - arm.medium
+
+      - compile_extension_test:
+          name: "Compile << matrix.php_major_minor >> extension for testing"
+          matrix:
+            parameters:
+              php_major_minor:
+                - "7.0"
+                - "7.1"
+                - "7.2"
+                - "7.3"
+                - "7.4"
+                - "8.0"
+                - "8.1"
+                - "8.2"
+                - "8.3"
+              switch_php_version:
+                - nts
+
+      - compile_extension_test:
+          name: "<< matrix.resource_class >>: Compile << matrix.php_major_minor >> ZTS asan extension for testing"
+          matrix:
+            parameters:
+              php_major_minor:
+                - "7.4"
+                - "8.0"
+                - "8.1"
+                - "8.2"
+                - "8.3"
+              switch_php_version:
+                - debug-zts-asan
+              resource_class:
+                - medium
+                - arm.medium
+
       - test:
-          requires: [ 'Prepare Code' ]
+          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'medium: Compile rust code for testing' ]
           matrix:
             parameters:
               php_major_minor:
@@ -5025,7 +5161,7 @@ workflows:
                 - test_opcache
 
       - test:
-          requires: [ 'Prepare Code' ]
+          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'medium: Compile rust code for testing' ]
           coverage: true
           codecov_flags: tracer-php
           matrix:
@@ -5037,7 +5173,7 @@ workflows:
                 - test_unit_coverage
 
       - test:
-          requires: [ 'Prepare Code' ]
+          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'medium: Compile rust code for testing' ]
           matrix:
             parameters:
               php_major_minor:
@@ -5049,7 +5185,7 @@ workflows:
                 - test_extension_ci
 
       - test:
-          requires: [ 'Prepare Code' ]
+          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'medium: Compile rust code for testing' ]
           matrix:
             parameters:
               resource_class:
@@ -5078,13 +5214,13 @@ workflows:
 
       # sidecar is version independent
       - test_sidecar_sender:
-          requires: [ 'Prepare Code' ]
+          requires: [ 'Prepare Code', 'medium: Compile 8.2 ZTS asan extension for testing', 'medium: Compile rust code for testing' ]
           php_major_minor: '8.2'
           switch_php_version: debug-zts-asan
           resource_class: medium
 
       - test_multi_observer:
-          requires: [ 'Prepare Code' ]
+          requires: [ 'Prepare Code', 'medium: Compile << matrix.php_major_minor >> ZTS asan extension for testing', 'medium: Compile rust code for testing' ]
           matrix:
             parameters:
               php_major_minor:
@@ -5096,7 +5232,7 @@ workflows:
                 - debug-zts-asan
 
       - coverage:
-          requires: [ 'Prepare Code' ]
+          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'medium: Compile rust code for testing' ]
           matrix:
             parameters:
               php_major_minor:
@@ -5112,7 +5248,7 @@ workflows:
               make_target:
                 - test_coverage
       - asan:
-          requires: [ 'Prepare Code' ]
+          requires: [ 'Prepare Code', '<< matrix.resource_class >>: Compile << matrix.php_major_minor >> ZTS asan extension for testing', '<< matrix.resource_class >>: Compile rust code for testing' ]
           matrix:
             parameters:
               php_major_minor:
@@ -5139,7 +5275,7 @@ workflows:
                 switch_php_version: debug-zts-asan
 
       - integration:
-          requires: [ 'Prepare Code' ]
+          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'medium: Compile rust code for testing' ]
           resource_class: medium+
           matrix:
             parameters:
@@ -5160,7 +5296,7 @@ workflows:
                 - test_integration
 
       - integration:
-          requires: [ 'Prepare Code' ]
+          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'medium: Compile rust code for testing' ]
           resource_class: medium+
           coverage: true
           codecov_flags: tracer-php
@@ -5174,7 +5310,7 @@ workflows:
                 - test_distributed_tracing_coverage
 
       - integration_snapshots:
-          requires: [ 'Prepare Code' ]
+          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'medium: Compile rust code for testing' ]
           # Due to Symfony OOM during composer update
           resource_class: xlarge
           matrix:
@@ -5194,7 +5330,7 @@ workflows:
                 - test_integrations
 
       - integration_snapshots:
-          requires: [ 'Prepare Code' ]
+          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'medium: Compile rust code for testing' ]
           # Due to Symfony OOM during composer update
           resource_class: xlarge
           coverage: true
@@ -5209,7 +5345,7 @@ workflows:
                 - test_integrations_coverage
 
       - integration:
-          requires: [ 'Prepare Code' ]
+          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'medium: Compile rust code for testing' ]
           resource_class: medium+
           sapi: fpm-fcgi
           disable_runner_distributed_tracing: true
@@ -5236,7 +5372,7 @@ workflows:
           # and switch to a non-debug PHP build.
           # Once the fix for https://github.com/phpredis/phpredis/issues/1869 is released, we can remove this additional
           # runner and add back again test_integrations_phpredis5 to the PHP 8.0 test suite.
-          requires: [ 'Prepare Code' ]
+          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'medium: Compile rust code for testing' ]
           with_executor: 'with_redis'
           matrix:
             parameters:
@@ -5251,7 +5387,7 @@ workflows:
                 - test_integrations_phpredis5
 
       - integration:
-          requires: [ 'Prepare Code' ]
+          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'medium: Compile rust code for testing' ]
           resource_class: medium+
           sapi: fpm-fcgi
           disable_runner_distributed_tracing: true
@@ -5267,130 +5403,125 @@ workflows:
                 - test_distributed_tracing_coverage
 
       - xdebug_tests:
-          requires: [ 'Prepare Code' ]
+          requires: [ 'Prepare Code', 'Compile 7.0 extension for testing', 'medium: Compile rust code for testing' ]
           name: "PHP 70 Xdebug tests"
           docker_image: "datadog/dd-trace-ci:php-7.0_buster"
           xdebug_version_one: "2.7.2"
       - xdebug_tests:
-          requires: [ 'Prepare Code' ]
+          requires: [ 'Prepare Code', 'Compile 7.1 extension for testing', 'medium: Compile rust code for testing' ]
           name: "PHP 71 Xdebug tests"
           docker_image: "datadog/dd-trace-ci:php-7.1_buster"
           xdebug_version_one: "2.9.5"
           xdebug_version_two: "2.9.2"
-      # - unit_tests: # disabled due to posisbly leaking tests
-      #     requires: [ 'Prepare Code' ]
-      #     name: "PHP 70 Unit tests-zts"
-      #     docker_image: "datadog/docker-library:ddtrace_alpine_php-7.0-zts-debug"
       - xdebug_tests:
-          requires: [ 'Prepare Code' ]
+          requires: [ 'Prepare Code', 'Compile 7.2 extension for testing', 'medium: Compile rust code for testing' ]
           name: "PHP 72 Xdebug tests"
           docker_image: "datadog/dd-trace-ci:php-7.2_buster"
           xdebug_version_one: "2.9.5"
           xdebug_version_two: "2.9.2"
       - xdebug_tests:
-          requires: [ 'Prepare Code' ]
+          requires: [ 'Prepare Code', 'Compile 7.3 extension for testing', 'medium: Compile rust code for testing' ]
           name: "PHP 73 Xdebug tests"
           docker_image: "datadog/dd-trace-ci:php-7.3_buster"
           xdebug_version_one: "2.9.5"
           xdebug_version_two: "2.9.2"
       - xdebug_tests:
-          requires: [ 'Prepare Code' ]
+          requires: [ 'Prepare Code', 'Compile 7.4 extension for testing', 'medium: Compile rust code for testing' ]
           name: "PHP 74 Xdebug tests"
           docker_image: "datadog/dd-trace-ci:php-7.4_buster"
           xdebug_version_one: "2.9.5"
           xdebug_version_two: "2.9.2"
       - xdebug_tests:
-          requires: [ 'Prepare Code' ]
+          requires: [ 'Prepare Code', 'Compile 8.0 extension for testing', 'medium: Compile rust code for testing' ]
           name: "PHP 80 Xdebug tests"
           docker_image: "datadog/dd-trace-ci:php-8.0_buster"
           xdebug_version_one: "3.0.0"
       - xdebug_tests:
-          requires: [ 'Prepare Code' ]
+          requires: [ 'Prepare Code', 'Compile 8.1 extension for testing', 'medium: Compile rust code for testing' ]
           name: "PHP 81 Xdebug tests"
           docker_image: "datadog/dd-trace-ci:php-8.1_buster"
           xdebug_version_one: "3.1.0"
       - xdebug_tests:
-          requires: [ 'Prepare Code' ]
+          requires: [ 'Prepare Code', 'Compile 8.2 extension for testing', 'medium: Compile rust code for testing' ]
           name: "PHP 82 Xdebug tests"
           docker_image: "datadog/dd-trace-ci:php-8.2_buster"
           xdebug_version_one: "3.2.2"
       - xdebug_tests:
-          requires: [ 'Prepare Code' ]
+          requires: [ 'Prepare Code', 'Compile 8.3 extension for testing', 'medium: Compile rust code for testing' ]
           name: "PHP 83 Xdebug tests"
           docker_image: "datadog/dd-trace-ci:php-8.3_buster"
           xdebug_version_one: "3.3.0"
 
       - placeholder:
-          requires: [ 'Prepare Code' ]
+          requires: [ 'Prepare Code', 'medium: Compile rust code for testing' ]
           name: Language tests
 
       - php_language_tests:
-          requires: [ 'Language tests' ]
+          requires: [ 'Language tests', 'Compile 8.3 extension for testing' ]
           name: "PHP 83 language tests"
           xfail_list: dockerfiles/ci/xfail_tests/8.3.list
           docker_image: "datadog/dd-trace-ci:php-8.3_buster"
           parallel_workers: true
       - php_language_tests:
-          requires: [ 'Language tests' ]
+          requires: [ 'Language tests', 'Compile 8.2 extension for testing' ]
           name: "PHP 82 language tests"
           xfail_list: dockerfiles/ci/xfail_tests/8.2.list
           docker_image: "datadog/dd-trace-ci:php-8.2_buster"
           parallel_workers: true
       - php_language_tests:
-          requires: [ 'Language tests' ]
+          requires: [ 'Language tests', 'Compile 8.1 extension for testing' ]
           name: "PHP 81 language tests"
           xfail_list: dockerfiles/ci/xfail_tests/8.1.list
           docker_image: "datadog/dd-trace-ci:php-8.1_buster"
           parallel_workers: true
       - php_language_tests:
-          requires: [ 'Language tests' ]
+          requires: [ 'Language tests', 'Compile 8.0 extension for testing' ]
           name: "PHP 80 language tests"
           xfail_list: dockerfiles/ci/xfail_tests/8.0.list
           docker_image: "datadog/dd-trace-ci:php-8.0_buster"
           parallel_workers: true
       - php_language_tests:
-          requires: [ 'Language tests' ]
+          requires: [ 'Language tests', 'Compile 7.4 extension for testing' ]
           name: "PHP 74 language tests"
           xfail_list: dockerfiles/ci/xfail_tests/7.4.list
           docker_image: "datadog/dd-trace-ci:php-7.4_buster"
           parallel_workers: true
       - php_language_tests:
-          requires: [ 'Language tests' ]
+          requires: [ 'Language tests', 'Compile 7.3 extension for testing' ]
           name: "PHP 73 language tests"
           xfail_list: dockerfiles/ci/xfail_tests/7.3.list
           docker_image: "datadog/dd-trace-ci:php-7.3_buster"
       - php_language_tests:
-          requires: [ 'Language tests' ]
+          requires: [ 'Language tests', 'Compile 7.2 extension for testing' ]
           name: "PHP 72 language tests"
           xfail_list: dockerfiles/ci/xfail_tests/7.2.list
           docker_image: "datadog/dd-trace-ci:php-7.2_buster"
       - php_language_tests:
-          requires: [ 'Language tests' ]
+          requires: [ 'Language tests', 'Compile 7.1 extension for testing' ]
           name: "PHP 71 language tests"
           xfail_list: dockerfiles/ci/xfail_tests/7.1.list
           docker_image: "datadog/dd-trace-ci:php-7.1_buster"
       - php_language_tests:
-          requires: [ 'Language tests' ]
+          requires: [ 'Language tests', 'Compile 7.0 extension for testing' ]
           name: "PHP 70 language tests"
           xfail_list: dockerfiles/ci/xfail_tests/7.0.list
           docker_image: "datadog/dd-trace-ci:php-7.0_buster"
       - internal_integrations:
-          requires: [ 'Prepare Code' ]
+          requires: [ 'Prepare Code', 'Compile 8.0 extension for testing', 'medium: Compile rust code for testing' ]
           name: "PHP 80 curl integration tests a shared lib"
           ext_name: "curl"
           docker_image: "datadog/dd-trace-ci:php-8.0-shared-ext"
       - static_analysis:
-          requires: [ 'Prepare Code' ]
+          requires: [ 'Prepare Code', 'Compile 7.1 extension for testing', 'medium: Compile rust code for testing' ]
           name: "Static Analysis 71"
           docker_image: datadog/dd-trace-ci:php-7.1_buster
           scenario: opentracing_beta6
       - static_analysis:
-          requires: [ 'Prepare Code' ]
+          requires: [ 'Prepare Code', 'Compile 8.0 extension for testing', 'medium: Compile rust code for testing' ]
           name: "Static Analysis 80"
           docker_image: datadog/dd-trace-ci:php-8.0_buster
           scenario: opentracing10
-      - "cbindgen up-to-date":
-          requires: [ 'Prepare Code' ]
+      - "cbindgen up-to-date"
       - "Post-Install Hook":
           requires: [ 'Prepare Code' ]
 

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -100,22 +100,6 @@ aliases:
     attach_workspace:
       at: ~/datadog
 
-  - &STEP_APPEND_BUILD_ID
-    run:
-      name: Append build id to version number
-      command: |
-        githash="${CIRCLE_SHA1?}"
-        if [[ "x$CIRCLE_BRANCH" == "x" ]] ; then
-          echo "The environment variable CIRCLE_BRANCH was not set or was empty."
-          exit 1
-        fi
-        if [[ "$CIRCLE_BRANCH" =~ "ddtrace-" ]] ; then
-          echo "Release branch detected; not adding git sha1 to version number."
-        else
-          echo -n "+$githash" >>VERSION
-          echo "Appended +$githash to version number."
-        fi
-
   - &STEP_EXT_INSTALL
     run:
       name: Build and install extension
@@ -352,6 +336,52 @@ commands:
       - lib_curl_workaround:
           command: << parameters.lib_curl_command >>
       - <<: *STEP_EXT_INSTALL
+
+  append_build_id:
+    parameters:
+      shell:
+        type: string
+        default: /bin/bash -eo pipefail
+    steps:
+      - run:
+          name: Append build id to version number
+          shell: << parameters.shell >>
+          command: |
+            githash="${CIRCLE_SHA1?}"
+            if [[ "x$CIRCLE_BRANCH" == "x" ]] ; then
+              echo "The environment variable CIRCLE_BRANCH was not set or was empty."
+              exit 1
+            fi
+            if [[ "$CIRCLE_BRANCH" =~ "ddtrace-" ]] ; then
+              echo "Release branch detected; not adding git sha1 to version number."
+            else
+              echo -n "+$githash" >>VERSION
+              echo "Appended +$githash to version number."
+            fi
+
+
+  fetch_job_artifact:
+    parameters:
+      job:
+        type: string
+      artifact:
+        type: string
+      directory:
+        type: string
+        default: "."
+    steps:
+      - run:
+          name: "Get artifact << parameters.artifact >> from job << parameters.job >>"
+          command: |
+            set +x
+            cd << parameters.directory >>
+            if [[ '<< parameters.job >>' != "${LAST_ARTIFACTS_JOB:-}" ]]; then 
+              job_id=$(curl -X GET "https://circleci.com/api/v2/workflow/$CIRCLE_WORKFLOW_ID/job" -H "Accept: application/json" | grep -Eo '\{[^}]*"<< parameters.job >>"[^}]*' | grep -Eo '"job_number":[^,]+' | tail -c +14)
+              export LAST_ARTIFACTS_RESULT=$(curl -X GET "https://circleci.com/api/v2/project/github/DataDog/dd-trace-php/$job_id/artifacts" -H "Accept: application/json")
+              export LAST_ARTIFACTS_JOB='<< parameters.job >>'
+            fi
+            artifact_url=$(echo "$LAST_ARTIFACTS_RESULT" | grep -Eo '\{[^}]*"<< parameters.artifact >>"[^}]*' | grep -Eo '"url":"[^"]+' | tail -c +8)
+            curl -LO "$artifact_url"
 
   copy_valgrind_rc:
     parameters:
@@ -935,7 +965,12 @@ jobs:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
       - <<: *STEP_CHECKOUT
-      - <<: *STEP_ATTACH_WORKSPACE
+      - fetch_job_artifact:
+          job: "package extension"
+          artifact: 'dd-library-php-[^"]+x86_64-linux-gnu.tar.gz'
+      - fetch_job_artifact:
+          job: "package extension"
+          artifact: 'datadog-setup.php'
       - run:
           command: |
             docker run --rm -v $(pwd):/root -i ubuntu:jammy bash -s \<<COMMANDS
@@ -943,7 +978,7 @@ jobs:
             apt-get update -y
             DEBIAN_FRONTEND=noninteractive apt-get install -y php8.1 php8.1-dom php-pear
             cd /root
-            php ./build/packages/datadog-setup.php --php-bin all --file $(ls build/packages/dd-library-php-*-x86_64-linux-gnu.tar.gz)
+            php datadog-setup.php --php-bin all --file $(ls dd-library-php-*-x86_64-linux-gnu.tar.gz)
             rm /etc/php/8.1/cli/conf.d/10-opcache.ini
             sed -i 's/datadog.trace.sources_path/\;datadog.trace.sources_path/' /etc/php/8.1/cli/conf.d/98-ddtrace.ini
             DD_TRACE_GIT_METADATA_ENABLED=0 pecl run-tests --showdiff --ini=" -d datadog.trace.cli_enabled=1" \$(find tests/ext -type d)
@@ -1921,16 +1956,19 @@ jobs:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
       - <<: *STEP_CHECKOUT
-      - <<: *STEP_ATTACH_WORKSPACE
       - <<: *STEP_PREPARE_TEST_RESULTS_DIR
       - <<: *STEP_EXPORT_CI_ENV
+      - fetch_job_artifact:
+          job: "package extension"
+          artifact: |-
+            datadog-php-tracer_[^"]+'"$(if [ $(uname -m) = "aarch64" ]; then echo arm64; else echo amd64; fi)"'.deb
       - <<: *STEP_WAIT_REQUEST_REPLAYER
       - <<: *STEP_RESOLVE_HTTPBIN_HOSTNAME_TO_IP
       - <<: *STEP_WAIT_TEST_AGENT
       - run:
           name: Install .deb from artifacts
           command: |
-            sudo dpkg -i ./build/packages/*$(if [ $(uname -m) = "aarch64" ]; then echo aarch64; else echo amd64; fi)*.deb
+            sudo dpkg -i *$(if [ $(uname -m) = "aarch64" ]; then echo arm64; else echo amd64; fi)*.deb
             php --ri=ddtrace
       - run:
           name: Run phpt tests against shippable package
@@ -1967,7 +2005,12 @@ jobs:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
       - <<: *STEP_CHECKOUT
-      - <<: *STEP_ATTACH_WORKSPACE
+      - run: mkdir -p build/packages
+      - fetch_job_artifact:
+          job: "package extension"
+          artifact: |-
+            datadog-php-tracer_[^"]+'"$(if [ $(uname -m) = "aarch64" ]; then echo arm64; else echo amd64; fi)"'.deb
+          directory: build/packages
       - setup_remote_docker
       - run: make -f dockerfiles/frameworks/Makefile << parameters.framework_target >>
 
@@ -2002,11 +2045,35 @@ jobs:
       - run:
           name: Install git
           command: apk add git
+      - run:
+          name: Install curl
+          command: apk add curl
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
       - <<: *STEP_CHECKOUT
-      - <<: *STEP_ATTACH_WORKSPACE
+      - run: mkdir -p build/packages
+      - when:
+          condition:
+            equal: [php_installer, << parameters.install_type >>]
+          steps:
+            - fetch_job_artifact:
+                job: "package extension"
+                artifact: 'dd-library-php-[^"]+x86_64-linux-musl.tar.gz'
+                directory: build/packages
+            - fetch_job_artifact:
+                job: "package extension"
+                artifact: 'datadog-setup.php'
+                directory: build/packages
+      - when:
+          condition:
+            equal: [native_package, << parameters.install_type >>]
+          steps:
+            - fetch_job_artifact:
+                job: "package extension"
+                artifact: |-
+                  datadog-php-tracer_[^"]+'"$(uname -m)"'.apk
+                directory: build/packages
       - run:
           name: Validate alpine package
           command: ./dockerfiles/verify_packages/verify.sh
@@ -2051,7 +2118,28 @@ jobs:
             yum update -y
             yum install -y git
       - <<: *STEP_CHECKOUT
-      - <<: *STEP_ATTACH_WORKSPACE
+      - run: mkdir -p build/packages
+      - when:
+          condition:
+            equal: [php_installer, << parameters.install_type >>]
+          steps:
+            - fetch_job_artifact:
+                job: "package extension"
+                artifact: 'dd-library-php-[^"]+x86_64-linux-gnu.tar.gz'
+                directory: build/packages
+            - fetch_job_artifact:
+                job: "package extension"
+                artifact: 'datadog-setup.php'
+                directory: build/packages
+      - when:
+          condition:
+            equal: [native_package, << parameters.install_type >>]
+          steps:
+            - fetch_job_artifact:
+                job: "package extension"
+                artifact: |-
+                  datadog-php-tracer-[^"]+'"$(uname -m)"'.rpm
+                directory: build/packages
       - run:
           name: Validate centos package
           command: << parameters.configuration >> ./dockerfiles/verify_packages/verify.sh
@@ -2076,7 +2164,28 @@ jobs:
             yum update -y
             yum install -y git
       - <<: *STEP_CHECKOUT
-      - <<: *STEP_ATTACH_WORKSPACE
+      - run: mkdir -p build/packages
+      - when:
+          condition:
+            equal: [php_installer, << parameters.install_type >>]
+          steps:
+            - fetch_job_artifact:
+                job: "package extension"
+                artifact: 'dd-library-php-[^"]+x86_64-linux-gnu.tar.gz'
+                directory: build/packages
+            - fetch_job_artifact:
+                job: "package extension"
+                artifact: 'datadog-setup.php'
+                directory: build/packages
+      - when:
+          condition:
+            equal: [native_package, << parameters.install_type >>]
+          steps:
+            - fetch_job_artifact:
+                job: "package extension"
+                artifact: |-
+                  datadog-php-tracer-[^"]+'"$(uname -m)"'.rpm
+                directory: build/packages
       - run: mkdir -p test-results
       - run:
           name: Test installing packages on target systems
@@ -2122,8 +2231,33 @@ jobs:
           command: |
             apt-get update
             apt-get install -y git
+      - run:
+          name: Install curl
+          command: |
+            apt-get install -y curl
       - <<: *STEP_CHECKOUT
-      - <<: *STEP_ATTACH_WORKSPACE
+      - run: mkdir -p build/packages
+      - when:
+          condition:
+            equal: [php_installer, << parameters.install_type >>]
+          steps:
+            - fetch_job_artifact:
+                job: "package extension"
+                artifact: 'dd-library-php-[^"]+x86_64-linux-gnu.tar.gz'
+                directory: build/packages
+            - fetch_job_artifact:
+                job: "package extension"
+                artifact: 'datadog-setup.php'
+                directory: build/packages
+      - when:
+          condition:
+            equal: [native_package, << parameters.install_type >>]
+          steps:
+            - fetch_job_artifact:
+                job: "package extension"
+                artifact: |-
+                  datadog-php-tracer_[^"]+'"$(if [ $(uname -m) = "aarch64" ]; then echo arm64; else echo amd64; fi)"'.deb
+                directory: build/packages
       - run:
           name: Validate debian package
           command: << parameters.configuration >> bash ./dockerfiles/verify_packages/verify.sh
@@ -2147,7 +2281,12 @@ jobs:
             sudo apt-get update
             sudo apt-get install -y git
       - <<: *STEP_CHECKOUT
-      - <<: *STEP_ATTACH_WORKSPACE
+      - run: mkdir -p build/packages
+      - fetch_job_artifact:
+          job: "package extension"
+          artifact: |-
+            datadog-php-tracer-[^"]+'"$(uname -m)"'.tar.gz
+          directory: build/packages
       - setup_docker:
           docker_image: debian:bullseye
       - run:
@@ -2167,11 +2306,19 @@ jobs:
       - run:
           name: Install git
           command: apk add git
+      - run:
+          name: Install curl
+          command: apk add curl
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
       - <<: *STEP_CHECKOUT
-      - <<: *STEP_ATTACH_WORKSPACE
+      - run: mkdir -p build/packages
+      - fetch_job_artifact:
+          job: "package extension"
+          artifact: |-
+            datadog-php-tracer_[^"]+'"$(uname -m)"'.apk
+          directory: build/packages
       - run:
           name: Test
           command: ./dockerfiles/verify_packages/verify_no_ext_json.sh
@@ -2202,10 +2349,31 @@ jobs:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
       - <<: *STEP_CHECKOUT
-      - <<: *STEP_ATTACH_WORKSPACE
+      - append_build_id
       - run:
           name: Let testing images to write to build/packages dir
-          command: chmod a+w build/packages
+          command: mkdir -p build/packages && chmod a+w build/packages
+
+      - fetch_job_artifact:
+          job: "package extension"
+          artifact: 'dd-library-php-[^"]+x86_64-linux-gnu.tar.gz'
+          directory: build/packages
+
+      - fetch_job_artifact:
+          job: "package extension"
+          artifact: 'dd-library-php-[^"]+x86_64-linux-musl.tar.gz'
+          directory: build/packages
+
+      - fetch_job_artifact:
+          job: "package extension"
+          artifact: 'datadog-php-tracer-[^"]+x86_64.tar.gz'
+          directory: build/packages
+
+      - fetch_job_artifact:
+          job: "package extension"
+          artifact: "datadog-setup.php"
+          directory: build/packages
+
       - run:
           name: Run tests
           command: make -C dockerfiles/verify_packages test_installer
@@ -2223,6 +2391,9 @@ jobs:
       batch:
         # Batch is only used to run a number of these jobs in parallel via a testing matrix.
         type: integer
+      parent_job:
+        type: string
+        default: "package extension"
     steps: &randomized_tests_steps
       - run:
           name: Ensure enough memory via swapfile
@@ -2235,7 +2406,6 @@ jobs:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
       - <<: *STEP_CHECKOUT
-      - <<: *STEP_ATTACH_WORKSPACE
       - run:
           command: ls -al
       - run:
@@ -2244,6 +2414,10 @@ jobs:
       - run:
           name: "Increase virtual memory limit for elasticsearch"
           command: sudo sysctl -w vm.max_map_count=262144
+      - fetch_job_artifact:
+          job: "<< parameters.parent_job >>"
+          artifact: |-
+            dd-library-php-[^"]+'"$(uname -m)"'-linux-gnu.tar.gz
       - run:
           name: Copy tracer package
           command: make -C tests/randomized library.local
@@ -2273,6 +2447,9 @@ jobs:
       batch:
         # Batch is only used to run a number of these jobs in parallel via a testing matrix.
         type: integer
+      parent_job:
+        type: string
+        default: "package extension"
     steps: *randomized_tests_steps
 
   randomized_tests_asan:
@@ -2286,6 +2463,9 @@ jobs:
       batch:
         # Batch is only used to run a number of these jobs in parallel via a testing matrix.
         type: integer
+      parent_job:
+        type: string
+        default: "package extension zts-debug-asan"
     steps: *randomized_tests_steps
 
   randomized_tests_arm_asan:
@@ -2299,6 +2479,9 @@ jobs:
       batch:
         # Batch is only used to run a number of these jobs in parallel via a testing matrix.
         type: integer
+      parent_job:
+        type: string
+        default: "package extension zts-debug-asan"
     steps: *randomized_tests_steps
 
   pecl_build:
@@ -2732,7 +2915,7 @@ jobs:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
       - <<: *STEP_CHECKOUT
-      - <<: *STEP_ATTACH_WORKSPACE
+      - append_build_id
       - setup_docker:
           docker_image: datadog/dd-trace-ci:php-compile-extension-alpine
       - run:
@@ -2760,7 +2943,7 @@ jobs:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
       - <<: *STEP_CHECKOUT
-      - <<: *STEP_ATTACH_WORKSPACE
+      - append_build_id
       - setup_docker:
           docker_image: datadog/dd-trace-ci:php-compile-extension-alpine-<< parameters.php_major_minor >>
       - run: mkdir -p extensions_$(uname -m) standalone_$(uname -m)
@@ -2803,7 +2986,7 @@ jobs:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
       - <<: *STEP_CHECKOUT
-      - <<: *STEP_ATTACH_WORKSPACE
+      - append_build_id
       - setup_docker:
           docker_image: << parameters.docker_image >>
       - run: mkdir -p extensions_$(uname -m)
@@ -2890,7 +3073,7 @@ jobs:
           name: Restore Cargo Package Cache
           keys:
             - profiling-cargo-cache-<< parameters.triplet >>-{{ checksum "profiling/Cargo.toml" }}
-      - <<: *STEP_APPEND_BUILD_ID
+      - append_build_id
       - build_profiler:
           prefix: datadog-profiling/<< parameters.triplet >>/lib/php/<< parameters.abi_no >>
       - persist_to_workspace:
@@ -2997,7 +3180,7 @@ jobs:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
       - <<: *STEP_CHECKOUT
-      - <<: *STEP_ATTACH_WORKSPACE
+      - append_build_id
       - setup_docker:
           docker_image: << parameters.docker_image >>
       - run:
@@ -3046,7 +3229,10 @@ jobs:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
       - <<: *STEP_CHECKOUT
-      - <<: *STEP_ATTACH_WORKSPACE
+      - fetch_job_artifact:
+          job: "package extension"
+          artifact: |-
+            dd-library-php-ssi-[^"]+'"$(uname -m)"'-linux.tar.gz
       - setup_docker:
           docker_image: << parameters.docker_image >>
       - switch_php:
@@ -3056,10 +3242,8 @@ jobs:
           command: |
             set -xeuo pipefail
 
-            arch=$(uname -m)
-            package=$(find ./build/packages -maxdepth 1 -name "dd-library-php-ssi-*-${arch}-linux.tar.gz")
             rm -rf dd-library-php-ssi
-            tar -xzf ${package}
+            tar -xzf dd-library-php-ssi-*-linux.tar.gz
             export DD_LOADER_PACKAGE_PATH=${PWD}/dd-library-php-ssi
 
             cd loader
@@ -3086,7 +3270,10 @@ jobs:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
       - <<: *STEP_CHECKOUT
-      - <<: *STEP_ATTACH_WORKSPACE
+      - fetch_job_artifact:
+          job: "package extension"
+          artifact: |-
+            dd-library-php-ssi-[^"]+'"$(uname -m)"'-linux.tar.gz
       - setup_docker:
           docker_image: << parameters.docker_image >>
       - run:
@@ -3096,10 +3283,8 @@ jobs:
 
             apk add --no-cache curl-dev << parameters.alpine_packages >>
 
-            arch=$(uname -m)
-            package=$(find ./build/packages -maxdepth 1 -name "dd-library-php-ssi-*-${arch}-linux.tar.gz")
             rm -rf dd-library-php-ssi
-            tar -xzf ${package}
+            tar -xzf dd-library-php-ssi-*-linux.tar.gz
             export DD_LOADER_PACKAGE_PATH=${PWD}/dd-library-php-ssi
 
             cd loader
@@ -3119,7 +3304,7 @@ jobs:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
       - <<: *STEP_CHECKOUT
-      - <<: *STEP_ATTACH_WORKSPACE
+      - append_build_id
       - setup_docker:
           docker_image: datadog/dd-trace-ci:centos-7
       - run:
@@ -3158,7 +3343,7 @@ jobs:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
       - <<: *STEP_CHECKOUT
-      - <<: *STEP_ATTACH_WORKSPACE
+      - append_build_id
       - setup_docker:
           docker_image: << parameters.docker_image >>
       - run: mkdir -p extensions_$(uname -m) standalone_$(uname -m)
@@ -3241,6 +3426,8 @@ jobs:
         type: string
     steps:
       - checkout
+      - append_build_id:
+          shell: bash.exe
       - run:
           name: Pull submodules
           shell: powershell.exe
@@ -3261,10 +3448,15 @@ jobs:
           command: |
             docker exec php powershell.exe "cd app; switch-php nts; C:\php\SDK\phpize.bat; .\configure.bat --enable-debug-pack; nmake; move x64\Release\php_ddtrace.dll extensions_windows_x86_64\php_ddtrace-<< parameters.so_suffix >>.dll; move x64\Release\php_ddtrace.pdb extensions_windows_x86_64_debugsymbols\php_ddtrace-<< parameters.so_suffix >>.pdb"
       - run:
+          name: Reuse libdatadog build
+          shell: powershell.exe
+          command: |
+            docker exec php powershell.exe "mkdir app\x64\Release_TS; mv app\x64\Release\target app\x64\Release_TS\target"
+      - run:
           name: Build zts
           shell: powershell.exe
           command: |
-            docker exec php powershell.exe "cd app; switch-php zts; nmake clean; C:\php\SDK\phpize.bat; .\configure.bat --enable-debug-pack; nmake; move x64\Release_TS\php_ddtrace.dll extensions_windows_x86_64\php_ddtrace-<< parameters.so_suffix >>-zts.dll; move x64\Release_TS\php_ddtrace.pdb extensions_windows_x86_64_debugsymbols\php_ddtrace-<< parameters.so_suffix >>-zts.pdb"
+            docker exec php powershell.exe "cd app; switch-php zts; C:\php\SDK\phpize.bat; .\configure.bat --enable-debug-pack; nmake; move x64\Release_TS\php_ddtrace.dll extensions_windows_x86_64\php_ddtrace-<< parameters.so_suffix >>-zts.dll; move x64\Release_TS\php_ddtrace.pdb extensions_windows_x86_64_debugsymbols\php_ddtrace-<< parameters.so_suffix >>-zts.pdb"
       - persist_to_workspace:
           root: '.'
           paths: [ './extensions_windows_x86_64', './extensions_windows_x86_64_debugsymbols' ]
@@ -3280,7 +3472,7 @@ jobs:
     <<: *BARE_DOCKER_MACHINE
     steps:
       - <<: *STEP_CHECKOUT
-      - <<: *STEP_ATTACH_WORKSPACE
+      - append_build_id
       - setup_docker:
           docker_image: "datadog/dd-trace-ci:php-<< parameters.php_version >>_centos-7"
       - run: mkdir -p appsec_$(uname -m)
@@ -3334,7 +3526,7 @@ jobs:
     <<: *BARE_DOCKER_MACHINE
     steps:
       - <<: *STEP_CHECKOUT
-      - <<: *STEP_ATTACH_WORKSPACE
+      - append_build_id
       - setup_docker:
           docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-<< parameters.php_version >>"
       - run: mkdir -p appsec_$(uname -m)
@@ -3378,7 +3570,7 @@ jobs:
     <<: *BARE_DOCKER_MACHINE
     steps:
       - <<: *STEP_CHECKOUT
-      - <<: *STEP_ATTACH_WORKSPACE
+      - append_build_id
       - setup_docker:
           docker_image: "datadog/libddwaf:toolchain"
       - run: mkdir -p appsec_$(uname -m)
@@ -3427,7 +3619,7 @@ jobs:
           paths:
             - ".git"
       - <<: *STEP_ATTACH_WORKSPACE
-      - <<: *STEP_APPEND_BUILD_ID
+      - append_build_id
       - <<: *STEP_COMPOSER_SELF_UPDATE
       - <<: *STEP_COMPOSER_UPDATE
       - <<: *STEP_COMPOSER_GENERATE
@@ -3442,43 +3634,26 @@ jobs:
 
   "package extension":
     working_directory: ~/datadog
-    # The `Dockerfile` to this image is located at https://github.com/DataDog/docker-library/blob/master/dd-trace-php/Dockerfile_fpm
-    docker: [ image: 'datadog/docker-library:ddtrace_php_fpm_packaging' ]
+    docker: [ image: 'datadog/dd-trace-ci:php_fpm_packaging' ]
     parameters:
       asan_build:
         type: boolean
         default: false
+    resource_class: xlarge
     steps:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
       - <<: *STEP_CHECKOUT
       - <<: *STEP_ATTACH_WORKSPACE
-      - unless:
-          condition: << parameters.asan_build >>
-          steps:
-            - run:
-                name: Package Profiler
-                command: |
-                  # The layout matches what the dd-prof-php releases had to minimize
-                  # transition work.
-                  for triplet in x86_64-unknown-linux-gnu x86_64-alpine-linux-musl aarch64-unknown-linux-gnu aarch64-alpine-linux-musl; do
-                    # Add licensing. TODO: generate rust libs to third-party CSV.
-                    cp -v profiling/LICENSE* profiling/NOTICE "datadog-profiling/${triplet}/"
-                    mkdir -vp "datadog-profiling/${triplet}/bin"
-                    # Add undocumented installer currently used by relenv
-                    cp -v profiling/datadog-profiling-install.sh "datadog-profiling/${triplet}/bin/"
-                  done
-                  find
-                  tar -czf "datadog-profiling.tar.gz" "datadog-profiling/"
       - run:
           name: Build packages
           command: |
             <<# parameters.asan_build >>export DDTRACE_MAKE_PACKAGES_ASAN=1<</ parameters.asan_build >>
-            make packages
+            make -j9 calculate_package_sha256_sums packages
       - run:
           name: Display sha256sums
-          command: cd build/packages && find . -type f -exec sha256sum {} + && cd -
+          command: cat package_sha256sums
       - run:
           name: Spot-check shape of library name
           command: |
@@ -3503,9 +3678,6 @@ jobs:
       - store_artifacts: { path: 'build/packages', destination: / }
       - store_artifacts: { path: 'packages.tar.gz', destination: '/all/packages.tar.gz' }
       - store_artifacts: { path: 'pecl', destination: '/pecl' }
-      - persist_to_workspace:
-          root: '.'
-          paths: ['./build/packages', 'dockerfiles/verify_packages']
 
   "x-profiling phpt tests on Alpine":
     working_directory: ~/datadog
@@ -3519,17 +3691,23 @@ jobs:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
       - <<: *STEP_CHECKOUT
-      - <<: *STEP_ATTACH_WORKSPACE
+      - run:
+          name: Install curl
+          command: apk add curl
+      - fetch_job_artifact:
+          job: "package extension"
+          artifact: 'dd-library-php-[^"]+x86_64-linux-musl.tar.gz'
+      - fetch_job_artifact:
+          job: "package extension"
+          artifact: 'datadog-setup.php'
       - run:
           name: Run cross-product profiling phpt tests
           command: |
               set -eu
               apk update
               apk add autoconf coreutils gcc make
-              cd ./build/packages
               installable_bundle=$(find . -maxdepth 1 -name 'dd-library-php-*-x86_64-linux-musl.tar.gz')
               php datadog-setup.php --file "${installable_bundle}" --php-bin php --enable-profiling
-              cd -
               # run phpize just to get run-tests.php
               phpize
               php run-tests.php -p $(which php) --show-diff -g "FAIL,XFAIL,BORK,WARN,LEAK,XLEAK,SKIP" tests/ext/profiling
@@ -3576,7 +3754,6 @@ jobs:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
       - <<: *STEP_CHECKOUT
-      - <<: *STEP_ATTACH_WORKSPACE
 
       - run:
           name: Install python 3.12
@@ -3592,13 +3769,17 @@ jobs:
       - run:
           name: Clone System Tests repo
           command: git clone https://github.com/DataDog/system-tests.git
-      - run:
-          name: Copy .tar.gz file to system test binaries folder
-          command: |
-            ls -la build/packages
-            installable_bundle=$(find build/packages -maxdepth 1 -name 'dd-library-php-*-x86_64-linux-gnu.tar.gz' | xargs)
-            echo using $installable_bundle
-            cp $installable_bundle build/packages/datadog-setup.php system-tests/binaries/
+
+      - fetch_job_artifact:
+          job: "package extension"
+          artifact: 'dd-library-php-[^"]+x86_64-linux-gnu.tar.gz'
+          directory: system-tests/binaries
+
+      - fetch_job_artifact:
+          job: "package extension"
+          artifact: "datadog-setup.php"
+          directory: system-tests/binaries
+
       - run:
           name: Build
           command: << parameters.build >>
@@ -3877,7 +4058,6 @@ workflows:
           resource_class: "arm.medium"
 
       - compile_appsec_extension_centos:
-          requires: [ 'Prepare Code' ]
           matrix:
             parameters:
               php_version:
@@ -3895,7 +4075,6 @@ workflows:
                 - "arm.medium"
 
       - compile_appsec_extension_alpine:
-          requires: [ 'Prepare Code' ]
           matrix:
             parameters:
               php_version:
@@ -3913,7 +4092,6 @@ workflows:
                 - "arm.medium"
 
       - compile_appsec_helper:
-          requires: [ 'Prepare Code' ]
           matrix:
             parameters:
               resource_class:
@@ -3921,7 +4099,6 @@ workflows:
                 - "arm.medium"
 
       - compile_alpine:
-          requires: [ 'Prepare Code' ]
           matrix:
             parameters:
               php_major_minor:
@@ -3937,7 +4114,6 @@ workflows:
           resource_class: "medium"
           name: "Compile alpine x86_64 PHP << matrix.php_major_minor >>"
       - compile_alpine:
-          requires: [ 'Prepare Code' ]
           matrix:
             parameters:
               php_major_minor:
@@ -3953,7 +4129,6 @@ workflows:
           resource_class: "arm.medium"
           name: "Compile alpine aarch64 PHP << matrix.php_major_minor >>"
       - compile_rust_alpine:
-          requires: [ 'Prepare Code' ]
           matrix:
             parameters:
               resource_class:
@@ -3992,14 +4167,12 @@ workflows:
           name: "Link aarch64 alpine"
           docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine"
       - compile_extension_centos:
-          requires: [ 'Prepare Code' ]
           name: "Compile x86_64 PHP 70 nts + zts + debug"
           php_version: "7.0"
           docker_image: "datadog/dd-trace-ci:php-7.0_centos-7"
           so_suffix: "20151012"
           persist_ldflags: true
       - compile_extension_centos:
-          requires: [ 'Prepare Code' ]
           name: "Compile aarch64 PHP 70 nts + zts + debug"
           php_version: "7.0"
           docker_image: "datadog/dd-trace-ci:php-7.0_centos-7"
@@ -4007,46 +4180,39 @@ workflows:
           persist_ldflags: true
           resource_class: "arm.medium"
       - compile_extension_centos:
-          requires: [ 'Prepare Code' ]
           name: "Compile x86_64 PHP 71 nts + zts + debug"
           php_version: "7.1"
           docker_image: "datadog/dd-trace-ci:php-7.1_centos-7"
           so_suffix: "20160303"
       - compile_extension_centos:
-          requires: [ 'Prepare Code' ]
           name: "Compile aarch64 PHP 71 nts + zts + debug"
           php_version: "7.1"
           docker_image: "datadog/dd-trace-ci:php-7.1_centos-7"
           so_suffix: "20160303"
           resource_class: "arm.medium"
       - compile_extension_centos:
-          requires: [ 'Prepare Code' ]
           name: "Compile x86_64 PHP 72 nts + zts + debug"
           php_version: "7.2"
           docker_image: "datadog/dd-trace-ci:php-7.2_centos-7"
           so_suffix: "20170718"
       - compile_extension_centos:
-          requires: [ 'Prepare Code' ]
           name: "Compile aarch64 PHP 72 nts + zts + debug"
           php_version: "7.2"
           docker_image: "datadog/dd-trace-ci:php-7.2_centos-7"
           so_suffix: "20170718"
           resource_class: "arm.medium"
       - compile_extension_windows:
-          requires: [ 'Prepare Code' ]
           name: "Compile Windows PHP 72 nts + zts"
           docker_image: "datadog/dd-trace-ci:php-7.2_windows"
           php_version: "7.2"
           so_suffix: "20170718"
       - compile_extension_centos:
-          requires: [ 'Prepare Code' ]
           name: "Compile x86_64 PHP 73 nts + zts + debug"
           php_version: "7.3"
           docker_image: "datadog/dd-trace-ci:php-7.3_centos-7"
           so_suffix: "20180731"
           catch_warnings: false # On debug builds: unused parameter '__zend_filename'
       - compile_extension_centos:
-          requires: [ 'Prepare Code' ]
           name: "Compile aarch64 PHP 73 nts + zts + debug"
           php_version: "7.3"
           docker_image: "datadog/dd-trace-ci:php-7.3_centos-7"
@@ -4054,112 +4220,94 @@ workflows:
           catch_warnings: false # On debug builds: unused parameter '__zend_filename'
           resource_class: "arm.medium"
       - compile_extension_windows:
-          requires: [ 'Prepare Code' ]
           name: "Compile Windows PHP 73 nts + zts"
           docker_image: "datadog/dd-trace-ci:php-7.3_windows"
           php_version: "7.3"
           so_suffix: "20180731"
       - compile_extension_centos:
-          requires: [ 'Prepare Code' ]
           name: "Compile x86_64 PHP 74 nts + zts + debug"
           php_version: "7.4"
           docker_image: "datadog/dd-trace-ci:php-7.4_centos-7"
           so_suffix: "20190902"
       - compile_extension_centos:
-          requires: [ 'Prepare Code' ]
           name: "Compile aarch64 PHP 74 nts + zts + debug"
           php_version: "7.4"
           docker_image: "datadog/dd-trace-ci:php-7.4_centos-7"
           so_suffix: "20190902"
           resource_class: "arm.medium"
       - compile_extension_windows:
-          requires: [ 'Prepare Code' ]
           name: "Compile Windows PHP 74 nts + zts"
           docker_image: "datadog/dd-trace-ci:php-7.4_windows"
           php_version: "7.4"
           so_suffix: "20190902"
       - compile_extension_centos:
-          requires: [ 'Prepare Code' ]
           name: "Compile x86_64 PHP 80 nts + zts + debug"
           docker_image: "datadog/dd-trace-ci:php-8.0_centos-7"
           php_version: "8.0"
           so_suffix: "20200930"
       - compile_extension_centos:
-          requires: [ 'Prepare Code' ]
           name: "Compile aarch64 PHP 80 nts + zts + debug"
           docker_image: "datadog/dd-trace-ci:php-8.0_centos-7"
           php_version: "8.0"
           so_suffix: "20200930"
           resource_class: "arm.medium"
       - compile_extension_windows:
-          requires: [ 'Prepare Code' ]
           name: "Compile Windows PHP 80 nts + zts"
           docker_image: "datadog/dd-trace-ci:php-8.0_windows"
           php_version: "8.0"
           so_suffix: "20200930"
       - compile_extension_centos:
-          requires: [ 'Prepare Code' ]
           name: "Compile x86_64 PHP 81 nts + zts + debug"
           docker_image: "datadog/dd-trace-ci:php-8.1_centos-7"
           php_version: "8.1"
           so_suffix: "20210902"
       - compile_extension_centos:
-          requires: [ 'Prepare Code' ]
           name: "Compile aarch64 PHP 81 nts + zts + debug"
           docker_image: "datadog/dd-trace-ci:php-8.1_centos-7"
           php_version: "8.1"
           so_suffix: "20210902"
           resource_class: "arm.medium"
       - compile_extension_windows:
-          requires: [ 'Prepare Code' ]
           name: "Compile Windows PHP 81 nts + zts"
           docker_image: "datadog/dd-trace-ci:php-8.1_windows"
           php_version: "8.1"
           so_suffix: "20210902"
       - compile_extension_centos:
-          requires: [ 'Prepare Code' ]
           name: "Compile x86_64 PHP 82 nts + zts + debug"
           docker_image: "datadog/dd-trace-ci:php-8.2_centos-7"
           php_version: "8.2"
           so_suffix: "20220829"
       - compile_extension_centos:
-          requires: [ 'Prepare Code' ]
           name: "Compile aarch64 PHP 82 nts + zts + debug"
           docker_image: "datadog/dd-trace-ci:php-8.2_centos-7"
           php_version: "8.2"
           so_suffix: "20220829"
           resource_class: "arm.medium"
       - compile_extension_windows:
-          requires: [ 'Prepare Code' ]
           name: "Compile Windows PHP 82 nts + zts"
           docker_image: "datadog/dd-trace-ci:php-8.2_windows"
           php_version: "8.2"
           so_suffix: "20220829"
       - compile_extension_centos:
-          requires: [ 'Prepare Code' ]
           name: "Compile x86_64 PHP 83 nts + zts + debug"
           docker_image: "datadog/dd-trace-ci:php-8.3_centos-7"
           php_version: "8.3"
           so_suffix: "20230831"
       - compile_extension_centos:
-          requires: [ 'Prepare Code' ]
           name: "Compile aarch64 PHP 83 nts + zts + debug"
           docker_image: "datadog/dd-trace-ci:php-8.3_centos-7"
           php_version: "8.3"
           so_suffix: "20230831"
           resource_class: "arm.medium"
       - compile_extension_windows:
-          requires: [ 'Prepare Code' ]
           name: "Compile Windows PHP 83 nts + zts"
           docker_image: "datadog/dd-trace-ci:php-8.3_windows"
           php_version: "8.3"
           so_suffix: "20230831"
 
       - compile_rust_centos:
-          requires: [ 'Prepare Code' ]
           name: "Compile x86_64 rust"
       - compile_rust_centos:
-          requires: [ 'Prepare Code' ]
           name: "Compile aarch64 rust"
           resource_class: "arm.large"
 
@@ -4259,56 +4407,46 @@ workflows:
             - compile_appsec_helper
 
       - compile_extension_asan:
-          requires: [ 'Prepare Code' ]
           name: "Compile x86_64 PHP 74 debug-zts-asan"
           docker_image: "datadog/dd-trace-ci:php-7.4_buster"
           so_suffix: "20190902"
       - compile_extension_asan:
-          requires: [ 'Prepare Code' ]
           name: "Compile aarch64 PHP 74 debug-zts-asan"
           docker_image: "datadog/dd-trace-ci:php-7.4_buster"
           so_suffix: "20190902"
           resource_class: "arm.medium"
       - compile_extension_asan:
-          requires: [ 'Prepare Code' ]
           name: "Compile x86_64 PHP 80 debug-zts-asan"
           docker_image: "datadog/dd-trace-ci:php-8.0_buster"
           so_suffix: "20200930"
       - compile_extension_asan:
-          requires: [ 'Prepare Code' ]
           name: "Compile aarch64 PHP 80 debug-zts-asan"
           docker_image: "datadog/dd-trace-ci:php-8.0_buster"
           so_suffix: "20200930"
           resource_class: "arm.medium"
       - compile_extension_asan:
-          requires: [ 'Prepare Code' ]
           name: "Compile x86_64 PHP 81 debug-zts-asan"
           docker_image: "datadog/dd-trace-ci:php-8.1_buster"
           so_suffix: "20210902"
       - compile_extension_asan:
-          requires: [ 'Prepare Code' ]
           name: "Compile aarch64 PHP 81 debug-zts-asan"
           docker_image: "datadog/dd-trace-ci:php-8.1_buster"
           so_suffix: "20210902"
           resource_class: "arm.medium"
       - compile_extension_asan:
-          requires: [ 'Prepare Code' ]
           name: "Compile x86_64 PHP 82 debug-zts-asan"
           docker_image: "datadog/dd-trace-ci:php-8.2_buster"
           so_suffix: "20220829"
       - compile_extension_asan:
-          requires: [ 'Prepare Code' ]
           name: "Compile aarch64 PHP 82 debug-zts-asan"
           docker_image: "datadog/dd-trace-ci:php-8.2_buster"
           so_suffix: "20220829"
           resource_class: "arm.medium"
       - compile_extension_asan:
-          requires: [ 'Prepare Code' ]
           name: "Compile x86_64 PHP 83 debug-zts-asan"
           docker_image: "datadog/dd-trace-ci:php-8.3_buster"
           so_suffix: "20230831"
       - compile_extension_asan:
-          requires: [ 'Prepare Code' ]
           name: "Compile aarch64 PHP 83 debug-zts-asan"
           docker_image: "datadog/dd-trace-ci:php-8.3_buster"
           so_suffix: "20230831"
@@ -4318,6 +4456,7 @@ workflows:
           name: "package extension zts-debug-asan"
           asan_build: true
           requires:
+            - "Prepare Code"
             - "Compile x86_64 PHP 74 debug-zts-asan"
             - "Compile aarch64 PHP 74 debug-zts-asan"
             - "Compile x86_64 PHP 80 debug-zts-asan"
@@ -4731,28 +4870,24 @@ workflows:
             TEST_LIBRARY=php ./run.sh PARAMETRIC
 
       - "compile_loader":
-          requires: [ 'Prepare Code' ]
           name: "Compile Loader Linux x86_64"
           docker_image: "datadog/dd-trace-ci:php-8.3_buster"
           resource_class: "medium"
           os: "linux-gnu"
 
       - "compile_loader":
-          requires: [ 'Prepare Code' ]
           name: "Compile Loader Linux aarch64"
           docker_image: "datadog/dd-trace-ci:php-8.3_buster"
           resource_class: "arm.medium"
           os: "linux-gnu"
 
       - "compile_loader":
-          requires: [ 'Prepare Code' ]
           name: "Compile Loader Alpine x86_64"
           docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-8.0"
           resource_class: "medium"
           os: "linux-musl"
 
       - "compile_loader":
-          requires: [ 'Prepare Code' ]
           name: "Compile Loader Alpine aarch64"
           docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-8.0"
           resource_class: "arm.medium"

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1896,8 +1896,7 @@ jobs:
                 command: sudo composer self-update --2 --no-interaction
       - switch_php:
           php_version: << parameters.switch_php_version >>
-      - install_extension:
-          lib_curl_command: << parameters.lib_curl_command >>
+      - <<: *STEP_LINK_EXTENSION
       - run:
           name: Install required packages
           command: sudo apt update && sudo apt install -y jq
@@ -1906,6 +1905,9 @@ jobs:
       - <<: *STEP_COMPOSER_TESTS_UPDATE
       - <<: *STEP_EXPORT_CI_ENV
       - <<: *STEP_DISABLE_XDEBUG
+      - <<: *STEP_AWAIT_LINK_EXTENSION
+      - install_extension:
+          lib_curl_command: << parameters.lib_curl_command >>
       - <<: *STEP_WAIT_MYSQL
       - <<: *STEP_WAIT_REQUEST_REPLAYER
       - <<: *STEP_WAIT_TEST_AGENT
@@ -4862,119 +4864,6 @@ workflows:
           name: "PHP 83 PECL tests"
           docker_image: "datadog/dd-trace-ci:php-8.3_buster"
 
-      - integration_tests:
-          requires: [ 'Prepare Code' ]
-          name: "PHP 72 web tests with apache (+ opcache)"
-          resource_class: medium+
-          sapi: apache2handler
-          integration_testsuite: "test_web"
-          docker_image: "datadog/dd-trace-ci:php-7.2_buster"
-          php_major_minor: "7.2"
-      - integration_tests:
-          requires: [ 'Prepare Code' ]
-          name: "PHP 72 web tests with nginx + FastCGI"
-          resource_class: medium+
-          sapi: cgi-fcgi
-          integration_testsuite: "test_web"
-          docker_image: "datadog/dd-trace-ci:php-7.2_buster"
-          php_major_minor: "7.2"
-      - integration_tests:
-          requires: [ 'Prepare Code' ]
-          name: "PHP 73 web tests with nginx + FastCGI"
-          resource_class: medium+
-          sapi: cgi-fcgi
-          integration_testsuite: "test_web"
-          docker_image: "datadog/dd-trace-ci:php-7.3_buster"
-          php_major_minor: "7.3"
-      - integration_tests:
-          requires: [ 'Prepare Code' ]
-          name: "PHP 74 web tests with apache (+ opcache)"
-          resource_class: medium+
-          sapi: apache2handler
-          integration_testsuite: "test_web"
-          docker_image: "datadog/dd-trace-ci:php-7.4_buster"
-          php_major_minor: "7.4"
-      - integration_tests:
-          requires: [ 'Prepare Code' ]
-          name: "PHP 74 web tests with nginx + FastCGI"
-          resource_class: medium+
-          sapi: cgi-fcgi
-          integration_testsuite: "test_web"
-          docker_image: "datadog/dd-trace-ci:php-7.4_buster"
-          php_major_minor: "7.4"
-      - integration_tests:
-          requires: [ 'Prepare Code' ]
-          name: "PHP 80 web tests with apache (+ opcache)"
-          resource_class: medium+
-          sapi: apache2handler
-          integration_testsuite: "test_web"
-          docker_image: "datadog/dd-trace-ci:php-8.0_buster"
-          php_major_minor: "8.0"
-      - integration_tests:
-          requires: [ 'Prepare Code' ]
-          name: "PHP 80 web tests with nginx + FastCGI"
-          resource_class: medium+
-          sapi: cgi-fcgi
-          integration_testsuite: "test_web"
-          docker_image: "datadog/dd-trace-ci:php-8.0_buster"
-          php_major_minor: "8.0"
-      - integration_tests:
-          requires: [ 'Prepare Code' ]
-          name: "PHP 81 web tests with apache (+ opcache)"
-          resource_class: medium+
-          sapi: apache2handler
-          integration_testsuite: "test_web"
-          docker_image: "datadog/dd-trace-ci:php-8.1_buster"
-          php_major_minor: "8.1"
-      - integration_tests:
-          requires: [ 'Prepare Code' ]
-          name: "PHP 81 web tests with nginx + FastCGI"
-          resource_class: medium+
-          sapi: cgi-fcgi
-          integration_testsuite: "test_web"
-          docker_image: "datadog/dd-trace-ci:php-8.1_buster"
-          php_major_minor: "8.1"
-      - integration_tests:
-          requires: [ 'Prepare Code' ]
-          name: "PHP 82 web tests with apache (+ opcache)"
-          resource_class: medium+
-          sapi: apache2handler
-          integration_testsuite: "test_web"
-          docker_image: "datadog/dd-trace-ci:php-8.2_buster"
-          php_major_minor: "8.2"
-      - integration_tests:
-          requires: [ 'Prepare Code' ]
-          name: "PHP 82 web tests with nginx + FastCGI"
-          resource_class: medium+
-          sapi: cgi-fcgi
-          integration_testsuite: "test_web"
-          docker_image: "datadog/dd-trace-ci:php-8.2_buster"
-          php_major_minor: "8.2"
-      - integration_tests:
-          requires: [ 'Prepare Code' ]
-          name: "PHP 83 web tests with apache (+ opcache)"
-          resource_class: medium+
-          sapi: apache2handler
-          integration_testsuite: "test_web"
-          docker_image: "datadog/dd-trace-ci:php-8.3_buster"
-          php_major_minor: "8.3"
-      - integration_tests:
-          requires: [ 'Prepare Code' ]
-          name: "PHP 83 web tests with nginx + FastCGI"
-          resource_class: medium+
-          sapi: cgi-fcgi
-          integration_testsuite: "test_web"
-          docker_image: "datadog/dd-trace-ci:php-8.3_buster"
-          php_major_minor: "8.3"
-      - integration_tests:
-          requires: [ 'Prepare Code' ]
-          name: "PHP 74 custom autoloaded web tests with nginx + PHP-FPM"
-          resource_class: medium+
-          sapi: fpm-fcgi
-          integration_testsuite: "test_web_custom"
-          docker_image: "datadog/dd-trace-ci:php-7.4_buster"
-          php_major_minor: "7.4"
-
       - min_install_tests:
           requires: [ 'package extension' ]
           name: "PHP min install tests"
@@ -5445,6 +5334,103 @@ workflows:
               make_target:
                 - test_integrations_phpredis5
 
+      - integration_tests:
+          requires: [ 'Prepare Code', 'Compile 7.2 extension for testing', 'Compile rust code for testing' ]
+          name: "PHP 72 web tests with apache (+ opcache)"
+          resource_class: medium+
+          sapi: apache2handler
+          integration_testsuite: "test_web"
+          docker_image: "datadog/dd-trace-ci:php-7.2_buster"
+          php_major_minor: "7.2"
+      - integration_tests:
+          requires: [ 'Prepare Code', 'Compile 7.2 extension for testing', 'Compile rust code for testing' ]
+          name: "PHP 72 web tests with nginx + FastCGI"
+          resource_class: medium+
+          sapi: cgi-fcgi
+          integration_testsuite: "test_web"
+          docker_image: "datadog/dd-trace-ci:php-7.2_buster"
+          php_major_minor: "7.2"
+      - integration_tests:
+          requires: [ 'Prepare Code', 'Compile 7.3 extension for testing', 'Compile rust code for testing' ]
+          name: "PHP 73 web tests with nginx + FastCGI"
+          resource_class: medium+
+          sapi: cgi-fcgi
+          integration_testsuite: "test_web"
+          docker_image: "datadog/dd-trace-ci:php-7.3_buster"
+          php_major_minor: "7.3"
+      - integration_tests:
+          requires: [ 'Prepare Code', 'Compile 7.4 extension for testing', 'Compile rust code for testing' ]
+          name: "PHP 74 web tests with apache (+ opcache)"
+          resource_class: medium+
+          sapi: apache2handler
+          integration_testsuite: "test_web"
+          docker_image: "datadog/dd-trace-ci:php-7.4_buster"
+          php_major_minor: "7.4"
+      - integration_tests:
+          requires: [ 'Prepare Code', 'Compile 7.4 extension for testing', 'Compile rust code for testing' ]
+          name: "PHP 74 web tests with nginx + FastCGI"
+          resource_class: medium+
+          sapi: cgi-fcgi
+          integration_testsuite: "test_web"
+          docker_image: "datadog/dd-trace-ci:php-7.4_buster"
+          php_major_minor: "7.4"
+      - integration_tests:
+          requires: [ 'Prepare Code', 'Compile 8.0 extension for testing', 'Compile rust code for testing' ]
+          name: "PHP 80 web tests with apache (+ opcache)"
+          resource_class: medium+
+          sapi: apache2handler
+          integration_testsuite: "test_web"
+          docker_image: "datadog/dd-trace-ci:php-8.0_buster"
+          php_major_minor: "8.0"
+      - integration_tests:
+          requires: [ 'Prepare Code', 'Compile 8.0 extension for testing', 'Compile rust code for testing' ]
+          name: "PHP 80 web tests with nginx + FastCGI"
+          resource_class: medium+
+          sapi: cgi-fcgi
+          integration_testsuite: "test_web"
+          docker_image: "datadog/dd-trace-ci:php-8.0_buster"
+          php_major_minor: "8.0"
+      - integration_tests:
+          requires: [ 'Prepare Code', 'Compile 8.1 extension for testing', 'Compile rust code for testing' ]
+          name: "PHP 81 web tests with nginx + FastCGI"
+          resource_class: medium+
+          sapi: cgi-fcgi
+          integration_testsuite: "test_web"
+          docker_image: "datadog/dd-trace-ci:php-8.1_buster"
+          php_major_minor: "8.1"
+      - integration_tests:
+          requires: [ 'Prepare Code', 'Compile 8.2 extension for testing', 'Compile rust code for testing']
+          name: "PHP 82 web tests with apache (+ opcache)"
+          resource_class: medium+
+          sapi: apache2handler
+          integration_testsuite: "test_web"
+          docker_image: "datadog/dd-trace-ci:php-8.2_buster"
+          php_major_minor: "8.2"
+      - integration_tests:
+          requires: [ 'Prepare Code', 'Compile 8.3 extension for testing', 'Compile rust code for testing' ]
+          name: "PHP 83 web tests with apache (+ opcache)"
+          resource_class: medium+
+          sapi: apache2handler
+          integration_testsuite: "test_web"
+          docker_image: "datadog/dd-trace-ci:php-8.3_buster"
+          php_major_minor: "8.3"
+      - integration_tests:
+          requires: [ 'Prepare Code', 'Compile 8.3 extension for testing', 'Compile rust code for testing' ]
+          name: "PHP 83 web tests with nginx + FastCGI"
+          resource_class: medium+
+          sapi: cgi-fcgi
+          integration_testsuite: "test_web"
+          docker_image: "datadog/dd-trace-ci:php-8.3_buster"
+          php_major_minor: "8.3"
+      - integration_tests:
+          requires: [ 'Prepare Code', 'Compile 7.4 extension for testing', 'Compile rust code for testing' ]
+          name: "PHP 74 custom autoloaded web tests with nginx + PHP-FPM"
+          resource_class: medium+
+          sapi: fpm-fcgi
+          integration_testsuite: "test_web_custom"
+          docker_image: "datadog/dd-trace-ci:php-7.4_buster"
+          php_major_minor: "7.4"
+
       - integration:
           requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'Compile rust code for testing' ]
           resource_class: medium+
@@ -5511,57 +5497,53 @@ workflows:
           docker_image: "datadog/dd-trace-ci:php-8.3_buster"
           xdebug_version_one: "3.3.0"
 
-      - placeholder:
-          requires: [ 'Prepare Code', 'Compile rust code for testing' ]
-          name: Language tests
-
       - php_language_tests:
-          requires: [ 'Language tests', 'Compile 8.3 extension for testing' ]
+          requires: [ 'Compile rust code for testing', 'Compile 8.3 extension for testing' ]
           name: "PHP 83 language tests"
           xfail_list: dockerfiles/ci/xfail_tests/8.3.list
           docker_image: "datadog/dd-trace-ci:php-8.3_buster"
           parallel_workers: true
       - php_language_tests:
-          requires: [ 'Language tests', 'Compile 8.2 extension for testing' ]
+          requires: [ 'Compile rust code for testing', 'Compile 8.2 extension for testing' ]
           name: "PHP 82 language tests"
           xfail_list: dockerfiles/ci/xfail_tests/8.2.list
           docker_image: "datadog/dd-trace-ci:php-8.2_buster"
           parallel_workers: true
       - php_language_tests:
-          requires: [ 'Language tests', 'Compile 8.1 extension for testing' ]
+          requires: [ 'Compile rust code for testing', 'Compile 8.1 extension for testing' ]
           name: "PHP 81 language tests"
           xfail_list: dockerfiles/ci/xfail_tests/8.1.list
           docker_image: "datadog/dd-trace-ci:php-8.1_buster"
           parallel_workers: true
       - php_language_tests:
-          requires: [ 'Language tests', 'Compile 8.0 extension for testing' ]
+          requires: [ 'Compile rust code for testing', 'Compile 8.0 extension for testing' ]
           name: "PHP 80 language tests"
           xfail_list: dockerfiles/ci/xfail_tests/8.0.list
           docker_image: "datadog/dd-trace-ci:php-8.0_buster"
           parallel_workers: true
       - php_language_tests:
-          requires: [ 'Language tests', 'Compile 7.4 extension for testing' ]
+          requires: [ 'Compile rust code for testing', 'Compile 7.4 extension for testing' ]
           name: "PHP 74 language tests"
           xfail_list: dockerfiles/ci/xfail_tests/7.4.list
           docker_image: "datadog/dd-trace-ci:php-7.4_buster"
           parallel_workers: true
       - php_language_tests:
-          requires: [ 'Language tests', 'Compile 7.3 extension for testing' ]
+          requires: [ 'Compile rust code for testing', 'Compile 7.3 extension for testing' ]
           name: "PHP 73 language tests"
           xfail_list: dockerfiles/ci/xfail_tests/7.3.list
           docker_image: "datadog/dd-trace-ci:php-7.3_buster"
       - php_language_tests:
-          requires: [ 'Language tests', 'Compile 7.2 extension for testing' ]
+          requires: [ 'Compile rust code for testing', 'Compile 7.2 extension for testing' ]
           name: "PHP 72 language tests"
           xfail_list: dockerfiles/ci/xfail_tests/7.2.list
           docker_image: "datadog/dd-trace-ci:php-7.2_buster"
       - php_language_tests:
-          requires: [ 'Language tests', 'Compile 7.1 extension for testing' ]
+          requires: [ 'Compile rust code for testing', 'Compile 7.1 extension for testing' ]
           name: "PHP 71 language tests"
           xfail_list: dockerfiles/ci/xfail_tests/7.1.list
           docker_image: "datadog/dd-trace-ci:php-7.1_buster"
       - php_language_tests:
-          requires: [ 'Language tests', 'Compile 7.0 extension for testing' ]
+          requires: [ 'Compile rust code for testing', 'Compile 7.0 extension for testing' ]
           name: "PHP 70 language tests"
           xfail_list: dockerfiles/ci/xfail_tests/7.0.list
           docker_image: "datadog/dd-trace-ci:php-7.0_buster"

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -103,7 +103,7 @@ aliases:
   - &STEP_EXT_INSTALL
     run:
       name: Build and install extension
-      command: make sudo install install_ini BUILD_DIR=$(pwd)/tmp/build_extension
+      command: make sudo install install_ini BUILD_DIR=$(pwd)/tmp/build_extension $(if [ -f libddtrace_php.a ]; then echo EXTRA_CONFIGURE_OPTIONS=--with-ddtrace-rust-library=$(pwd)/libddtrace_php.a; fi)
 
   - &STEP_CODE_COVERAGE
     when:
@@ -250,17 +250,22 @@ aliases:
       background: true
       command: |
         echo $$ > /tmp/link_extension.pid
-        sed -i 's/-export-symbols .*\/ddtrace\.sym/-Wl,--retain-symbols-file=ddtrace.sym/g' ddtrace.ldflags
-        gcc -shared -Wl,-whole-archive ddtrace.a -Wl,-no-whole-archive $(cat ddtrace.ldflags) libddtrace_php.a -Wl,-soname -Wl,ddtrace.so -o ddtrace.so
-        mkdir -p tmp/build_extension/modules
-        mv ddtrace.so tmp/build_extension/modules/
+        # If it's missing, we're building in the job
+        if [ -f ddtrace.a ]; then
+          sed -i 's/-export-symbols .*\/ddtrace\.sym/-Wl,--retain-symbols-file=ddtrace.sym/g' ddtrace.ldflags
+          gcc -shared -Wl,-whole-archive ddtrace.a -Wl,-no-whole-archive $(cat ddtrace.ldflags) libddtrace_php.a -Wl,-soname -Wl,ddtrace.so -o ddtrace.so
+          mkdir -p tmp/build_extension/modules
+          mv ddtrace.so tmp/build_extension/modules/
+        fi
 
   - &STEP_AWAIT_LINK_EXTENSION
     run:
       name: Wait for extension linking
       command: |
         tail --pid=$(cat /tmp/link_extension.pid) -f /dev/null || true
-        echo "export DD_TRACE_ASSUME_COMPILED=1" >> $BASH_ENV
+        if [ -f tmp/build_extension/modules/ddtrace.so ]; then
+          echo "export DD_TRACE_ASSUME_COMPILED=1" >> $BASH_ENV
+        fi
 
   - &STEP_STORE_TEST_RESULTS
     store_test_results:
@@ -280,7 +285,7 @@ commands:
     steps:
       - run:
           name: Checkout code
-          shell: "<<# parameters.is_windows >>bash.exe<</ parameters.is_windows >><<^ parameters.is_windows >>/bin/bash -eo pipefail<</ parameters.is_windows >>"
+          shell: "<<# parameters.is_windows >>bash.exe<</ parameters.is_windows >>"
           command: |
             git config --global gc.auto 0
     
@@ -446,6 +451,9 @@ commands:
       extra:
         type: string
         default: none
+      ramdisk:
+        type: boolean
+        default: false
     steps:
       - run:
           name: Fix mounted folder permissions mismatch on buster (user 1000 vs user 3434 in docker)
@@ -585,11 +593,12 @@ commands:
                   -e CIRCLECI \
                   -e CIRCLE_PROJECT_USERNAME \
                   -e CIRCLE_PROJECT_REPONAME \
+                  <<# parameters.ramdisk >>--tmpfs /mnt/ramdisk:uid=3434,gid=3434,exec<</ parameters.ramdisk >> \
                   -v $(pwd):/home/circleci/datadog \
                   -v /tmp/bashenv:/home/circleci/bashenv \
                   -v /rust:/rust \
                   -v /tmp/artifacts:/tmp/artifacts \
-                  $(if [ -n "${CARGO_TARGET_DIR:-}" ]; then echo -v ${CARGO_TARGET_DIR}:${CARGO_TARGET_DIR} -e CARGO_TARGET_DIR=${CARGO_TARGET_DIR}; fi) \
+                  $(if [ -n "${CARGO_TARGET_DIR:-}" ]; then echo "-e CARGO_TARGET_DIR=${CARGO_TARGET_DIR}"; fi) \
                   $image \
                   sh -c 'echo Started; sleep 10000' 2>&1 | tee /tmp/docker.out &
               tail -F /tmp/docker.out | grep -Em1 'Started|Error response from daemon'
@@ -739,6 +748,7 @@ jobs:
           command: sudo apt update; sudo apt -y install libcurl4-nss-dev
       - update_composer_with_cache
       - <<: *STEP_AWAIT_LINK_EXTENSION
+      - <<: *STEP_EXT_INSTALL
       - run:
           name: Install phpstan
           command: |
@@ -806,7 +816,6 @@ jobs:
           command: |
             export REPORT_EXIT_STATUS=1
             export DD_TRACE_CLI_ENABLED=1
-            cd tmp/build_extension
             targetdir() {
               if [[ ${1:0:1} -eq 2 ]]; then
                 echo $1
@@ -814,9 +823,9 @@ jobs:
                 echo "3.0.0"
               fi
             }
-            php run-tests.php -g FAIL,XFAIL,BORK,WARN,LEAK,XLEAK,SKIP -p $(which php) --show-all -d zend_extension=xdebug-<< parameters.xdebug_version_one >>.so ../../tests/xdebug/$(targetdir << parameters.xdebug_version_one >>)
+            php /usr/local/src/php/run-tests.php -g FAIL,XFAIL,BORK,WARN,LEAK,XLEAK,SKIP -p $(which php) --show-all -d zend_extension=xdebug-<< parameters.xdebug_version_one >>.so tests/xdebug/$(targetdir << parameters.xdebug_version_one >>)
             if [[ ! "<<parameters.xdebug_version_two>>" == "none" ]]; then
-              php run-tests.php -g FAIL,XFAIL,BORK,WARN,LEAK,XLEAK,SKIP -p $(which php) --show-all -d zend_extension=xdebug-<< parameters.xdebug_version_two >>.so ../../tests/xdebug/$(targetdir << parameters.xdebug_version_two >>)
+              php /usr/local/src/php/run-tests.php -g FAIL,XFAIL,BORK,WARN,LEAK,XLEAK,SKIP -p $(which php) --show-all -d zend_extension=xdebug-<< parameters.xdebug_version_two >>.so tests/xdebug/$(targetdir << parameters.xdebug_version_two >>)
             fi;
       - run:
           name: Run unit tests with xdebug
@@ -1618,6 +1627,7 @@ jobs:
           extra: with_snapshots
       - switch_php:
           php_version: << parameters.switch_php_version >>
+      - <<: *STEP_LINK_EXTENSION
       - when:
           condition:
             and:
@@ -2603,7 +2613,12 @@ jobs:
         default: large
       triplet:
         type: string
+      asan:
+        type: boolean
+        default: false
     <<: *BARE_DOCKER_MACHINE
+    environment:
+      - CARGO_TARGET_DIR: /mnt/ramdisk/cargo
     steps:
       - restore_cache:
           keys:
@@ -2613,13 +2628,14 @@ jobs:
       - restore_cache:
           name: Restore Cargo Package Cache
           keys:
-            - rust-cargo-cache-<< parameters.triplet >>-{{ checksum "Cargo.lock" }}
+            - cargo-cache-<< parameters.triplet >>-{{ checksum "Cargo.lock" }}
       - setup_docker:
           docker_image: datadog/dd-trace-ci:buster
+          ramdisk: true
       - run:
           name: Compile sidecar
           command: |
-            SHARED=1 host_os=linux-gnu ./compile_rust.sh
+            <<# parameters.asan >>COMPILE_ASAN=1<</ parameters.asan >> SHARED=1 host_os=linux-gnu ./compile_rust.sh
             cp -v ${CARGO_TARGET_DIR:-target}/debug/libddtrace_php.a .
       - persist_to_workspace:
           root: '.'
@@ -3026,7 +3042,7 @@ jobs:
       - restore_cache:
           name: Restore Cargo Package Cache
           keys:
-            - rust-cargo-cache-<< parameters.triplet >>-{{ checksum "Cargo.lock" }}
+            - cargo-cache-<< parameters.triplet >>-{{ checksum "Cargo.lock" }}
       - append_build_id
       - setup_docker:
           docker_image: datadog/dd-trace-ci:php-compile-extension-alpine
@@ -3091,7 +3107,7 @@ jobs:
         default: unknown
       resource_class:
         type: string
-        default: medium # mostly for more RAM for ramdisk
+        default: medium
     <<: *BARE_DOCKER_MACHINE
     steps:
       - restore_cache:
@@ -3129,7 +3145,7 @@ jobs:
         type: string
       resource_class:
         type: string
-        default: medium # mostly for more RAM for ramdisk
+        default: medium
     <<: *BARE_DOCKER_MACHINE
     steps:
       - git_checkout
@@ -3138,26 +3154,30 @@ jobs:
       - restore_cache:
           name: Restore Cargo Package Cache
           keys:
-            - rust-cargo-cache-<< parameters.triplet >>-{{ checksum "Cargo.lock" }}
+            - cargo-cache-<< parameters.triplet >>-{{ checksum "Cargo.lock" }}
       - run:
           name: cargo fetch
           command: |
+            SUDO=$(! command -v sudo >/dev/null || echo "sudo") 
             # On occasion, we've observed the .package-cache being in the cache.
             # If it's there, it will cause commands to stall, waiting for the file to be released.
             if [ -e '/rust/cargo/.package-cache' ] ; then
                 echo "WARNING: .package-cache was part of the cache and shouldn't be!"
-                rm -vf '/rust/cargo/.package-cache'
+                $SUDO rm -vf '/rust/cargo/.package-cache'
             fi
 
-            cargo fetch -v --target << parameters.triplet >>
-            chmod -R 777 '/rust/cargo'
+            $SUDO mkdir /.cargo
+            $SUDO chmod 777 /.cargo
+            
+            $SUDO cargo fetch -v --target << parameters.triplet >>
+            $SUDO chmod -R 777 '/rust/cargo'
 
             # ensure the .package-cache isn't there
-            rm -vf '/rust/cargo/.package-cache'
+            $SUDO rm -vf '/rust/cargo/.package-cache'
 
       - save_cache:
           name: Save Cargo Package Cache
-          key: rust-cargo-cache-<< parameters.triplet >>-{{ checksum "Cargo.lock" }}
+          key: cargo-cache-<< parameters.triplet >>-{{ checksum "Cargo.lock" }}
           paths:
             - /rust/cargo
 
@@ -3183,7 +3203,7 @@ jobs:
       - restore_cache:
           name: Restore Cargo Package Cache
           keys:
-            - profiling-rust-cargo-cache-<< parameters.triplet >>-{{ checksum "profiling/Cargo.toml" }}
+            - cargo-cache-<< parameters.triplet >>-{{ checksum "profiling/Cargo.toml" }}
       - append_build_id
       - build_profiler:
           prefix: datadog-profiling/<< parameters.triplet >>/lib/php/<< parameters.abi_no >>
@@ -3213,10 +3233,11 @@ jobs:
       - <<: *STEP_ATTACH_WORKSPACE
       - setup_docker:
           docker_image: << parameters.docker_image >>
+          ramdisk: true
       - restore_cache:
           name: Restore Cargo Package Cache
           keys:
-            - rust-cargo-cache-<< parameters.triplet >>-{{ checksum "Cargo.lock" }}
+            - cargo-cache-<< parameters.triplet >>-{{ checksum "Cargo.lock" }}
       - run:
           name: cargo tests
           command: |
@@ -3420,7 +3441,7 @@ jobs:
       - restore_cache:
           name: Restore Cargo Package Cache
           keys:
-            - rust-cargo-cache-<< parameters.triplet >>-{{ checksum "Cargo.lock" }}
+            - cargo-cache-<< parameters.triplet >>-{{ checksum "Cargo.lock" }}
       - append_build_id
       - setup_docker:
           docker_image: datadog/dd-trace-ci:centos-7
@@ -5127,13 +5148,20 @@ workflows:
           resource_class: "arm.medium"
 
       - compile_rust_test:
-          name: "medium: Compile rust code for testing"
-          resource_class: medium
+          name: "Compile rust code for testing"
+          resource_class: xlarge
           triplet: "x86_64-unknown-linux-gnu"
+
       - compile_rust_test:
-          name: "arm.medium: Compile rust code for testing"
-          resource_class: arm.medium
+          name: "medium: Compile ASAN rust code for testing"
+          resource_class: xlarge
+          triplet: "x86_64-unknown-linux-gnu"
+          asan: true
+      - compile_rust_test:
+          name: "arm.medium: Compile ASAN rust code for testing"
+          resource_class: arm.xlarge
           triplet: "aarch64-unknown-linux-gnu"
+          asan: true
 
       - compile_extension_test:
           name: "Compile << matrix.php_major_minor >> extension for testing"
@@ -5169,7 +5197,7 @@ workflows:
                 - arm.medium
 
       - test:
-          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'medium: Compile rust code for testing' ]
+          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'Compile rust code for testing' ]
           matrix:
             parameters:
               php_major_minor:
@@ -5192,7 +5220,7 @@ workflows:
                 - test_opcache
 
       - test:
-          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'medium: Compile rust code for testing' ]
+          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'Compile rust code for testing' ]
           coverage: true
           codecov_flags: tracer-php
           matrix:
@@ -5204,7 +5232,7 @@ workflows:
                 - test_unit_coverage
 
       - test:
-          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'medium: Compile rust code for testing' ]
+          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'Compile rust code for testing' ]
           matrix:
             parameters:
               php_major_minor:
@@ -5216,7 +5244,7 @@ workflows:
                 - test_extension_ci
 
       - test:
-          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'medium: Compile rust code for testing' ]
+          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'Compile rust code for testing' ]
           matrix:
             parameters:
               resource_class:
@@ -5245,13 +5273,13 @@ workflows:
 
       # sidecar is version independent
       - test_sidecar_sender:
-          requires: [ 'Prepare Code', 'medium: Compile 8.2 ZTS asan extension for testing', 'medium: Compile rust code for testing' ]
+          requires: [ 'Prepare Code', 'medium: Compile 8.2 ZTS asan extension for testing', 'medium: Compile ASAN rust code for testing' ]
           php_major_minor: '8.2'
           switch_php_version: debug-zts-asan
           resource_class: medium
 
       - test_multi_observer:
-          requires: [ 'Prepare Code', 'medium: Compile << matrix.php_major_minor >> ZTS asan extension for testing', 'medium: Compile rust code for testing' ]
+          requires: [ 'Prepare Code', 'medium: Compile << matrix.php_major_minor >> ZTS asan extension for testing', 'medium: Compile ASAN rust code for testing' ]
           matrix:
             parameters:
               php_major_minor:
@@ -5263,7 +5291,7 @@ workflows:
                 - debug-zts-asan
 
       - coverage:
-          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'medium: Compile rust code for testing' ]
+          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'Compile rust code for testing' ]
           matrix:
             parameters:
               php_major_minor:
@@ -5279,7 +5307,7 @@ workflows:
               make_target:
                 - test_coverage
       - asan:
-          requires: [ 'Prepare Code', '<< matrix.resource_class >>: Compile << matrix.php_major_minor >> ZTS asan extension for testing', '<< matrix.resource_class >>: Compile rust code for testing' ]
+          requires: [ 'Prepare Code', '<< matrix.resource_class >>: Compile << matrix.php_major_minor >> ZTS asan extension for testing', '<< matrix.resource_class >>: Compile ASAN rust code for testing' ]
           matrix:
             parameters:
               php_major_minor:
@@ -5306,7 +5334,7 @@ workflows:
                 switch_php_version: debug-zts-asan
 
       - integration:
-          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'medium: Compile rust code for testing' ]
+          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'Compile rust code for testing' ]
           resource_class: medium+
           matrix:
             parameters:
@@ -5327,7 +5355,7 @@ workflows:
                 - test_integration
 
       - integration:
-          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'medium: Compile rust code for testing' ]
+          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'Compile rust code for testing' ]
           resource_class: medium+
           coverage: true
           codecov_flags: tracer-php
@@ -5341,7 +5369,7 @@ workflows:
                 - test_distributed_tracing_coverage
 
       - integration_snapshots:
-          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'medium: Compile rust code for testing' ]
+          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'Compile rust code for testing' ]
           # Due to Symfony OOM during composer update
           resource_class: xlarge
           matrix:
@@ -5361,7 +5389,7 @@ workflows:
                 - test_integrations
 
       - integration_snapshots:
-          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'medium: Compile rust code for testing' ]
+          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'Compile rust code for testing' ]
           # Due to Symfony OOM during composer update
           resource_class: xlarge
           coverage: true
@@ -5376,7 +5404,7 @@ workflows:
                 - test_integrations_coverage
 
       - integration:
-          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'medium: Compile rust code for testing' ]
+          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'Compile rust code for testing' ]
           resource_class: medium+
           sapi: fpm-fcgi
           disable_runner_distributed_tracing: true
@@ -5403,7 +5431,7 @@ workflows:
           # and switch to a non-debug PHP build.
           # Once the fix for https://github.com/phpredis/phpredis/issues/1869 is released, we can remove this additional
           # runner and add back again test_integrations_phpredis5 to the PHP 8.0 test suite.
-          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'medium: Compile rust code for testing' ]
+          requires: [ 'Prepare Code' ]
           with_executor: 'with_redis'
           matrix:
             parameters:
@@ -5413,12 +5441,12 @@ workflows:
                 - '8.2'
                 - '8.3'
               switch_php_version:
-                - debug
+                - nts
               make_target:
                 - test_integrations_phpredis5
 
       - integration:
-          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'medium: Compile rust code for testing' ]
+          requires: [ 'Prepare Code', 'Compile << matrix.php_major_minor >> extension for testing', 'Compile rust code for testing' ]
           resource_class: medium+
           sapi: fpm-fcgi
           disable_runner_distributed_tracing: true
@@ -5434,57 +5462,57 @@ workflows:
                 - test_distributed_tracing_coverage
 
       - xdebug_tests:
-          requires: [ 'Prepare Code', 'Compile 7.0 extension for testing', 'medium: Compile rust code for testing' ]
+          requires: [ 'Prepare Code', 'Compile 7.0 extension for testing', 'Compile rust code for testing' ]
           name: "PHP 70 Xdebug tests"
           docker_image: "datadog/dd-trace-ci:php-7.0_buster"
           xdebug_version_one: "2.7.2"
       - xdebug_tests:
-          requires: [ 'Prepare Code', 'Compile 7.1 extension for testing', 'medium: Compile rust code for testing' ]
+          requires: [ 'Prepare Code', 'Compile 7.1 extension for testing', 'Compile rust code for testing' ]
           name: "PHP 71 Xdebug tests"
           docker_image: "datadog/dd-trace-ci:php-7.1_buster"
           xdebug_version_one: "2.9.5"
           xdebug_version_two: "2.9.2"
       - xdebug_tests:
-          requires: [ 'Prepare Code', 'Compile 7.2 extension for testing', 'medium: Compile rust code for testing' ]
+          requires: [ 'Prepare Code', 'Compile 7.2 extension for testing', 'Compile rust code for testing' ]
           name: "PHP 72 Xdebug tests"
           docker_image: "datadog/dd-trace-ci:php-7.2_buster"
           xdebug_version_one: "2.9.5"
           xdebug_version_two: "2.9.2"
       - xdebug_tests:
-          requires: [ 'Prepare Code', 'Compile 7.3 extension for testing', 'medium: Compile rust code for testing' ]
+          requires: [ 'Prepare Code', 'Compile 7.3 extension for testing', 'Compile rust code for testing' ]
           name: "PHP 73 Xdebug tests"
           docker_image: "datadog/dd-trace-ci:php-7.3_buster"
           xdebug_version_one: "2.9.5"
           xdebug_version_two: "2.9.2"
       - xdebug_tests:
-          requires: [ 'Prepare Code', 'Compile 7.4 extension for testing', 'medium: Compile rust code for testing' ]
+          requires: [ 'Prepare Code', 'Compile 7.4 extension for testing', 'Compile rust code for testing' ]
           name: "PHP 74 Xdebug tests"
           docker_image: "datadog/dd-trace-ci:php-7.4_buster"
           xdebug_version_one: "2.9.5"
           xdebug_version_two: "2.9.2"
       - xdebug_tests:
-          requires: [ 'Prepare Code', 'Compile 8.0 extension for testing', 'medium: Compile rust code for testing' ]
+          requires: [ 'Prepare Code', 'Compile 8.0 extension for testing', 'Compile rust code for testing' ]
           name: "PHP 80 Xdebug tests"
           docker_image: "datadog/dd-trace-ci:php-8.0_buster"
           xdebug_version_one: "3.0.0"
       - xdebug_tests:
-          requires: [ 'Prepare Code', 'Compile 8.1 extension for testing', 'medium: Compile rust code for testing' ]
+          requires: [ 'Prepare Code', 'Compile 8.1 extension for testing', 'Compile rust code for testing' ]
           name: "PHP 81 Xdebug tests"
           docker_image: "datadog/dd-trace-ci:php-8.1_buster"
           xdebug_version_one: "3.1.0"
       - xdebug_tests:
-          requires: [ 'Prepare Code', 'Compile 8.2 extension for testing', 'medium: Compile rust code for testing' ]
+          requires: [ 'Prepare Code', 'Compile 8.2 extension for testing', 'Compile rust code for testing' ]
           name: "PHP 82 Xdebug tests"
           docker_image: "datadog/dd-trace-ci:php-8.2_buster"
           xdebug_version_one: "3.2.2"
       - xdebug_tests:
-          requires: [ 'Prepare Code', 'Compile 8.3 extension for testing', 'medium: Compile rust code for testing' ]
+          requires: [ 'Prepare Code', 'Compile 8.3 extension for testing', 'Compile rust code for testing' ]
           name: "PHP 83 Xdebug tests"
           docker_image: "datadog/dd-trace-ci:php-8.3_buster"
           xdebug_version_one: "3.3.0"
 
       - placeholder:
-          requires: [ 'Prepare Code', 'medium: Compile rust code for testing' ]
+          requires: [ 'Prepare Code', 'Compile rust code for testing' ]
           name: Language tests
 
       - php_language_tests:
@@ -5538,17 +5566,17 @@ workflows:
           xfail_list: dockerfiles/ci/xfail_tests/7.0.list
           docker_image: "datadog/dd-trace-ci:php-7.0_buster"
       - internal_integrations:
-          requires: [ 'Prepare Code', 'Compile 8.0 extension for testing', 'medium: Compile rust code for testing' ]
+          requires: [ 'Prepare Code', 'Compile 8.0 extension for testing', 'Compile rust code for testing' ]
           name: "PHP 80 curl integration tests a shared lib"
           ext_name: "curl"
           docker_image: "datadog/dd-trace-ci:php-8.0-shared-ext"
       - static_analysis:
-          requires: [ 'Prepare Code', 'Compile 7.1 extension for testing', 'medium: Compile rust code for testing' ]
+          requires: [ 'Prepare Code', 'Compile 7.1 extension for testing', 'Compile rust code for testing' ]
           name: "Static Analysis 71"
           docker_image: datadog/dd-trace-ci:php-7.1_buster
           scenario: opentracing_beta6
       - static_analysis:
-          requires: [ 'Prepare Code', 'Compile 8.0 extension for testing', 'medium: Compile rust code for testing' ]
+          requires: [ 'Prepare Code', 'Compile 8.0 extension for testing', 'Compile rust code for testing' ]
           name: "Static Analysis 80"
           docker_image: datadog/dd-trace-ci:php-8.0_buster
           scenario: opentracing10

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1738,7 +1738,6 @@ jobs:
             - <<: *STEP_WAIT_MYSQL
       - <<: *STEP_WAIT_REQUEST_REPLAYER
       - <<: *STEP_WAIT_TEST_AGENT
-      - <<: *STEP_AWAIT_LINK_EXTENSION
       - run:
           name: Run tests
           command: |
@@ -2602,6 +2601,8 @@ jobs:
       resource_class:
         type: string
         default: large
+      triplet:
+        type: string
     <<: *BARE_DOCKER_MACHINE
     steps:
       - restore_cache:
@@ -2609,6 +2610,10 @@ jobs:
             - source-v1-{{ .Branch }}-{{ .Revision }}
       - git_checkout
       - append_build_id
+      - restore_cache:
+          name: Restore Cargo Package Cache
+          keys:
+            - rust-cargo-cache-<< parameters.triplet >>-{{ checksum "Cargo.lock" }}
       - setup_docker:
           docker_image: datadog/dd-trace-ci:buster
       - run:
@@ -2644,7 +2649,7 @@ jobs:
           name: Build << parameters.switch_php_version >> extension
           command: |
             switch-php << parameters.switch_php_version >>
-            make -j static CFLAGS="-std=gnu11 -O2 -g -Wall -Wextra -Werror -Wno-error=return-local-addr" ECHO_ARG="-e"
+            make -j static
             cp -v tmp/build_extension/modules/ddtrace.a ddtrace.a
             cp -v tmp/build_extension/ddtrace.ldflags ddtrace.ldflags
       - persist_to_workspace:
@@ -3010,12 +3015,18 @@ jobs:
       resource_class:
         type: string
         default: large
+      triplet:
+        type: string
     <<: *BARE_DOCKER_MACHINE
     steps:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
       - git_checkout
+      - restore_cache:
+          name: Restore Cargo Package Cache
+          keys:
+            - rust-cargo-cache-<< parameters.triplet >>-{{ checksum "Cargo.lock" }}
       - append_build_id
       - setup_docker:
           docker_image: datadog/dd-trace-ci:php-compile-extension-alpine
@@ -3127,11 +3138,10 @@ jobs:
       - restore_cache:
           name: Restore Cargo Package Cache
           keys:
-            - profiling-cargo-cache-<< parameters.triplet >>-{{ checksum "profiling/Cargo.toml" }}
+            - rust-cargo-cache-<< parameters.triplet >>-{{ checksum "Cargo.lock" }}
       - run:
           name: cargo fetch
           command: |
-            cd profiling
             # On occasion, we've observed the .package-cache being in the cache.
             # If it's there, it will cause commands to stall, waiting for the file to be released.
             if [ -e '/rust/cargo/.package-cache' ] ; then
@@ -3147,7 +3157,7 @@ jobs:
 
       - save_cache:
           name: Save Cargo Package Cache
-          key: profiling-cargo-cache-<< parameters.triplet >>-{{ checksum "profiling/Cargo.toml" }}
+          key: rust-cargo-cache-<< parameters.triplet >>-{{ checksum "Cargo.lock" }}
           paths:
             - /rust/cargo
 
@@ -3173,7 +3183,7 @@ jobs:
       - restore_cache:
           name: Restore Cargo Package Cache
           keys:
-            - profiling-cargo-cache-<< parameters.triplet >>-{{ checksum "profiling/Cargo.toml" }}
+            - profiling-rust-cargo-cache-<< parameters.triplet >>-{{ checksum "profiling/Cargo.toml" }}
       - append_build_id
       - build_profiler:
           prefix: datadog-profiling/<< parameters.triplet >>/lib/php/<< parameters.abi_no >>
@@ -3206,7 +3216,7 @@ jobs:
       - restore_cache:
           name: Restore Cargo Package Cache
           keys:
-            - profiling-cargo-cache-<< parameters.triplet >>-{{ checksum "profiling/Cargo.toml" }}
+            - rust-cargo-cache-<< parameters.triplet >>-{{ checksum "Cargo.lock" }}
       - run:
           name: cargo tests
           command: |
@@ -3399,12 +3409,18 @@ jobs:
       resource_class:
         type: string
         default: large
+      triplet:
+        type: string
     <<: *BARE_DOCKER_MACHINE
     steps:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
       - git_checkout
+      - restore_cache:
+          name: Restore Cargo Package Cache
+          keys:
+            - rust-cargo-cache-<< parameters.triplet >>-{{ checksum "Cargo.lock" }}
       - append_build_id
       - setup_docker:
           docker_image: datadog/dd-trace-ci:centos-7
@@ -4225,14 +4241,16 @@ workflows:
           resource_class: "arm.medium"
           name: "Compile alpine aarch64 PHP << matrix.php_major_minor >>"
       - compile_rust_alpine:
-          matrix:
-            parameters:
-              resource_class:
-                - "medium"
-                - "arm.medium"
+          name: "Compile alpine x86_64 rust"
+          resource_class: medium
+          triplet: "x86_64-alpine-linux-musl"
+      - compile_rust_alpine:
+          name: "Compile alpine aarch64 rust"
+          resource_class: arm.medium
+          triplet: "aarch64-alpine-linux-musl"
       - link_extension:
           requires:
-            - compile_rust_alpine
+            - "Compile alpine x86_64 rust"
             - "Compile alpine x86_64 PHP 7.0"
             - "Compile alpine x86_64 PHP 7.1"
             - "Compile alpine x86_64 PHP 7.2"
@@ -4248,7 +4266,7 @@ workflows:
           docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine"
       - link_extension:
           requires:
-            - compile_rust_alpine
+            - "Compile alpine aarch64 rust"
             - "Compile alpine aarch64 PHP 7.0"
             - "Compile alpine aarch64 PHP 7.1"
             - "Compile alpine aarch64 PHP 7.2"
@@ -4403,9 +4421,11 @@ workflows:
 
       - compile_rust_centos:
           name: "Compile x86_64 rust"
+          triplet: "x86_64-unknown-linux-gnu"
       - compile_rust_centos:
           name: "Compile aarch64 rust"
           resource_class: "arm.large"
+          triplet: "aarch64-unknown-linux-gnu"
 
       - link_extension:
           requires:
@@ -5096,13 +5116,24 @@ workflows:
 
       - "Prepare Code"
 
+      - "cache cargo deps":
+          name: "cache cargo deps - x86_64-unknown-linux-gnu"
+          docker_image: "datadog/dd-trace-ci:buster"
+          triplet: "x86_64-unknown-linux-gnu"
+      - "cache cargo deps":
+          name: "cache cargo deps - aarch64-unknown-linux-gnu"
+          docker_image: "datadog/dd-trace-ci:buster"
+          triplet: "aarch64-unknown-linux-gnu"
+          resource_class: "arm.medium"
+
       - compile_rust_test:
-          name: "<< matrix.resource_class >>: Compile rust code for testing"
-          matrix:
-            parameters:
-              resource_class:
-                - medium
-                - arm.medium
+          name: "medium: Compile rust code for testing"
+          resource_class: medium
+          triplet: "x86_64-unknown-linux-gnu"
+      - compile_rust_test:
+          name: "arm.medium: Compile rust code for testing"
+          resource_class: arm.medium
+          triplet: "aarch64-unknown-linux-gnu"
 
       - compile_extension_test:
           name: "Compile << matrix.php_major_minor >> extension for testing"
@@ -5119,7 +5150,7 @@ workflows:
                 - "8.2"
                 - "8.3"
               switch_php_version:
-                - nts
+                - debug
 
       - compile_extension_test:
           name: "<< matrix.resource_class >>: Compile << matrix.php_major_minor >> ZTS asan extension for testing"
@@ -5382,7 +5413,7 @@ workflows:
                 - '8.2'
                 - '8.3'
               switch_php_version:
-                - nts
+                - debug
               make_target:
                 - test_integrations_phpredis5
 

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -248,61 +248,70 @@ aliases:
     store_test_results:
       path: test-results
 
-  - &STEP_CHECKOUT
-    run:
-      name: Checkout code
-      command: |
-        git config --global gc.auto 0
-
-        export CIRCLE_REPOSITORY_URL="${CIRCLE_REPOSITORY_URL/git@github.com:/https://github.com/}"
-
-        if [ -e "$HOME/datadog/.git" ] ; then
-          echo 'Fetching into existing repository'
-          existing_repo='true'
-          cd "$HOME/datadog"
-          git remote set-url origin "$CIRCLE_REPOSITORY_URL" || true
-
-          echo 'Fetching from remote repository'
-          retry_count=3
-          if [ -n "$CIRCLE_TAG" ]; then
-            for i in $(seq 1 $retry_count); do
-              git fetch --force --no-recurse-submodules --tags origin && break || sleep 1
-            done
-          elif [ -z "$CIRCLE_PR_NUMBER" ]; then
-            for i in $(seq 1 $retry_count); do
-              git fetch --force --no-recurse-submodules origin "+refs/heads/$CIRCLE_BRANCH:refs/remotes/origin/$CIRCLE_BRANCH" && break || sleep 1
-            done
-          fi
-        else
-          echo 'Cloning git repository'
-          existing_repo='false'
-          mkdir -p "$HOME/datadog"
-          cd "$HOME/datadog"
-          git clone --no-checkout "$CIRCLE_REPOSITORY_URL" .
-        fi
-
-        if [ -n "$CIRCLE_TAG" ]; then
-          echo 'Checking out tag'
-          git checkout --force "$CIRCLE_TAG"
-          git reset --hard "$CIRCLE_SHA1"
-        else
-          echo 'Checking out branch'
-          if [ -n "$CIRCLE_PR_NUMBER" ]; then
-            git fetch --force origin "+refs/pull/${CIRCLE_PR_NUMBER}/head:refs/remotes/origin/$CIRCLE_BRANCH"
-          fi
-          git checkout --force -B "$CIRCLE_BRANCH" "$CIRCLE_SHA1"
-          git --no-pager log --no-color -n 1 --format='HEAD is now at %h %s'
-        fi
-
-        echo 'Updating submodules'
-        git submodule update --init --recursive
-
   - &BARE_DOCKER_MACHINE
     resource_class: << parameters.resource_class >>
     machine:
       image: ubuntu-2004:current
 
 commands:
+  git_checkout:
+    parameters:
+      is_windows:
+        type: boolean
+        default: false
+    steps:
+      - run:
+          name: Checkout code
+          shell: "<<# parameters.is_windows >>bash.exe<</ parameters.is_windows >><<^ parameters.is_windows >>/bin/bash -eo pipefail<</ parameters.is_windows >>"
+          command: |
+            git config --global gc.auto 0
+    
+            export CIRCLE_REPOSITORY_URL="${CIRCLE_REPOSITORY_URL/git@github.com:/https://github.com/}"
+    
+            APP_DIR="$HOME/datadog"
+            if [ -e "$APP_DIR/.git" ] ; then
+              echo 'Fetching into existing repository'
+              existing_repo='true'
+              cd "$APP_DIR"
+              git remote set-url origin "$CIRCLE_REPOSITORY_URL" || true
+    
+              echo 'Fetching from remote repository'
+              retry_count=3
+              if [ -n "$CIRCLE_TAG" ]; then
+                for i in $(seq 1 $retry_count); do
+                  git fetch --force --no-recurse-submodules --tags origin && break || sleep 1
+                done
+              elif [ -z "$CIRCLE_PR_NUMBER" ]; then
+                for i in $(seq 1 $retry_count); do
+                  git fetch --force --no-recurse-submodules origin "+refs/heads/$CIRCLE_BRANCH:refs/remotes/origin/$CIRCLE_BRANCH" && break || sleep 1
+                done
+              fi
+            else
+              echo 'Cloning git repository'
+              existing_repo='false'
+              mkdir -p "$APP_DIR"
+              cd "$APP_DIR"
+              git clone --no-checkout "$CIRCLE_REPOSITORY_URL" .
+            fi
+    
+            if [ -n "$CIRCLE_TAG" ]; then
+              echo 'Checking out tag'
+              git checkout --force "$CIRCLE_TAG"
+              git reset --hard "$CIRCLE_SHA1"
+            else
+              echo 'Checking out branch'
+              if [ -n "$CIRCLE_PR_NUMBER" ]; then
+                git fetch --force origin "+refs/pull/${CIRCLE_PR_NUMBER}/head:refs/remotes/origin/$CIRCLE_BRANCH"
+              fi
+              git checkout --force -B "$CIRCLE_BRANCH" "$CIRCLE_SHA1"
+              git --no-pager log --no-color -n 1 --format='HEAD is now at %h %s'
+            fi
+    
+            echo 'Updating submodules'
+            # we don't need appsec submodules on windows
+            <<# parameters.is_windows >>git submodule update --init libdatadog<</ parameters.is_windows >>
+            <<^ parameters.is_windows >>git submodule update --init --recursive<</ parameters.is_windows >>
+
   lib_curl_workaround:
     parameters:
       command:
@@ -706,7 +715,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - lib_curl_workaround:
           command: sudo apt update; sudo apt -y install libcurl4-nss-dev
@@ -734,7 +743,7 @@ jobs:
           command: |
             apt-get update
             apt-get install -y git
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
           name: Start Supervisor
@@ -766,7 +775,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - <<: *STEP_EXT_INSTALL
       - <<: *STEP_EXPORT_CI_ENV
@@ -821,7 +830,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
           name: Set core pattern
@@ -875,7 +884,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
           name: Set core pattern
@@ -923,7 +932,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
           name: Set core pattern
@@ -964,7 +973,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - fetch_job_artifact:
           job: "package extension"
           artifact: 'dd-library-php-[^"]+x86_64-linux-gnu.tar.gz'
@@ -1006,7 +1015,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
           name: Install php
@@ -1051,6 +1060,7 @@ jobs:
           path: /tmp/artifacts
 
   test_windows:
+    working_directory: ~/datadog
     resource_class: 'windows.medium'
     machine:
       image: 'windows-server-2019-vs2019:2022.08.1'
@@ -1059,12 +1069,7 @@ jobs:
       docker_image:
         type: string
     steps:
-      - checkout
-      - run:
-          name: Pull submodules
-          shell: powershell.exe
-          command: |
-            git submodule update --init --recursive
+      - git_checkout: { is_windows: true }
       - run:
           name: Setup docker container
           shell: powershell.exe
@@ -1132,7 +1137,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - setup_docker:
           docker_image: datadog/dd-trace-ci:php-<< parameters.php_major_minor >>_buster
@@ -1185,7 +1190,7 @@ jobs:
     working_directory: ~/datadog
     <<: *BARE_DOCKER_MACHINE
     steps:
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - restore_cache:
           name: "Restore Cache"
@@ -1230,7 +1235,7 @@ jobs:
     working_directory: ~/datadog
     <<: *BARE_DOCKER_MACHINE
     steps:
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - restore_cache:
           name: "Restore Hunter Cache"
@@ -1271,7 +1276,7 @@ jobs:
     working_directory: ~/datadog
     <<: *BARE_DOCKER_MACHINE
     steps:
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
           name: Integration tests
@@ -1287,7 +1292,7 @@ jobs:
     working_directory: ~/datadog
     <<: *BARE_DOCKER_MACHINE
     steps:
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - restore_cache:
           name: "Restore Cache"
@@ -1322,7 +1327,7 @@ jobs:
     working_directory: ~/datadog
     <<: *BARE_DOCKER_MACHINE
     steps:
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - restore_cache:
           name: "Restore Cache"
@@ -1388,7 +1393,7 @@ jobs:
     working_directory: ~/datadog
     <<: *BARE_DOCKER_MACHINE
     steps:
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - restore_cache:
           name: "Restore Cache"
@@ -1426,7 +1431,7 @@ jobs:
     working_directory: ~/datadog
     <<: *BARE_DOCKER_MACHINE
     steps:
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - restore_cache:
           name: "Restore Cache"
@@ -1466,7 +1471,7 @@ jobs:
     working_directory: ~/datadog
     <<: *BARE_DOCKER_MACHINE
     steps:
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - restore_cache:
           name: "Restore Cache"
@@ -1574,7 +1579,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - setup_docker:
           docker_image: datadog/dd-trace-ci:php-<< parameters.php_major_minor >>_buster
@@ -1676,7 +1681,7 @@ jobs:
             - run:
                 name: Updating composer to v2
                 command: sudo composer self-update --2 --no-interaction
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - switch_php:
           php_version: << parameters.switch_php_version >>
@@ -1738,7 +1743,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - prepare_extension_and_composer_with_cache
       - <<: *STEP_PREPARE_TEST_RESULTS_DIR
@@ -1827,7 +1832,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - setup_docker:
           docker_image: datadog/dd-trace-ci:php-<< parameters.php_major_minor >>_buster
@@ -1890,7 +1895,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - switch_php:
           php_version: << parameters.switch_php_version >>
@@ -1955,7 +1960,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_PREPARE_TEST_RESULTS_DIR
       - <<: *STEP_EXPORT_CI_ENV
       - fetch_job_artifact:
@@ -2004,7 +2009,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - run: mkdir -p build/packages
       - fetch_job_artifact:
           job: "package extension"
@@ -2051,7 +2056,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - run: mkdir -p build/packages
       - when:
           condition:
@@ -2117,7 +2122,7 @@ jobs:
             sed -i s/^mirrorlist=http/#mirrorlist=http/g /etc/yum.repos.d/*.repo
             yum update -y
             yum install -y git
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - run: mkdir -p build/packages
       - when:
           condition:
@@ -2163,7 +2168,7 @@ jobs:
           command: |
             yum update -y
             yum install -y git
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - run: mkdir -p build/packages
       - when:
           condition:
@@ -2235,7 +2240,7 @@ jobs:
           name: Install curl
           command: |
             apt-get install -y curl
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - run: mkdir -p build/packages
       - when:
           condition:
@@ -2280,7 +2285,7 @@ jobs:
           command: |
             sudo apt-get update
             sudo apt-get install -y git
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - run: mkdir -p build/packages
       - fetch_job_artifact:
           job: "package extension"
@@ -2312,7 +2317,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - run: mkdir -p build/packages
       - fetch_job_artifact:
           job: "package extension"
@@ -2333,7 +2338,7 @@ jobs:
       docker_image:
         type: string
     steps:
-      - checkout
+      - git_checkout: { is_windows: true }
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
           name: Build nts
@@ -2348,7 +2353,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - append_build_id
       - run:
           name: Let testing images to write to build/packages dir
@@ -2405,7 +2410,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - run:
           command: ls -al
       - run:
@@ -2493,7 +2498,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
           name: Make PECL build
@@ -2521,7 +2526,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
           name: Install from PECL build
@@ -2565,7 +2570,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
           name: Install cmake << parameters.cmake_version >>
@@ -2679,7 +2684,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
           name: Install cmake << parameters.cmake_version >>
@@ -2827,7 +2832,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
           name: Switch PHP to nts
@@ -2914,7 +2919,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - append_build_id
       - setup_docker:
           docker_image: datadog/dd-trace-ci:php-compile-extension-alpine
@@ -2942,7 +2947,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - append_build_id
       - setup_docker:
           docker_image: datadog/dd-trace-ci:php-compile-extension-alpine-<< parameters.php_major_minor >>
@@ -2985,7 +2990,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - append_build_id
       - setup_docker:
           docker_image: << parameters.docker_image >>
@@ -3020,7 +3025,7 @@ jobs:
         default: medium # mostly for more RAM for ramdisk
     <<: *BARE_DOCKER_MACHINE
     steps:
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - setup_docker:
           docker_image: << parameters.docker_image >>
       - restore_cache:
@@ -3066,7 +3071,7 @@ jobs:
     environment:
       - CARGO_TARGET_DIR: /mnt/ramdisk/cargo
     steps:
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - setup_docker:
           docker_image: << parameters.docker_image >>
       - restore_cache:
@@ -3098,7 +3103,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - setup_docker:
           docker_image: << parameters.docker_image >>
@@ -3179,7 +3184,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - append_build_id
       - setup_docker:
           docker_image: << parameters.docker_image >>
@@ -3228,7 +3233,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - fetch_job_artifact:
           job: "package extension"
           artifact: |-
@@ -3269,7 +3274,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - fetch_job_artifact:
           job: "package extension"
           artifact: |-
@@ -3303,7 +3308,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - append_build_id
       - setup_docker:
           docker_image: datadog/dd-trace-ci:centos-7
@@ -3342,7 +3347,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - append_build_id
       - setup_docker:
           docker_image: << parameters.docker_image >>
@@ -3392,7 +3397,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - setup_docker:
           docker_image: << parameters.docker_image >>
@@ -3412,6 +3417,7 @@ jobs:
           paths: [ './extensions_*' ]
 
   compile_extension_windows:
+    working_directory: ~/datadog
     resource_class: 'windows.medium'
     machine:
       image: 'windows-server-2019-vs2019:2022.08.1'
@@ -3425,14 +3431,9 @@ jobs:
       php_version:
         type: string
     steps:
-      - checkout
+      - git_checkout: { is_windows: true }
       - append_build_id:
           shell: bash.exe
-      - run:
-          name: Pull submodules
-          shell: powershell.exe
-          command: |
-            git submodule update --init --recursive
       - run:
           name: Setup docker container
           shell: powershell.exe
@@ -3471,7 +3472,7 @@ jobs:
         type: string
     <<: *BARE_DOCKER_MACHINE
     steps:
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - append_build_id
       - setup_docker:
           docker_image: "datadog/dd-trace-ci:php-<< parameters.php_version >>_centos-7"
@@ -3525,7 +3526,7 @@ jobs:
         type: string
     <<: *BARE_DOCKER_MACHINE
     steps:
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - append_build_id
       - setup_docker:
           docker_image: "datadog/dd-trace-ci:php-compile-extension-alpine-<< parameters.php_version >>"
@@ -3569,7 +3570,7 @@ jobs:
         default: medium
     <<: *BARE_DOCKER_MACHINE
     steps:
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - append_build_id
       - setup_docker:
           docker_image: "datadog/libddwaf:toolchain"
@@ -3613,7 +3614,7 @@ jobs:
             - source-v1-{{ .Branch }}-{{ .Revision }}
             - source-v1-{{ .Branch }}-
             - source-v1-
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - save_cache:
           key: source-v1-{{ .Branch }}-{{ .Revision }}
           paths:
@@ -3644,7 +3645,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
           name: Build packages
@@ -3690,7 +3691,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - run:
           name: Install curl
           command: apk add curl
@@ -3720,7 +3721,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
       - <<: *STEP_ATTACH_WORKSPACE
       - run:
           name: Install cbindgen
@@ -3753,7 +3754,7 @@ jobs:
       - restore_cache:
           keys:
             - source-v1-{{ .Branch }}-{{ .Revision }}
-      - <<: *STEP_CHECKOUT
+      - git_checkout
 
       - run:
           name: Install python 3.12

--- a/Makefile
+++ b/Makefile
@@ -161,7 +161,7 @@ test_c2php: $(SO_FILE) $(INIT_HOOK_TEST_FILES) $(BUILD_DIR)/run-tests.php
 	export USE_ZEND_ALLOC=0; \
 	export ZEND_DONT_UNLOAD_MODULES=1; \
 	export USE_TRACKED_ALLOC=1; \
-	$(shell grep -Pzo '(?<=--ENV--)(?s).+?(?=--)' $(INIT_HOOK_TEST_FILES)) valgrind -q --tool=memcheck --trace-children=yes --vex-iropt-register-updates=allregs-at-mem-access bash -c '$(RUN_TESTS_CMD) -d extension=$(SO_FILE) -d datadog.trace.sources_path=$(TRACER_SOURCE_DIR) $(INIT_HOOK_TEST_FILES)'; \
+	$(shell grep -Pzo '(?<=--ENV--)(?s).+?(?=--)' $(INIT_HOOK_TEST_FILES)) valgrind -q --tool=memcheck --trace-children=yes --vex-iropt-register-updates=allregs-at-mem-access bash -c '$(RUN_TESTS_CMD) -d extension=$(SO_FILE) -d datadog.trace.sources_path=$(TRACER_SOURCE_DIR) -d pcre.jit=0 $(INIT_HOOK_TEST_FILES)'; \
 	)
 
 test_with_init_hook: $(SO_FILE) $(INIT_HOOK_TEST_FILES) $(BUILD_DIR)/run-tests.php

--- a/Makefile
+++ b/Makefile
@@ -157,6 +157,7 @@ test_c_mem: $(SO_FILE) $(TEST_FILES) $(TEST_STUB_FILES) $(BUILD_DIR)/run-tests.p
 test_c2php: $(SO_FILE) $(INIT_HOOK_TEST_FILES) $(BUILD_DIR)/run-tests.php
 	( \
 	set -xe; \
+	sed -i 's/stream_socket_accept($$listenSock, 5)/stream_socket_accept($$listenSock, 20)/' $(BUILD_DIR)/run-tests.php; \
 	export DD_TRACE_CLI_ENABLED=1; \
 	export USE_ZEND_ALLOC=0; \
 	export ZEND_DONT_UNLOAD_MODULES=1; \

--- a/compile_rust.sh
+++ b/compile_rust.sh
@@ -15,4 +15,11 @@ case "${host_os}" in
     ;;
 esac
 
+set -x
+
+if test -n "$COMPILE_ASAN"; then
+  export LDFLAGS="-fsanitize=address"
+  export CFLAGS="-fsanitize=address -fno-omit-frame-pointer"
+fi
+
 SIDECAR_VERSION=$(cat ../VERSION) RUSTFLAGS="$RUSTFLAGS" RUSTC_BOOTSTRAP=1 "${DDTRACE_CARGO:-cargo}" build $(test "${PROFILE:-debug}" = "debug" || echo --profile "$PROFILE") "$@"

--- a/config.m4
+++ b/config.m4
@@ -1,8 +1,8 @@
 PHP_ARG_ENABLE(ddtrace, whether to enable Datadog tracing support,
   [  --enable-ddtrace   Enable Datadog tracing support])
 
-PHP_ARG_WITH(ddtrace-sanitize, whether to enable AddressSanitizer for ddtrace,
-  [  --with-ddtrace-sanitize Build Datadog tracing with AddressSanitizer support], no, no)
+PHP_ARG_ENABLE(ddtrace-sanitize, whether to enable AddressSanitizer for ddtrace,
+  [  --enable-ddtrace-sanitize Build Datadog tracing with AddressSanitizer support], no, no)
 
 PHP_ARG_WITH(ddtrace-rust-library, the rust library is located; i.e. to compile without cargo,
   [  --with-ddtrace-rust-library Location to rust library for linking against], -, will be compiled)
@@ -325,7 +325,7 @@ EOT
 
     cat <<EOT >> Makefile.fragments
 $ddtrace_rust_lib: $( (find "$ext_srcdir/components-rs" -name "*.rs" -o -name "Cargo.toml"; find "$ext_srcdir/../../libdatadog" -name "*.rs" -not -path "*/target/*"; find "$ext_srcdir/libdatadog" -name "*.rs" -not -path "*/target/*") 2>/dev/null | xargs )
-	(cd "$ext_srcdir"; CARGO_TARGET_DIR=\$(builddir)/target/ SHARED=$(test "$ext_shared" = "yes" && echo 1) PROFILE="$ddtrace_cargo_profile" host_os="$host_os" DDTRACE_CARGO=\$(DDTRACE_CARGO) sh ./compile_rust.sh \$(shell echo "\$(MAKEFLAGS)" | $EGREP -o "[[-]]j[[0-9]]+"))
+	(cd "$ext_srcdir"; CARGO_TARGET_DIR=\$(builddir)/target/ SHARED=$(test "$ext_shared" = "yes" && echo 1) PROFILE="$ddtrace_cargo_profile" host_os="$host_os" DDTRACE_CARGO=\$(DDTRACE_CARGO) $(if test "$PHP_DDTRACE_SANITIZE" != "no"; then echo COMPILE_ASAN=1; fi) sh ./compile_rust.sh \$(shell echo "\$(MAKEFLAGS)" | $EGREP -o "[[-]]j[[0-9]]+"))
 EOT
   fi
 

--- a/dockerfiles/packaging/fpm_packaging/Dockerfile
+++ b/dockerfiles/packaging/fpm_packaging/Dockerfile
@@ -1,0 +1,23 @@
+FROM cimg/ruby:3.3.4 AS base
+
+USER root
+WORKDIR /home/circleci
+
+RUN apt-get update && apt-get -y install vim less build-essential rpm lintian jq
+
+# Need at least tar 1.35 to work around concurrency problems with atime and inode count checks
+# See also: https://stackoverflow.com/a/77765876
+FROM base as compile-tar
+RUN curl -LO https://ftp.gnu.org/gnu/tar/tar-1.35.tar.gz
+RUN tar xfz tar-1.35.tar.gz
+RUN (cd tar-1.35 && FORCE_UNSAFE_CONFIGURE=1 ./configure --prefix=/usr && make install)
+
+FROM base as final
+ADD fpm_apk_pax_header.patch /tmp
+RUN sudo gem install fpm -v 1.15.1
+RUN (cd /usr/local/lib/ruby/gems/3.3.0/gems/fpm-1.15.1; patch -p 1 < /tmp/fpm_apk_pax_header.patch ) && rm -f /tmp/fpm_apk_pax_header.patch
+
+COPY --from=compile-tar /usr/bin/tar /usr/bin/tar
+
+USER circleci
+ENTRYPOINT [ "bash" ]

--- a/dockerfiles/packaging/fpm_packaging/README.md
+++ b/dockerfiles/packaging/fpm_packaging/README.md
@@ -1,0 +1,5 @@
+## Build for x86_64
+
+```
+docker buildx build --platform=linux/amd64 -t datadog/dd-trace-ci:php_fpm_packaging --push .
+```

--- a/dockerfiles/packaging/fpm_packaging/fpm_apk_pax_header.patch
+++ b/dockerfiles/packaging/fpm_packaging/fpm_apk_pax_header.patch
@@ -1,0 +1,29 @@
+From 18221cceb06860395120b56cca7e270539b74073 Mon Sep 17 00:00:00 2001
+From: Pawel Chojnacki <pawel.chcki@gmail.com>
+Date: Wed, 30 Jan 2019 16:35:50 +0100
+Subject: [PATCH] Add guard against modifying LongLink entry and leave entries
+ above 80 chars alone
+
+---
+ lib/fpm/package/apk.rb | 6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/lib/fpm/package/apk.rb b/lib/fpm/package/apk.rb
+index dd69067..bc9ff50 100644
+--- a/lib/fpm/package/apk.rb
++++ b/lib/fpm/package/apk.rb
+@@ -435,6 +435,12 @@ class FPM::Package::APK< FPM::Package
+   # This takes an unchanged directory name and "paxifies" it.
+   def add_paxstring(ret)
+
++    # Check if this is special Tar filename to mark that the next entry file name will be longer than 100 characters.
++    return ret if ret.match? "././@LongLink"
++
++    # adding PaxHeaders prefix to entries over 80 characters is impossible without creating extra entries
++    return ret if ret.length > 80
++
+     pax_slash = ret.rindex('/')
+     if(pax_slash == nil)
+       pax_slash = 0
+--
+2.18.0

--- a/tests/ext/background-sender/agent_sampling_sidecar.phpt
+++ b/tests/ext/background-sender/agent_sampling_sidecar.phpt
@@ -2,6 +2,7 @@
 The sidecar trace flusher sender informs about changes to the agent sample rate
 --SKIPIF--
 <?php include __DIR__ . '/../includes/skipif_no_dev_env.inc'; ?>
+<?php if (getenv('USE_ZEND_ALLOC') === '0' && !getenv("SKIP_ASAN")) die('skip: valgrind reports sendmsg(msg.msg_control) points to uninitialised byte(s), but it is unproblematic and outside our control in rust code'); ?>
 --ENV--
 DD_TRACE_LOG_LEVEL=info,startup=off
 DD_AGENT_HOST=request-replayer

--- a/tests/randomized/Makefile
+++ b/tests/randomized/Makefile
@@ -66,7 +66,7 @@ pull.buster.%:
 library.local:
 	@mkdir -p $(LIBRARY_DOWNLOAD_PATH)
 #	For now we only handle centos in randomized tests
-	@cp ../../build/packages/dd-library-php-*-$(ARCHITECTURE)-linux-gnu.tar.gz $(LIBRARY_DOWNLOAD_PATH)/dd-library-php.tar.gz
+	@cp ../../dd-library-php-*-$(ARCHITECTURE)-linux-gnu.tar.gz $(LIBRARY_DOWNLOAD_PATH)/dd-library-php.tar.gz
 
 library.download:
 	@echo "Downloading library at url: $(LIBRARY_TEST_URL)"

--- a/tooling/bin/generate-final-artifact.sh
+++ b/tooling/bin/generate-final-artifact.sh
@@ -40,20 +40,20 @@ for architecture in "${architectures[@]}"; do
     for php_api in "${php_apis[@]}"; do
         mkdir -p ${tmp_folder_final_gnu_trace}/ext/$php_api ${tmp_folder_final_musl_trace}/ext/$php_api;
         if [[ -z ${DDTRACE_MAKE_PACKAGES_ASAN:-} ]]; then
-            cp ./extensions_${architecture}/ddtrace-$php_api.so ${tmp_folder_final_gnu_trace}/ext/$php_api/ddtrace.so;
-            cp ./extensions_${architecture}/ddtrace-$php_api-zts.so ${tmp_folder_final_gnu_trace}/ext/$php_api/ddtrace-zts.so;
-            cp ./extensions_${architecture}/ddtrace-$php_api-debug.so ${tmp_folder_final_gnu_trace}/ext/$php_api/ddtrace-debug.so;
-            cp ./extensions_${architecture}/ddtrace-$php_api-alpine.so ${tmp_folder_final_musl_trace}/ext/$php_api/ddtrace.so;
+            ln ./extensions_${architecture}/ddtrace-$php_api.so ${tmp_folder_final_gnu_trace}/ext/$php_api/ddtrace.so;
+            ln ./extensions_${architecture}/ddtrace-$php_api-zts.so ${tmp_folder_final_gnu_trace}/ext/$php_api/ddtrace-zts.so;
+            ln ./extensions_${architecture}/ddtrace-$php_api-debug.so ${tmp_folder_final_gnu_trace}/ext/$php_api/ddtrace-debug.so;
+            ln ./extensions_${architecture}/ddtrace-$php_api-alpine.so ${tmp_folder_final_musl_trace}/ext/$php_api/ddtrace.so;
             if [[ ${php_api} -ge 20151012 ]]; then # zts on alpine starting 7.0
-                cp ./extensions_${architecture}/ddtrace-$php_api-alpine-zts.so ${tmp_folder_final_musl_trace}/ext/$php_api/ddtrace-zts.so;
+                ln ./extensions_${architecture}/ddtrace-$php_api-alpine-zts.so ${tmp_folder_final_musl_trace}/ext/$php_api/ddtrace-zts.so;
             fi
             if [[ ${php_api} -ge 20170718 && $architecture == "x86_64" ]]; then # Windows support starts on 7.2
                 mkdir -p ${tmp_folder_final_windows_trace}/ext/$php_api;
-                cp ./extensions_windows_${architecture}/php_ddtrace-$php_api.dll ${tmp_folder_final_windows_trace}/ext/$php_api/php_ddtrace.dll;
-                cp ./extensions_windows_${architecture}/php_ddtrace-$php_api-zts.dll ${tmp_folder_final_windows_trace}/ext/$php_api/php_ddtrace-zts.dll;
+                ln ./extensions_windows_${architecture}/php_ddtrace-$php_api.dll ${tmp_folder_final_windows_trace}/ext/$php_api/php_ddtrace.dll;
+                ln ./extensions_windows_${architecture}/php_ddtrace-$php_api-zts.dll ${tmp_folder_final_windows_trace}/ext/$php_api/php_ddtrace-zts.dll;
             fi
         else
-            cp ./extensions_${architecture}/ddtrace-$php_api-debug-zts.so ${tmp_folder_final_gnu_trace}/ext/$php_api/ddtrace-debug-zts.so;
+            ln ./extensions_${architecture}/ddtrace-$php_api-debug-zts.so ${tmp_folder_final_gnu_trace}/ext/$php_api/ddtrace-debug-zts.so;
         fi
     done;
     cp -r ./src ${tmp_folder_final_gnu_trace};
@@ -66,46 +66,38 @@ for architecture in "${architectures[@]}"; do
     # Profiling
     ########################
     if [[ -z ${DDTRACE_MAKE_PACKAGES_ASAN:-} ]]; then
-        tmp_folder_profiling=$tmp_folder/profiling
-        tmp_folder_profiling_archive=$tmp_folder_profiling/datadog-profiling.tar.gz
-        mkdir -p $tmp_folder_profiling
-
-        cp -v datadog-profiling.tar.gz "$tmp_folder_profiling_archive"
-
-        tar -xf $tmp_folder_profiling_archive -C $tmp_folder_profiling
-
         # Extension
         php_apis=(20160303 20170718 20180731 20190902 20200930 20210902 20220829 20230831)
         for version in "${php_apis[@]}"
         do
             mkdir -v -p \
-                $tmp_folder_final/$architecture-linux-gnu/dd-library-php/profiling/ext/$version \
-                $tmp_folder_final/$architecture-linux-musl/dd-library-php/profiling/ext/$version
+                $tmp_folder_final_gnu/dd-library-php/profiling/ext/$version \
+                $tmp_folder_final_musl/dd-library-php/profiling/ext/$version
 
-            cp -v \
-                $tmp_folder_profiling/datadog-profiling/$architecture-unknown-linux-gnu/lib/php/$version/datadog-profiling.so \
-                $tmp_folder_final/$architecture-linux-gnu/dd-library-php/profiling/ext/$version/datadog-profiling.so
-            cp -v \
-                $tmp_folder_profiling/datadog-profiling/$architecture-unknown-linux-gnu/lib/php/$version/datadog-profiling-zts.so \
-                $tmp_folder_final/$architecture-linux-gnu/dd-library-php/profiling/ext/$version/datadog-profiling-zts.so
+            ln -v \
+                ./datadog-profiling/$architecture-unknown-linux-gnu/lib/php/$version/datadog-profiling.so \
+                $tmp_folder_final_gnu/dd-library-php/profiling/ext/$version/datadog-profiling.so
+            ln -v \
+                ./datadog-profiling/$architecture-unknown-linux-gnu/lib/php/$version/datadog-profiling-zts.so \
+                $tmp_folder_final_gnu/dd-library-php/profiling/ext/$version/datadog-profiling-zts.so
 
-            cp -v \
-                $tmp_folder_profiling/datadog-profiling/$architecture-alpine-linux-musl/lib/php/$version/datadog-profiling.so \
-                $tmp_folder_final/$architecture-linux-musl/dd-library-php/profiling/ext/$version/datadog-profiling.so
-            cp -v \
-                $tmp_folder_profiling/datadog-profiling/$architecture-alpine-linux-musl/lib/php/$version/datadog-profiling-zts.so \
-                $tmp_folder_final/$architecture-linux-musl/dd-library-php/profiling/ext/$version/datadog-profiling-zts.so
+            ln -v \
+                ./datadog-profiling/$architecture-alpine-linux-musl/lib/php/$version/datadog-profiling.so \
+                $tmp_folder_final_musl/dd-library-php/profiling/ext/$version/datadog-profiling.so
+            ln -v \
+                ./datadog-profiling/$architecture-alpine-linux-musl/lib/php/$version/datadog-profiling-zts.so \
+                $tmp_folder_final_musl/dd-library-php/profiling/ext/$version/datadog-profiling-zts.so
         done
 
         # Licenses
-        cp -v \
-            $tmp_folder_profiling/datadog-profiling/$architecture-unknown-linux-gnu/LICENSE* \
-            $tmp_folder_profiling/datadog-profiling/$architecture-unknown-linux-gnu/NOTICE* \
+        ln -v \
+            ./profiling/LICENSE* \
+            ./profiling/NOTICE \
             $tmp_folder_final_gnu/dd-library-php/profiling/
 
-        cp -v \
-            $tmp_folder_profiling/datadog-profiling/$architecture-alpine-linux-musl/LICENSE* \
-            $tmp_folder_profiling/datadog-profiling/$architecture-alpine-linux-musl/NOTICE* \
+        ln -v \
+            ./profiling/LICENSE* \
+            ./profiling/NOTICE \
             $tmp_folder_final_musl/dd-library-php/profiling/
     fi
 

--- a/tooling/bin/generate-ssi-package.sh
+++ b/tooling/bin/generate-ssi-package.sh
@@ -10,7 +10,7 @@ packages_build_dir=$2
 # '+' char is not allowed
 release_version_sanitized=${release_version/+/-}
 
-tmp_folder=/tmp/bundle
+tmp_folder=/tmp/ssi-bundle
 tmp_folder_final=$tmp_folder/final
 
 architectures=(x86_64 aarch64)
@@ -32,11 +32,11 @@ for architecture in "${architectures[@]}"; do
     ########################
     # Loader
     ########################
-    cp libddtrace_php_${architecture}.so ${gnu}/loader/libddtrace_php.so
-    cp libddtrace_php_${architecture}-alpine.so ${musl}/loader/libddtrace_php.so
+    ln libddtrace_php_${architecture}.so ${gnu}/loader/libddtrace_php.so
+    ln libddtrace_php_${architecture}-alpine.so ${musl}/loader/libddtrace_php.so
 
-    cp dd_library_loader-${architecture}-linux-gnu.so ${gnu}/loader/dd_library_loader.so
-    cp dd_library_loader-${architecture}-linux-musl.so ${musl}/loader/dd_library_loader.so
+    ln dd_library_loader-${architecture}-linux-gnu.so ${gnu}/loader/dd_library_loader.so
+    ln dd_library_loader-${architecture}-linux-musl.so ${musl}/loader/dd_library_loader.so
 
     echo 'zend_extension=${DD_LOADER_PACKAGE_PATH}/linux-gnu/loader/dd_library_loader.so' > ${gnu}/loader/dd_library_loader.ini
     echo 'zend_extension=${DD_LOADER_PACKAGE_PATH}/linux-musl/loader/dd_library_loader.so' > ${musl}/loader/dd_library_loader.ini
@@ -49,14 +49,14 @@ for architecture in "${architectures[@]}"; do
     for php_api in "${php_apis[@]}"; do
         mkdir -p ${gnu}/trace/ext/$php_api ${musl}/trace/ext/$php_api
         # gnu
-        cp ./standalone_${architecture}/ddtrace-$php_api.so ${gnu}/trace/ext/$php_api/ddtrace.so
-        cp ./standalone_${architecture}/ddtrace-$php_api-zts.so ${gnu}/trace/ext/$php_api/ddtrace-zts.so
-        cp ./standalone_${architecture}/ddtrace-$php_api-debug.so ${gnu}/trace/ext/$php_api/ddtrace-debug.so
+        ln ./standalone_${architecture}/ddtrace-$php_api.so ${gnu}/trace/ext/$php_api/ddtrace.so
+        ln ./standalone_${architecture}/ddtrace-$php_api-zts.so ${gnu}/trace/ext/$php_api/ddtrace-zts.so
+        ln ./standalone_${architecture}/ddtrace-$php_api-debug.so ${gnu}/trace/ext/$php_api/ddtrace-debug.so
 
         # musl
-        cp ./standalone_${architecture}/ddtrace-$php_api-alpine.so ${musl}/trace/ext/$php_api/ddtrace.so
+        ln ./standalone_${architecture}/ddtrace-$php_api-alpine.so ${musl}/trace/ext/$php_api/ddtrace.so
         if [[ ${php_api} -ge 20151012 ]]; then # zts on alpine starting 7.0
-            cp ./standalone_${architecture}/ddtrace-$php_api-alpine-zts.so ${musl}/trace/ext/$php_api/ddtrace-zts.so
+            ln ./standalone_${architecture}/ddtrace-$php_api-alpine-zts.so ${musl}/trace/ext/$php_api/ddtrace-zts.so
         fi
     done;
 


### PR DESCRIPTION
This is not the final incantation (i.e. more to come in future PRs), but containing all changes affecting multiple types of jobs at once:

- package extension is parallelized, now taking only 10 min; also uses `ln` instead of `cp` to save time copying things around.
  - There also was a redundant tar -> untar cycle in profiling, where the profiler artifacts were first tar-ed together, then untared at the expected location for the packaging script. This was a historic relic from the past and has now been unified.
  - This needs tar 1.35 to avoid tar exiting with exit code 1 if any inode link count changes in parallel... I'm also using that occasion to move the fpm packaging docker image to datadog/dd-trace-ci (instead of datadog/docker-library)
- all jobs depending on package extension fetch the artifact via API taking tens of seconds instead of attaching the workspace, taking minutes; also saving the package extension step from needing to persist its workspace
- Prepare Code is no longer a dependency of compiling-only tasks (the only relevant step was `append_build_id`, but that one is nearly zero-cost and can just be done in the individual jobs too), giving an 1 minute headstart compared to before.
- I think the ramdisk usage disappeared when we introduced setup_docker instead of the docker image executor. Putting it back into setup_docker. And using it for libdatadog compilation too.
- Using the cargo cache based on the root `Cargo.lock` now, rather than having it profiler specific.
- Compiling the rust (in an xlarge executor - but needs to be done only 3 times and just for 2.5 min, so...) and extension archives in separate jobs and (very quickly) linking it together in the individual tests (having a job in between to link the archives together would increase run time too much, so we just do that in the test jobs).
  - Given that the rust compilation runs in parallel with Prepare Code here, we only have about 1 min 50 sec overhead due to rust compilation. This is quite faster than the 3 min 45 sec it took before. So, it essentially means the jobs are completed 2 min earlier, as well as shaving off some cost in every single test.
- Windows compilation now compiles the rust code only once instead of twice (i.e. nts and zts), saving 3 minutes.
- Windows avoids fetching appsec git submodules, saving about 15 seconds. The filesystem I/O itself seems to be slow on windows. Mostly due to the expansive tests/ directory.

The windows docker image also has been slimmed down, which nearly halves fetching time. (But done in a different PR.)

Also noteworthy non-starters:
- git on windows takes more than a minute
  - Fetching --depth 1 git repository - saves nothing
  - Caching the git repository on windows - saving a few seconds