### PR TITLE
add aws credentials to circleci system tests

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -2535,7 +2535,7 @@ jobs:
             docker-compose --version
       - run:
           name: Clone System Tests repo
-          command: git clone https://github.com/DataDog/system-tests.git
+          command: git clone https://github.com/DataDog/system-tests.git && git checkout conti/fix-php-errors
       - run:
           name: Copy .tar.gz file to system test binaries folder
           command: |

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -2548,6 +2548,11 @@ jobs:
           command: << parameters.build >>
       - run:
           name: Run
+          environment:
+            - AWS_ACCESS_KEY_ID: $SYSTEM_TESTS_IDM_AWS_ACCESS_KEY_ID
+            - AWS_SECRET_ACCESS_KEY: $SYSTEM_TESTS_IDM_AWS_SECRET_ACCESS_KEY
+            - AWS_REGION: us-east-1
+            - AWS_DEFAULT_REGION: us-east-1  # AWS services should use `AWS_REGION`, but some still use the older `AWS_DEFAULT_REGION`
           command: << parameters.run >>
       - store_artifacts:
           path: system-tests/logs

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -3401,6 +3401,26 @@ workflows:
 
       - system_tests:
           requires: [ 'package extension' ]
+          name: "System tests Integration Tests"
+          build: |
+            cd system-tests
+            ./build.sh php
+          run: |
+            cd system-tests
+            DD_API_KEY=$SYSTEM_TESTS_DD_API_KEY ./run.sh INTEGRATIONS
+
+      - system_tests:
+          requires: [ 'package extension' ]
+          name: "System tests Cross Tracer Propagation Tests for Messaging"
+          build: |
+            cd system-tests
+            ./build.sh php
+          run: |
+            cd system-tests
+            DD_API_KEY=$SYSTEM_TESTS_DD_API_KEY ./run.sh CROSSED_TRACING_LIBRARIES
+
+      - system_tests:
+          requires: [ 'package extension' ]
           name: "Parametric tests"
           build: |
             cd system-tests/parametric


### PR DESCRIPTION
### Description

adds aws env variables necessary for system tests that use AWS resources

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
