### PR TITLE
Remove the 'debug' versions from the SSI package to reduce its size

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -5087,7 +5087,6 @@ workflows:
                 - "7.2"
                 - "7.3"
               switch_php_version:
-                - debug
                 - nts
 
       - "test_loader_linux":
@@ -5107,7 +5106,6 @@ workflows:
                 - "8.3"
                 - "8.4"
               switch_php_version:
-                - debug
                 - zts
                 - nts
 
@@ -5125,7 +5123,6 @@ workflows:
                 - "7.2"
                 - "7.3"
               switch_php_version:
-                - debug
                 - nts
 
       - "test_loader_linux":
@@ -5144,7 +5141,6 @@ workflows:
                 - "8.3"
                 - "8.4"
               switch_php_version:
-                - debug
                 - zts
                 - nts
 

--- a/tooling/bin/generate-ssi-package.sh
+++ b/tooling/bin/generate-ssi-package.sh
@@ -51,13 +51,10 @@ for architecture in "${architectures[@]}"; do
         # gnu
         ln ./standalone_${architecture}/ddtrace-$php_api.so ${gnu}/trace/ext/$php_api/ddtrace.so
         ln ./standalone_${architecture}/ddtrace-$php_api-zts.so ${gnu}/trace/ext/$php_api/ddtrace-zts.so
-        ln ./standalone_${architecture}/ddtrace-$php_api-debug.so ${gnu}/trace/ext/$php_api/ddtrace-debug.so
 
         # musl
         ln ./standalone_${architecture}/ddtrace-$php_api-alpine.so ${musl}/trace/ext/$php_api/ddtrace.so
-        if [[ ${php_api} -ge 20151012 ]]; then # zts on alpine starting 7.0
-            ln ./standalone_${architecture}/ddtrace-$php_api-alpine-zts.so ${musl}/trace/ext/$php_api/ddtrace-zts.so
-        fi
+        ln ./standalone_${architecture}/ddtrace-$php_api-alpine-zts.so ${musl}/trace/ext/$php_api/ddtrace-zts.so
     done;
 
     cp -r ./src ${trace}/


### PR DESCRIPTION
### Description

With the release of the version `1.5.0` (and the addition of PHP `8.4`), we exceed the limitation of 120MB we set for the Kubernetes injection image.

Let's remove the `debug` versions that should not be used except in a local dev environment.


### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
