### PR TITLE
Fully disable the sidecar on lambda by setting all related configs to false

### DIFF
--- a/appsec/src/extension/configuration.c
+++ b/appsec/src/extension/configuration.c
@@ -216,6 +216,11 @@ static void _register_testing_objects(void);
 
 bool dd_config_minit(int module_number)
 {
+    // We have to disable remote config by default on lambda due to issues with the sidecar there. We'll eventually fix it though.
+    if (getenv("AWS_LAMBDA_FUNCTION_NAME")) {
+        config_entries[DDAPPSEC_CONFIG_DD_REMOTE_CONFIG_ENABLED].default_encoded_value = (zai_str) ZAI_STR_FROM_CSTR("false");
+    }
+
     if (!zai_config_minit(config_entries,
             (sizeof config_entries / sizeof *config_entries),
             dd_ini_env_to_ini_name, module_number)) {

--- a/ext/configuration.c
+++ b/ext/configuration.c
@@ -183,7 +183,9 @@ bool ddtrace_config_minit(int module_number) {
 #ifndef _WIN32
     // Sidecar is currently broken - no traces sent. Investigation pending, background sender just works though.
     if (getenv("AWS_LAMBDA_FUNCTION_NAME")) {
+        config_entries[DDTRACE_CONFIG_DD_REMOTE_CONFIG_ENABLED].default_encoded_value = (zai_str) ZAI_STR_FROM_CSTR("false");
         config_entries[DDTRACE_CONFIG_DD_TRACE_SIDECAR_TRACE_SENDER].default_encoded_value = (zai_str) ZAI_STR_FROM_CSTR("false");
+        config_entries[DDTRACE_CONFIG_DD_INSTRUMENTATION_TELEMETRY_ENABLED].default_encoded_value = (zai_str) ZAI_STR_FROM_CSTR("false");
     }
 #endif
 


### PR DESCRIPTION
It doesn't work properly there, so just disable it until we fix it.

This effectively disabled appsec remote config too, but it's what we got, and lambda is currently rather best-effort support.