### PR TITLE
Fix OpenAI tests

### DIFF
--- a/tests/Common/SnapshotTestTrait.php
+++ b/tests/Common/SnapshotTestTrait.php
@@ -57,7 +57,7 @@ trait SnapshotTestTrait
 
     private function startMetricsSnapshotSession()
     {
-        $this->server = new UDPServer(self::$dogstatsdAddr, self::$dogstatsdPort);
+        $this->server = new UDPServer(self::$dogstatsdAddr, self::$dogstatsdPort + GLOBAL_PORT_OFFSET);
     }
 
     /**


### PR DESCRIPTION
### Description

Set a different port for the UDP server for each CI step run in parallel.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
