### PR TITLE
fix(profiling) invalid unicode handling in timeline

### DIFF
--- a/profiling/src/bindings/mod.rs
+++ b/profiling/src/bindings/mod.rs
@@ -317,6 +317,11 @@ extern "C" {
     #[cfg(php7)]
     pub fn zend_register_extension(extension: &ZendExtension, handle: *mut c_void) -> ZendResult;
 
+    /// Converts the `const char *` into a `zai_str`. A None as well as empty
+    /// strings will be converted into a string view to a static empty string
+    /// (single byte of null, len of 0).
+    pub fn zai_str_from_cstr(cstr: *const c_char) -> zai_str<'static>;
+
     /// Converts the `zstr` into a `zai_str`. A None as well as empty
     /// strings will be converted into a string view to a static empty string
     /// (single byte of null, len of 0).

--- a/profiling/src/timeline.rs
+++ b/profiling/src/timeline.rs
@@ -204,14 +204,7 @@ unsafe extern "C" fn ddog_php_prof_zend_error_observer(
     }
 
     #[cfg(zend_error_observer_80)]
-    let file = unsafe {
-        let mut len = 0;
-        let file = file as *const u8;
-        while *file.add(len) != 0 {
-            len += 1;
-        }
-        std::str::from_utf8_unchecked(std::slice::from_raw_parts(file, len)).to_string()
-    };
+    let file = unsafe { zend::zai_str_from_cstr(file).into_string() };
     #[cfg(not(zend_error_observer_80))]
     let file = unsafe { zend::zai_str_from_zstr(file.as_mut()).into_string() };
 

--- a/zend_abstract_interface/zai_string/string.c
+++ b/zend_abstract_interface/zai_string/string.c
@@ -2,6 +2,8 @@
 
 char *ZAI_STRING_EMPTY_PTR = "";
 
+extern inline zai_str zai_str_from_cstr(const char *cstr);
+
 extern inline zai_str zai_str_from_zstr(zend_string *zstr);
 
 extern inline zai_string zai_string_concat3(zai_str first, zai_str second, zai_str third);

--- a/zend_abstract_interface/zai_string/string.h
+++ b/zend_abstract_interface/zai_string/string.h
@@ -75,7 +75,7 @@ static inline zai_str zai_str_new(const char *ptr, size_t len) {
  *
  * If the pointer is known to be non-null, use ZAI_STR_FROM_CSTR directly.
  */
-static inline zai_str zai_str_from_cstr(const char *cstr) {
+inline zai_str zai_str_from_cstr(const char *cstr) {
     if (cstr) {
         return (zai_str)ZAI_STR_FROM_CSTR(cstr);
     }


### PR DESCRIPTION
### Description

Fixes handling of invalid unicode for errors in timeline

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
