### PR TITLE
Fix PHP 8.4 deprecations

### DIFF
--- a/src/DDTrace/Integrations/AMQP/AMQPIntegration.php
+++ b/src/DDTrace/Integrations/AMQP/AMQPIntegration.php
@@ -486,7 +486,7 @@ class AMQPIntegration extends Integration
         SpanData $span,
         string $name,
         string $spanKind,
-        string $resourceDetail = null,
+        $resourceDetail = null,
         $exception = null
     ) {
         $span->name = "amqp.$name";

--- a/src/DDTrace/Integrations/CodeIgniter/V2/CodeIgniterIntegration.php
+++ b/src/DDTrace/Integrations/CodeIgniter/V2/CodeIgniterIntegration.php
@@ -15,7 +15,7 @@ class CodeIgniterIntegration extends Integration
     /**
      * Add instrumentation to CodeIgniter requests
      */
-    public function init(\CI_Router $router = null): int
+    public function init($router = null): int
     {
         $integration = $this;
         $rootSpan = \DDTrace\root_span();

--- a/src/DDTrace/Integrations/Logs/LogsIntegration.php
+++ b/src/DDTrace/Integrations/Logs/LogsIntegration.php
@@ -38,8 +38,8 @@ class LogsIntegration extends Integration
     }
 
     public static function getPlaceholders(
-        string $traceIdSubstitute = null,
-        string $spanIdSubstitute = null
+        $traceIdSubstitute = null,
+        $spanIdSubstitute = null
     ): array {
         $placeholders = [
             '%dd.trace_id%' => 'dd.trace_id="' . ($traceIdSubstitute ?? logs_correlation_trace_id()) . '"',
@@ -84,8 +84,8 @@ class LogsIntegration extends Integration
 
     public static function appendTraceIdentifiersToMessage(
         string $message,
-        string $traceIdSubstitute = null,
-        string $spanIdSubstitute = null
+        $traceIdSubstitute = null,
+        $spanIdSubstitute = null
     ): string {
         $placeholders = LogsIntegration::getPlaceholders($traceIdSubstitute, $spanIdSubstitute);
         LogsIntegration::replacePlaceholders($message, $placeholders);
@@ -108,9 +108,9 @@ class LogsIntegration extends Integration
 
     public static function replacePlaceholders(
         string $message,
-        array $placeholders = null,
-        string $traceIdSubstitute = null,
-        string $spanIdSubstitute = null
+        $placeholders = null,
+        $traceIdSubstitute = null,
+        $spanIdSubstitute = null
     ): string {
         return strtr(
             $message,
@@ -120,8 +120,8 @@ class LogsIntegration extends Integration
 
     public static function addTraceIdentifiersToContext(
         array $context,
-        string $traceIdSubstitute = null,
-        string $spanIdSubstitute = null
+        $traceIdSubstitute = null,
+        $spanIdSubstitute = null
     ): array {
         if (!isset($context['dd.trace_id'])) {
             $context['dd.trace_id'] = $traceIdSubstitute ?? logs_correlation_trace_id();

--- a/src/DDTrace/Integrations/Logs/LogsIntegration.php
+++ b/src/DDTrace/Integrations/Logs/LogsIntegration.php
@@ -114,7 +114,7 @@ class LogsIntegration extends Integration
     ): string {
         return strtr(
             $message,
-            $placeholders ? $placeholders : LogsIntegration::getPlaceholders($traceIdSubstitute, $spanIdSubstitute)
+            $placeholders ?: LogsIntegration::getPlaceholders($traceIdSubstitute, $spanIdSubstitute)
         );
     }
 

--- a/src/DDTrace/Integrations/WordPress/WordPressIntegrationLoader.php
+++ b/src/DDTrace/Integrations/WordPress/WordPressIntegrationLoader.php
@@ -118,7 +118,7 @@ class WordPressIntegrationLoader
         WordPressIntegration $integration,
         SpanData $span,
         string $name,
-        string $resource = null
+        $resource = null
     ) {
         $span->name = $name;
         $span->resource = $resource ?: $name;

--- a/src/DDTrace/OpenTelemetry/Span.php
+++ b/src/DDTrace/OpenTelemetry/Span.php
@@ -380,7 +380,7 @@ final class Span extends API\Span implements ReadWriteSpanInterface
     /**
      * @inheritDoc
      */
-    public function addEvent(string $name, iterable $attributes = [], int $timestamp = null): SpanInterface
+    public function addEvent(string $name, iterable $attributes = [], $timestamp = null): SpanInterface
     {
         if (!$this->hasEnded()) {
             $this->span->events[] = new SpanEvent(
@@ -427,7 +427,7 @@ final class Span extends API\Span implements ReadWriteSpanInterface
     /**
      * @inheritDoc
      */
-    public function setStatus(string $code, string $description = null): SpanInterface
+    public function setStatus(string $code, $description = null): SpanInterface
     {
         if ($this->hasEnded()) {
             return $this;
@@ -459,7 +459,7 @@ final class Span extends API\Span implements ReadWriteSpanInterface
     /**
      * @inheritDoc
      */
-    public function end(int $endEpochNanos = null): void
+    public function end($endEpochNanos = null): void
     {
         if ($this->hasEnded()) {
             return;
@@ -472,7 +472,7 @@ final class Span extends API\Span implements ReadWriteSpanInterface
         $this->spanProcessor->onEnd($this);
     }
 
-    public function endOTelSpan(int $endEpochNanos = null): void
+    public function endOTelSpan($endEpochNanos = null): void
     {
         if ($this->hasEnded()) {
             return;
@@ -572,7 +572,7 @@ final class Span extends API\Span implements ReadWriteSpanInterface
         $this->totalRecordedEvents = count($otel);
     }
 
-    private function createAndSaveSpanLink(SpanContextInterface $context, iterable $attributes = [], LinkInterface $link = null)
+    private function createAndSaveSpanLink(SpanContextInterface $context, iterable $attributes = [], $link = null)
     {
         $spanLink = new SpanLink();
         $spanLink->traceId = $context->getTraceId();

--- a/src/DDTrace/OpenTelemetry/Span.php
+++ b/src/DDTrace/OpenTelemetry/Span.php
@@ -12,6 +12,7 @@ use DDTrace\Tag;
 use DDTrace\OpenTelemetry\Convention;
 use DDTrace\Util\ObjectKVStore;
 use OpenTelemetry\API\Trace as API;
+use OpenTelemetry\SDK\Trace\LinkInterface;
 use OpenTelemetry\API\Trace\SpanContextInterface;
 use OpenTelemetry\API\Trace\SpanInterface;
 use OpenTelemetry\Context\ContextInterface;
@@ -427,7 +428,7 @@ final class Span extends API\Span implements ReadWriteSpanInterface
     /**
      * @inheritDoc
      */
-    public function setStatus(string $code, $description = null): SpanInterface
+    public function setStatus(string $code, ?string $description = null): SpanInterface
     {
         if ($this->hasEnded()) {
             return $this;
@@ -459,7 +460,7 @@ final class Span extends API\Span implements ReadWriteSpanInterface
     /**
      * @inheritDoc
      */
-    public function end($endEpochNanos = null): void
+    public function end(?int $endEpochNanos = null): void
     {
         if ($this->hasEnded()) {
             return;
@@ -472,7 +473,7 @@ final class Span extends API\Span implements ReadWriteSpanInterface
         $this->spanProcessor->onEnd($this);
     }
 
-    public function endOTelSpan($endEpochNanos = null): void
+    public function endOTelSpan(?int $endEpochNanos = null): void
     {
         if ($this->hasEnded()) {
             return;
@@ -572,7 +573,7 @@ final class Span extends API\Span implements ReadWriteSpanInterface
         $this->totalRecordedEvents = count($otel);
     }
 
-    private function createAndSaveSpanLink(SpanContextInterface $context, iterable $attributes = [], $link = null)
+    private function createAndSaveSpanLink(SpanContextInterface $context, iterable $attributes = [], ?LinkInterface $link = null)
     {
         $spanLink = new SpanLink();
         $spanLink->traceId = $context->getTraceId();

--- a/src/DDTrace/OpenTelemetry/SpanBuilder.php
+++ b/src/DDTrace/OpenTelemetry/SpanBuilder.php
@@ -96,7 +96,7 @@ final class SpanBuilder implements API\SpanBuilderInterface
         return $this;
     }
 
-    public function addEvent(string $name, iterable $attributes = [], int $timestamp = null): SpanBuilderInterface
+    public function addEvent(string $name, iterable $attributes = [], $timestamp = null): SpanBuilderInterface
     {
         $this->events[] = new Event(
             $name, 

--- a/src/DDTrace/OpenTelemetry/SpanBuilder.php
+++ b/src/DDTrace/OpenTelemetry/SpanBuilder.php
@@ -96,10 +96,10 @@ final class SpanBuilder implements API\SpanBuilderInterface
         return $this;
     }
 
-    public function addEvent(string $name, iterable $attributes = [], $timestamp = null): SpanBuilderInterface
+    public function addEvent(string $name, iterable $attributes = [], ?int $timestamp = null): SpanBuilderInterface
     {
         $this->events[] = new Event(
-            $name, 
+            $name,
             $timestamp ?? (int)(microtime(true) * 1e9),
             $this->tracerSharedState
                 ->getSpanLimits()
@@ -107,7 +107,7 @@ final class SpanBuilder implements API\SpanBuilderInterface
                 ->builder($attributes)
                 ->build(),
         );
-             
+
         return $this;
     }
 

--- a/src/DDTrace/OpenTracer/Tracer.php
+++ b/src/DDTrace/OpenTracer/Tracer.php
@@ -28,7 +28,7 @@ final class Tracer implements OTTracer
     /**
      * @param TracerInterface|null $tracer
      */
-    public function __construct(TracerInterface $tracer = null)
+    public function __construct($tracer = null)
     {
         $this->tracer = $tracer ?: GlobalTracer::get();
     }
@@ -39,7 +39,7 @@ final class Tracer implements OTTracer
      * @param array $config
      * @return self
      */
-    public static function make(Transport $transport = null, array $propagators = null, array $config = [])
+    public static function make($transport = null, $propagators = null, array $config = [])
     {
         return new self(
             new DDTracer($transport, $propagators, $config)

--- a/src/DDTrace/OpenTracer1/Tracer.php
+++ b/src/DDTrace/OpenTracer1/Tracer.php
@@ -30,7 +30,7 @@ final class Tracer implements OTTracer
     /**
      * @param TracerInterface|null $tracer
      */
-    public function __construct(TracerInterface $tracer = null)
+    public function __construct($tracer = null)
     {
         $this->tracer = $tracer ?: GlobalTracer::get();
     }
@@ -41,7 +41,7 @@ final class Tracer implements OTTracer
      * @param array $config
      * @return self
      */
-    public static function make(Transport $transport = null, array $propagators = null, array $config = [])
+    public static function make($transport = null, $propagators = null, array $config = [])
     {
         return new self(
             new DDTracer($transport, $propagators, $config)

--- a/src/DDTrace/ScopeManager.php
+++ b/src/DDTrace/ScopeManager.php
@@ -26,7 +26,7 @@ final class ScopeManager implements ScopeManagerInterface
      */
     private $rootContext;
 
-    public function __construct(SpanContext $rootContext = null)
+    public function __construct($rootContext = null)
     {
         $this->rootContext = $rootContext;
     }

--- a/src/DDTrace/Tracer.php
+++ b/src/DDTrace/Tracer.php
@@ -79,7 +79,7 @@ final class Tracer implements TracerInterface
      * @param Propagator[] $propagators
      * @param array $config
      */
-    public function __construct(Transport $transport = null, array $propagators = null, array $config = [])
+    public function __construct($transport = null, $propagators = null, array $config = [])
     {
         $this->transport = $transport ?: new Internal();
         $textMapPropagator = new TextMap($this);

--- a/src/ddtrace_php_api.stubs.php
+++ b/src/ddtrace_php_api.stubs.php
@@ -156,7 +156,7 @@ namespace OpenTelemetry\SDK\Trace {
         /**
          * @inheritDoc
          */
-        public function addEvent(string $name, iterable $attributes = [], int $timestamp = null) : \OpenTelemetry\API\Trace\SpanInterface
+        public function addEvent(string $name, iterable $attributes = [], $timestamp = null) : \OpenTelemetry\API\Trace\SpanInterface
         {
         }
         /**
@@ -174,16 +174,16 @@ namespace OpenTelemetry\SDK\Trace {
         /**
          * @inheritDoc
          */
-        public function setStatus(string $code, string $description = null) : \OpenTelemetry\API\Trace\SpanInterface
+        public function setStatus(string $code, $description = null) : \OpenTelemetry\API\Trace\SpanInterface
         {
         }
         /**
          * @inheritDoc
          */
-        public function end(int $endEpochNanos = null) : void
+        public function end($endEpochNanos = null) : void
         {
         }
-        public function endOTelSpan(int $endEpochNanos = null) : void
+        public function endOTelSpan($endEpochNanos = null) : void
         {
         }
         public function getResource() : \OpenTelemetry\SDK\Resource\ResourceInfo
@@ -212,7 +212,7 @@ namespace OpenTelemetry\SDK\Trace {
         public function addLink(\OpenTelemetry\API\Trace\SpanContextInterface $context, iterable $attributes = []) : \OpenTelemetry\API\Trace\SpanBuilderInterface
         {
         }
-        public function addEvent(string $name, iterable $attributes = [], int $timestamp = null) : \OpenTelemetry\API\Trace\SpanBuilderInterface
+        public function addEvent(string $name, iterable $attributes = [], $timestamp = null) : \OpenTelemetry\API\Trace\SpanBuilderInterface
         {
         }
         public function recordException(\Throwable $exception, iterable $attributes = []) : \OpenTelemetry\API\Trace\SpanBuilderInterface
@@ -506,7 +506,7 @@ namespace DDTrace\Contracts {
 namespace DDTrace {
     final class ScopeManager implements \DDTrace\Contracts\ScopeManager
     {
-        public function __construct(\DDTrace\SpanContext $rootContext = null)
+        public function __construct($rootContext = null)
         {
         }
         /**
@@ -1341,7 +1341,7 @@ namespace DDTrace {
          * @param Propagator[] $propagators
          * @param array $config
          */
-        public function __construct(\DDTrace\Transport $transport = null, array $propagators = null, array $config = [])
+        public function __construct($transport = null, $propagators = null, array $config = [])
         {
         }
         public function limited()

--- a/src/ddtrace_php_api.stubs.php
+++ b/src/ddtrace_php_api.stubs.php
@@ -174,16 +174,16 @@ namespace OpenTelemetry\SDK\Trace {
         /**
          * @inheritDoc
          */
-        public function setStatus(string $code, $description = null) : \OpenTelemetry\API\Trace\SpanInterface
+        public function setStatus(string $code, ?string $description = null) : \OpenTelemetry\API\Trace\SpanInterface
         {
         }
         /**
          * @inheritDoc
          */
-        public function end($endEpochNanos = null) : void
+        public function end(?int $endEpochNanos = null) : void
         {
         }
-        public function endOTelSpan($endEpochNanos = null) : void
+        public function endOTelSpan(?int $endEpochNanos = null) : void
         {
         }
         public function getResource() : \OpenTelemetry\SDK\Resource\ResourceInfo
@@ -212,7 +212,7 @@ namespace OpenTelemetry\SDK\Trace {
         public function addLink(\OpenTelemetry\API\Trace\SpanContextInterface $context, iterable $attributes = []) : \OpenTelemetry\API\Trace\SpanBuilderInterface
         {
         }
-        public function addEvent(string $name, iterable $attributes = [], $timestamp = null) : \OpenTelemetry\API\Trace\SpanBuilderInterface
+        public function addEvent(string $name, iterable $attributes = [], ?int $timestamp = null) : \OpenTelemetry\API\Trace\SpanBuilderInterface
         {
         }
         public function recordException(\Throwable $exception, iterable $attributes = []) : \OpenTelemetry\API\Trace\SpanBuilderInterface


### PR DESCRIPTION
### Description

This PR removes implicitly nullable parameters because these result in deprecation warnings for PHP 8.4.

https://www.php.net/manual/en/migration84.deprecated.php#migration84.deprecated.core.implicitly-nullable-parameter

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
