### PR TITLE
Fix DD_AUTOLOAD_NO_COMPILE

### DIFF
--- a/ext/configuration.h
+++ b/ext/configuration.h
@@ -92,7 +92,7 @@ enum ddtrace_sampling_rules_format {
 
 #define DD_CONFIGURATION_ALL                                                                                   \
     CONFIG(STRING, DD_TRACE_SOURCES_PATH, DD_DEFAULT_SOURCES_PATH, .ini_change = zai_config_system_ini_change) \
-    CONFIG(STRING, DD_AUTOLOAD_NO_COMPILE, "0", .ini_change = zai_config_system_ini_change)                    \
+    CONFIG(BOOL, DD_AUTOLOAD_NO_COMPILE, "false", .ini_change = zai_config_system_ini_change)                  \
     CONFIG(STRING, DD_TRACE_AGENT_URL, "", .ini_change = zai_config_system_ini_change)                         \
     CONFIG(STRING, DD_AGENT_HOST, "", .ini_change = zai_config_system_ini_change)                              \
     CONFIG(STRING, DD_DOGSTATSD_URL, "")                                                                       \

--- a/tests/ext/autoload-php-files/dd_init_open_basedir.phpt
+++ b/tests/ext/autoload-php-files/dd_init_open_basedir.phpt
@@ -2,6 +2,7 @@
 Calling dd_init.php is confined to open_basedir settings
 --ENV--
 DD_TRACE_LOG_LEVEL=info,startup=off,datadog_sidecar=off
+DD_AUTOLOAD_NO_COMPILE=1
 --INI--
 open_basedir="{PWD}"
 datadog.trace.sources_path="{PWD}/.."


### PR DESCRIPTION
This mode is supposed to bring some performance improvements, but it turns out it was always disabled, due to the type confusion.