### PR TITLE
Do not implicitly fall back to spl_autoload() if no autoloader is registered on PHP 7

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -98,6 +98,7 @@ The default value for datadog.log_backtrace is now set to true, meaning that on 
 - Implement fallback for when memfd is not available on Linux Datadog/libdatadog#591
 - Use the Windows User ID as sidecar identifier instead of the Session ID Datadog/libdatadog#558
 - Fix error check in trampoline.c Datadog/libdatadog#569
+- Do not implicitly fall back to spl_autoload() if no autoloader is registered on PHP 7 #2822
 
 ### Internal
 - Send x-datadog-test-session-token metric and send metrics to request-replayer #2802

--- a/tests/ext/autoload-php-files/default_spl_autoloader.phpt
+++ b/tests/ext/autoload-php-files/default_spl_autoloader.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Execute the default spl_autoload implementation if spl_autoload_register() is called without args
+--INI--
+datadog.trace.sources_path="{PWD}/.."
+--FILE--
+<?php
+
+spl_autoload_register();
+
+var_dump(class_exists('splautoload'));
+
+echo "Request start" . PHP_EOL;
+
+?>
+--EXPECT--
+bool(true)
+Request start

--- a/tests/ext/autoload-php-files/legacy_autoloader.phpt
+++ b/tests/ext/autoload-php-files/legacy_autoloader.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Execute the default spl_autoload implementation if spl_autoload_register() is called without args
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die("skip: __autoload was removed in PHP 8") ?>
+--INI--
+error_reporting=8191
+datadog.trace.sources_path="{PWD}/.."
+--FILE--
+<?php
+
+function __autoload($class) {
+    print "Autoload $class attempted!\n";
+}
+
+var_dump(class_exists('splautoload'));
+
+echo "Request start" . PHP_EOL;
+
+?>
+--EXPECT--
+Autoload splautoload attempted!
+bool(false)
+Request start

--- a/tests/ext/autoload-php-files/legacy_autoloader.phpt
+++ b/tests/ext/autoload-php-files/legacy_autoloader.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Execute the default spl_autoload implementation if spl_autoload_register() is called without args
+Execute __autoload() if present
 --SKIPIF--
 <?php if (PHP_VERSION_ID >= 80000) die("skip: __autoload was removed in PHP 8") ?>
 --INI--

--- a/tests/ext/autoload-php-files/skip_default_autoloader.phpt
+++ b/tests/ext/autoload-php-files/skip_default_autoloader.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Do not execute the default spl_autoload implementation if no autoloader is specified
+--INI--
+datadog.trace.sources_path="{PWD}/.."
+--FILE--
+<?php
+
+var_dump(class_exists('splautoload'));
+
+echo "Request start" . PHP_EOL;
+
+?>
+--EXPECT--
+bool(false)
+Request start

--- a/tests/ext/autoload-php-files/splautoload.inc
+++ b/tests/ext/autoload-php-files/splautoload.inc
@@ -1,0 +1,5 @@
+<?php
+
+class splautoload {
+    var $foo = "Autoloaded!";
+}


### PR DESCRIPTION
This could lead to accidental inclusion of files, breaking __autoload() and possibly including the wrong file.