### PR TITLE
#2926: Do not overwrite service in PSR18 integration

### DIFF
--- a/src/DDTrace/Integrations/Psr18/Psr18Integration.php
+++ b/src/DDTrace/Integrations/Psr18/Psr18Integration.php
@@ -27,7 +27,6 @@ class Psr18Integration extends Integration
             function (SpanData $span, $args, $retval) use ($integration) {
                 $span->resource = 'sendRequest';
                 $span->name = 'Psr\Http\Client\ClientInterface.sendRequest';
-                $span->service = 'psr18';
                 $span->type = Type::HTTP_CLIENT;
                 $span->meta[Tag::SPAN_KIND] = 'client';
                 $span->meta[Tag::COMPONENT] = Psr18Integration::NAME;

--- a/tests/Integrations/Guzzle/V7/GuzzleIntegrationTest.php
+++ b/tests/Integrations/Guzzle/V7/GuzzleIntegrationTest.php
@@ -18,7 +18,7 @@ class GuzzleIntegrationTest extends \DDTrace\Tests\Integrations\Guzzle\V6\Guzzle
             $this->getMockedClient()->sendRequest($request);
         });
         $this->assertFlameGraph($traces, [
-            SpanAssertion::build('Psr\Http\Client\ClientInterface.sendRequest', 'psr18', 'http', 'sendRequest')
+            SpanAssertion::build('Psr\Http\Client\ClientInterface.sendRequest', 'phpunit', 'http', 'sendRequest')
                 ->withExactTags([
                     'http.method' => 'PUT',
                     'http.url' => 'http://example.com',
@@ -36,7 +36,7 @@ class GuzzleIntegrationTest extends \DDTrace\Tests\Integrations\Guzzle\V6\Guzzle
                             'network.destination.name' => 'example.com',
                             TAG::SPAN_KIND => 'client',
                             Tag::COMPONENT => 'guzzle',
-                            '_dd.base_service' => 'psr18'
+                            '_dd.base_service' => 'phpunit'
                         ]),
                 ])
         ]);

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_cancel_fine_tune.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_cancel_fine_tune.json
@@ -58,6 +58,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/fine-tunes/ftjob-AF1WoRqd3aJAHsqc9NY7iL8F/cancel?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0",
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_cancel_fine_tune.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_cancel_fine_tune.json
@@ -59,6 +59,6 @@
          "http.url": "https://api.openai.com/v1/fine-tunes/ftjob-AF1WoRqd3aJAHsqc9NY7iL8F/cancel?foo=bar",
          "network.destination.name": "api.openai.com",
          "span.kind": "client",
-         "version": "1.0",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_cancel_fine_tune.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_cancel_fine_tune.json
@@ -45,14 +45,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "POST",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_chat_completion.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_chat_completion.json
@@ -42,14 +42,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "POST",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_chat_completion.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_chat_completion.json
@@ -55,6 +55,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/chat/completions?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0",
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_chat_completion.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_chat_completion.json
@@ -56,6 +56,6 @@
          "http.url": "https://api.openai.com/v1/chat/completions?foo=bar",
          "network.destination.name": "api.openai.com",
          "span.kind": "client",
-         "version": "1.0",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_chat_completion_stream.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_chat_completion_stream.json
@@ -51,6 +51,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/chat/completions?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_chat_completion_stream.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_chat_completion_stream.json
@@ -38,14 +38,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "POST",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_chat_completion_stream_with_error.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_chat_completion_stream_with_error.json
@@ -52,6 +52,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/chat/completions?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_chat_completion_stream_with_error.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_chat_completion_stream_with_error.json
@@ -39,14 +39,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "POST",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_chat_completion_with_functions.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_chat_completion_with_functions.json
@@ -41,14 +41,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "POST",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_chat_completion_with_functions.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_chat_completion_with_functions.json
@@ -54,6 +54,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/chat/completions?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_chat_completion_with_image_input.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_chat_completion_with_image_input.json
@@ -43,14 +43,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "POST",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_chat_completion_with_image_input.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_chat_completion_with_image_input.json
@@ -56,6 +56,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/chat/completions?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_chat_completion_with_multiple_roles.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_chat_completion_with_multiple_roles.json
@@ -57,6 +57,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/chat/completions?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_chat_completion_with_multiple_roles.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_chat_completion_with_multiple_roles.json
@@ -44,14 +44,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "POST",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_completion.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_completion.json
@@ -42,14 +42,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "POST",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_completion.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_completion.json
@@ -55,6 +55,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/completions?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_completion_stream.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_completion_stream.json
@@ -38,14 +38,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "POST",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_completion_stream.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_completion_stream.json
@@ -51,6 +51,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/completions?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_completions_with_multiple_error_messages.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_completions_with_multiple_error_messages.json
@@ -32,14 +32,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "POST",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_completions_with_multiple_error_messages.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_completions_with_multiple_error_messages.json
@@ -45,6 +45,7 @@
          "http.status_code": "404",
          "http.url": "https://api.openai.com/v1/completions?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_embedding.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_embedding.json
@@ -51,6 +51,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/embeddings?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_embedding.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_embedding.json
@@ -38,14 +38,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "POST",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_embedding_with_multiple_inputs.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_embedding_with_multiple_inputs.json
@@ -52,6 +52,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/embeddings?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_embedding_with_multiple_inputs.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_embedding_with_multiple_inputs.json
@@ -39,14 +39,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "POST",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_file.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_file.json
@@ -51,6 +51,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/files?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_file.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_file.json
@@ -38,14 +38,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "POST",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_image.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_image.json
@@ -37,14 +37,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "POST",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_image.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_image.json
@@ -50,6 +50,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/images/generations?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_image_edit.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_image_edit.json
@@ -51,6 +51,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/images/edits?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_image_edit.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_image_edit.json
@@ -38,14 +38,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "POST",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_image_variation.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_image_variation.json
@@ -36,14 +36,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "POST",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_image_variation.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_image_variation.json
@@ -49,6 +49,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/images/variations?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_moderation.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_moderation.json
@@ -55,14 +55,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "POST",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_moderation.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_moderation.json
@@ -68,6 +68,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/moderations?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_transcription_to_json.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_transcription_to_json.json
@@ -35,14 +35,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "POST",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_transcription_to_json.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_transcription_to_json.json
@@ -48,6 +48,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/audio/transcriptions?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_transcription_to_text.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_transcription_to_text.json
@@ -37,14 +37,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "POST",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_transcription_to_text.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_transcription_to_text.json
@@ -50,6 +50,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/audio/transcriptions?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_transcription_to_verbose_json.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_transcription_to_verbose_json.json
@@ -37,14 +37,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "POST",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_transcription_to_verbose_json.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_transcription_to_verbose_json.json
@@ -50,6 +50,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/audio/transcriptions?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_translation_to_json.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_translation_to_json.json
@@ -35,14 +35,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "POST",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_translation_to_json.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_translation_to_json.json
@@ -48,6 +48,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/audio/translations?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_translation_to_text.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_translation_to_text.json
@@ -50,6 +50,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/audio/translations?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_translation_to_text.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_translation_to_text.json
@@ -37,14 +37,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "POST",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_translation_to_verbose_json.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_translation_to_verbose_json.json
@@ -50,6 +50,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/audio/translations?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_translation_to_verbose_json.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_create_translation_to_verbose_json.json
@@ -37,14 +37,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "POST",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_delete_file.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_delete_file.json
@@ -33,14 +33,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "DELETE",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_delete_file.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_delete_file.json
@@ -46,6 +46,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/files/file-XjGxS3KTG0uNmNOK362iJua3?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_delete_model.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_delete_model.json
@@ -33,14 +33,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "DELETE",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_delete_model.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_delete_model.json
@@ -46,6 +46,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/models/curie:ft-acmeco-2021-03-03-21-44-20?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_download_file.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_download_file.json
@@ -29,14 +29,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "GET",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_download_file.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_download_file.json
@@ -42,6 +42,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/files/file-XjGxS3KTG0uNmNOK362iJua3/content?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_list_files.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_list_files.json
@@ -45,6 +45,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/files?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_list_files.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_list_files.json
@@ -32,14 +32,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "GET",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_list_fine_tune_events.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_list_fine_tune_events.json
@@ -33,14 +33,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "GET",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_list_fine_tune_events.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_list_fine_tune_events.json
@@ -46,6 +46,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/fine-tunes/ftjob-AF1WoRqd3aJAHsqc9NY7iL8F/events?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_list_fine_tune_events_stream.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_list_fine_tune_events_stream.json
@@ -31,14 +31,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "GET",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_list_fine_tune_events_stream.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_list_fine_tune_events_stream.json
@@ -44,6 +44,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/fine-tunes/ft-MaoEAULREoazpupm8uB7qoIl/events?stream=true?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_list_models.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_list_models.json
@@ -45,6 +45,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/models?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_list_models.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_list_models.json
@@ -32,14 +32,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "GET",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_list_models_with_error.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_list_models_with_error.json
@@ -44,6 +44,7 @@
          "http.status_code": "401",
          "http.url": "https://api.openai.com/v1/models?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_list_models_with_error.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_list_models_with_error.json
@@ -31,14 +31,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "GET",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_list_models_with_null_error_type.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_list_models_with_null_error_type.json
@@ -31,14 +31,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "GET",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_list_models_with_null_error_type.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_list_models_with_null_error_type.json
@@ -44,6 +44,7 @@
          "http.status_code": "429",
          "http.url": "https://api.openai.com/v1/models?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_log_prompt_completion_sample_rate.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_log_prompt_completion_sample_rate.json
@@ -42,14 +42,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "POST",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_log_prompt_completion_sample_rate.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_log_prompt_completion_sample_rate.json
@@ -55,6 +55,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/completions?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_logs_disabled.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_logs_disabled.json
@@ -45,6 +45,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/models?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_logs_disabled.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_logs_disabled.json
@@ -32,14 +32,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "GET",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_metrics_disabled.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_metrics_disabled.json
@@ -45,6 +45,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/models?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_metrics_disabled.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_metrics_disabled.json
@@ -32,14 +32,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "GET",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_open_ai_service.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_open_ai_service.json
@@ -31,14 +31,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai",
          "component": "psr18",
          "env": "test",
          "http.method": "GET",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_retrieve_file.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_retrieve_file.json
@@ -50,6 +50,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/files/file-XjGxS3KTG0uNmNOK362iJua3?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_retrieve_file.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_retrieve_file.json
@@ -37,14 +37,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "GET",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_retrieve_fine_tune.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_retrieve_fine_tune.json
@@ -50,6 +50,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/fine_tuning/jobs/ftjob-AF1WoRqd3aJAHsqc9NY7iL8F?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_retrieve_fine_tune.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_retrieve_fine_tune.json
@@ -37,14 +37,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "GET",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_retrieve_model.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_retrieve_model.json
@@ -47,6 +47,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/models/da-vince?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_retrieve_model.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_retrieve_model.json
@@ -34,14 +34,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "GET",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_span_char_limit.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_span_char_limit.json
@@ -42,14 +42,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "POST",

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_span_char_limit.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_span_char_limit.json
@@ -55,6 +55,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/completions?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_span_prompt_completion_sample_rate.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_span_prompt_completion_sample_rate.json
@@ -53,6 +53,7 @@
          "http.status_code": "200",
          "http.url": "https://api.openai.com/v1/completions?foo=bar",
          "network.destination.name": "api.openai.com",
-         "span.kind": "client"
+         "span.kind": "client",
+         "version": "1.0"
        }
      }]]

--- a/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_span_prompt_completion_sample_rate.json
+++ b/tests/snapshots/tests.integrations.open_ai.open_ai_test.test_span_prompt_completion_sample_rate.json
@@ -40,14 +40,13 @@
   },
      {
        "name": "Psr\\Http\\Client\\ClientInterface.sendRequest",
-       "service": "psr18",
+       "service": "openai-test",
        "resource": "sendRequest",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,
        "type": "http",
        "meta": {
-         "_dd.base_service": "openai-test",
          "component": "psr18",
          "env": "test",
          "http.method": "POST",


### PR DESCRIPTION
As described in the issue https://github.com/DataDog/dd-trace-php/issues/2926, for consistency and correctness, do not hardcode the service for this integration otherwise there is no way to control it and it forces that everyone has a service on their service map that is actually just a component.

### Description

<!-- Fixes #2926 -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
