### PR TITLE
Fix appsec pipeline

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1386,7 +1386,7 @@ jobs:
           keys:
             - hunter-cache-ubuntu-<< parameters.resource_class >>-
       - setup_docker:
-          docker_image: ubuntu:23.10
+          docker_image: ubuntu:24.04
       - run:
           name: Install dependencies
           command: |
@@ -1421,7 +1421,7 @@ jobs:
           keys:
             - hunter-cache-ubuntu-<< parameters.resource_class >>-
       - setup_docker:
-          docker_image: ubuntu:23.10
+          docker_image: ubuntu:24.04
       - run:
           name: Install dependencies
           command: |
@@ -1494,7 +1494,7 @@ jobs:
           keys:
             - hunter-cache-ubuntu-<< parameters.resource_class >>-
       - setup_docker:
-          docker_image: ubuntu:23.10
+          docker_image: ubuntu:24.04
       - run:
           name: Install dependencies
           command: |
@@ -1532,7 +1532,7 @@ jobs:
           keys:
             - hunter-cache-ubuntu-<< parameters.resource_class >>-
       - setup_docker:
-          docker_image: ubuntu:23.10
+          docker_image: ubuntu:24.04
       - run:
           name: Install dependencies
           command: |
@@ -1572,7 +1572,7 @@ jobs:
           keys:
             - hunter-cache-ubuntu-<< parameters.resource_class >>-
       - setup_docker:
-          docker_image: ubuntu:23.10
+          docker_image: ubuntu:24.04
       - run:
           name: Install dependencies
           command: |

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -1427,7 +1427,7 @@ jobs:
           command: |
             export DEBIAN_FRONTEND=noninteractive
             apt update
-            apt install -y wget sudo git g++ gcc gcovr cmake make curl libcurl4-gnutls-dev clang clang-tidy clang-format git php-dev php8.2-xml php-cgi
+            apt install -y wget sudo git g++ gcc gcovr cmake make curl libcurl4-gnutls-dev clang clang-tidy clang-format git php-dev php8.3-xml php-cgi
       - run:
           name: Install rust
           command: |

--- a/appsec/src/extension/configuration.c
+++ b/appsec/src/extension/configuration.c
@@ -218,7 +218,7 @@ bool dd_config_minit(int module_number)
 {
     // We have to disable remote config by default on lambda due to issues with
     // the sidecar there. We'll eventually fix it though.
-    if (getenv("AWS_LAMBDA_FUNCTION_NAME")) {
+    if (getenv("AWS_LAMBDA_FUNCTION_NAME")) { // NOLINT
         config_entries[DDAPPSEC_CONFIG_DD_REMOTE_CONFIG_ENABLED]
             .default_encoded_value = (zai_str)ZAI_STR_FROM_CSTR("false");
     }

--- a/appsec/src/helper/subscriber/waf.cpp
+++ b/appsec/src/helper/subscriber/waf.cpp
@@ -239,7 +239,7 @@ void instance::listener::call(dds::parameter_view &data, event &event)
             derivatives_.emplace(
                 derivative.key(), std::move(parameter_to_json(derivative)));
         } else {
-            derivatives_.emplace(derivative.key(), std::move(derivative));
+            derivatives_.emplace(derivative.key(), derivative);
         }
     }
 

--- a/appsec/tests/helper/client_test.cpp
+++ b/appsec/tests/helper/client_test.cpp
@@ -559,8 +559,9 @@ TEST(ClientTest, RequestInitLimiter)
     {
         network::request_init::request msg;
         msg.data = parameter::map();
-        msg.data.add("server.request.headers.no_cookies",
-            parameter::string("acunetix-product"sv));
+        auto headers = parameter::map();
+        headers.add("user-agent", parameter::string("acunetix-product"sv));
+        msg.data.add("server.request.headers.no_cookies", std::move(headers));
 
         network::request req(std::move(msg));
 
@@ -763,9 +764,9 @@ TEST(ClientTest, RequestInitBrokerThrows)
     {
         network::request_init::request msg;
         msg.data = parameter::map();
-        msg.data.add("server.request.headers.no_cookies",
-            parameter::string("acunetix-product"sv));
-
+        auto headers = parameter::map();
+        headers.add("user-agent", parameter::string("acunetix-product"sv));
+        msg.data.add("server.request.headers.no_cookies", std::move(headers));
         network::request req(std::move(msg));
 
         std::shared_ptr<network::base_response> res;
@@ -2602,8 +2603,9 @@ TEST(ClientTest, SchemasAreNotAddedOnRequestShutdownWhenDisabled)
     { // Request Shutdown
         network::request_shutdown::request msg;
         msg.data = parameter::map();
-        msg.data.add("server.request.headers.no_cookies",
-            parameter::string("acunetix-product"sv));
+        auto headers = parameter::map();
+        headers.add("user-agent", parameter::string("acunetix-product"sv));
+        msg.data.add("server.request.headers.no_cookies", std::move(headers));
 
         network::request req(std::move(msg));
 


### PR DESCRIPTION
### Description

Appsec pipeline was broken. This PR fixes all errors:
- Update appsec ubuntu docker images to 24:04
- Amend helper tests generating segmentation fault on fuzzer
- Fix linting issues

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
