### PR TITLE
ci(profiling) fix profiling ASAN tests

### DIFF
--- a/.github/workflows/prof_asan.yml
+++ b/.github/workflows/prof_asan.yml
@@ -7,7 +7,7 @@ jobs:
   prof-asan:
     runs-on: ubuntu-latest
     container:
-      image: datadog/dd-trace-ci:php-8.3_bookworm-4
+      image: datadog/dd-trace-ci:php-8.3_bookworm-5
       # https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user
       options: --user root --privileged
 

--- a/.github/workflows/prof_asan.yml
+++ b/.github/workflows/prof_asan.yml
@@ -40,7 +40,7 @@ jobs:
           export LDFLAGS='-fsanitize=address'
           export RUSTC_LINKER=lld-17
           triplet=$(uname -m)-unknown-linux-gnu
-          RUST_NIGHTLY_VERSION="-2024-02-27"
+          RUST_NIGHTLY_VERSION="-2024-11-04"
           RUSTFLAGS='-Zsanitizer=address' cargo +nightly${RUST_NIGHTLY_VERSION} build -Zbuild-std --target $triplet --release
           cp -v "$CARGO_TARGET_DIR/$triplet/release/libdatadog_php_profiling.so" "$(php-config --extension-dir)/datadog-profiling.so"
 

--- a/.github/workflows/prof_asan.yml
+++ b/.github/workflows/prof_asan.yml
@@ -6,8 +6,11 @@ on:
 jobs:
   prof-asan:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        php-version: [8.3, 8.4]
     container:
-      image: datadog/dd-trace-ci:php-8.3_bookworm-5
+      image: datadog/dd-trace-ci:php-${{matrix.php-version}}_bookworm-5
       # https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user
       options: --user root --privileged
 
@@ -33,11 +36,12 @@ jobs:
         run: |
           set -eux
           switch-php nts-asan
+          rm $(php-config --ini-dir)/sqlsrv.ini #sqlsrv leaks memory and triggers asan
           cd profiling
           export CARGO_TARGET_DIR=/tmp/build-cargo
           export CC=clang-17
           export CFLAGS='-fsanitize=address  -fno-omit-frame-pointer'
-          export LDFLAGS='-fsanitize=address'
+          export LDFLAGS='-fsanitize=address -shared-libasan'
           export RUSTC_LINKER=lld-17
           triplet=$(uname -m)-unknown-linux-gnu
           RUST_NIGHTLY_VERSION="-2024-11-04"

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -85,8 +85,8 @@ services:
   '8.4-buster': { <<: *linux_php_service, image: 'datadog/dd-trace-ci:php-8.4_buster' }
   'php-master-buster': { <<: *linux_php_service, image: 'datadog/dd-trace-ci:php-master_buster' }
   # --- Bookworm ---
-  '8.2-bookworm': { <<: *linux_php_service, image: 'datadog/dd-trace-ci:php-8.2_bookworm-3' }
-  '8.3-bookworm': { <<: *linux_php_service, image: 'datadog/dd-trace-ci:php-8.3_bookworm-3' }
+  '8.2-bookworm': { <<: *linux_php_service, image: 'datadog/dd-trace-ci:php-8.2_bookworm-5' }
+  '8.3-bookworm': { <<: *linux_php_service, image: 'datadog/dd-trace-ci:php-8.3_bookworm-5' }
   # --- CentOS 6 ---
   '7.0-centos7': { <<: *linux_php_service, image: 'datadog/dd-trace-ci:php-7.0_centos-7' }
   '7.1-centos7': { <<: *linux_php_service, image: 'datadog/dd-trace-ci:php-7.1_centos-7' }

--- a/dockerfiles/ci/bookworm/Dockerfile
+++ b/dockerfiles/ci/bookworm/Dockerfile
@@ -68,10 +68,7 @@ ENV PHPIZE_DEPS \
     clang-17 \
     cmake \
     dpkg-dev \
-    g++ \
-    gcc \
     file \
-    lcov \
     libc-dev \
     make \
     pkg-config \
@@ -128,7 +125,54 @@ RUN set -eux; \
         echo 'Defaults    env_keep += "DEBIAN_FRONTEND"' >> /etc/sudoers.d/env_keep; \
     \
 # Allow nginx to be run as non-root for tests
-    chown -R circleci:circleci /var/log/nginx/ /var/lib/nginx/;
+    chown -R circleci:circleci /var/log/nginx/ /var/lib/nginx/; \
+    \
+# Make clang the default compiler
+    update-alternatives --install /usr/bin/cc cc /usr/bin/clang-17 100; \
+    update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-17 100; \
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-17 100; \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-17 100; \
+    update-alternatives --install /usr/bin/ld ld /usr/bin/ld.lld-17 100; \
+    echo "-L /usr/lib/llvm-17/lib/clang/17/lib/linux" > /usr/lib/llvm-17/bin/clang.cfg; \
+# Include libasan library path
+    echo /usr/lib/llvm-17/lib/clang/17/lib/linux > /etc/ld.so.conf.d/libasan.conf && ldconfig
+
+# Install lcov
+RUN set -eux; \
+    LCOV_VERSION="1.15"; \
+    LCOV_SHA256="c1cda2fa33bec9aa2c2c73c87226cfe97de0831887176b45ee523c5e30f8053a"; \
+    cd /tmp && curl -OL https://github.com/linux-test-project/lcov/releases/download/v${LCOV_VERSION}/lcov-${LCOV_VERSION}.tar.gz; \
+    (echo "${LCOV_SHA256} lcov-${LCOV_VERSION}.tar.gz" | sha256sum -c -); \
+    mkdir lcov && cd lcov; \
+    tar -xf ../lcov-${LCOV_VERSION}.tar.gz --strip 1; \
+    make install; \
+    lcov --version; \
+    rm -rfv /tmp/*
+
+# Install gdb
+RUN set -eux; \
+    apt install -y libmpfr-dev libgmp-dev; \
+    GDB_VERSION="15.2"; \
+    GDB_SHA256="9d16bc2539a2a20dc3ef99b48b8414d51c51305c8577eb7a1da00996f6dea223";\
+    cd /tmp && curl -OL https://ftp.gnu.org/gnu/gdb/gdb-${GDB_VERSION}.tar.gz; \
+    (echo "${GDB_SHA256} gdb-${GDB_VERSION}.tar.gz" | sha256sum -c -); \
+    mkdir gdb && cd gdb; \
+    tar -xf ../gdb-${GDB_VERSION}.tar.gz --strip 1;\
+    ./configure; \
+    make -j "$((`nproc`+1))"; \
+    make install
+
+# Install valgrind
+RUN set -eux; \
+    VALGRIND_VERSION="3.23.0"; \
+    VALGRIND_SHA1="ec410c75d3920d4f9249a5cfa2cac31e1bf6d586"; \
+    cd /tmp && curl -OL https://sourceware.org/pub/valgrind/valgrind-${VALGRIND_VERSION}.tar.bz2; \
+    (echo "${VALGRIND_SHA1}" valgrind-${VALGRIND_VERSION}.tar.bz2 | sha1sum -c -); \
+    mkdir valgrind && cd valgrind; \
+    tar -xjf ../valgrind-${VALGRIND_VERSION}.tar.bz2 --strip 1;\
+    ./configure; \
+    make -j "$((`nproc`+1))"; \
+    make install
 
 # Install SqlServer PHP Driver
 # https://learn.microsoft.com/en-us/sql/connect/odbc/linux-mac/installing-the-microsoft-odbc-driver-for-sql-server

--- a/dockerfiles/ci/bookworm/Dockerfile
+++ b/dockerfiles/ci/bookworm/Dockerfile
@@ -217,8 +217,7 @@ RUN set -eux; \
     chown -R circleci:circleci /opt;
 
 ARG RUST_VERSION="1.76.0"
-# Need a nightly that is at least 1.71.1
-ARG RUST_NIGHTLY_VERSION="-2024-02-27"
+ARG RUST_NIGHTLY_VERSION="-2024-11-04"
 # Mount a cache into /rust/cargo if you want to pre-fetch packages or something
 ENV CARGO_HOME=/rust/cargo
 ENV RUSTUP_HOME=/rust/rustup

--- a/dockerfiles/ci/bookworm/build-extensions.sh
+++ b/dockerfiles/ci/bookworm/build-extensions.sh
@@ -6,6 +6,9 @@ SHARED_BUILD=$(if php -i | grep -q enable-pcntl=shared; then echo 1; else echo 0
 PHP_VERSION_ID=$(php -r 'echo PHP_MAJOR_VERSION . PHP_MINOR_VERSION;')
 PHP_ZTS=$(php -r 'echo PHP_ZTS;')
 
+# This make `pecl install` use all available cores
+export MAKEFLAGS="-j $(nproc)"
+
 XDEBUG_VERSIONS=(-3.1.2)
 if [[ $PHP_VERSION_ID -le 70 ]]; then
   XDEBUG_VERSIONS=(-2.7.2)
@@ -56,8 +59,8 @@ fi
 HOST_ARCH=$(if [[ $(file $(readlink -f $(which php))) == *aarch64* ]]; then echo "aarch64"; else echo "x86_64"; fi)
 
 export PKG_CONFIG=/usr/bin/$HOST_ARCH-linux-gnu-pkg-config
-export CC=$HOST_ARCH-linux-gnu-gcc
-export CXX=$HOST_ARCH-linux-gnu-g++
+# export CC=$HOST_ARCH-linux-gnu-gcc
+# export CXX=$HOST_ARCH-linux-gnu-g++
 
 iniDir=$(php -i | awk -F"=> " '/Scan this dir for additional .ini files/ {print $2}');
 

--- a/dockerfiles/ci/bookworm/build-php.sh
+++ b/dockerfiles/ci/bookworm/build-php.sh
@@ -13,7 +13,16 @@ INSTALL_DIR=$BASE_INSTALL_DIR/$INSTALL_VERSION
 
 if [[ ${INSTALL_VERSION} == *asan* ]]; then
   export CFLAGS='-fsanitize=address -DZEND_TRACK_ARENA_ALLOC'
-  export LDFLAGS='-fsanitize=address'
+  # GCC has `-shared-libasan` default, clang has '-static-libasan' default
+  export LDFLAGS='-fsanitize=address -shared-libasan'
+fi
+
+if [[ ${PHP_VERSION_ID} -le 73 ]]; then
+  if [[ -z "${CFLAGS:-}" ]]; then
+    export CFLAGS="-Wno-implicit-function-declaration -DHAVE_POSIX_READDIR_R=1 -DHAVE_OLD_READDIR_R=0"
+  else
+    export CFLAGS="${CFLAGS} -Wno-implicit-function-declaration -DHAVE_POSIX_READDIR_R=1 -DHAVE_OLD_READDIR_R=0"
+  fi
 fi
 
 mkdir -p /tmp/build-php && cd /tmp/build-php
@@ -23,7 +32,7 @@ mkdir -p ${INSTALL_DIR}/conf.d
 HOST_ARCH=$(if [[ $TARGETPLATFORM == "linux/arm64" ]]; then echo "aarch64"; else echo "x86_64"; fi)
 
 PKG_CONFIG=/usr/bin/$HOST_ARCH-linux-gnu-pkg-config \
-CC=$HOST_ARCH-linux-gnu-gcc \
+# CC=$HOST_ARCH-linux-gnu-gcc \
 LIBS=-ldl \
 ${PHP_SRC_DIR}/configure \
     $(if [[ $SHARED_BUILD -ne 0 ]]; then echo \


### PR DESCRIPTION
### Description

This PR bumps Rust Nightly to `2024-11-04` to be able to run ASAN tests again. Additionally in order to get the bookworm containers compile in our CI, it bumps LLVM there to 17 (like we did for the buster containers already) and adds a PHP 8.4 ASAN run.

[PROF-10137](https://datadoghq.atlassian.net/browse/PROF-10137)

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.


[PROF-10137]: https://datadoghq.atlassian.net/browse/PROF-10137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ