### PR TITLE
Update Cargo.lock, pin cbindgen in CircleCI, and rerun cbindgen

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -3867,7 +3867,8 @@ jobs:
       - git_checkout
       - run:
           name: Install cbindgen
-          command: cargo install cbindgen
+          # cbindgen 0.27 requires Rust 1.74+
+          command: cargo install cbindgen@0.26.0
       - run:
           name: Regenerate cbindgen headers and
           command: |

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -562,6 +562,97 @@ dependencies = [
 ]
 
 [[package]]
+name = "bolero"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "212e8dca6d4001cc6cac941d6932ddaa8cd27f57e5e44a9da19c913eb6a43b33"
+dependencies = [
+ "bolero-afl",
+ "bolero-engine",
+ "bolero-generator",
+ "bolero-honggfuzz",
+ "bolero-kani",
+ "bolero-libfuzzer",
+ "cfg-if",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "bolero-afl"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e1b34f05de1527425bb05287da09ff1ff1612538648824db49e16d9693b24065"
+dependencies = [
+ "bolero-engine",
+ "cc",
+]
+
+[[package]]
+name = "bolero-engine"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6206263ebdd42e093c1229dab3957f61c9fd68d73c00f238ae25a378778b6bd3"
+dependencies = [
+ "anyhow",
+ "backtrace",
+ "bolero-generator",
+ "lazy_static",
+ "pretty-hex",
+ "rand 0.8.5",
+]
+
+[[package]]
+name = "bolero-generator"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ac749fb4f2e14734e835a9352c0d1eb2ab62a025d4c56a823fa3f391e015741a"
+dependencies = [
+ "bolero-generator-derive",
+ "either",
+ "rand_core 0.6.4",
+]
+
+[[package]]
+name = "bolero-generator-derive"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53397bfda19ccb48527faa14025048fc4bb76f090ccdeef1e5a355bfe4a94467"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
+name = "bolero-honggfuzz"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf78581db1a7263620a8767e645b93ad287c70122ae76f5bd67040c7f06ff8e3"
+dependencies = [
+ "bolero-engine",
+]
+
+[[package]]
+name = "bolero-kani"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0e55cec272a617f5ae4ce670db035108eb97c10cd4f67de851a3c8d3f18f19cb"
+dependencies = [
+ "bolero-engine",
+]
+
+[[package]]
+name = "bolero-libfuzzer"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb42f66ee3ec89b9c411994de59d4710ced19df96fea2059feea1c2d73904c5b"
+dependencies = [
+ "bolero-engine",
+ "cc",
+]
+
+[[package]]
 name = "bollard"
 version = "0.16.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -742,9 +833,9 @@ checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
 name = "chrono"
-version = "0.4.34"
+version = "0.4.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bc015644b92d5890fab7489e49d21f879d5c990186827d42ec511919404f38b"
+checksum = "a21f936df1771bf62b77f047b726c4625ff2e8aa607c01ec06e5a05bd8463401"
 dependencies = [
  "android-tzdata",
  "iana-time-zone",
@@ -1028,6 +1119,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crossbeam-queue"
+version = "0.3.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df0346b5d5e76ac2fe4e327c5fd1118d6be7c51dfb18f9b7922923f287471e35"
+dependencies = [
+ "crossbeam-utils",
+]
+
+[[package]]
 name = "crossbeam-utils"
 version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1250,7 +1350,6 @@ dependencies = [
  "httpmock",
  "hyper 0.14.28",
  "io-lifetimes",
- "kernel32-sys",
  "lazy_static",
  "libc 0.2.154",
  "manual_future",
@@ -1276,7 +1375,7 @@ dependencies = [
  "tracing-log",
  "tracing-subscriber",
  "uuid",
- "winapi 0.2.8",
+ "winapi 0.3.9",
  "windows 0.51.1",
  "zwohash",
 ]
@@ -1415,7 +1514,10 @@ name = "ddcommon-ffi"
 version = "0.0.1"
 dependencies = [
  "anyhow",
+ "bolero",
  "build_common",
+ "chrono",
+ "crossbeam-queue",
  "ddcommon 0.0.1",
  "hyper 0.14.28",
 ]
@@ -3381,6 +3483,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "925383efa346730478fb4838dbe9137d2a47675ad789c546d150a6e1dd4ab31c"
 
 [[package]]
+name = "pretty-hex"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c6fa0831dd7cc608c38a5e323422a0077678fa5744aa2be4ad91c4ece8eec8d5"
+
+[[package]]
 name = "pretty_assertions"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3418,6 +3526,16 @@ checksum = "a0bda9164fe05bc9225752d54aae413343c36f684380005398a6a8fde95fe785"
 dependencies = [
  "autocfg",
  "indexmap 1.9.3",
+]
+
+[[package]]
+name = "proc-macro-crate"
+version = "1.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7f4c021e1093a56626774e81216a4ce732a735e5bad4868a03f3ed65ca0c3919"
+dependencies = [
+ "once_cell",
+ "toml_edit",
 ]
 
 [[package]]
@@ -4799,6 +4917,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "toml_datetime"
+version = "0.6.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
+
+[[package]]
+name = "toml_edit"
+version = "0.19.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1b5bb770da30e5cbfde35a2d7b9b8a2c4b8ef89548a7a6aeab5c9a576e3e7421"
+dependencies = [
+ "indexmap 2.2.6",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
 name = "tonic"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5475,6 +5610,15 @@ name = "windows_x86_64_msvc"
 version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dff9641d1cd4be8d1a070daf9e3773c5f67e78b4d9d42263020c057706765c04"
+
+[[package]]
+name = "winnow"
+version = "0.5.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f593a95398737aeed53e489c785df13f3618e41dbcd6718c6addbf1395aa6876"
+dependencies = [
+ "memchr",
+]
 
 [[package]]
 name = "x86"

--- a/components-rs/common.h
+++ b/components-rs/common.h
@@ -104,6 +104,104 @@ typedef struct ddog_Option_Error {
 
 typedef struct ddog_Option_Error ddog_MaybeError;
 
+typedef struct ddog_ArrayQueue {
+  struct ddog_ArrayQueue *inner;
+  void (*item_delete_fn)(void*);
+} ddog_ArrayQueue;
+
+typedef enum ddog_ArrayQueue_NewResult_Tag {
+  DDOG_ARRAY_QUEUE_NEW_RESULT_OK,
+  DDOG_ARRAY_QUEUE_NEW_RESULT_ERR,
+} ddog_ArrayQueue_NewResult_Tag;
+
+typedef struct ddog_ArrayQueue_NewResult {
+  ddog_ArrayQueue_NewResult_Tag tag;
+  union {
+    struct {
+      struct ddog_ArrayQueue *ok;
+    };
+    struct {
+      struct ddog_Error err;
+    };
+  };
+} ddog_ArrayQueue_NewResult;
+
+/**
+ * Data structure for the result of the push() and force_push() functions.
+ * force_push() replaces the oldest element if the queue is full, while push() returns the given
+ * value if the queue is full. For push(), it's redundant to return the value since the caller
+ * already has it, but it's returned for consistency with crossbeam API and with force_push().
+ */
+typedef enum ddog_ArrayQueue_PushResult_Tag {
+  DDOG_ARRAY_QUEUE_PUSH_RESULT_OK,
+  DDOG_ARRAY_QUEUE_PUSH_RESULT_FULL,
+  DDOG_ARRAY_QUEUE_PUSH_RESULT_ERR,
+} ddog_ArrayQueue_PushResult_Tag;
+
+typedef struct ddog_ArrayQueue_PushResult {
+  ddog_ArrayQueue_PushResult_Tag tag;
+  union {
+    struct {
+      void *full;
+    };
+    struct {
+      struct ddog_Error err;
+    };
+  };
+} ddog_ArrayQueue_PushResult;
+
+typedef enum ddog_ArrayQueue_PopResult_Tag {
+  DDOG_ARRAY_QUEUE_POP_RESULT_OK,
+  DDOG_ARRAY_QUEUE_POP_RESULT_EMPTY,
+  DDOG_ARRAY_QUEUE_POP_RESULT_ERR,
+} ddog_ArrayQueue_PopResult_Tag;
+
+typedef struct ddog_ArrayQueue_PopResult {
+  ddog_ArrayQueue_PopResult_Tag tag;
+  union {
+    struct {
+      void *ok;
+    };
+    struct {
+      struct ddog_Error err;
+    };
+  };
+} ddog_ArrayQueue_PopResult;
+
+typedef enum ddog_ArrayQueue_BoolResult_Tag {
+  DDOG_ARRAY_QUEUE_BOOL_RESULT_OK,
+  DDOG_ARRAY_QUEUE_BOOL_RESULT_ERR,
+} ddog_ArrayQueue_BoolResult_Tag;
+
+typedef struct ddog_ArrayQueue_BoolResult {
+  ddog_ArrayQueue_BoolResult_Tag tag;
+  union {
+    struct {
+      bool ok;
+    };
+    struct {
+      struct ddog_Error err;
+    };
+  };
+} ddog_ArrayQueue_BoolResult;
+
+typedef enum ddog_ArrayQueue_UsizeResult_Tag {
+  DDOG_ARRAY_QUEUE_USIZE_RESULT_OK,
+  DDOG_ARRAY_QUEUE_USIZE_RESULT_ERR,
+} ddog_ArrayQueue_UsizeResult_Tag;
+
+typedef struct ddog_ArrayQueue_UsizeResult {
+  ddog_ArrayQueue_UsizeResult_Tag tag;
+  union {
+    struct {
+      uintptr_t ok;
+    };
+    struct {
+      struct ddog_Error err;
+    };
+  };
+} ddog_ArrayQueue_UsizeResult;
+
 typedef enum ddog_Option_U32_Tag {
   DDOG_OPTION_U32_SOME_U32,
   DDOG_OPTION_U32_NONE_U32,
@@ -332,6 +430,76 @@ void ddog_Error_drop(struct ddog_Error *error);
 ddog_CharSlice ddog_Error_message(const struct ddog_Error *error);
 
 void ddog_MaybeError_drop(ddog_MaybeError);
+
+/**
+ * Creates a new ArrayQueue with the given capacity and item_delete_fn.
+ * The item_delete_fn is called when an item is dropped from the queue.
+ */
+DDOG_CHECK_RETURN
+struct ddog_ArrayQueue_NewResult ddog_ArrayQueue_new(uintptr_t capacity,
+                                                     void (*item_delete_fn)(void*));
+
+/**
+ * Drops the ArrayQueue.
+ * # Safety
+ * The pointer is null or points to a valid memory location allocated by ArrayQueue_new.
+ */
+void ddog_ArrayQueue_drop(struct ddog_ArrayQueue *queue);
+
+/**
+ * Pushes an item into the ArrayQueue. It returns the given value if the queue is full.
+ * # Safety
+ * The pointer is null or points to a valid memory location allocated by ArrayQueue_new. The value
+ * is null or points to a valid memory location that can be deallocated by the item_delete_fn.
+ */
+struct ddog_ArrayQueue_PushResult ddog_ArrayQueue_push(const struct ddog_ArrayQueue *queue_ptr,
+                                                       void *value);
+
+/**
+ * Pushes an element into the queue, replacing the oldest element if necessary.
+ * # Safety
+ * The pointer is null or points to a valid memory location allocated by ArrayQueue_new. The value
+ * is null or points to a valid memory location that can be deallocated by the item_delete_fn.
+ */
+DDOG_CHECK_RETURN
+struct ddog_ArrayQueue_PushResult ddog_ArrayQueue_force_push(const struct ddog_ArrayQueue *queue_ptr,
+                                                             void *value);
+
+/**
+ * Pops an item from the ArrayQueue.
+ * # Safety
+ * The pointer is null or points to a valid memory location allocated by ArrayQueue_new.
+ */
+DDOG_CHECK_RETURN
+struct ddog_ArrayQueue_PopResult ddog_ArrayQueue_pop(const struct ddog_ArrayQueue *queue_ptr);
+
+/**
+ * Checks if the ArrayQueue is empty.
+ * # Safety
+ * The pointer is null or points to a valid memory location allocated by ArrayQueue_new.
+ */
+struct ddog_ArrayQueue_BoolResult ddog_ArrayQueue_is_empty(const struct ddog_ArrayQueue *queue_ptr);
+
+/**
+ * Returns the length of the ArrayQueue.
+ * # Safety
+ * The pointer is null or points to a valid memory location allocated by ArrayQueue_new.
+ */
+struct ddog_ArrayQueue_UsizeResult ddog_ArrayQueue_len(const struct ddog_ArrayQueue *queue_ptr);
+
+/**
+ * Returns true if the underlying queue is full.
+ * # Safety
+ * The pointer is null or points to a valid memory location allocated by ArrayQueue_new.
+ */
+struct ddog_ArrayQueue_BoolResult ddog_ArrayQueue_is_full(const struct ddog_ArrayQueue *queue_ptr);
+
+/**
+ * Returns the capacity of the ArrayQueue.
+ * # Safety
+ * The pointer is null or points to a valid memory location allocated by ArrayQueue_new.
+ */
+struct ddog_ArrayQueue_UsizeResult ddog_ArrayQueue_capacity(const struct ddog_ArrayQueue *queue_ptr);
 
 DDOG_CHECK_RETURN struct ddog_Endpoint *ddog_endpoint_from_url(ddog_CharSlice url);
 


### PR DESCRIPTION
### Description

Updates the Cargo.lock because it's not current on master, and pins cbindgen to 0.26 in CircleCi. The new cbindgen release requires Rust 1.74, we're on 1.71. This is causing a CircleCI job to fail. Been broken since #2773, I think.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
