### PR TITLE
Fix profiler ZTS build on alpine

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -650,7 +650,9 @@ commands:
     steps:
       - run:
           name: Build Profiler NTS
+          shell: /bin/bash -ieo pipefail
           command: |
+            source "$BASH_ENV"
             if [ -d '/opt/rh/devtoolset-7' ] ; then
                 set +eo pipefail
                 source scl_source enable devtoolset-7
@@ -659,7 +661,7 @@ commands:
             set -u
             prefix="<< parameters.prefix >>"
             mkdir -vp "${prefix}"
-            command -v switch-php && switch-php "${PHP_VERSION}"
+            switch-php "${PHP_VERSION}"
             cd profiling
             echo "${CARGO_TARGET_DIR}"
             cargo build --release
@@ -668,7 +670,9 @@ commands:
             objcopy --compress-debug-sections "${prefix}/datadog-profiling.so"
       - run:
           name: Build Profiler ZTS
+          shell: /bin/bash -ieo pipefail
           command: |
+            source "$BASH_ENV"
             if [ -d '/opt/rh/devtoolset-7' ] ; then
                 set +eo pipefail
                 source scl_source enable devtoolset-7
@@ -677,7 +681,7 @@ commands:
             set -u
             prefix="<< parameters.prefix >>"
             mkdir -vp "${prefix}"
-            command -v switch-php && switch-php "${PHP_VERSION}-zts"
+            switch-php "${PHP_VERSION}-zts"
             cd profiling
             echo "${CARGO_TARGET_DIR}"
             touch build.rs #make sure `build.rs` gets executed after `switch-php` call

--- a/dockerfiles/ci/alpine_compile_extension/env-init
+++ b/dockerfiles/ci/alpine_compile_extension/env-init
@@ -1,16 +1,17 @@
 #!/bin/sh
 
 switch_php() {
-  phpType=$1
+  phpType=${1#*-}
   
-  if [ ${phpType} != 'zts' ] && [ ${phpType} != 'nts' ]; then
-      echo "Invalid PHP version. Valid versions are: 'nts' and 'zts-"
+  if [ "${phpType}" != 'zts' ] && [ "${phpType}" != 'nts' ] && [ "${phpType#*.}" = "${phpType}" ]; then
+      echo "Invalid PHP version. Valid versions are: 'nts' and 'zts'"
       return 1
   fi
   
-  if [ ${phpType} = 'zts' ]; then
+  if [ "${phpType}" = 'zts' ]; then
     export PATH="$(echo "${PATH}" | sed 's/\(\/usr\/local\/php-[^:]*\)\(-zts\|\)\/bin/\1-zts\/bin/')"
   else
-    export PATH="$(echo "${PATH}" | sed 's/\(\/usr\/local\/php-[^:]*\)\(-zts\|\)\/bin/\1\/bin/')"
+    export PATH="$(echo "${PATH}" | sed 's/\(\/usr\/local\/php-[^:-]*\)\(-zts\|\)\/bin/\1\/bin/')"
   fi
 }
+alias switch-php=switch_php


### PR DESCRIPTION
Make switch-php accept the same inputs than on centos build so that `build_profiler` works correctly on both targets.

Apparently `build_profiler` was trying to use `switch-php` before, and if it didn't exist ... just built NTS and pretended it was the ZTS target on alpine. That obviously does not work.