### PR TITLE
ci: update PHP 8.4 to rc4

### DIFF
--- a/.gitlab/ci-images.yml
+++ b/.gitlab/ci-images.yml
@@ -35,7 +35,7 @@ CentOS:
     - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_TOKEN" $CI_REGISTRY
     - docker buildx bake --no-cache --pull --push $PHP_VERSION
 
-Alpine Compile Extension:
+Alpine:
   stage: ci-build
   rules:
     - when: manual
@@ -62,7 +62,7 @@ Alpine Compile Extension:
     - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_TOKEN" $CI_REGISTRY
     - docker buildx bake --no-cache --pull --push $PHP_VERSION
 
-Ubuntu Bookworm:
+Bookworm:
   stage: ci-build
   rules:
     - when: manual
@@ -91,7 +91,7 @@ Ubuntu Bookworm:
     - docker login -u "$CI_REGISTRY_USER" -p "$CI_REGISTRY_TOKEN" $CI_REGISTRY
     - docker buildx bake --no-cache --pull --push $PHP_VERSION
 
-Ubuntu Buster:
+Buster:
   stage: ci-build
   rules:
     - when: manual

--- a/dockerfiles/ci/alpine_compile_extension/docker-compose.yml
+++ b/dockerfiles/ci/alpine_compile_extension/docker-compose.yml
@@ -129,8 +129,8 @@ services:
       x-bake: *bake
       args:
         php_version: 8.4.0
-        php_url: https://downloads.php.net/~saki/php-8.4.0RC1.tar.gz
-        php_sha: ff924ce24493cd546c7227c2cedf75c32d23815b0a6e5c1658d9b005837631ff
+        php_url: https://downloads.php.net/~calvinb/php-8.4.0RC4.tar.gz
+        php_sha: 3964fee49465e6fcae77ad030ae31aa720ade0a51c53df6e255e36eb867fd4b2
         php_api: 20240924
     volumes:
       - ../../:/app

--- a/dockerfiles/ci/bookworm/docker-compose.yml
+++ b/dockerfiles/ci/bookworm/docker-compose.yml
@@ -22,8 +22,8 @@ services:
       args:
         <<: *build-base
         phpVersion: "8.4"
-        phpTarGzUrl: https://downloads.php.net/~saki/php-8.4.0RC3.tar.gz
-        phpSha256Hash: "1937d125c9bb42bc4d8dcd3b8bb25d377814aea50be492bbc64b3554b73af371"
+        phpTarGzUrl: https://downloads.php.net/~calvinb/php-8.4.0RC4.tar.gz
+        phpSha256Hash: "3964fee49465e6fcae77ad030ae31aa720ade0a51c53df6e255e36eb867fd4b2"
 
   php-8.3:
     image: datadog/dd-trace-ci:php-8.3_bookworm-$BOOKWORM_NEXT_VERSION

--- a/dockerfiles/ci/buster/docker-compose.yml
+++ b/dockerfiles/ci/buster/docker-compose.yml
@@ -17,8 +17,8 @@ services:
       x-bake: *bake
       args:
         phpVersion: "8.4"
-        phpTarGzUrl: https://downloads.php.net/~saki/php-8.4.0RC3.tar.gz
-        phpSha256Hash: "1937d125c9bb42bc4d8dcd3b8bb25d377814aea50be492bbc64b3554b73af371"
+        phpTarGzUrl: https://downloads.php.net/~calvinb/php-8.4.0RC4.tar.gz
+        phpSha256Hash: "3964fee49465e6fcae77ad030ae31aa720ade0a51c53df6e255e36eb867fd4b2"
 
   php-8.3:
     image: datadog/dd-trace-ci:php-8.3_buster

--- a/dockerfiles/ci/centos/7/docker-compose.yml
+++ b/dockerfiles/ci/centos/7/docker-compose.yml
@@ -117,6 +117,6 @@ services:
       x-bake: *bake
       args:
         phpVersion: "8.4"
-        phpTarGzUrl: https://downloads.php.net/~saki/php-8.4.0RC3.tar.gz
-        phpSha256Hash: "1937d125c9bb42bc4d8dcd3b8bb25d377814aea50be492bbc64b3554b73af371"
+        phpTarGzUrl: https://downloads.php.net/~calvinb/php-8.4.0RC4.tar.gz
+        phpSha256Hash: "3964fee49465e6fcae77ad030ae31aa720ade0a51c53df6e255e36eb867fd4b2"
     image: 'datadog/dd-trace-ci:php-8.4_centos-7'

--- a/dockerfiles/ci/windows/docker-compose.yml
+++ b/dockerfiles/ci/windows/docker-compose.yml
@@ -87,8 +87,8 @@ services:
       args:
         phpVersion: "8.4.0RC3"
         vsVersion: "vs17"
-        phpTarGzUrl: https://downloads.php.net/~saki/php-8.4.0RC3.tar.gz
-        phpSha256Hash: "1937d125c9bb42bc4d8dcd3b8bb25d377814aea50be492bbc64b3554b73af371"
+        phpTarGzUrl: https://downloads.php.net/~calvinb/php-8.4.0RC4.tar.gz
+        phpSha256Hash: "3964fee49465e6fcae77ad030ae31aa720ade0a51c53df6e255e36eb867fd4b2"
 
   php-8.3:
     image: datadog/dd-trace-ci:php-8.3_windows


### PR DESCRIPTION
### Description

PHP 8.4 RC4 got released, this updates docker images to the latest rc

[PROF-10137](https://datadoghq.atlassian.net/browse/PROF-10137)

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.


[PROF-10137]: https://datadoghq.atlassian.net/browse/PROF-10137?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ