### PR TITLE
Fix Redis tests flakiness

### DIFF
--- a/tests/Integrations/PHPRedis/V3/PHPRedisClusterTest.php
+++ b/tests/Integrations/PHPRedis/V3/PHPRedisClusterTest.php
@@ -133,11 +133,19 @@ class PHPRedisClusterTest extends IntegrationTestCase
     /**
      * @dataProvider dataProviderTestMethodsSimpleSpan
      */
-    public function testMethodsOnlySpan($method, $arg)
+    public function testMethodsOnlySpan($method, $arg, $canFail = false)
     {
         $redis = $this->redis;
-        $traces = $this->isolateTracer(function () use ($redis, $method, $arg) {
-            null === $arg ? $redis->$method($this->connection1) : $redis->$method($this->connection1, $arg);
+        $hasError = false;
+        $traces = $this->isolateTracer(function () use ($redis, $method, $arg, $canFail, &$hasError) {
+            try {
+                null === $arg ? $redis->$method($this->connection1) : $redis->$method($this->connection1, $arg);
+            } catch (\RedisClusterException $e) {
+                if (!$canFail) {
+                    throw $e;
+                }
+                $hasError = true;
+            }
         });
 
         $this->assertFlameGraph($traces, [
@@ -145,8 +153,13 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 "RedisCluster.$method",
                 'phpredis',
                 'redis',
-                "RedisCluster.$method"
-            )->withExactTags($this->baseTags()),
+                "RedisCluster.$method",
+                [],
+                null,
+                $hasError
+            )
+            ->withExactTags($this->baseTags())
+            ->skipTagsLike('/^error\..*/'),
         ]);
     }
 
@@ -156,8 +169,8 @@ class PHPRedisClusterTest extends IntegrationTestCase
             'ping' => ['ping', null],
             'echo' => ['echo', 'hey'],
             'save' => ['save', null],
-            'bgRewriteAOF' => ['bgRewriteAOF', null],
-            'flushAll' => ['flushAll', null],
+            'bgRewriteAOF' => ['bgRewriteAOF', null, true],
+            'flushAll' => ['flushAll', null, true],
             'flushDb' => ['flushDb', null],
         ];
     }

--- a/tests/Integrations/PHPRedis/V4/PHPRedisClusterTest.php
+++ b/tests/Integrations/PHPRedis/V4/PHPRedisClusterTest.php
@@ -133,11 +133,19 @@ class PHPRedisClusterTest extends IntegrationTestCase
     /**
      * @dataProvider dataProviderTestMethodsSimpleSpan
      */
-    public function testMethodsOnlySpan($method, $arg)
+    public function testMethodsOnlySpan($method, $arg, $canFail = false)
     {
         $redis = $this->redis;
-        $traces = $this->isolateTracer(function () use ($redis, $method, $arg) {
-            null === $arg ? $redis->$method($this->connection1) : $redis->$method($this->connection1, $arg);
+        $hasError = false;
+        $traces = $this->isolateTracer(function () use ($redis, $method, $arg, $canFail, &$hasError) {
+            try {
+                null === $arg ? $redis->$method($this->connection1) : $redis->$method($this->connection1, $arg);
+            } catch (\RedisClusterException $e) {
+                if (!$canFail) {
+                    throw $e;
+                }
+                $hasError = true;
+            }
         });
 
         $this->assertFlameGraph($traces, [
@@ -145,8 +153,13 @@ class PHPRedisClusterTest extends IntegrationTestCase
                 "RedisCluster.$method",
                 'phpredis',
                 'redis',
-                "RedisCluster.$method"
-            )->withExactTags($this->baseTags()),
+                "RedisCluster.$method",
+                [],
+                null,
+                $hasError
+            )
+            ->withExactTags($this->baseTags())
+            ->skipTagsLike('/^error\..*/'),
         ]);
     }
 
@@ -156,8 +169,8 @@ class PHPRedisClusterTest extends IntegrationTestCase
             'ping' => ['ping', null],
             'echo' => ['echo', 'hey'],
             'save' => ['save', null],
-            'bgRewriteAOF' => ['bgRewriteAOF', null],
-            'flushAll' => ['flushAll', null],
+            'bgRewriteAOF' => ['bgRewriteAOF', null, true],
+            'flushAll' => ['flushAll', null, true],
             'flushDb' => ['flushDb', null],
         ];
     }


### PR DESCRIPTION
### Description

Fix [this error](https://app.circleci.com/pipelines/github/DataDog/dd-trace-php/17484/workflows/db4d6f24-1dbb-491e-a5d7-a03750fd1d9c/jobs/5160204/steps)
```
1) DDTrace\Tests\Integrations\PHPRedis\V4\PHPRedisClusterTest::testMethodsOnlySpan with data set "bgRewriteAOF" ('bgRewriteAOF', null)
RedisClusterException: Unable to send command at a specific node
```

Some Redis commands can fail, so we must account for this in the assertion.

So far, I've only encountered the issue with the `PHPRedisClusterTest`. Let's wait and see if we also need it for the regular `Redis` client.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
