### PR TITLE
Fix integration tests using Predis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1154,7 +1154,7 @@ test_integrations_amqp2: global_test_run_dependencies tests/Integrations/AMQP/V2
 	$(call run_tests_debug,tests/Integrations/AMQP/V2)
 test_integrations_amqp35: global_test_run_dependencies tests/Integrations/AMQP/V3_5/composer.lock-php$(PHP_MAJOR_MINOR)
 	$(call run_tests_debug,tests/Integrations/AMQP/V3_5)
-test_integrations_deferred_loading: global_test_run_dependencies tests/Integrations/Predis/composer.lock-php$(PHP_MAJOR_MINOR)
+test_integrations_deferred_loading: global_test_run_dependencies tests/Integrations/DeferredLoading/composer.lock-php$(PHP_MAJOR_MINOR)
 	$(call run_tests_debug,tests/Integrations/DeferredLoading)
 test_integrations_curl: global_test_run_dependencies
 	$(call run_tests_debug,tests/Integrations/Curl)

--- a/tests/Integrations/DeferredLoading/composer.json
+++ b/tests/Integrations/DeferredLoading/composer.json
@@ -1,0 +1,5 @@
+{
+    "require": {
+        "predis/predis": "^1.1"
+    }
+}

--- a/tests/Integrations/DeferredLoading/index.php
+++ b/tests/Integrations/DeferredLoading/index.php
@@ -1,6 +1,6 @@
 <?php
 
-require __DIR__ . '/../Predis/vendor/autoload.php';
+require __DIR__ . '/vendor/autoload.php';
 
 // This script HAS to invoke at least two integrations via deferred integration loading mechanism.
 


### PR DESCRIPTION
### Description

Both scenarios DeferredLoading and Predis were running `composer install` in the same directory.
It seems it could break the installation

i.e. https://app.circleci.com/pipelines/github/DataDog/dd-trace-php/17446/workflows/0a933327-d943-4704-b7c9-4f9f560cb329/jobs/5142824


### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
