### PR TITLE
[loader] Fix detection of JIT enabled

### DIFF
--- a/loader/dd_library_loader.c
+++ b/loader/dd_library_loader.c
@@ -119,13 +119,13 @@ static bool ddloader_is_opcache_jit_enabled() {
     if (php_api_no > 20230831) { // PHP > 8.3 (https://wiki.php.net/rfc/jit_config_defaults)
         // opcache.jit == disable (default: disable)
         zval *opcache_jit = ddloader_ini_get_configuration(ZEND_STRL("opcache.jit"));
-        if (!opcache_jit || Z_TYPE_P(opcache_jit) != IS_STRING || strcmp(Z_STRVAL_P(opcache_jit), "disable") == 0 || strcmp(Z_STRVAL_P(opcache_jit), "off") == 0) {
+        if (!opcache_jit || Z_TYPE_P(opcache_jit) != IS_STRING || Z_STRLEN_P(opcache_jit) == 0 || strcmp(Z_STRVAL_P(opcache_jit), "disable") == 0 || strcmp(Z_STRVAL_P(opcache_jit), "off") == 0) {
             return false;
         }
     } else {
         // opcache.jit_buffer_size = 0 (default: 0)
         zval *opcache_jit_buffer_size = ddloader_ini_get_configuration(ZEND_STRL("opcache.jit_buffer_size"));
-        if (!opcache_jit_buffer_size || Z_TYPE_P(opcache_jit_buffer_size) != IS_STRING || strcmp(Z_STRVAL_P(opcache_jit_buffer_size), "0") == 0) {
+        if (!opcache_jit_buffer_size || Z_TYPE_P(opcache_jit_buffer_size) != IS_STRING || Z_STRLEN_P(opcache_jit_buffer_size) == 0 || strcmp(Z_STRVAL_P(opcache_jit_buffer_size), "0") == 0) {
             return false;
         }
     }


### PR DESCRIPTION
### Description

Testing PHP 8.4 with [Ondrej PPA](https://launchpad.net/~ondrej/+archive/ubuntu/php), tracer was disabled because `opcache.jit` is an empty string

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
