### PR TITLE
Fix improper symbol exports in appsec ext/helper

### DIFF
--- a/appsec/cmake/cond_flag.cmake
+++ b/appsec/cmake/cond_flag.cmake
@@ -1,0 +1,14 @@
+macro(target_linker_flag_conditional target) # flags as argv
+    try_compile(LINKER_HAS_FLAG "${CMAKE_CURRENT_BINARY_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/check.c"
+        LINK_OPTIONS ${ARGN}
+        OUTPUT_VARIABLE LINKER_HAS_FLAG_ERROR_LOG)
+
+    if(LINKER_HAS_FLAG)
+        target_link_options(${target} PRIVATE ${ARGN})
+        message(STATUS "Linker has flag ${ARGN}")
+    else()
+        #message(STATUS "Linker does not have flag: ${LINKER_HAS_FLAG_ERROR_LOG}")
+    endif()
+endmacro()
+
+

--- a/appsec/cmake/extension.cmake
+++ b/appsec/cmake/extension.cmake
@@ -26,19 +26,6 @@ target_compile_definitions(extension PRIVATE TESTING=1 ZEND_ENABLE_STATIC_TSRMLS
 target_link_libraries(extension PRIVATE mpack PhpConfig zai)
 target_include_directories(extension PRIVATE ..)
 
-macro(target_linker_flag_conditional target) # flags as argv
-    try_compile(LINKER_HAS_FLAG "${CMAKE_CURRENT_BINARY_DIR}" "${CMAKE_CURRENT_SOURCE_DIR}/cmake/check.c"
-        LINK_OPTIONS ${ARGN}
-        OUTPUT_VARIABLE LINKER_HAS_FLAG_ERROR_LOG)
-
-    if(LINKER_HAS_FLAG)
-        target_link_options(${target} PRIVATE ${ARGN})
-        message(STATUS "Linker has flag ${ARGN}")
-    else()
-        #message(STATUS "Linker does not have flag: ${LINKER_HAS_FLAG_ERROR_LOG}")
-    endif()
-endmacro()
-
 # we don't have any C++ now, but just so we don't forget in the future...
 check_cxx_compiler_flag("-fno-gnu-unique" COMPILER_HAS_NO_GNU_UNIQUE)
 if(COMPILER_HAS_NO_GNU_UNIQUE)
@@ -49,11 +36,13 @@ target_compile_options(extension PRIVATE -Wall -Wextra -Werror)
 # our thread local variables are only used by ourselves
 target_compile_options(extension PRIVATE -ftls-model=local-dynamic)
 
+include(cmake/cond_flag.cmake)
+
 target_linker_flag_conditional(extension -Wl,--as-needed)
 # ld doesn't necessarily respect the visibility of hidden symbols if
 # they're inside static libraries, so use a linker script only exporting
 # ddappsec.version as a safeguard
-target_linker_flag_conditional(extension "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/ddappsec.version")
+target_linker_flag_conditional(extension "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/src/extension/ddappsec.version")
 
 # Mac OS
 target_linker_flag_conditional(extension -flat_namespace "-undefined suppress")

--- a/appsec/cmake/helper.cmake
+++ b/appsec/cmake/helper.cmake
@@ -45,6 +45,9 @@ set_target_properties(ddappsec-helper PROPERTIES
     SUFFIX .so
 )
 
+include(cmake/cond_flag.cmake)
+target_linker_flag_conditional(ddappsec-helper "-Wl,--version-script=${CMAKE_CURRENT_SOURCE_DIR}/src/helper/helper.version")
+
 patch_away_libc(ddappsec-helper)
 
 try_compile(STDLIBXX_FS_NO_LIB_NEEDED ${CMAKE_CURRENT_BINARY_DIR}

--- a/appsec/src/extension/ddappsec.version
+++ b/appsec/src/extension/ddappsec.version
@@ -1,4 +1,6 @@
 {
-	global: get_module;
+	global:
+		get_module;
+		dd_appsec_maybe_enable_helper;
 	local: *;
 };

--- a/appsec/src/helper/helper.version
+++ b/appsec/src/helper/helper.version
@@ -1,0 +1,7 @@
+{
+	global:
+	  appsec_helper_main;
+	  appsec_helper_shutdown;
+	local: *;
+};
+


### PR DESCRIPTION
### Description

Both the extension and the helper need version scripts to prevent symbols from being exported. -fvisibility=hidden is not sufficient because it's not being applied to some of the static libraries they link against.

On the extensions side: the path to the version script was wrong, as this error was ultimately ignored because invalid ld options were being ingored. This resulted in some extra zai_* functions being exported.

On the helper side: symbols from libunwind, libc++ and possibly others were being exported.

<!---
Any description you feel is relevant and gives more background to this PR, if necessary.
-->

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
