### PR TITLE
Add new ini config `datadog.crashtracking_enabled`

### DIFF
--- a/ext/configuration.h
+++ b/ext/configuration.h
@@ -91,10 +91,8 @@ enum ddtrace_sampling_rules_format {
     "(?i)(?:(?:\"|%22)?)(?:(?:old[-_]?|new[-_]?)?p(?:ass)?w(?:or)?d(?:1|2)?|pass(?:[-_]?phrase)?|secret|(?:api[-_]?|private[-_]?|public[-_]?|access[-_]?|secret[-_]?|app(?:lication)?[-_]?)key(?:[-_]?id)?|token|consumer[-_]?(?:id|key|secret)|sign(?:ed|ature)?|auth(?:entication|orization)?)(?:(?:\\s|%20)*(?:=|%3D)[^&]+|(?:\"|%22)(?:\\s|%20)*(?::|%3A)(?:\\s|%20)*(?:\"|%22)(?:%2[^2]|%[^2]|[^\"%])+(?:\"|%22))|(?:bearer(?:\\s|%20)+[a-z0-9._\\-]+|token(?::|%3A)[a-z0-9]{13}|gh[opsu]_[0-9a-zA-Z]{36}|ey[I-L](?:[\\w=-]|%3D)+\\.ey[I-L](?:[\\w=-]|%3D)+(?:\\.(?:[\\w.+/=-]|%3D|%2F|%2B)+)?|-{5}BEGIN(?:[a-z\\s]|%20)+PRIVATE(?:\\s|%20)KEY-{5}[^\\-]+-{5}END(?:[a-z\\s]|%20)+PRIVATE(?:\\s|%20)KEY(?:-{5})?(?:\\n|%0A)?|(?:ssh-(?:rsa|dss)|ecdsa-[a-z0-9]+-[a-z0-9]+)(?:\\s|%20|%09)+(?:[a-z0-9/.+]|%2F|%5C|%2B){100,}(?:=|%3D)*(?:(?:\\s|%20|%09)+[a-z0-9._-]+)?)"
 
 #ifdef __SANITIZE_ADDRESS__
-#define DD_LOG_BACKTRACE_DEFAULT "false"
 #define DD_CRASHTRACKING_ENABLED_DEFAULT "false"
 #else
-#define DD_LOG_BACKTRACE_DEFAULT "true"
 #define DD_CRASHTRACKING_ENABLED_DEFAULT "true"
 #endif
 
@@ -171,7 +169,7 @@ enum ddtrace_sampling_rules_format {
     CONFIG(INT, DD_TRACE_AGENT_CONNECT_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_AGENT_CONNECT_TIMEOUT_VAL),             \
            .ini_change = zai_config_system_ini_change)                                                         \
     CONFIG(INT, DD_TRACE_DEBUG_PRNG_SEED, "-1", .ini_change = ddtrace_reseed_seed_change)                      \
-    CONFIG(BOOL, DD_LOG_BACKTRACE, DD_LOG_BACKTRACE_DEFAULT)                                                   \
+    CONFIG(BOOL, DD_LOG_BACKTRACE, "false")                                                                    \
     CONFIG(BOOL, DD_CRASHTRACKING_ENABLED, DD_CRASHTRACKING_ENABLED_DEFAULT)                                   \
     CONFIG(BOOL, DD_TRACE_GENERATE_ROOT_SPAN, "true", .ini_change = ddtrace_span_alter_root_span_config)       \
     CONFIG(INT, DD_TRACE_SPANS_LIMIT, "1000")                                                                  \

--- a/ext/configuration.h
+++ b/ext/configuration.h
@@ -92,8 +92,10 @@ enum ddtrace_sampling_rules_format {
 
 #ifdef __SANITIZE_ADDRESS__
 #define DD_LOG_BACKTRACE_DEFAULT "false"
+#define DD_CRASHTRACKING_ENABLED_DEFAULT "false"
 #else
 #define DD_LOG_BACKTRACE_DEFAULT "true"
+#define DD_CRASHTRACKING_ENABLED_DEFAULT "true"
 #endif
 
 #define DD_CONFIGURATION_ALL                                                                                   \
@@ -169,7 +171,8 @@ enum ddtrace_sampling_rules_format {
     CONFIG(INT, DD_TRACE_AGENT_CONNECT_TIMEOUT, DD_CFG_EXPSTR(DD_TRACE_AGENT_CONNECT_TIMEOUT_VAL),             \
            .ini_change = zai_config_system_ini_change)                                                         \
     CONFIG(INT, DD_TRACE_DEBUG_PRNG_SEED, "-1", .ini_change = ddtrace_reseed_seed_change)                      \
-    CONFIG(BOOL, DD_LOG_BACKTRACE, DD_LOG_BACKTRACE_DEFAULT)                                                                    \
+    CONFIG(BOOL, DD_LOG_BACKTRACE, DD_LOG_BACKTRACE_DEFAULT)                                                   \
+    CONFIG(BOOL, DD_CRASHTRACKING_ENABLED, DD_CRASHTRACKING_ENABLED_DEFAULT)                                   \
     CONFIG(BOOL, DD_TRACE_GENERATE_ROOT_SPAN, "true", .ini_change = ddtrace_span_alter_root_span_config)       \
     CONFIG(INT, DD_TRACE_SPANS_LIMIT, "1000")                                                                  \
     CONFIG(BOOL, DD_TRACE_128_BIT_TRACEID_GENERATION_ENABLED, "true")                                          \

--- a/tests/ext/crashtracker_and_backtrace_are_mutually_exclusive.phpt
+++ b/tests/ext/crashtracker_and_backtrace_are_mutually_exclusive.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Settings 'datadog.log_backtrace' and 'datadog.crashtracking_enabled' are mutually exclusive
+--SKIPIF--
+<?php
+if (PHP_OS != "Linux") die('skip: Crashtracker/backtrace are only available on Linux');
+if (getenv('DD_TRACE_CLI_ENABLED') === '0') die("skip: tracer is disabled");
+?>
+--ENV--
+DD_TRACE_LOG_LEVEL=warn,span=off,startup=off
+DD_LOG_BACKTRACE=1
+DD_CRASHTRACKING_ENABLED=1
+--INI--
+datadog.trace.log_file=file://stdout
+--FILE--
+<?php
+
+print_r(1);
+
+?>
+--EXPECTF--
+[ddtrace] [warning] Settings 'datadog.log_backtrace' and 'datadog.crashtracking_enabled' are mutually exclusive. Cannot enable the backtrace.
+1

--- a/tests/ext/crashtracker_segfault_disabled.phpt
+++ b/tests/ext/crashtracker_segfault_disabled.phpt
@@ -1,0 +1,54 @@
+--TEST--
+Send crashtracker report when segmentation fault signal is raised and config enables it
+--SKIPIF--
+<?php
+if (!extension_loaded('posix')) die('skip: posix extension required');
+if (getenv('SKIP_ASAN') || getenv('USE_ZEND_ALLOC') === '0') die("skip: intentionally causes segfaults");
+if (getenv('PHP_PEAR_RUNTESTS') === '1') die("skip: pecl run-tests does not support %A in EXPECTF");
+if (getenv('DD_TRACE_CLI_ENABLED') === '0') die("skip: tracer is disabled");
+if (PHP_VERSION_ID < 70200) die("skip: TEST_PHP_EXTRA_ARGS is only available on PHP 7.2+");
+include __DIR__ . '/includes/skipif_no_dev_env.inc';
+?>
+--ENV--
+DD_TRACE_LOG_LEVEL=0
+DD_AGENT_HOST=request-replayer
+DD_TRACE_AGENT_PORT=80
+DD_CRASHTRACKING_ENABLED=0
+--INI--
+datadog.trace.agent_test_session_token=tests/ext/crashtracker_segfault.phpt
+--FILE--
+<?php
+
+include __DIR__ . '/includes/request_replayer.inc';
+$rr = new RequestReplayer();
+$rr->replayRequest(); // cleanup possible leftover
+
+usleep(100000); // Let time to the sidecar to open the crashtracker socket
+
+$php = getenv('TEST_PHP_EXECUTABLE');
+$args = getenv('TEST_PHP_ARGS')." ".getenv("TEST_PHP_EXTRA_ARGS");
+$cmd = $php." ".$args." -r 'posix_kill(posix_getpid(), 11);'";
+system($cmd);
+
+$rr->waitForRequest(function ($request) {
+    if ($request["uri"] != "/telemetry/proxy/api/v2/apmtelemetry") {
+        return false;
+    }
+    $body = json_decode($request["body"], true);
+    if ($body["request_type"] != "logs" || !isset($body["payload"][0]["message"])) {
+        return false;
+    }
+
+    $payload = $body["payload"][0];
+    $payload["message"] = json_decode($payload["message"], true);
+    $output = json_encode($payload, JSON_PRETTY_PRINT);
+
+    echo $output;
+
+    return true;
+});
+
+?>
+--EXPECTF--
+Fatal error: Uncaught Exception: wait for replay timeout in %s
+%A

--- a/tests/ext/crashtracker_segfault_disabled.phpt
+++ b/tests/ext/crashtracker_segfault_disabled.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Send crashtracker report when segmentation fault signal is raised and config enables it
+Don't send crashtracker report when segmentation fault signal is raised and config disables it
 --SKIPIF--
 <?php
 if (!extension_loaded('posix')) die('skip: posix extension required');
@@ -15,7 +15,7 @@ DD_AGENT_HOST=request-replayer
 DD_TRACE_AGENT_PORT=80
 DD_CRASHTRACKING_ENABLED=0
 --INI--
-datadog.trace.agent_test_session_token=tests/ext/crashtracker_segfault.phpt
+datadog.trace.agent_test_session_token=tests/ext/crashtracker_segfault_disabled.phpt
 --FILE--
 <?php
 

--- a/tests/ext/crashtracker_segfault_disabled.phpt
+++ b/tests/ext/crashtracker_segfault_disabled.phpt
@@ -50,5 +50,6 @@ $rr->waitForRequest(function ($request) {
 
 ?>
 --EXPECTF--
+%A
 Fatal error: Uncaught Exception: wait for replay timeout in %s
 %A

--- a/tests/ext/includes/request_replayer.inc
+++ b/tests/ext/includes/request_replayer.inc
@@ -21,13 +21,13 @@ class RequestReplayer
         );
 
         $this->flushInterval = getenv('DD_TRACE_AGENT_FLUSH_INTERVAL')
-            ? (int) getenv('DD_TRACE_AGENT_FLUSH_INTERVAL')
-            : 5000;
+            ? (int) getenv('DD_TRACE_AGENT_FLUSH_INTERVAL') * 100
+            : 50000;
     }
 
     public function waitForFlush()
     {
-        usleep($this->flushInterval * 2 * 1000);
+        usleep($this->flushInterval * 2);
     }
 
     public function waitForRequest($matcher)
@@ -37,7 +37,7 @@ class RequestReplayer
             if ($i++ == 100) {
                 throw new Exception("wait for replay timeout");
             }
-            usleep($this->flushInterval * 1000);
+            usleep($this->flushInterval);
 
             $requests = $this->replayAllRequests();
             if (is_array($requests)) {
@@ -57,7 +57,7 @@ class RequestReplayer
             if ($i++ == 100) {
                 throw new Exception("wait for replay timeout");
             }
-            usleep($this->flushInterval * 1000);
+            usleep($this->flushInterval);
         } while (empty($data = $this->replayRequest($ignoreTelemetry)));
         return $data;
     }

--- a/tests/ext/includes/request_replayer.inc
+++ b/tests/ext/includes/request_replayer.inc
@@ -12,6 +12,11 @@ class RequestReplayer
      */
     private $flushInterval;
 
+    /**
+     * @var int
+     */
+    private $maxIteration;
+
     public function __construct()
     {
         $this->endpoint = sprintf(
@@ -23,6 +28,8 @@ class RequestReplayer
         $this->flushInterval = getenv('DD_TRACE_AGENT_FLUSH_INTERVAL')
             ? (int) getenv('DD_TRACE_AGENT_FLUSH_INTERVAL') * 100
             : 50000;
+
+        $this->maxIteration = (strncasecmp(PHP_OS, "WIN", 3) === 0) ? 500 : 200;
     }
 
     public function waitForFlush()
@@ -34,7 +41,7 @@ class RequestReplayer
     {
         $i = 0;
         do {
-            if ($i++ == 100) {
+            if ($i++ == $this->maxIteration) {
                 throw new Exception("wait for replay timeout");
             }
             usleep($this->flushInterval);
@@ -54,7 +61,7 @@ class RequestReplayer
     {
         $i = 0;
         do {
-            if ($i++ == 100) {
+            if ($i++ == $this->maxIteration) {
                 throw new Exception("wait for replay timeout");
             }
             usleep($this->flushInterval);


### PR DESCRIPTION
### Description

Corresponding env var `DD_CRASHTRACKING_ENABLED` is handled at least by dd-trace-dotnet and dd-trace-py, and is required by a system-test.

Additionally, I reduced the wait time in the request replayer. 
Previously, the default was 5 seconds per iteration with a maximum of 100 iterations. 
Now, it’s 0.5 seconds per iteration, with a maximum of 200 iterations (500 on Windows).

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
