### PR TITLE
feat(profiling) add timestamp to exception sample

### DIFF
--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -684,7 +684,9 @@ impl Profiler {
                 let (wall_time, cpu_time) = CLOCKS.with(|cell| cell.borrow_mut().rotate_clocks());
 
                 let labels = Profiler::common_labels(0);
-                let mut timestamp = 0;
+                let n_labels = labels.len();
+
+                let mut timestamp = NO_TIMESTAMP;
                 #[cfg(feature = "timeline")]
                 {
                     let system_settings = self.system_settings.load(Ordering::SeqCst);
@@ -695,8 +697,6 @@ impl Profiler {
                         }
                     }
                 }
-
-                let n_labels = labels.len();
 
                 match self.prepare_and_send_message(
                     frames,
@@ -790,6 +790,18 @@ impl Profiler {
 
                 let n_labels = labels.len();
 
+                let mut timestamp = NO_TIMESTAMP;
+                #[cfg(feature = "timeline")]
+                {
+                    let system_settings = self.system_settings.load(Ordering::SeqCst);
+                    // SAFETY: system settings are stable during a request.
+                    if unsafe { *ptr::addr_of!((*system_settings).profiling_timeline_enabled) } {
+                        if let Ok(now) = SystemTime::now().duration_since(UNIX_EPOCH) {
+                            timestamp = now.as_nanos() as i64;
+                        }
+                    }
+                }
+
                 match self.prepare_and_send_message(
                     frames,
                     SampleValues {
@@ -797,7 +809,7 @@ impl Profiler {
                         ..Default::default()
                     },
                     labels,
-                    NO_TIMESTAMP,
+                    timestamp,
                 ) {
                     Ok(_) => trace!(
                         "Sent stack sample of {depth} frames, {n_labels} labels with Exception {exception} to profiler."


### PR DESCRIPTION
### Description

This will add a timestamp to the exception sample in order to show it in the timeline view, see also:
- https://github.com/DataDog/profiling-backend/pull/5730
- https://github.com/DataDog/web-ui/pull/152074

![image](https://github.com/user-attachments/assets/06b6df6c-a229-4828-876a-bf73cc4f677c)

PROF-10122

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
