### PR TITLE
Track peak memory usage in root span metrics

### DIFF
--- a/appsec/tests/extension/client_init_record_span_tags.phpt
+++ b/appsec/tests/extension/client_init_record_span_tags.phpt
@@ -109,4 +109,6 @@ Array
     [_dd.agent_psr] => 1
     [_sampling_priority_v1] => 1
     [php.compilation.total_time_ms] => %f
+    [php.memory.peak_usage_bytes] => %f
+    [php.memory.peak_real_usage_bytes] => %f
 )

--- a/appsec/tests/extension/rinit_record_span_tags.phpt
+++ b/appsec/tests/extension/rinit_record_span_tags.phpt
@@ -102,4 +102,6 @@ Array
     [_dd.agent_psr] => 1
     [_sampling_priority_v1] => 1
     [php.compilation.total_time_ms] => %f
+    [php.memory.peak_usage_bytes] => %f
+    [php.memory.peak_real_usage_bytes] => %f
 )

--- a/appsec/tests/extension/root_span_add_tag.phpt
+++ b/appsec/tests/extension/root_span_add_tag.phpt
@@ -56,7 +56,7 @@ array(1) {
       string(16) "%s"
     }
     ["metrics"]=>
-    array(4) {
+    array(6) {
       [%s"]=>
       float(%d)
       ["_dd.agent_psr"]=>
@@ -65,6 +65,10 @@ array(1) {
       float(1)
       ["php.compilation.total_time_ms"]=>
       float(%s)
+      ["php.memory.peak_usage_bytes"]=>
+      float(%f)
+      ["php.memory.peak_real_usage_bytes"]=>
+      float(%f)
     }
   }
 }

--- a/appsec/tests/extension/root_span_add_tag_with_intermediate_spans.phpt
+++ b/appsec/tests/extension/root_span_add_tag_with_intermediate_spans.phpt
@@ -84,4 +84,6 @@ Array
     [_dd.agent_psr] => 1
     [_sampling_priority_v1] => 1
     [php.compilation.total_time_ms] => %s
+    [php.memory.peak_usage_bytes] => %f
+    [php.memory.peak_real_usage_bytes] => %f
 )

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -224,7 +224,7 @@ services:
       - DD_DISABLE_ERROR_RESPONSES=true
       - SNAPSHOTS_DIR=/snapshots
       - SNAPSHOT_CI=0
-      - SNAPSHOT_REMOVED_ATTRS=start,duration,metrics.php.compilation.total_time_ms,metrics.process_id
+      - SNAPSHOT_REMOVED_ATTRS=start,duration,metrics.php.compilation.total_time_ms,metrics.php.memory.peak_usage_bytes,metrics.php.memory.peak_real_usage_bytes,metrics.process_id
       - ENABLED_CHECKS=trace_stall,trace_peer_service,trace_dd_service
 
 

--- a/ext/configuration.h
+++ b/ext/configuration.h
@@ -115,6 +115,7 @@ enum ddtrace_sampling_rules_format {
     CONFIG(BOOL, DD_TRACE_AUTO_FLUSH_ENABLED, "false")                                                         \
     CONFIG(BOOL, DD_TRACE_CLI_ENABLED, "false")                                                                \
     CONFIG(BOOL, DD_TRACE_MEASURE_COMPILE_TIME, "true")                                                        \
+    CONFIG(BOOL, DD_TRACE_MEASURE_PEAK_MEMORY_USAGE, "true")                                                   \
     CONFIG(BOOL, DD_TRACE_DEBUG, "false", .ini_change = ddtrace_alter_dd_trace_debug)                          \
     CONFIG(BOOL, DD_TRACE_ENABLED, "true", .ini_change = ddtrace_alter_dd_trace_disabled_config,               \
            .env_config_fallback = ddtrace_conf_otel_traces_exporter)                                           \

--- a/ext/serializer.c
+++ b/ext/serializer.c
@@ -1847,8 +1847,14 @@ void ddtrace_serialize_span_to_array(ddtrace_span_data *span, zval *array) {
         }
     }
 
-    if (ddtrace_span_is_entrypoint_root(span) && get_DD_TRACE_MEASURE_COMPILE_TIME()) {
-        add_assoc_double(&metrics_zv, "php.compilation.total_time_ms", ddtrace_compile_time_get() / 1000.);
+    if (ddtrace_span_is_entrypoint_root(span)) {
+        if (get_DD_TRACE_MEASURE_COMPILE_TIME()) {
+            add_assoc_double(&metrics_zv, "php.compilation.total_time_ms", ddtrace_compile_time_get() / 1000.);
+        }
+        if (get_DD_TRACE_MEASURE_PEAK_MEMORY_USAGE()) {
+            add_assoc_double(&metrics_zv, "php.memory.peak_usage_bytes", zend_memory_peak_usage(false));
+            add_assoc_double(&metrics_zv, "php.memory.peak_real_usage_bytes", zend_memory_peak_usage(true));
+        }
     }
 
     LOGEV(SPAN, {

--- a/github-actions-helpers/Build.Github.cs
+++ b/github-actions-helpers/Build.Github.cs
@@ -164,7 +164,7 @@ partial class Build
                     char[] charsToTrim = { ' ', ',' };
                     string cleaned = value.TrimStart('-', '+').Trim(charsToTrim);
 
-                    string[] keysToReplace = { "start", "duration", "php.compilation.total_time_ms", "process_id" };
+                    string[] keysToReplace = { "start", "duration", "php.compilation.total_time_ms", "metrics.php.memory.peak_usage_bytes", "metrics.php.memory.peak_real_usage_bytes", "process_id" };
                     foreach (var key in keysToReplace)
                     {
                         if (cleaned.Contains(key))

--- a/tests/Common/SnapshotTestTrait.php
+++ b/tests/Common/SnapshotTestTrait.php
@@ -123,7 +123,7 @@ trait SnapshotTestTrait
      */
     private function stopAndCompareSnapshotSession(
         string $token,
-        array $fieldsToIgnore = ['metrics.php.compilation.total_time_ms', 'meta.error.stack', 'meta._dd.p.tid'],
+        array $fieldsToIgnore = ['metrics.php.compilation.total_time_ms', 'metrics.php.memory.peak_usage_bytes', 'metrics.php.memory.peak_real_usage_bytes', 'meta.error.stack', 'meta._dd.p.tid'],
         int $numExpectedTraces = 1,
         bool $snapshotMetrics = false,
         array $fieldsToIgnoreMetrics = ['openai.request.duration'],
@@ -290,7 +290,7 @@ trait SnapshotTestTrait
 
     public function tracesFromWebRequestSnapshot(
         $fn,
-        $fieldsToIgnore = ['metrics.php.compilation.total_time_ms', 'meta.error.stack', 'meta._dd.p.tid', 'start', 'duration'],
+        $fieldsToIgnore = ['metrics.php.compilation.total_time_ms', 'metrics.php.memory.peak_usage_bytes', 'metrics.php.memory.peak_real_usage_bytes', 'meta.error.stack', 'meta._dd.p.tid', 'start', 'duration'],
         $numExpectedTraces = 1,
         $tracer = null
     ) {
@@ -317,7 +317,7 @@ trait SnapshotTestTrait
 
     public function isolateTracerSnapshot(
         $fn,
-        $fieldsToIgnore = ['metrics.php.compilation.total_time_ms', 'meta.error.stack', 'meta._dd.p.tid'],
+        $fieldsToIgnore = ['metrics.php.compilation.total_time_ms', 'metrics.php.memory.peak_usage_bytes', 'metrics.php.memory.peak_real_usage_bytes', 'meta.error.stack', 'meta._dd.p.tid'],
         $numExpectedTraces = 1,
         $tracer = null,
         $config = [],
@@ -370,7 +370,7 @@ trait SnapshotTestTrait
 
     public function snapshotFromTraces(
         $traces,
-        $fieldsToIgnore = ['metrics.php.compilation.total_time_ms', 'meta.error.stack', 'meta._dd.p.tid'],
+        $fieldsToIgnore = ['metrics.php.compilation.total_time_ms', 'metrics.php.memory.peak_usage_bytes', 'metrics.php.memory.peak_real_usage_bytes', 'meta.error.stack', 'meta._dd.p.tid'],
         $tokenSubstitute = null,
         $ignoreSampledAway = false
     ) {

--- a/tests/Common/SpanChecker.php
+++ b/tests/Common/SpanChecker.php
@@ -87,6 +87,8 @@ final class SpanChecker
             }
             if (isset($span['metrics'])) {
                 unset($span['metrics']['php.compilation.total_time_ms']);
+                unset($span['metrics']['php.memory.peak_usage_bytes']);
+                unset($span['metrics']['php.memory.peak_real_usage_bytes']);
                 unset($span['metrics']['process_id']);
                 foreach ($span['metrics'] as $k => $v) {
                     $out .= str_repeat(' ', $indent) . '  ' . $k . ' => ' . $v . "\n";
@@ -523,6 +525,12 @@ final class SpanChecker
             // Ignore compilation-time metric unless explicitly tested
             if (!isset($metrics['php.compilation.total_time_ms'])) {
                 unset($spanMetrics['php.compilation.total_time_ms']);
+            }
+            if (!isset($metrics['php.memory.peak_usage_bytes'])) {
+                unset($spanMetrics['php.memory.peak_usage_bytes']);
+            }
+            if (!isset($metrics['php.memory.peak_real_usage_bytes'])) {
+                unset($spanMetrics['php.memory.peak_real_usage_bytes']);
             }
             if (isset($metrics['process_id'])) {
                 unset($metrics['process_id']);

--- a/tests/Integrations/Custom/Autoloaded/CompileTimeDisabledTest.php
+++ b/tests/Integrations/Custom/Autoloaded/CompileTimeDisabledTest.php
@@ -16,6 +16,7 @@ final class CompileTimeDisabledTest extends WebFrameworkTestCase
     {
         return array_merge(parent::getEnvs(), [
             'DD_TRACE_MEASURE_COMPILE_TIME' => '0',
+            'DD_TRACE_MEASURE_PEAK_MEMORY_USAGE' => '0',
         ]);
     }
 
@@ -26,12 +27,14 @@ final class CompileTimeDisabledTest extends WebFrameworkTestCase
          * For the compile-time metrics specifically, this goofs things up, so let's disable.
          */
         self::putenv('DD_TRACE_MEASURE_COMPILE_TIME=0');
+        self::putenv('DD_TRACE_MEASURE_PEAK_MEMORY_USAGE=0');
         \dd_trace_internal_fn('ddtrace_reload_config');
     }
 
     protected function ddTearDown()
     {
         self::putenv('DD_TRACE_MEASURE_COMPILE_TIME');
+        self::putenv('DD_TRACE_MEASURE_PEAK_MEMORY_USAGE');
         dd_trace_internal_fn('ddtrace_reload_config');
         parent::ddTearDown();
     }
@@ -44,5 +47,7 @@ final class CompileTimeDisabledTest extends WebFrameworkTestCase
         });
 
         self::assertFalse(isset($traces[0][0]['metrics']['php.compilation.total_time_ms']));
+        self::assertFalse(isset($traces[0][0]['metrics']['php.memory.peak_usage_bytes']));
+        self::assertFalse(isset($traces[0][0]['metrics']['php.memory.peak_real_usage_bytes']));
     }
 }

--- a/tests/Integrations/Custom/Autoloaded/CompileTimeEnabledTest.php
+++ b/tests/Integrations/Custom/Autoloaded/CompileTimeEnabledTest.php
@@ -16,6 +16,7 @@ final class CompileTimeEnabledTest extends WebFrameworkTestCase
     {
         return array_merge(parent::getEnvs(), [
             'DD_TRACE_MEASURE_COMPILE_TIME' => '1',
+            'DD_TRACE_MEASURE_PEAK_MEMORY_USAGE' => '1',
         ]);
     }
 
@@ -26,12 +27,14 @@ final class CompileTimeEnabledTest extends WebFrameworkTestCase
          * For the compile-time metrics specifically, this goofs things up, so let's disable.
          */
         self::putenv('DD_TRACE_MEASURE_COMPILE_TIME=0');
+        self::putenv('DD_TRACE_MEASURE_PEAK_MEMORY_USAGE=0');
         \dd_trace_internal_fn('ddtrace_reload_config');
     }
 
     protected function ddTearDown()
     {
         self::putenv('DD_TRACE_MEASURE_COMPILE_TIME');
+        self::putenv('DD_TRACE_MEASURE_PEAK_MEMORY_USAGE');
         dd_trace_internal_fn('ddtrace_reload_config');
         parent::ddTearDown();
     }
@@ -44,5 +47,7 @@ final class CompileTimeEnabledTest extends WebFrameworkTestCase
         });
 
         self::assertTrue(isset($traces[0][0]['metrics']['php.compilation.total_time_ms']));
+        self::assertTrue(isset($traces[0][0]['metrics']['php.memory.peak_usage_bytes']));
+        self::assertTrue(isset($traces[0][0]['metrics']['php.memory.peak_real_usage_bytes']));
     }
 }

--- a/tests/Integrations/Guzzle/V6/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V6/GuzzleIntegrationTest.php
@@ -516,6 +516,8 @@ class GuzzleIntegrationTest extends IntegrationTestCase
         }, [
             'start',
             'metrics.php.compilation.total_time_ms',
+            'metrics.php.memory.peak_usage_bytes',
+            'metrics.php.memory.peak_real_usage_bytes',
             'meta.error.stack',
             'meta._dd.p.tid',
             'meta.curl.appconnect_time_us',

--- a/tests/Integrations/Guzzle/V7/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V7/GuzzleIntegrationTest.php
@@ -84,6 +84,8 @@ class GuzzleIntegrationTest extends \DDTrace\Tests\Integrations\Guzzle\V6\Guzzle
         }, [
             'start',
             'metrics.php.compilation.total_time_ms',
+            'metrics.php.memory.peak_usage_bytes',
+            'metrics.php.memory.peak_real_usage_bytes',
             'meta.error.stack',
             'meta._dd.p.tid',
             'meta.curl.appconnect_time_us',

--- a/tests/Integrations/Symfony/V4_4/MessengerTest.php
+++ b/tests/Integrations/Symfony/V4_4/MessengerTest.php
@@ -10,6 +10,8 @@ class MessengerTest extends WebFrameworkTestCase
 {
     const FIELDS_TO_IGNORE = [
         'metrics.php.compilation.total_time_ms',
+        'metrics.php.memory.peak_usage_bytes',
+        'metrics.php.memory.peak_real_usage_bytes',
         'meta.error.stack',
         'meta._dd..tid',
         'meta.messaging.message_id',

--- a/tests/Integrations/Symfony/V5_2/MessengerTest.php
+++ b/tests/Integrations/Symfony/V5_2/MessengerTest.php
@@ -10,6 +10,8 @@ class MessengerTest extends WebFrameworkTestCase
 {
     const FIELDS_TO_IGNORE = [
         'metrics.php.compilation.total_time_ms',
+        'metrics.php.memory.peak_usage_bytes',
+        'metrics.php.memory.peak_real_usage_bytes',
         'meta.error.stack',
         'meta._dd..tid',
         'meta.messaging.message_id',

--- a/tests/Integrations/Symfony/V6_2/MessengerTest.php
+++ b/tests/Integrations/Symfony/V6_2/MessengerTest.php
@@ -10,6 +10,8 @@ class MessengerTest extends WebFrameworkTestCase
 {
     const FIELDS_TO_IGNORE = [
         'metrics.php.compilation.total_time_ms',
+        'metrics.php.memory.peak_usage_bytes',
+        'metrics.php.memory.peak_real_usage_bytes',
         'meta.error.stack',
         'meta._dd..tid',
         'meta.messaging.message_id',

--- a/tests/Integrations/Symfony/V7_0/MessengerTest.php
+++ b/tests/Integrations/Symfony/V7_0/MessengerTest.php
@@ -10,6 +10,8 @@ class MessengerTest extends WebFrameworkTestCase
 {
     const FIELDS_TO_IGNORE = [
         'metrics.php.compilation.total_time_ms',
+        'metrics.php.memory.peak_usage_bytes',
+        'metrics.php.memory.peak_real_usage_bytes',
         'meta.error.stack',
         'meta._dd.p.tid',
         'meta.messaging.message_id',

--- a/tests/ext/close_spans_until.phpt
+++ b/tests/ext/close_spans_until.phpt
@@ -48,7 +48,7 @@ int(2)
 [ddtrace] [span] Switching to different SpanStack: %d
 int(1)
 int(0)
-[ddtrace] [span] Encoding span %d: trace_id=%s, name='close_spans_until.php', service='close_spans_until.php', resource: 'close_spans_until.php', type 'cli' with tags: runtime-id='%s', _dd.p.dm='-0', _dd.p.tid='%s'; and metrics: process_id='%d', _dd.agent_psr='1', _sampling_priority_v1='1', php.compilation.total_time_ms='%f'
+[ddtrace] [span] Encoding span %d: trace_id=%s, name='close_spans_until.php', service='close_spans_until.php', resource: 'close_spans_until.php', type 'cli' with tags: runtime-id='%s', _dd.p.dm='-0', _dd.p.tid='%s'; and metrics: process_id='%d', _dd.agent_psr='1', _sampling_priority_v1='1', php.compilation.total_time_ms='%f', php.memory.peak_usage_bytes='%f', php.memory.peak_real_usage_bytes='%f'
 [ddtrace] [span] Encoding span %d: trace_id=%s, name='traced', service='close_spans_until.php', resource: 'traced', type 'cli' with tags: -; and metrics: -
 [ddtrace] [span] Encoding span %d: trace_id=%s, name='', service='close_spans_until.php', resource: '', type 'cli' with tags: -; and metrics: -
 [ddtrace] [span] Encoding span %d: trace_id=%s, name='', service='close_spans_until.php', resource: '', type 'cli' with tags: -; and metrics: -

--- a/tests/ext/distributed_tracing/distributed_trace_bogus_ids.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_bogus_ids.phpt
@@ -47,7 +47,7 @@ array(1) {
       string(16) "%s"
     }
     ["metrics"]=>
-    array(4) {
+    array(6) {
       ["process_id"]=>
       float(%f)
       ["_dd.agent_psr"]=>
@@ -55,6 +55,10 @@ array(1) {
       ["_sampling_priority_v1"]=>
       float(1)
       ["php.compilation.total_time_ms"]=>
+      float(%f)
+      ["php.memory.peak_usage_bytes"]=>
+      float(%f)
+      ["php.memory.peak_real_usage_bytes"]=>
       float(%f)
     }
   }

--- a/tests/ext/distributed_tracing/distributed_trace_inherit.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_inherit.phpt
@@ -59,12 +59,16 @@ array(2) {
       string(7) "datadog"
     }
     ["metrics"]=>
-    array(3) {
+    array(5) {
       ["process_id"]=>
       float(%f)
       ["_sampling_priority_v1"]=>
       float(3)
       ["php.compilation.total_time_ms"]=>
+      float(%f)
+      ["php.memory.peak_usage_bytes"]=>
+      float(%f)
+      ["php.memory.peak_real_usage_bytes"]=>
       float(%f)
     }
   }

--- a/tests/ext/integrations/source_code/commit_sha_env_var.phpt
+++ b/tests/ext/integrations/source_code/commit_sha_env_var.phpt
@@ -49,7 +49,7 @@ array(2) {
       string(16) "%s"
     }
     ["metrics"]=>
-    array(4) {
+    array(6) {
       ["process_id"]=>
       float(%f)
       ["_dd.agent_psr"]=>
@@ -57,6 +57,10 @@ array(2) {
       ["_sampling_priority_v1"]=>
       float(1)
       ["php.compilation.total_time_ms"]=>
+      float(%f)
+      ["php.memory.peak_usage_bytes"]=>
+      float(%f)
+      ["php.memory.peak_real_usage_bytes"]=>
       float(%f)
     }
   }

--- a/tests/ext/integrations/source_code/git_metadata_injection_from_env.phpt
+++ b/tests/ext/integrations/source_code/git_metadata_injection_from_env.phpt
@@ -52,7 +52,7 @@ array(2) {
       string(16) "%s"
     }
     ["metrics"]=>
-    array(4) {
+    array(6) {
       ["process_id"]=>
       float(%d)
       ["_dd.agent_psr"]=>
@@ -60,6 +60,10 @@ array(2) {
       ["_sampling_priority_v1"]=>
       float(1)
       ["php.compilation.total_time_ms"]=>
+      float(%f)
+      ["php.memory.peak_usage_bytes"]=>
+      float(%f)
+      ["php.memory.peak_real_usage_bytes"]=>
       float(%f)
     }
   }

--- a/tests/ext/integrations/source_code/git_metadata_injection_from_global_tags.phpt
+++ b/tests/ext/integrations/source_code/git_metadata_injection_from_global_tags.phpt
@@ -55,7 +55,7 @@ array(2) {
       string(16) "%s"
     }
     ["metrics"]=>
-    array(4) {
+    array(6) {
       ["process_id"]=>
       float(%d)
       ["_dd.agent_psr"]=>
@@ -63,6 +63,10 @@ array(2) {
       ["_sampling_priority_v1"]=>
       float(1)
       ["php.compilation.total_time_ms"]=>
+      float(%f)
+      ["php.memory.peak_usage_bytes"]=>
+      float(%f)
+      ["php.memory.peak_real_usage_bytes"]=>
       float(%f)
     }
   }

--- a/tests/ext/integrations/source_code/git_metadata_injection_remove_credentials_from_env.phpt
+++ b/tests/ext/integrations/source_code/git_metadata_injection_remove_credentials_from_env.phpt
@@ -52,7 +52,7 @@ array(2) {
       string(16) "%s"
     }
     ["metrics"]=>
-    array(4) {
+    array(6) {
       ["process_id"]=>
       float(%d)
       ["_dd.agent_psr"]=>
@@ -60,6 +60,10 @@ array(2) {
       ["_sampling_priority_v1"]=>
       float(1)
       ["php.compilation.total_time_ms"]=>
+      float(%f)
+      ["php.memory.peak_usage_bytes"]=>
+      float(%f)
+      ["php.memory.peak_real_usage_bytes"]=>
       float(%f)
     }
   }

--- a/tests/ext/integrations/source_code/repository_url_env_var.phpt
+++ b/tests/ext/integrations/source_code/repository_url_env_var.phpt
@@ -49,7 +49,7 @@ array(2) {
       string(16) "%s"
     }
     ["metrics"]=>
-    array(4) {
+    array(6) {
       ["process_id"]=>
       float(%d)
       ["_dd.agent_psr"]=>
@@ -57,6 +57,10 @@ array(2) {
       ["_sampling_priority_v1"]=>
       float(1)
       ["php.compilation.total_time_ms"]=>
+      float(%f)
+      ["php.memory.peak_usage_bytes"]=>
+      float(%f)
+      ["php.memory.peak_real_usage_bytes"]=>
       float(%f)
     }
   }

--- a/tests/ext/sandbox-prehook/dd_trace_method.phpt
+++ b/tests/ext/sandbox-prehook/dd_trace_method.phpt
@@ -121,7 +121,7 @@ array(3) {
       string(16) "%s"
     }
     ["metrics"]=>
-    array(6) {
+    array(8) {
       ["process_id"]=>
       float(%f)
       ["foo"]=>
@@ -133,6 +133,10 @@ array(3) {
       ["_sampling_priority_v1"]=>
       float(1)
       ["php.compilation.total_time_ms"]=>
+      float(%f)
+      ["php.memory.peak_usage_bytes"]=>
+      float(%f)
+      ["php.memory.peak_real_usage_bytes"]=>
       float(%f)
     }
   }
@@ -190,7 +194,7 @@ array(3) {
       string(16) "%s"
     }
     ["metrics"]=>
-    array(4) {
+    array(6) {
       ["process_id"]=>
       float(%f)
       ["_dd.agent_psr"]=>
@@ -198,6 +202,10 @@ array(3) {
       ["_sampling_priority_v1"]=>
       float(1)
       ["php.compilation.total_time_ms"]=>
+      float(%f)
+      ["php.memory.peak_usage_bytes"]=>
+      float(%f)
+      ["php.memory.peak_real_usage_bytes"]=>
       float(%f)
     }
   }

--- a/tests/ext/sandbox/dd_trace_function_complex.phpt
+++ b/tests/ext/sandbox/dd_trace_function_complex.phpt
@@ -128,7 +128,7 @@ array(5) {
       string(16) "%s"
     }
     ["metrics"]=>
-    array(6) {
+    array(8) {
       ["process_id"]=>
       float(%f)
       ["foo"]=>
@@ -140,6 +140,10 @@ array(5) {
       ["_sampling_priority_v1"]=>
       float(1)
       ["php.compilation.total_time_ms"]=>
+      float(%f)
+      ["php.memory.peak_usage_bytes"]=>
+      float(%f)
+      ["php.memory.peak_real_usage_bytes"]=>
       float(%f)
     }
   }
@@ -223,7 +227,7 @@ array(5) {
       string(16) "%s"
     }
     ["metrics"]=>
-    array(4) {
+    array(6) {
       ["process_id"]=>
       float(%f)
       ["_dd.agent_psr"]=>
@@ -231,6 +235,10 @@ array(5) {
       ["_sampling_priority_v1"]=>
       float(1)
       ["php.compilation.total_time_ms"]=>
+      float(%f)
+      ["php.memory.peak_usage_bytes"]=>
+      float(%f)
+      ["php.memory.peak_real_usage_bytes"]=>
       float(%f)
     }
   }
@@ -262,7 +270,7 @@ array(5) {
       string(16) "%s"
     }
     ["metrics"]=>
-    array(4) {
+    array(6) {
       ["process_id"]=>
       float(%f)
       ["_dd.agent_psr"]=>
@@ -270,6 +278,10 @@ array(5) {
       ["_sampling_priority_v1"]=>
       float(1)
       ["php.compilation.total_time_ms"]=>
+      float(%f)
+      ["php.memory.peak_usage_bytes"]=>
+      float(%f)
+      ["php.memory.peak_real_usage_bytes"]=>
       float(%f)
     }
   }

--- a/tests/ext/sandbox/dd_trace_function_internal.phpt
+++ b/tests/ext/sandbox/dd_trace_function_internal.phpt
@@ -51,7 +51,7 @@ array(1) {
       string(16) "%s"
     }
     ["metrics"]=>
-    array(4) {
+    array(6) {
       ["process_id"]=>
       float(%f)
       ["_dd.agent_psr"]=>
@@ -59,6 +59,10 @@ array(1) {
       ["_sampling_priority_v1"]=>
       float(1)
       ["php.compilation.total_time_ms"]=>
+      float(%f)
+      ["php.memory.peak_usage_bytes"]=>
+      float(%f)
+      ["php.memory.peak_real_usage_bytes"]=>
       float(%f)
     }
   }

--- a/tests/ext/sandbox/dd_trace_method.phpt
+++ b/tests/ext/sandbox/dd_trace_method.phpt
@@ -136,7 +136,7 @@ array(3) {
       string(16) "%s"
     }
     ["metrics"]=>
-    array(6) {
+    array(8) {
       ["process_id"]=>
       float(%f)
       ["foo"]=>
@@ -148,6 +148,10 @@ array(3) {
       ["_sampling_priority_v1"]=>
       float(1)
       ["php.compilation.total_time_ms"]=>
+      float(%f)
+      ["php.memory.peak_usage_bytes"]=>
+      float(%f)
+      ["php.memory.peak_real_usage_bytes"]=>
       float(%f)
     }
   }
@@ -209,7 +213,7 @@ array(3) {
       string(16) "%s"
     }
     ["metrics"]=>
-    array(4) {
+    array(6) {
       ["process_id"]=>
       float(%f)
       ["_dd.agent_psr"]=>
@@ -217,6 +221,10 @@ array(3) {
       ["_sampling_priority_v1"]=>
       float(1)
       ["php.compilation.total_time_ms"]=>
+      float(%f)
+      ["php.memory.peak_usage_bytes"]=>
+      float(%f)
+      ["php.memory.peak_real_usage_bytes"]=>
       float(%f)
     }
   }

--- a/tests/ext/sandbox/die_in_sandbox.phpt
+++ b/tests/ext/sandbox/die_in_sandbox.phpt
@@ -16,6 +16,6 @@ x();
 ?>
 --EXPECTF--
 [ddtrace] [warning] UnwindExit thrown in ddtrace's closure defined at %s:%d for x(): <exit>
-[ddtrace] [span] Encoding span %d: trace_id=%s, name='die_in_sandbox.php', service='die_in_sandbox.php', resource: 'die_in_sandbox.php', type 'cli' with tags: runtime-id='%s', _dd.p.dm='-0', _dd.p.tid='%s'; and metrics: process_id='%d', _dd.agent_psr='1', _sampling_priority_v1='1', php.compilation.total_time_ms='%f'
+[ddtrace] [span] Encoding span %d: trace_id=%s, name='die_in_sandbox.php', service='die_in_sandbox.php', resource: 'die_in_sandbox.php', type 'cli' with tags: runtime-id='%s', _dd.p.dm='-0', _dd.p.tid='%s'; and metrics: process_id='%d', _dd.agent_psr='1', _sampling_priority_v1='1', php.compilation.total_time_ms='%f', php.memory.peak_usage_bytes='%f', php.memory.peak_real_usage_bytes='%f'
 [ddtrace] [span] Encoding span %d: trace_id=%s, name='x', service='die_in_sandbox.php', resource: 'x', type 'cli' with tags: -; and metrics: -
 [ddtrace] [info] Flushing trace of size 2 to send-queue for %s

--- a/tests/ext/sandbox/errors_are_flagged_from_userland.phpt
+++ b/tests/ext/sandbox/errors_are_flagged_from_userland.phpt
@@ -55,7 +55,7 @@ array(1) {
       string(16) "%s"
     }
     ["metrics"]=>
-    array(4) {
+    array(6) {
       ["process_id"]=>
       float(%f)
       ["_dd.agent_psr"]=>
@@ -63,6 +63,10 @@ array(1) {
       ["_sampling_priority_v1"]=>
       float(1)
       ["php.compilation.total_time_ms"]=>
+      float(%f)
+      ["php.memory.peak_usage_bytes"]=>
+      float(%f)
+      ["php.memory.peak_real_usage_bytes"]=>
       float(%f)
     }
   }

--- a/tests/ext/sandbox/span_clone.phpt
+++ b/tests/ext/sandbox/span_clone.phpt
@@ -240,7 +240,7 @@ array(1) {
       string(16) "%s"
     }
     ["metrics"]=>
-    array(4) {
+    array(6) {
       ["process_id"]=>
       float(%f)
       ["_dd.agent_psr"]=>
@@ -248,6 +248,10 @@ array(1) {
       ["_sampling_priority_v1"]=>
       float(1)
       ["php.compilation.total_time_ms"]=>
+      float(%f)
+      ["php.memory.peak_usage_bytes"]=>
+      float(%f)
+      ["php.memory.peak_real_usage_bytes"]=>
       float(%f)
     }
   }

--- a/tests/ext/span_with_removed_exception.phpt
+++ b/tests/ext/span_with_removed_exception.phpt
@@ -77,7 +77,7 @@ array(1) {
       string(16) "%s"
     }
     ["metrics"]=>
-    array(4) {
+    array(6) {
       ["process_id"]=>
       float(%f)
       ["_dd.agent_psr"]=>
@@ -85,6 +85,10 @@ array(1) {
       ["_sampling_priority_v1"]=>
       float(1)
       ["php.compilation.total_time_ms"]=>
+      float(%f)
+      ["php.memory.peak_usage_bytes"]=>
+      float(%f)
+      ["php.memory.peak_real_usage_bytes"]=>
       float(%f)
     }
   }
@@ -118,7 +122,7 @@ array(1) {
       string(16) "%s"
     }
     ["metrics"]=>
-    array(4) {
+    array(6) {
       ["process_id"]=>
       float(%f)
       ["_dd.agent_psr"]=>
@@ -126,6 +130,10 @@ array(1) {
       ["_sampling_priority_v1"]=>
       float(1)
       ["php.compilation.total_time_ms"]=>
+      float(%f)
+      ["php.memory.peak_usage_bytes"]=>
+      float(%f)
+      ["php.memory.peak_real_usage_bytes"]=>
       float(%f)
     }
   }
@@ -159,7 +167,7 @@ array(1) {
       string(16) "%s"
     }
     ["metrics"]=>
-    array(4) {
+    array(6) {
       ["process_id"]=>
       float(%f)
       ["_dd.agent_psr"]=>
@@ -167,6 +175,10 @@ array(1) {
       ["_sampling_priority_v1"]=>
       float(1)
       ["php.compilation.total_time_ms"]=>
+      float(%f)
+      ["php.memory.peak_usage_bytes"]=>
+      float(%f)
+      ["php.memory.peak_real_usage_bytes"]=>
       float(%f)
     }
   }

--- a/tests/ext/start_span_with_all_properties.phpt
+++ b/tests/ext/start_span_with_all_properties.phpt
@@ -82,7 +82,7 @@ array(2) {
       string(16) "%s"
     }
     ["metrics"]=>
-    array(4) {
+    array(6) {
       ["process_id"]=>
       float(%f)
       ["_dd.agent_psr"]=>
@@ -90,6 +90,10 @@ array(2) {
       ["_sampling_priority_v1"]=>
       float(1)
       ["php.compilation.total_time_ms"]=>
+      float(%f)
+      ["php.memory.peak_usage_bytes"]=>
+      float(%f)
+      ["php.memory.peak_real_usage_bytes"]=>
       float(%f)
     }
   }
@@ -123,7 +127,7 @@ array(2) {
       string(16) "%s"
     }
     ["metrics"]=>
-    array(5) {
+    array(7) {
       ["process_id"]=>
       float(%f)
       ["cc"]=>
@@ -133,6 +137,10 @@ array(2) {
       ["_sampling_priority_v1"]=>
       float(1)
       ["php.compilation.total_time_ms"]=>
+      float(%f)
+      ["php.memory.peak_usage_bytes"]=>
+      float(%f)
+      ["php.memory.peak_real_usage_bytes"]=>
       float(%f)
     }
   }

--- a/tests/ext/start_span_without_closing.phpt
+++ b/tests/ext/start_span_without_closing.phpt
@@ -54,7 +54,7 @@ array(1) {
       string(16) "%s"
     }
     ["metrics"]=>
-    array(4) {
+    array(6) {
       ["process_id"]=>
       float(%f)
       ["_dd.agent_psr"]=>
@@ -62,6 +62,10 @@ array(1) {
       ["_sampling_priority_v1"]=>
       float(1)
       ["php.compilation.total_time_ms"]=>
+      float(%f)
+      ["php.memory.peak_usage_bytes"]=>
+      float(%f)
+      ["php.memory.peak_real_usage_bytes"]=>
       float(%f)
     }
   }


### PR DESCRIPTION
Fixes #2832.

Adding `php.memory.peak_usage_bytes` and `php.memory.peak_real_usage_bytes` metrics.