### PR TITLE
Fix crash with double parent key in tracestate

### DIFF
--- a/ext/distributed_tracing_headers.c
+++ b/ext/distributed_tracing_headers.c
@@ -263,11 +263,13 @@ static ddtrace_distributed_tracing_result ddtrace_read_distributed_tracing_ids_t
                         size_t valuelen = valueend - valuestart;
 
                         if (keylen == 1 && keystart[0] == 'p') {
-                            zval zv;
-                            ZVAL_STRINGL(&zv, valuestart, valuelen);
-                            zend_hash_update(&result.meta_tags, span_parent_key, &zv);
-                            zend_string_release(span_parent_key);
-                            span_parent_key = NULL;
+                            if (span_parent_key) {
+                                zval zv;
+                                ZVAL_STRINGL(&zv, valuestart, valuelen);
+                                zend_hash_update(&result.meta_tags, span_parent_key, &zv);
+                                zend_string_release(span_parent_key);
+                                span_parent_key = NULL;
+                            }
                         } else if (keylen == 1 && keystart[0] == 's') {
                             int extraced_priority = strtol(valuestart, NULL, 10);
                             if ((result.priority_sampling > 0) == (extraced_priority > 0)) {

--- a/tests/ext/distributed_tracing/distributed_trace_conflicting_span_ids_tracecontext.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_conflicting_span_ids_tracecontext.phpt
@@ -8,7 +8,7 @@ DD_TRACE_PROPAGATION_STYLE=tracecontext
 
 DDTrace\consume_distributed_tracing_headers([
     "traceparent" => "00-0000000000000000000000000000002a-0000000000000001-01",
-    "tracestate" => "dd=p:00000000000000bb;s:1",
+    "tracestate" => "dd=p:00000000000000bb;p:00000000000000bb;s:1",
 ]);
 
 $span = \DDTrace\start_span();


### PR DESCRIPTION
Access of span_parent_key would be NULL on second 'p'.