### PR TITLE
Fix flaky test

### DIFF
--- a/tests/ext/autoload-php-files/dd_init_open_basedir.phpt
+++ b/tests/ext/autoload-php-files/dd_init_open_basedir.phpt
@@ -1,7 +1,7 @@
 --TEST--
 Calling dd_init.php is confined to open_basedir settings
 --ENV--
-DD_TRACE_LOG_LEVEL=info,startup=off
+DD_TRACE_LOG_LEVEL=info,startup=off,datadog_sidecar=off
 --INI--
 open_basedir="{PWD}"
 datadog.trace.sources_path="{PWD}/.."


### PR DESCRIPTION
### Description

Other logs, like
`[ddtrace] [datadog_sidecar::service::blocking] The sidecar transport is closed. Reconnecting...` can be mixed in the output

e.g. https://app.circleci.com/pipelines/github/DataDog/dd-trace-php/17137/workflows/a83b3763-d86e-4723-a2d7-3520f7c61aa0/jobs/4978669

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
