### PR TITLE
ci: update xdebug/swoole

### DIFF
--- a/dockerfiles/ci/alpine_compile_extension/Dockerfile
+++ b/dockerfiles/ci/alpine_compile_extension/Dockerfile
@@ -9,7 +9,7 @@ ARG phpSha256Hash
 ARG phpApi
 
 ENV SRC_DIR=/usr/src
-ENV phpVersion=${phpVersion}
+ENV PHP_VERSION=${phpVersion}
 ENV PHP_API=${phpApi}
 ENV PHP_URL=${phpTarGzUrl:-https://www.php.net/distributions/php-${phpVersion}.tar.gz}
 ENV PHP_SHA256=${phpSha256Hash}

--- a/dockerfiles/ci/alpine_compile_extension/Dockerfile
+++ b/dockerfiles/ci/alpine_compile_extension/Dockerfile
@@ -3,19 +3,19 @@ FROM datadog/dd-trace-ci:php-compile-extension-alpine
 ADD ./docker-php-source /usr/bin/docker-php-source
 ADD ./install-php /usr/bin/install-php
 
-ARG php_version
-ARG php_url
-ARG php_sha
-ARG php_api
+ARG phpVersion
+ARG phpTarGzUrl
+ARG phpSha256Hash
+ARG phpApi
 
 ENV SRC_DIR=/usr/src
-ENV PHP_VERSION=${php_version}
-ENV PHP_API=${php_api}
-ENV PHP_URL=${php_url:-https://www.php.net/distributions/php-${php_version}.tar.gz}
-ENV PHP_SHA256=${php_sha}
+ENV phpVersion=${phpVersion}
+ENV PHP_API=${phpApi}
+ENV PHP_URL=${phpTarGzUrl:-https://www.php.net/distributions/php-${phpVersion}.tar.gz}
+ENV PHP_SHA256=${phpSha256Hash}
 ENV PHP_SRC_DIR=${SRC_DIR}/php
-ENV PHP_INI_DIR /usr/local/etc/php-${php_version}
-ENV PHP_INSTALL_DIR=/usr/local/php-${php_version}
+ENV PHP_INI_DIR /usr/local/etc/php-${phpVersion}
+ENV PHP_INSTALL_DIR=/usr/local/php-${phpVersion}
 
 RUN install-php
 ENV PATH ${PATH}:${PHP_INSTALL_DIR}/bin

--- a/dockerfiles/ci/alpine_compile_extension/docker-compose.yml
+++ b/dockerfiles/ci/alpine_compile_extension/docker-compose.yml
@@ -20,9 +20,9 @@ services:
       context: .
       x-bake: *bake
       args:
-        php_version: 7.0.33
-        php_sha: d71a6ecb6b13dc53fed7532a7f8f949c4044806f067502f8fb6f9facbb40452a
-        php_api: 20151012
+        phpVersion: 7.0.33
+        phpSha256Hash: d71a6ecb6b13dc53fed7532a7f8f949c4044806f067502f8fb6f9facbb40452a
+        phpApi: 20151012
     volumes:
         - ../../:/app
 
@@ -32,9 +32,9 @@ services:
       context: .
       x-bake: *bake
       args:
-        php_version: 7.1.33
-        php_sha: 0055f368ffefe51d5a4483755bd17475e88e74302c08b727952831c5b2682ea2
-        php_api: 20160303
+        phpVersion: 7.1.33
+        phpSha256Hash: 0055f368ffefe51d5a4483755bd17475e88e74302c08b727952831c5b2682ea2
+        phpApi: 20160303
     volumes:
         - ../../:/app
 
@@ -44,9 +44,9 @@ services:
       context: .
       x-bake: *bake
       args:
-        php_version: 7.2.34
-        php_sha: 8b2777c741e83f188d3ca6d8e98ece7264acafee86787298fae57e05d0dddc78
-        php_api: 20170718
+        phpVersion: 7.2.34
+        phpSha256Hash: 8b2777c741e83f188d3ca6d8e98ece7264acafee86787298fae57e05d0dddc78
+        phpApi: 20170718
     volumes:
         - ../../:/app
 
@@ -56,9 +56,9 @@ services:
       context: .
       x-bake: *bake
       args:
-        php_version: 7.3.33
-        php_sha: 9a369c32c6f52036b0a890f290327f148a1904ee66aa56e2c9a7546da6525ec8
-        php_api: 20180731
+        phpVersion: 7.3.33
+        phpSha256Hash: 9a369c32c6f52036b0a890f290327f148a1904ee66aa56e2c9a7546da6525ec8
+        phpApi: 20180731
     volumes:
         - ../../:/app
 
@@ -68,9 +68,9 @@ services:
       context: .
       x-bake: *bake
       args:
-        php_version: 7.4.33
-        php_sha: 5a2337996f07c8a097e03d46263b5c98d2c8e355227756351421003bea8f463e
-        php_api: 20190902
+        phpVersion: 7.4.33
+        phpSha256Hash: 5a2337996f07c8a097e03d46263b5c98d2c8e355227756351421003bea8f463e
+        phpApi: 20190902
     volumes:
         - ../../:/app
 
@@ -80,9 +80,9 @@ services:
       context: .
       x-bake: *bake
       args:
-        php_version: 8.0.30
-        php_sha: 449d2048fcb20a314d8c218097c6d1047a9f1c5bb72aa54d5d3eba0a27a4c80c
-        php_api: 20200930
+        phpVersion: 8.0.30
+        phpSha256Hash: 449d2048fcb20a314d8c218097c6d1047a9f1c5bb72aa54d5d3eba0a27a4c80c
+        phpApi: 20200930
     volumes:
       - ../../:/app
 
@@ -92,9 +92,9 @@ services:
       context: .
       x-bake: *bake
       args:
-        php_version: 8.1.31
-        php_sha: 618923b407c4575bfee085f00c4aaa16a5cc86d4b1eb893c0f352d61541bbfb1
-        php_api: 20210902
+        phpVersion: 8.1.31
+        phpSha256Hash: 618923b407c4575bfee085f00c4aaa16a5cc86d4b1eb893c0f352d61541bbfb1
+        phpApi: 20210902
     volumes:
       - ../../:/app
 
@@ -104,9 +104,9 @@ services:
       context: .
       x-bake: *bake
       args:
-        php_version: 8.2.26
-        php_sha: 04e47b46b347ed6404dcc9e9989486710b075eafc8490500fd271aeeac5d83cb
-        php_api: 20220829
+        phpVersion: 8.2.26
+        phpSha256Hash: 04e47b46b347ed6404dcc9e9989486710b075eafc8490500fd271aeeac5d83cb
+        phpApi: 20220829
     volumes:
       - ../../:/app
 
@@ -116,9 +116,9 @@ services:
       context: .
       x-bake: *bake
       args:
-        php_version: 8.3.14
-        php_sha: e4ee602c31e2f701c9f0209a2902dd4802727431246a9155bf56dda7bcf7fb4a
-        php_api: 20230831
+        phpVersion: 8.3.14
+        phpSha256Hash: e4ee602c31e2f701c9f0209a2902dd4802727431246a9155bf56dda7bcf7fb4a
+        phpApi: 20230831
     volumes:
       - ../../:/app
 
@@ -128,8 +128,8 @@ services:
       context: .
       x-bake: *bake
       args:
-        php_version: 8.4.1
-        php_sha: c3d1ce4157463ea43004289c01172deb54ce9c5894d8722f4e805461bf9feaec
-        php_api: 20240924
+        phpVersion: 8.4.1
+        phpSha256Hash: c3d1ce4157463ea43004289c01172deb54ce9c5894d8722f4e805461bf9feaec
+        phpApi: 20240924
     volumes:
       - ../../:/app

--- a/dockerfiles/ci/bookworm/build-extensions.sh
+++ b/dockerfiles/ci/bookworm/build-extensions.sh
@@ -124,16 +124,7 @@ else
   pecl install sqlsrv$SQLSRV_VERSION; echo "extension=sqlsrv.so" >> ${iniDir}/sqlsrv.ini;
   # Xdebug is disabled by default
   for VERSION in "${XDEBUG_VERSIONS[@]}"; do
-    if [[ "${VERSION}" == "-3.4.0" ]]; then
-      curl -LO https://github.com/xdebug/xdebug/archive/12adc6394adbf14f239429d72cf34faadddd19fb.tar.gz
-      tar -xvzf 12adc6394adbf14f239429d72cf34faadddd19fb.tar.gz;
-      cd xdebug-12adc6394adbf14f239429d72cf34faadddd19fb;
-      phpize;
-      ./configure;
-      make && make install;
-    else
-      pecl install xdebug$VERSION;
-    fi
+    pecl install xdebug$VERSION;
     cd $(php-config --extension-dir);
     mv xdebug.so xdebug$VERSION.so;
   done
@@ -143,5 +134,18 @@ else
   if [[ $PHP_VERSION_ID -ge 80 && $PHP_ZTS -eq 1 ]]; then
     pecl install parallel;
     echo "extension=parallel" >> ${iniDir}/parallel.ini;
+  fi
+
+  # ext-swoole needs PHP 8
+  if [[ $PHP_VERSION_ID -ge 80 ]]; then
+    pushd /tmp
+    pecl download swoole-6.0.0RC1; # we don't install swoole here
+    tar xzf swoole-6.0.0RC1.tgz
+    cd swoole-6.0.0RC1
+    phpize
+    ./configure --host=$HOST_ARCH-linux-gnu
+    make -j "$((`nproc`+1))"
+    make install
+    popd
   fi
 fi

--- a/dockerfiles/ci/bookworm/build-extensions.sh
+++ b/dockerfiles/ci/bookworm/build-extensions.sh
@@ -139,9 +139,15 @@ else
   # ext-swoole needs PHP 8
   if [[ $PHP_VERSION_ID -ge 80 ]]; then
     pushd /tmp
-    pecl download swoole-6.0.0RC1; # we don't install swoole here
-    tar xzf swoole-6.0.0RC1.tgz
-    cd swoole-6.0.0RC1
+    if [[ $PHP_VERSION_ID -ge 83 ]]; then
+      pecl download swoole-6.0.0RC1;
+      tar xzf swoole-6.0.0RC1.tgz
+      cd swoole-6.0.0RC1
+    else
+      pecl download swoole-5.1.6;
+      tar xzf swoole-5.1.6.tgz
+      cd swoole-5.1.6
+    fi
     phpize
     ./configure --host=$HOST_ARCH-linux-gnu
     make -j "$((`nproc`+1))"

--- a/dockerfiles/ci/buster/build-extensions.sh
+++ b/dockerfiles/ci/buster/build-extensions.sh
@@ -131,17 +131,7 @@ else
   pecl install sqlsrv$SQLSRV_VERSION;
   # Xdebug is disabled by default
   for VERSION in "${XDEBUG_VERSIONS[@]}"; do
-    if [[ "${VERSION}" == "-3.4.0" ]]; then
-      curl -LO https://github.com/xdebug/xdebug/archive/12adc6394adbf14f239429d72cf34faadddd19fb.tar.gz
-      tar -xvzf 12adc6394adbf14f239429d72cf34faadddd19fb.tar.gz;
-      cd xdebug-12adc6394adbf14f239429d72cf34faadddd19fb;
-      phpize;
-      ./configure;
-      make -j "$((`nproc`+1))";
-      make install;
-    else
-      pecl install xdebug$VERSION;
-    fi
+    pecl install xdebug$VERSION;
     cd $(php-config --extension-dir);
     mv xdebug.so xdebug$VERSION.so;
   done
@@ -154,12 +144,17 @@ else
   fi
 
   # ext-swoole needs PHP 8
-  # currently no swoole for PHP 8.4, see https://github.com/swoole/swoole-src/issues/5451
-  if [[ $PHP_VERSION_ID -ge 80 && $PHP_VERSION_ID -lt 84 ]]; then
+  if [[ $PHP_VERSION_ID -ge 80 ]]; then
     pushd /tmp
-    pecl download swoole-5.1.2; # we don't install swoole here
-    tar xzf swoole-5.1.2.tgz
-    cd swoole-5.1.2
+    if [[ $PHP_VERSION_ID -ge 83 ]]; then
+      pecl download swoole-6.0.0RC1;
+      tar xzf swoole-6.0.0RC1.tgz
+      cd swoole-6.0.0RC1
+    else
+      pecl download swoole-5.1.6;
+      tar xzf swoole-5.1.6.tgz
+      cd swoole-5.1.6
+    fi
     phpize
     ./configure --host=$HOST_ARCH-linux-gnu
     make -j "$((`nproc`+1))"

--- a/zend_abstract_interface/jit_utils/jit_blacklist.c
+++ b/zend_abstract_interface/jit_utils/jit_blacklist.c
@@ -235,7 +235,9 @@ static bool is_mapped(void *addr, size_t size) {
     return true;
 }
 #else
-static inline bool is_mapped(...) {
+static inline bool is_mapped(void *addr, size_t size) {
+    (void)addr;
+    (void)size;
     return true;
 }
 #endif


### PR DESCRIPTION
### Description

This updates Xdebug and swoole to the latest PHP 8.4 compatible versions

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
