### PR TITLE
Keep DDTraceStamp

### DIFF
--- a/src/DDTrace/Integrations/SymfonyMessenger/DDTraceStamp.php
+++ b/src/DDTrace/Integrations/SymfonyMessenger/DDTraceStamp.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace DDTrace\Integrations\SymfonyMessenger;
+
+use Symfony\Component\Messenger\Stamp\StampInterface;
+
+final class DDTraceStamp implements StampInterface
+{
+    private $headers;
+
+    public function __construct(array $headers)
+    {
+        $this->headers = $headers;
+    }
+
+    public function getHeaders(): array
+    {
+        return $this->headers;
+    }
+}

--- a/src/DDTrace/Integrations/SymfonyMessenger/DDTraceStamp.php
+++ b/src/DDTrace/Integrations/SymfonyMessenger/DDTraceStamp.php
@@ -4,6 +4,9 @@ namespace DDTrace\Integrations\SymfonyMessenger;
 
 use Symfony\Component\Messenger\Stamp\StampInterface;
 
+/**
+ * @deprecated since 1.5.0
+ */
 final class DDTraceStamp implements StampInterface
 {
     private $headers;


### PR DESCRIPTION
While we no longer make use of it, immediately removing it may break existing applications. Let's keep it for a few versions and drop it later.

See: https://github.com/DataDog/dd-trace-php/pull/2956#pullrequestreview-2442766665