### PR TITLE
Remove gid from socket/lock path of helper

### DIFF
--- a/appsec/src/extension/helper_process.c
+++ b/appsec/src/extension/helper_process.c
@@ -42,7 +42,7 @@ static const int timeout_send = 500;
 static const int timeout_recv_initial = 7500;
 static const int timeout_recv_subseq = 2000;
 
-#define DD_PATH_FORMAT "%s%sddappsec_" PHP_DDAPPSEC_VERSION "_%u.%u"
+#define DD_PATH_FORMAT "%s%sddappsec_" PHP_DDAPPSEC_VERSION "_%u"
 #define DD_SOCK_PATH_FORMAT DD_PATH_FORMAT ".sock"
 #define DD_LOCK_PATH_FORMAT DD_PATH_FORMAT ".lock"
 
@@ -135,24 +135,23 @@ bool dd_on_runtime_path_update(zval *nullable old_val, zval *nonnull new_val)
     UNUSED(old_val);
 
     uid_t uid = getuid();
-    gid_t gid = getgid();
     char *base = Z_STRVAL_P(new_val);
     size_t base_len = Z_STRLEN_P(new_val);
     char *separator = base[base_len - 1] != '/' ? "/" : "";
 
     size_t sock_name_len =
-        snprintf(NULL, 0, DD_SOCK_PATH_FORMAT, base, separator, uid, gid);
+        snprintf(NULL, 0, DD_SOCK_PATH_FORMAT, base, separator, uid);
     char *sock_name = safe_pemalloc(sock_name_len, sizeof(char), 1, 1);
     snprintf(sock_name, sock_name_len + 1, DD_SOCK_PATH_FORMAT, base, separator,
-        uid, gid);
+        uid);
     pefree(_mgr.socket_path, 1);
     _mgr.socket_path = sock_name;
 
     size_t lock_name_len =
-        snprintf(NULL, 0, DD_LOCK_PATH_FORMAT, base, separator, uid, gid);
+        snprintf(NULL, 0, DD_LOCK_PATH_FORMAT, base, separator, uid);
     char *lock_name = safe_pemalloc(lock_name_len, sizeof(char), 1, 1);
     snprintf(lock_name, lock_name_len + 1, DD_LOCK_PATH_FORMAT, base, separator,
-        uid, gid);
+        uid);
     pefree(_mgr.lock_path, 1);
     _mgr.lock_path = lock_name;
 

--- a/appsec/tests/extension/inc/mock_helper.php
+++ b/appsec/tests/extension/inc/mock_helper.php
@@ -13,7 +13,7 @@ class Helper {
 
     function __construct($opts = array()) {
         $runtime_path = key_exists('runtime_path', $opts) ? $opts['runtime_path'] : ini_get('datadog.appsec.helper_runtime_path');
-        $sock_path = $runtime_path . "/ddappsec_" . phpversion('ddappsec') . "_" . getmyuid() . "." . getmygid() . ".sock";
+        $sock_path = $runtime_path . "/ddappsec_" . phpversion('ddappsec') . "_" . getmyuid() . ".sock";
         $received_pipe = key_exists('received_pipe', $opts) ? $opts['received_pipe'] : true;
         $this->mock_helper_path = key_exists('mock_helper_path', $opts) ? $opts['mock_helper_path'] : getenv('MOCK_HELPER_BINARY');
         $this->lock_path = $runtime_path . "/ddappsec_" . phpversion('ddappsec') . ".lock";


### PR DESCRIPTION
### Description

Now that we're inside sidecar, we need to have the same uniqueness characteristics of sidecar; in particular, there's one instance of sidecar per uid, but not per (uid,gid) as was the case with the helper before.

<!---
Any description you feel is relevant and gives more background to this PR, if necessary.
-->

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
