### PR TITLE
Supported php84

### DIFF
--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -2408,7 +2408,7 @@ function get_ini_settings($sourcesDir, $appsecHelperPath, $appsecRulesPath)
  */
 function get_supported_php_versions()
 {
-    return ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3'];
+    return ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3', '8.4'];
 }
 
 main();

--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -2408,7 +2408,7 @@ function get_ini_settings($sourcesDir, $appsecHelperPath, $appsecRulesPath)
  */
 function get_supported_php_versions()
 {
-    return ['5.4', '5.5', '5.6', '7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3'];
+    return ['7.0', '7.1', '7.2', '7.3', '7.4', '8.0', '8.1', '8.2', '8.3'];
 }
 
 main();


### PR DESCRIPTION
### Description

This fixes an issue that already happened for PHP 8.3: https://github.com/DataDog/dd-trace-php/pull/2417

Also, I'm removing support for PHP 5.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [x] Appropriate labels assigned.
