### PR TITLE
Disable trace_generator_jit.phpt test on PHP 8.0

### DIFF
--- a/tests/ext/sandbox/install_hook/trace_generator_jit.phpt
+++ b/tests/ext/sandbox/install_hook/trace_generator_jit.phpt
@@ -2,7 +2,7 @@
 generator hooking works with JIT
 --SKIPIF--
 <?php if (!file_exists(ini_get("extension_dir") . "/opcache.so")) die('skip: opcache.so does not exist in extension_dir'); ?>
-<?php if (PHP_VERSION_ID < 80000) die('skip: JIT is only on PHP 8'); ?>
+<?php if (PHP_VERSION_ID < 80100) die('skip: JIT is only on PHP 8, and not stable enough on PHP 8.0'); ?>
 --INI--
 opcache.enable=1
 opcache.enable_cli = 1


### PR DESCRIPTION
### Description

Because JIT is not stable enough on PHP 8.0.

Could be related to [this fix](https://github.com/php/php-src/pull/10153) which seems to have been applied only to PHP 8.1.15 and 8.2.2, but not to PHP 8.0.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
