### PR TITLE
Fix abort() call on appsec helper unload

### DIFF
--- a/appsec/src/helper/main.cpp
+++ b/appsec/src/helper/main.cpp
@@ -125,6 +125,8 @@ int appsec_helper_main_impl()
 
         runner->run();
 
+        runner->unregister_for_rc_notifications();
+
         finished.store(true, std::memory_order_release);
     }};
     thread_id = thr.native_handle();

--- a/appsec/src/helper/runner.hpp
+++ b/appsec/src/helper/runner.hpp
@@ -26,13 +26,15 @@ public:
     runner &operator=(const runner &) = delete;
     runner(runner &&) = delete;
     runner &operator=(runner &&) = delete;
-    ~runner() noexcept;
+    ~runner() = default;
 
     static void resolve_symbols();
 
     void run() noexcept(false);
 
     void register_for_rc_notifications();
+
+    void unregister_for_rc_notifications();
 
     [[nodiscard]] bool interrupted() const
     {


### PR DESCRIPTION
### Description

runner was living too long (until shared library unload) due to a static shared pointer used for RC notifications. Plus, the destructor would have a call to shared_for_this(), which would try to revive the shared pointer being destroyed, which raise an exception due to there being no shared pointer anymore. We would catch this and abort().

Instead, destroy the runner earlier (when its own thread finishes). Reset the static shared pointer just before that.


<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
