### PR TITLE
fix: MongoDBIntegration condition typo

### DIFF
--- a/src/DDTrace/Integrations/MongoDB/MongoDBIntegration.php
+++ b/src/DDTrace/Integrations/MongoDB/MongoDBIntegration.php
@@ -26,7 +26,7 @@ function register_subscriber()
             if ($span) {
                 if (is_null(self::$useDeprecatedMethods)) {
                     // v1.20+: getServer() is deprecated in favor of getHost() and getPort()
-                    self::$useDeprecatedMethods = !method_exists($event, 'getHost') || method_exists($event, 'getPort');
+                    self::$useDeprecatedMethods = !method_exists($event, 'getHost') || !method_exists($event, 'getPort');
                 }
 
                 if (self::$useDeprecatedMethods) {


### PR DESCRIPTION
### Description

We want to use the new methods when they both exist (and hence, use deprecated methods when either of them _doesn't_ exist). 

I made a typo and forgot a `!`. My bad.

That said, we should look in another PR why our tests didn't catch this.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
