### PR TITLE
fix ini creation when `--extension-dir` is used

### DIFF
--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -1789,7 +1789,7 @@ function add_missing_ini_settings($iniFilePath, $settings, $replacements)
             // right extension setting is available.
             $settingRegex = '(' . preg_quote($setting['name']) . '\s?=\s?';
             if ($setting['name'] === 'extension' || $setting['name'] == 'zend_extension') {
-                $settingRegex .= preg_quote($setting['default']);
+                $settingRegex .= ".*".preg_quote($setting['default']);
             }
             $settingRegex .= ')';
 


### PR DESCRIPTION
### Description

When using the `--extension-dir` argument, the installer would not find a pre-existing `extension = /path/to/ddtrace.so` line, because it just matched against the default value which is without path.

Fixes #2788

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
