### PR TITLE
docs: Remove pre-beta state

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,6 +1,6 @@
 # Contributing to dd-trace-php
 
-As an open-source project we welcome contributions of many forms, but due to the experimental pre-beta nature of this repository, you should [reach out to us](https://github.com/DataDog/dd-trace-php/issues) before starting work on any major code changes. This will ensure we avoid duplicating work, or that your code can't be merged due to a rapidly changing base.
+As an open-source project we welcome contributions of many forms, but you should [reach out to us](https://github.com/DataDog/dd-trace-php/issues) before starting work on any major code changes. This will ensure we avoid duplicating work, or that your code can't be merged due to a rapidly changing base.
 
 ## Project initialization
 


### PR DESCRIPTION
### Description

<!---
Any description you feel is relevant and gives more background to this PR, if necessary.
-->

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

This piece of doc hasn't been updated since 2018 😛 

It's just a super small PR to remove the pre-beta mention. Maybe we should revise some aspect of the doc at one point, but let's see that later. In the meanwhile, stating we are in pre-beta is not great advertising. +1:

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
