### PR TITLE
ci: add verfy php 8.4

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -4892,7 +4892,7 @@ workflows:
                 - php:8.1-fpm-alpine
                 - php:8.2-fpm-alpine
                 - php:8.3-fpm-alpine
-                - php:8.4-rc-fpm-alpine
+                - php:8.4-fpm-alpine
       - verify_centos:
           requires: [ "package extension" ]
           matrix:
@@ -4912,7 +4912,7 @@ workflows:
                 - PHP_MAJOR=8 PHP_MINOR=1
                 - PHP_MAJOR=8 PHP_MINOR=2
                 - PHP_MAJOR=8 PHP_MINOR=3
-                # - PHP_MAJOR=8 PHP_MINOR=4
+                - PHP_MAJOR=8 PHP_MINOR=4
       - verify_debian:
           requires: [ "package extension" ]
           matrix:
@@ -4935,7 +4935,7 @@ workflows:
                 - PHP_VERSION=8.1
                 - PHP_VERSION=8.2
                 - PHP_VERSION=8.3
-                # - PHP_VERSION=8.4
+                - PHP_VERSION=8.4
 
       - verify_tar_gz:
           requires: [ "package extension" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -88,6 +88,7 @@ services:
   # --- Bookworm ---
   '8.2-bookworm': { <<: *linux_php_service, image: 'datadog/dd-trace-ci:php-8.2_bookworm-5' }
   '8.3-bookworm': { <<: *linux_php_service, image: 'datadog/dd-trace-ci:php-8.3_bookworm-5' }
+  '8.4-bookworm': { <<: *linux_php_service, image: 'datadog/dd-trace-ci:php-8.4_bookworm-5' }
   # --- CentOS 6 ---
   '7.0-centos7': { <<: *linux_php_service, image: 'datadog/dd-trace-ci:php-7.0_centos-7' }
   '7.1-centos7': { <<: *linux_php_service, image: 'datadog/dd-trace-ci:php-7.1_centos-7' }
@@ -97,6 +98,8 @@ services:
   '8.0-centos7': { <<: *linux_php_service, image: 'datadog/dd-trace-ci:php-8.0_centos-7' }
   '8.1-centos7': { <<: *linux_php_service, image: 'datadog/dd-trace-ci:php-8.1_centos-7' }
   '8.2-centos7': { <<: *linux_php_service, image: 'datadog/dd-trace-ci:php-8.2_centos-7' }
+  '8.3-centos7': { <<: *linux_php_service, image: 'datadog/dd-trace-ci:php-8.3_centos-7' }
+  '8.4-centos7': { <<: *linux_php_service, image: 'datadog/dd-trace-ci:php-8.4_centos-7' }
   # --- Windows ---
   '7.0-windows': { <<: *windows_php_service, image: 'datadog/dd-trace-ci:php-7.0_windows' }
   '7.1-windows': { <<: *windows_php_service, image: 'datadog/dd-trace-ci:php-7.1_windows' }


### PR DESCRIPTION
### Description

This adds the missing verify checks for PHP 8.4.
Relates to #2984

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
