### PR TITLE
Fix github actions permissions

### DIFF
--- a/.github/workflows/auto_add_pr_to_miletone.yml
+++ b/.github/workflows/auto_add_pr_to_miletone.yml
@@ -11,6 +11,11 @@ jobs:
   add_to_milestone:
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, '[Version Bump]') == false
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # need to modify existing PR
+      issues: write # need to potentially create a new milestone
+
     steps:
       - name: Checkout
         uses: actions/checkout@v2

--- a/.github/workflows/auto_check_snapshots.yml
+++ b/.github/workflows/auto_check_snapshots.yml
@@ -6,6 +6,9 @@ on:
 jobs:
   check-snapshots:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: write # need to add a comment to a PR
 
     steps:
       - name: Checkout

--- a/.github/workflows/auto_label_prs.yml
+++ b/.github/workflows/auto_label_prs.yml
@@ -7,6 +7,10 @@ jobs:
   add-labels:
 
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      issues: write # Update labels on PRs (might not be necessary, but we call the UpdateIssue API so...)
+      pull-requests: write # Update labels on PRs
 
     steps:
       - name: Checkout


### PR DESCRIPTION
As inspired by Datadog/dd-trace-dotnet#5728.

We recently turned off broad permissions, but that caused these workflows to fail / not work.