### PR TITLE
ci(profiling): Add PHP 8.0 to correctness tests

### DIFF
--- a/.github/workflows/prof_correctness.yml
+++ b/.github/workflows/prof_correctness.yml
@@ -10,7 +10,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        php-version: [8.1, 8.2, 8.3]
+        php-version: [8.0, 8.1, 8.2, 8.3]
         phpts: [nts, zts]
         include:
           - phpts: zts


### PR DESCRIPTION
### Description

This will add PHP 8.0 to profiling correctness tests

### Reviewer checklist
- [x] Test coverage seems ok.
- [x] Appropriate labels assigned.
