### PR TITLE
feat(profiling) add `stream_select()`-type functions to timeline

### DIFF
--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -144,10 +144,16 @@ static mut GLOBALS_ID_PTR: i32 = 0;
 /// consecutive return value.
 #[no_mangle]
 pub extern "C" fn get_module() -> &'static mut zend::ModuleEntry {
-    static DEPS: [zend::ModuleDep; 4] = [
+    static DEPS: [zend::ModuleDep; 8] = [
         zend::ModuleDep::required(cstr!("standard")),
         zend::ModuleDep::required(cstr!("json")),
         zend::ModuleDep::optional(cstr!("ddtrace")),
+        // Optionally, be dependent on these event extensions so that the functions they provide
+        // are registered in the function table and we can hook into them.
+        zend::ModuleDep::optional(cstr!("ev")),
+        zend::ModuleDep::optional(cstr!("event")),
+        zend::ModuleDep::optional(cstr!("libevent")),
+        zend::ModuleDep::optional(cstr!("uv")),
         zend::ModuleDep::end(),
     ];
 

--- a/profiling/src/timeline.rs
+++ b/profiling/src/timeline.rs
@@ -131,6 +131,7 @@ create_sleeping_fn!(ddog_php_prof_uv_run, UV_RUN_HANDLER, State::Select);
 create_sleeping_fn!(ddog_php_prof_event_base_loop, EVENT_BASE_LOOP_HANDLER, State::Select);
 create_sleeping_fn!(ddog_php_prof_eventbase_loop, EVENTBASE_LOOP_HANDLER, State::Select);
 create_sleeping_fn!(ddog_php_prof_ev_loop_run, EV_LOOP_RUN_HANDLER, State::Select);
+create_sleeping_fn!(ddog_php_prof_parallel_events_poll, PARALLEL_EVENTS_POLL_HANDLER, State::Select);
 
 /// Will be called by the ZendEngine on all errors happening. This is a PHP 8 API
 #[cfg(zend_error_observer)]
@@ -270,6 +271,13 @@ pub unsafe fn timeline_startup() {
             CStr::from_bytes_with_nul_unchecked(b"loop\0"),
             ptr::addr_of_mut!(EVENTBASE_LOOP_HANDLER),
             Some(ddog_php_prof_eventbase_loop),
+        ),
+        // provided by `ext-parallel` from https://pecl.php.net/package/parallel
+        zend::datadog_php_zim_handler::new(
+            CStr::from_bytes_with_nul_unchecked(b"parallel\\events\0"),
+            CStr::from_bytes_with_nul_unchecked(b"poll\0"),
+            ptr::addr_of_mut!(PARALLEL_EVENTS_POLL_HANDLER),
+            Some(ddog_php_prof_parallel_events_poll),
         ),
     ];
 

--- a/profiling/src/timeline.rs
+++ b/profiling/src/timeline.rs
@@ -125,7 +125,6 @@ create_sleeping_fn!(ddog_php_prof_frankenphp_handle_request, FRANKENPHP_HANDLE_R
 // Functions that are blocking on I/O
 create_sleeping_fn!(ddog_php_prof_stream_select, STREAM_SELECT_HANDLER, State::Select);
 create_sleeping_fn!(ddog_php_prof_socket_select, SOCKET_SELECT_HANDLER, State::Select);
-create_sleeping_fn!(ddog_php_prof_socket_accept, SOCKET_ACCEPT_HANDLER, State::Select);
 create_sleeping_fn!(ddog_php_prof_curl_multi_select, CURL_MULTI_SELECT_HANDLER, State::Select);
 create_sleeping_fn!(ddog_php_prof_uv_run, UV_RUN_HANDLER, State::Select);
 create_sleeping_fn!(ddog_php_prof_event_base_loop, EVENT_BASE_LOOP_HANDLER, State::Select);
@@ -225,11 +224,6 @@ pub unsafe fn timeline_startup() {
         ),
         zend::datadog_php_zif_handler::new(
             CStr::from_bytes_with_nul_unchecked(b"socket_select\0"),
-            ptr::addr_of_mut!(SOCKET_SELECT_HANDLER),
-            Some(ddog_php_prof_socket_select),
-        ),
-        zend::datadog_php_zif_handler::new(
-            CStr::from_bytes_with_nul_unchecked(b"socket_accept\0"),
             ptr::addr_of_mut!(SOCKET_SELECT_HANDLER),
             Some(ddog_php_prof_socket_select),
         ),

--- a/profiling/src/timeline.rs
+++ b/profiling/src/timeline.rs
@@ -4,12 +4,12 @@ use crate::zend::{
     InternalFunctionHandler,
 };
 use crate::REQUEST_LOCALS;
+use ddcommon::cstr;
 use libc::c_char;
 use log::{error, trace};
 #[cfg(php_zts)]
 use std::cell::Cell;
 use std::cell::RefCell;
-use std::ffi::CStr;
 use std::ptr;
 use std::time::Instant;
 use std::time::SystemTime;
@@ -193,54 +193,54 @@ pub fn timeline_minit() {
 pub unsafe fn timeline_startup() {
     let handlers = [
         zend::datadog_php_zif_handler::new(
-            CStr::from_bytes_with_nul_unchecked(b"sleep\0"),
+            cstr!("sleep"),
             ptr::addr_of_mut!(SLEEP_HANDLER),
             Some(ddog_php_prof_sleep),
         ),
         zend::datadog_php_zif_handler::new(
-            CStr::from_bytes_with_nul_unchecked(b"usleep\0"),
+            cstr!("usleep"),
             ptr::addr_of_mut!(USLEEP_HANDLER),
             Some(ddog_php_prof_usleep),
         ),
         zend::datadog_php_zif_handler::new(
-            CStr::from_bytes_with_nul_unchecked(b"time_nanosleep\0"),
+            cstr!("time_nanosleep"),
             ptr::addr_of_mut!(TIME_NANOSLEEP_HANDLER),
             Some(ddog_php_prof_time_nanosleep),
         ),
         zend::datadog_php_zif_handler::new(
-            CStr::from_bytes_with_nul_unchecked(b"time_sleep_until\0"),
+            cstr!("time_sleep_until"),
             ptr::addr_of_mut!(TIME_SLEEP_UNTIL_HANDLER),
             Some(ddog_php_prof_time_sleep_until),
         ),
         zend::datadog_php_zif_handler::new(
-            CStr::from_bytes_with_nul_unchecked(b"frankenphp_handle_request\0"),
+            cstr!("frankenphp_handle_request"),
             ptr::addr_of_mut!(FRANKENPHP_HANDLE_REQUEST_HANDLER),
             Some(ddog_php_prof_frankenphp_handle_request),
         ),
         zend::datadog_php_zif_handler::new(
-            CStr::from_bytes_with_nul_unchecked(b"stream_select\0"),
+            cstr!("stream_select"),
             ptr::addr_of_mut!(STREAM_SELECT_HANDLER),
             Some(ddog_php_prof_stream_select),
         ),
         zend::datadog_php_zif_handler::new(
-            CStr::from_bytes_with_nul_unchecked(b"socket_select\0"),
+            cstr!("socket_select"),
             ptr::addr_of_mut!(SOCKET_SELECT_HANDLER),
             Some(ddog_php_prof_socket_select),
         ),
         zend::datadog_php_zif_handler::new(
-            CStr::from_bytes_with_nul_unchecked(b"curl_multi_select\0"),
+            cstr!("curl_multi_select"),
             ptr::addr_of_mut!(CURL_MULTI_SELECT_HANDLER),
             Some(ddog_php_prof_curl_multi_select),
         ),
         // provided by `ext-uv` from https://pecl.php.net/package/uv
         zend::datadog_php_zif_handler::new(
-            CStr::from_bytes_with_nul_unchecked(b"uv_run\0"),
+            cstr!("uv_run"),
             ptr::addr_of_mut!(UV_RUN_HANDLER),
             Some(ddog_php_prof_uv_run),
         ),
         // provided by `ext-libevent` from https://pecl.php.net/package/libevent
         zend::datadog_php_zif_handler::new(
-            CStr::from_bytes_with_nul_unchecked(b"event_base_loop\0"),
+            cstr!("event_base_loop"),
             ptr::addr_of_mut!(EVENT_BASE_LOOP_HANDLER),
             Some(ddog_php_prof_event_base_loop),
         ),
@@ -254,22 +254,22 @@ pub unsafe fn timeline_startup() {
     let handlers = [
         // provided by `ext-ev` from https://pecl.php.net/package/ev
         zend::datadog_php_zim_handler::new(
-            CStr::from_bytes_with_nul_unchecked(b"evloop\0"),
-            CStr::from_bytes_with_nul_unchecked(b"run\0"),
+            cstr!("evloop"),
+            cstr!("run"),
             ptr::addr_of_mut!(EV_LOOP_RUN_HANDLER),
             Some(ddog_php_prof_ev_loop_run),
         ),
         // provided by `ext-event` from https://pecl.php.net/package/event
         zend::datadog_php_zim_handler::new(
-            CStr::from_bytes_with_nul_unchecked(b"eventbase\0"),
-            CStr::from_bytes_with_nul_unchecked(b"loop\0"),
+            cstr!("eventbase"),
+            cstr!("loop"),
             ptr::addr_of_mut!(EVENTBASE_LOOP_HANDLER),
             Some(ddog_php_prof_eventbase_loop),
         ),
         // provided by `ext-parallel` from https://pecl.php.net/package/parallel
         zend::datadog_php_zim_handler::new(
-            CStr::from_bytes_with_nul_unchecked(b"parallel\\events\0"),
-            CStr::from_bytes_with_nul_unchecked(b"poll\0"),
+            cstr!("parallel\\events"),
+            cstr!("poll"),
             ptr::addr_of_mut!(PARALLEL_EVENTS_POLL_HANDLER),
             Some(ddog_php_prof_parallel_events_poll),
         ),


### PR DESCRIPTION
### Description

This will wrap functions that are used to wait on blocking I/O, like `stream_select()` and others. It also moves the `frankenphp_handle_request()` to the `idle` visualisation because technically it is waiting on I/O, but it is used to wait for the next request, just like `RSHUTDOWN` -> `RINIT` so it should share the same vis.

In async PHP (using ReactPHP, AMPHP or others), spending time in a `stream_select()`-type function call means the event-loop is idle.

PPROF-10884

AMPHP event loop:
<img width="950" alt="image" src="https://github.com/user-attachments/assets/32d78cd8-90bc-48f9-b5fd-d632d2209aa1">

`ext-parallel`'s `\parallel\Events::poll()` method:
<img width="967" alt="image" src="https://github.com/user-attachments/assets/e16e5f86-4dd3-4eaa-84ce-092f1c767fb6">


### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
