### PR TITLE
Fix crash in profiler when span stack switch causes GC run

### DIFF
--- a/ext/span.c
+++ b/ext/span.c
@@ -320,8 +320,9 @@ void ddtrace_switch_span_stack(ddtrace_span_stack *target_stack) {
     }
 
     GC_ADDREF(&target_stack->std);
-    OBJ_RELEASE(&DDTRACE_G(active_stack)->std);
+    ddtrace_span_stack *active_stack = DDTRACE_G(active_stack);
     DDTRACE_G(active_stack) = target_stack;
+    OBJ_RELEASE(&active_stack->std);
 }
 
 ddtrace_span_data *ddtrace_init_dummy_span(void) {


### PR DESCRIPTION
gc_collect_cycles may be intercepted by profiler and when happening precisely within ddtrace_switch_span_stack, the DDTRACE_G(active_span) points to just freed memory.