### PR TITLE
Fix fatal error when reading uninit $meta on a span

### DIFF
--- a/appsec/src/extension/ddtrace.c
+++ b/appsec/src/extension/ddtrace.c
@@ -248,14 +248,14 @@ static zval *_get_span_modifiable_array_property(
 {
 #if PHP_VERSION_ID >= 80000
     zval *res =
-        zobj->handlers->get_property_ptr_ptr(zobj, propname, BP_VAR_R, NULL);
+        zobj->handlers->get_property_ptr_ptr(zobj, propname, BP_VAR_IS, NULL);
 #else
     zval obj;
     ZVAL_OBJ(&obj, zobj);
     zval prop;
     ZVAL_STR(&prop, propname);
     zval *res =
-        zobj->handlers->get_property_ptr_ptr(&obj, &prop, BP_VAR_R, NULL);
+        zobj->handlers->get_property_ptr_ptr(&obj, &prop, BP_VAR_IS, NULL);
 
 #endif
 


### PR DESCRIPTION
This seemed to happen in appsec preload shutdown.

I'm not sure _why_ meta was uninit in the first place, (yes a call to ddtrace_span_data_free_storage will make it undef, but why was that called - it's not a refcounting issue at least?!, I mean it wasn't an use after free?!).