### PR TITLE
Prevent crash in shutdown if hook was not stored

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -99,6 +99,7 @@ The default value for datadog.log_backtrace is now set to true, meaning that on 
 - Use the Windows User ID as sidecar identifier instead of the Session ID Datadog/libdatadog#558
 - Fix error check in trampoline.c Datadog/libdatadog#569
 - Do not implicitly fall back to spl_autoload() if no autoloader is registered on PHP 7 #2822
+- Prevent crash in shutdown if hook was not stored #2824
 
 ### Internal
 - Send x-datadog-test-session-token metric and send metrics to request-replayer #2802

--- a/zend_abstract_interface/hook/hook.c
+++ b/zend_abstract_interface/hook/hook.c
@@ -1083,7 +1083,8 @@ void zai_hook_finish(zend_execute_data *ex, zval *rv, zai_hook_memory_t *memory)
             zend_ulong address = zai_hook_frame_address(ex);
             zai_hook_table_find(&zai_hook_resolved, address, (void**)&hooks);
             zval *hook_zv;
-            if ((hook_zv = zend_hash_index_find(&hooks->hooks, (zend_ulong) -hook->id))) {
+            ZEND_ASSERT(CG(unclean_shutdown) || hooks != NULL);
+            if (hooks && (hook_zv = zend_hash_index_find(&hooks->hooks, (zend_ulong) -hook->id))) {
                 if (Z_TYPE_INFO_P(hook_zv) == ZAI_IS_SHARED_HOOK_PTR) {
                     // lookup primary by name
                     zend_class_entry *ce = NULL;


### PR DESCRIPTION
This seems to be possible to happen when fatal errors occur beforehand.

This specific fatal error occurred due to a timeout, hence it's not trivially reproducible.