### PR TITLE
Increase read timeout of sidecar for synchronous flushes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1926,7 +1926,6 @@ dependencies = [
  "datadog-trace-protobuf",
  "ddcommon 0.0.1",
  "http 0.2.11",
- "hyper 0.14.28",
  "serde",
  "tracing",
 ]

--- a/components-rs/sidecar.rs
+++ b/components-rs/sidecar.rs
@@ -133,7 +133,7 @@ pub extern "C" fn ddog_sidecar_connect_php(
     let mut stream = Box::new(try_c!(run_sidecar(cfg)));
     // Generally the Send buffer ought to be big enough for instantaneous transmission
     _ = stream.set_write_timeout(Some(Duration::from_millis(100)));
-    _ = stream.set_read_timeout(Some(Duration::from_secs(1)));
+    _ = stream.set_read_timeout(Some(Duration::from_secs(10)));
     *connection = Box::into_raw(stream);
 
     MaybeError::None


### PR DESCRIPTION
Flushing sometimes takes longer than 1 second, so we would emit WouldBlock and CI would fail.