### PR TITLE
ci(all): Pin Ubuntu version

### DIFF
--- a/.github/workflows/auto_add_pr_to_miletone.yml
+++ b/.github/workflows/auto_add_pr_to_miletone.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   add_to_milestone:
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, '[Version Bump]') == false
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.02
     permissions:
       contents: read
       pull-requests: write # need to modify existing PR
@@ -18,9 +18,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '7.0.101'
 

--- a/.github/workflows/auto_add_pr_to_miletone.yml
+++ b/.github/workflows/auto_add_pr_to_miletone.yml
@@ -10,7 +10,7 @@ on:
 jobs:
   add_to_milestone:
     if: github.event.pull_request.merged == true && startsWith(github.event.pull_request.title, '[Version Bump]') == false
-    runs-on: ubuntu-24.02
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: write # need to modify existing PR

--- a/.github/workflows/auto_check_snapshots.yml
+++ b/.github/workflows/auto_check_snapshots.yml
@@ -5,18 +5,18 @@ on:
 
 jobs:
   check-snapshots:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.02
     permissions:
       contents: read
       pull-requests: write # need to add a comment to a PR
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '7.0.101'
 

--- a/.github/workflows/auto_check_snapshots.yml
+++ b/.github/workflows/auto_check_snapshots.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   check-snapshots:
-    runs-on: ubuntu-24.02
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       pull-requests: write # need to add a comment to a PR

--- a/.github/workflows/auto_label_prs.yml
+++ b/.github/workflows/auto_label_prs.yml
@@ -6,7 +6,7 @@ on:
 jobs:
   add-labels:
 
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     permissions:
       contents: read
       issues: write # Update labels on PRs (might not be necessary, but we call the UpdateIssue API so...)
@@ -14,9 +14,9 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
-      - uses: actions/setup-dotnet@v1
+      - uses: actions/setup-dotnet@v4
         with:
           dotnet-version: '7.0.101'
 

--- a/.github/workflows/prof_asan.yml
+++ b/.github/workflows/prof_asan.yml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   prof-asan:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         php-version: [8.3, 8.4]

--- a/.github/workflows/prof_correctness.yml
+++ b/.github/workflows/prof_correctness.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   prof-correctness:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     strategy:
       matrix:
         php-version: [8.0, 8.1, 8.2, 8.3, 8.4]


### PR DESCRIPTION
### Description

GitHub [announced](https://github.blog/changelog/2024-11-05-notice-of-breaking-changes-for-github-actions/?#ubuntu-latest-upcoming-breaking-changes) to migrated `ubuntu-latest` to version 24.04 starting December 5th, so this is just to make sure this will work as expected.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
