### PR TITLE
Disable kubernetes injection tests

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -109,3 +109,12 @@ onboarding_tests_installer:
     matrix:
       - ONBOARDING_FILTER_WEBLOG: [test-app-php,test-app-php-container-83]
         SCENARIO: SIMPLE_INSTALLER_AUTO_INJECTION
+
+onboarding_tests_k8s_injection:
+  rules:
+    - when: never
+  parallel:
+    matrix:
+      - WEBLOG_VARIANT:
+          - dd-lib-php-init-test-83
+          - dd-lib-php-init-test-alpine


### PR DESCRIPTION
### Description

This PR disables kubernetes injection tests. Tests are already disable in one-pipeline but that will soon be changing with https://github.com/DataDog/libdatadog-build/pull/36 . The variants come from [this pr](https://github.com/DataDog/system-tests/pull/3126) , however, that PR is not ready to be merged yet

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
