### PR TITLE
Improve pcntl tests stability

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -50,7 +50,7 @@ download_artifacts:
   tags: [ "runner:main", "size:large" ]
   script:
     - |
-      sleep 1m # Let time for the CircleCI pipeline to start
+      sleep 2m # Let time for the CircleCI pipeline to start
       source .gitlab/download-circleci_artifact.sh
 
       download_circleci_artifact "gh/DataDog/dd-trace-php" "build_packages" "package extension" "dd-library-php-ssi-.*-x86_64-linux.tar.gz" "dd-library-php-ssi-x86_64-linux.tar.gz"

--- a/tests/Common/SpanChecker.php
+++ b/tests/Common/SpanChecker.php
@@ -195,7 +195,7 @@ final class SpanChecker
             // Not using a TestCase::markTestAsIncomplete() because it exits immediately,
             // while with an error log we are still able to proceed with tests.
             error_log(sprintf(
-                "WARNING: More then one candidate found for '%s' at the same level. "
+                "WARNING: More than one candidate found for '%s' at the same level. "
                     . "Proceeding in the order they appears. "
                     . "This might not work if this span is not a leaf span.",
                 $expectedNodeRoot

--- a/tests/Common/TracerTestTrait.php
+++ b/tests/Common/TracerTestTrait.php
@@ -485,7 +485,7 @@ trait TracerTestTrait
                         return $allResponses;
                     }
                 }
-                \usleep(1000);
+                \usleep(10000);
             }
         }
 

--- a/tests/Common/TracerTestTrait.php
+++ b/tests/Common/TracerTestTrait.php
@@ -518,6 +518,14 @@ trait TracerTestTrait
         };
     }
 
+    function untilTelemetryRequest($metricName) {
+        return function ($request) use ($metricName) {
+            return (strpos($request["uri"] ?? "", "/telemetry/") === 0)
+                && (strpos($request["body"] ?? "", $metricName) !== false)
+            ;
+        };
+    }
+
     /**
      * Set a property into an object from an array optionally applying a converter.
      *

--- a/tests/Common/TracerTestTrait.php
+++ b/tests/Common/TracerTestTrait.php
@@ -216,12 +216,12 @@ trait TracerTestTrait
     /**
      * This method executes a single script with the provided configuration.
      */
-    public function inCli($scriptPath, $customEnvs = [], $customInis = [], $arguments = '', $withOutput = false, $until = null)
+    public function inCli($scriptPath, $customEnvs = [], $customInis = [], $arguments = '', $withOutput = false, $until = null, $throw = true)
     {
         $this->resetRequestDumper();
         $output = $this->executeCli($scriptPath, $customEnvs, $customInis, $arguments, $withOutput);
         usleep(100000); // Add a slight delay to give the request-replayer time to handle and store all requests.
-        $out = [$this->parseTracesFromDumpedData($until)];
+        $out = [$this->parseTracesFromDumpedData($until, $throw)];
         if ($withOutput) {
             $out[] = $output;
         }
@@ -387,9 +387,9 @@ trait TracerTestTrait
      * @return array
      * @throws \Exception
      */
-    private function parseTracesFromDumpedData(callable $until = null)
+    private function parseTracesFromDumpedData(callable $until = null, $throw = false)
     {
-        $loaded = $this->retrieveDumpedTraceData($until);
+        $loaded = $this->retrieveDumpedTraceData($until, $throw);
         if (!$loaded) {
             return [];
         }
@@ -496,9 +496,9 @@ trait TracerTestTrait
         return $allResponses;
     }
 
-    public function retrieveDumpedTraceData(callable $until = null)
+    public function retrieveDumpedTraceData(callable $until = null, $throw = false)
     {
-        return array_values(array_filter($this->retrieveDumpedData($until), function ($request) {
+        return array_values(array_filter($this->retrieveDumpedData($until, $throw), function ($request) {
             // Filter telemetry requests
             return strpos($request["uri"] ?? "", "/telemetry/") !== 0;
         }));

--- a/tests/Common/TracerTestTrait.php
+++ b/tests/Common/TracerTestTrait.php
@@ -533,14 +533,19 @@ trait TracerTestTrait
             if (strpos($request["uri"] ?? "", "/telemetry/") === 0 || !isset($request['body'])) {
                 return false;
             }
-            $trace = $this->parseRawDumpedTraces(json_decode($request['body'], true));
-            try {
-                (new SpanChecker())->assertFlameGraph($trace, [$assertion]);
-            } catch (\Exception $e) {
-                return false;
+            $traces = $this->parseRawDumpedTraces(json_decode($request['body'], true));
+
+            foreach ($traces as $trace) {
+                try {
+                    (new SpanChecker())->assertFlameGraph([$trace], [$assertion]);
+                } catch (\Exception $e) {
+                    continue;
+                }
+
+                return true;
             }
 
-            return true;
+            return false;
         };
     }
 

--- a/tests/Integrations/CLI/Symfony/V4_4/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/Symfony/V4_4/CommonScenariosTest.php
@@ -153,7 +153,7 @@ class CommonScenariosTest extends IntegrationTestCase
             'DD_TRACE_GENERATE_ROOT_SPAN' => 'false',
             'DD_TRACE_AUTO_FLUSH_ENABLED' => 'true',
             'DD_TRACE_EXEC_ENABLED' => 'false',
-        ], [], 'about');
+        ], [], 'about', false, null, false);
 
         $this->assertFlameGraph(
             $traces,

--- a/tests/Integrations/CLI/Symfony/V5_2/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/Symfony/V5_2/CommonScenariosTest.php
@@ -153,7 +153,7 @@ class CommonScenariosTest extends IntegrationTestCase
             'DD_TRACE_GENERATE_ROOT_SPAN' => 'false',
             'DD_TRACE_AUTO_FLUSH_ENABLED' => 'true',
             'DD_TRACE_EXEC_ENABLED' => 'false',
-        ], [], 'about');
+        ], [], 'about', false, null, false);
 
         $this->assertFlameGraph(
             $traces,

--- a/tests/Integrations/CLI/Symfony/V6_2/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/Symfony/V6_2/CommonScenariosTest.php
@@ -153,7 +153,7 @@ class CommonScenariosTest extends IntegrationTestCase
             'DD_TRACE_GENERATE_ROOT_SPAN' => 'false',
             'DD_TRACE_AUTO_FLUSH_ENABLED' => 'true',
             'DD_TRACE_EXEC_ENABLED' => 'false',
-        ], [], 'about');
+        ], [], 'about', false, null, false);
 
         $this->assertFlameGraph(
             $traces,

--- a/tests/Integrations/Custom/Autoloaded/InstrumentationTest.php
+++ b/tests/Integrations/Custom/Autoloaded/InstrumentationTest.php
@@ -53,11 +53,7 @@ final class InstrumentationTest extends WebFrameworkTestCase
         $this->resetRequestDumper();
 
         $this->call(GetSpec::create("autoloaded", "/simple"));
-        $response = $this->retrieveDumpedData(function ($request) {
-            return (strpos($request["uri"] ?? "", "/telemetry/") === 0)
-                && (strpos($request["body"] ?? "", "spans_created") !== false)
-            ;
-        }, true);
+        $response = $this->retrieveDumpedData($this->untilTelemetryRequest("spans_created"));
 
         $this->assertGreaterThanOrEqual(3, $response);
         $payloads = $this->readTelemetryPayloads($response);

--- a/tests/Integrations/PCNTL/PCNTLTest.php
+++ b/tests/Integrations/PCNTL/PCNTLTest.php
@@ -251,8 +251,7 @@ final class PCNTLTest extends IntegrationTestCase
                 'DD_TRACE_CLI_ENABLED' => 'true',
                 'DD_TRACE_AUTO_FLUSH_ENABLED' => 'true',
                 'DD_TRACE_GENERATE_ROOT_SPAN' => 'false',
-                'DD_TRACE_AGENT_FLUSH_INTERVAL' => 0,
-                'DD_TRACE_SHUTDOWN_TIMEOUT' => '2000000'
+                'DD_TRACE_AGENT_FLUSH_INTERVAL' => 333,
             ],
             [],
             '',

--- a/tests/Integrations/PCNTL/PCNTLTest.php
+++ b/tests/Integrations/PCNTL/PCNTLTest.php
@@ -86,7 +86,11 @@ final class PCNTLTest extends IntegrationTestCase
                 'DD_TRACE_CLI_ENABLED' => 'true',
                 'DD_TRACE_SHUTDOWN_TIMEOUT' => 5000,
                 'DD_TRACE_GENERATE_ROOT_SPAN' => 'true',
-            ]
+            ],
+            [],
+            '',
+            false,
+            $this->untilNumberOfTraces(2)
         );
 
         $this->assertCount(2, $requests);
@@ -139,7 +143,11 @@ final class PCNTLTest extends IntegrationTestCase
                 'DD_TRACE_CLI_ENABLED' => 'true',
                 'DD_TRACE_SHUTDOWN_TIMEOUT' => 5000,
                 'DD_TRACE_GENERATE_ROOT_SPAN' => 'true',
-            ]
+            ],
+            [],
+            '',
+            false,
+            $this->untilNumberOfTraces(2)
         );
 
         $this->assertCount(2, $requests);
@@ -167,7 +175,11 @@ final class PCNTLTest extends IntegrationTestCase
                 'DD_TRACE_CLI_ENABLED' => 'true',
                 'DD_TRACE_SHUTDOWN_TIMEOUT' => 5000,
                 'DD_TRACE_GENERATE_ROOT_SPAN' => 'true',
-            ]
+            ],
+            [],
+            '',
+            false,
+            $this->untilNumberOfTraces(6)
         );
 
         $this->assertCount(6, $requests);
@@ -246,7 +258,11 @@ final class PCNTLTest extends IntegrationTestCase
                 'DD_TRACE_GENERATE_ROOT_SPAN' => 'false',
                 'DD_TRACE_AGENT_FLUSH_INTERVAL' => 0,
                 'DD_TRACE_SHUTDOWN_TIMEOUT' => 5000,
-            ]
+            ],
+            [],
+            '',
+            false,
+            $this->untilNumberOfTraces(4)
         );
         $this->assertCount(4, $requests);
 
@@ -279,7 +295,11 @@ final class PCNTLTest extends IntegrationTestCase
                 'DD_TRACE_AUTO_FLUSH_ENABLED' => 'false',
                 'DD_TRACE_GENERATE_ROOT_SPAN' => 'false',
                 'DD_TRACE_SHUTDOWN_TIMEOUT' => 5000,
-            ]
+            ],
+            [],
+            '',
+            false,
+            $this->untilNumberOfTraces(6)
         );
         $this->assertCount(6, $requests);
 

--- a/tests/Integrations/PCNTL/PCNTLTest.php
+++ b/tests/Integrations/PCNTL/PCNTLTest.php
@@ -268,14 +268,14 @@ final class PCNTLTest extends IntegrationTestCase
 
         for ($i = 0; $i < 4; $i += 2) {
             $this->assertFlameGraph([$requests[$i]], [
-                SpanAssertion::exists('curl_exec', '/httpbin_integration/ip'),
+                SpanAssertion::exists('curl_exec', '/httpbin_integration/child-'.($i/2)),
             ]);
 
             $this->assertFlameGraph([$requests[$i + 1]], [
                 SpanAssertion::exists('long_running_entry_point')->withChildren([
-                    SpanAssertion::exists('curl_exec', '/httpbin_integration/get'),
-                    SpanAssertion::exists('curl_exec', '/httpbin_integration/headers'),
-                    SpanAssertion::exists('curl_exec', '/httpbin_integration/user-agent'),
+                    SpanAssertion::exists('curl_exec', '/httpbin_integration/entry_point'),
+                    SpanAssertion::exists('curl_exec', '/httpbin_integration/main_process'),
+                    SpanAssertion::exists('curl_exec', '/httpbin_integration/end_entry_point'),
                     SpanAssertion::exists('pcntl_fork'),
                 ]),
             ]);

--- a/tests/Integrations/PCNTL/PCNTLTest.php
+++ b/tests/Integrations/PCNTL/PCNTLTest.php
@@ -84,7 +84,6 @@ final class PCNTLTest extends IntegrationTestCase
             __DIR__ . '/scripts/synthetic.php',
             [
                 'DD_TRACE_CLI_ENABLED' => 'true',
-                'DD_TRACE_SHUTDOWN_TIMEOUT' => 5000,
                 'DD_TRACE_GENERATE_ROOT_SPAN' => 'true',
             ],
             [],
@@ -116,7 +115,6 @@ final class PCNTLTest extends IntegrationTestCase
             __DIR__ . '/scripts/access-tracer-after-fork.php',
             [
                 'DD_TRACE_CLI_ENABLED' => 'true',
-                'DD_TRACE_SHUTDOWN_TIMEOUT' => 5000,
                 'DD_TRACE_GENERATE_ROOT_SPAN' => 'true',
                 'DD_TRACE_DEBUG' => 'false',
             ],
@@ -141,7 +139,6 @@ final class PCNTLTest extends IntegrationTestCase
             __DIR__ . '/scripts/short-running.php',
             [
                 'DD_TRACE_CLI_ENABLED' => 'true',
-                'DD_TRACE_SHUTDOWN_TIMEOUT' => 5000,
                 'DD_TRACE_GENERATE_ROOT_SPAN' => 'true',
             ],
             [],
@@ -173,7 +170,6 @@ final class PCNTLTest extends IntegrationTestCase
             __DIR__ . '/scripts/short-running-multiple.php',
             [
                 'DD_TRACE_CLI_ENABLED' => 'true',
-                'DD_TRACE_SHUTDOWN_TIMEOUT' => 5000,
                 'DD_TRACE_GENERATE_ROOT_SPAN' => 'true',
             ],
             [],
@@ -216,7 +212,6 @@ final class PCNTLTest extends IntegrationTestCase
             __DIR__ . '/scripts/short-running-multiple-nested.php',
             [
                 'DD_TRACE_CLI_ENABLED' => 'true',
-                'DD_TRACE_SHUTDOWN_TIMEOUT' => 5000,
                 'DD_TRACE_GENERATE_ROOT_SPAN' => 'true',
             ]
         );
@@ -257,7 +252,7 @@ final class PCNTLTest extends IntegrationTestCase
                 'DD_TRACE_AUTO_FLUSH_ENABLED' => 'true',
                 'DD_TRACE_GENERATE_ROOT_SPAN' => 'false',
                 'DD_TRACE_AGENT_FLUSH_INTERVAL' => 0,
-                'DD_TRACE_SHUTDOWN_TIMEOUT' => 5000,
+                'DD_TRACE_SHUTDOWN_TIMEOUT' => '2000000'
             ],
             [],
             '',
@@ -293,7 +288,6 @@ final class PCNTLTest extends IntegrationTestCase
                 'DD_TRACE_CLI_ENABLED' => 'true',
                 'DD_TRACE_AUTO_FLUSH_ENABLED' => 'false',
                 'DD_TRACE_GENERATE_ROOT_SPAN' => 'false',
-                'DD_TRACE_SHUTDOWN_TIMEOUT' => 5000,
             ],
             [],
             '',

--- a/tests/Integrations/PCNTL/scripts/long-running-autoflush.php
+++ b/tests/Integrations/PCNTL/scripts/long-running-autoflush.php
@@ -11,30 +11,25 @@ const ITERATIONS = 2;
 
 for ($iteration = 0; $iteration < ITERATIONS; $iteration++) {
     long_running_entry_point($iteration);
-
-    // Add a delay to ensure the spans from each iteration are sent separately
-    // if execution is too fast, they can be grouped in 1 "request", but we expect 2.
-    usleep(1000);
 }
 
 function long_running_entry_point($iteration)
 {
-    call_httpbin('entry_point');
+    call_httpbin('entry_point-'.$iteration);
 
     $forkPid = pcntl_fork();
 
     if ($forkPid > 0) {
         // Main
-        call_httpbin('main_process');
+        call_httpbin('main_process-'.$iteration);
     } else if ($forkPid === 0) {
         // Child
-        usleep(1000);
         call_httpbin('child-'.$iteration);
         exit(0);
     } else {
         error_log('Error');
         exit(-1);
     }
-    call_httpbin('end_entry_point');
+    call_httpbin('end_entry_point-'.$iteration);
     pcntl_waitpid($forkPid, $childStatus);
 }

--- a/tests/OpenTelemetry/Integration/InternalTelemetryTest.php
+++ b/tests/OpenTelemetry/Integration/InternalTelemetryTest.php
@@ -56,11 +56,7 @@ final class InternalTelemetryTest extends CLITestCase
 
         $this->executeCommand();
 
-        $requests = $this->retrieveDumpedData(function ($request) {
-            return (strpos($request["uri"] ?? "", "/telemetry/") === 0)
-                && (strpos($request["body"] ?? "", "spans_created") !== false)
-            ;
-        }, true);
+        $requests = $this->retrieveDumpedData($this->untilTelemetryRequest("spans_created"));
 
         $payloads = $this->readTelemetryPayloads($requests);
         $isMetric = function (array $payload) {

--- a/tests/OpenTracing/InternalTelemetryTest.php
+++ b/tests/OpenTracing/InternalTelemetryTest.php
@@ -37,11 +37,7 @@ final class InternalTelemetryTest extends CLITestCase
 
         $this->executeCommand();
 
-        $requests = $this->retrieveDumpedData(function ($request) {
-            return (strpos($request["uri"] ?? "", "/telemetry/") === 0)
-                && (strpos($request["body"] ?? "", "spans_created") !== false)
-            ;
-        }, true);
+        $requests = $this->retrieveDumpedData($this->untilTelemetryRequest("spans_created"));
 
         $payloads = $this->readTelemetryPayloads($requests);
         $isMetric = function (array $payload) {


### PR DESCRIPTION
### Description

It look more stable :finger_crossed:; it passed three times in a row.

There were several kinds of errors that could have occurred:
- The order of requests is not guaranteed.
- The number of requests (traces may have been grouped into a single request).
- A timeout could have occurred before the background sender finished sending traces.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
