### PR TITLE
fix(profiling): mismatch in utf8 handling

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1316,6 +1316,7 @@ dependencies = [
  "rmp-serde",
  "serde",
  "serde_json",
+ "tinybytes",
  "tokio",
  "tokio-util",
  "uuid",
@@ -1984,7 +1985,6 @@ dependencies = [
  "datadog-trace-protobuf",
  "ddcommon 0.0.1",
  "http 0.2.11",
- "hyper 0.14.28",
  "serde",
  "tracing",
 ]

--- a/profiling/src/timeline.rs
+++ b/profiling/src/timeline.rs
@@ -204,21 +204,20 @@ unsafe extern "C" fn ddog_php_prof_zend_error_observer(
     }
 
     #[cfg(zend_error_observer_80)]
-    let file = unsafe {
-        let mut len = 0;
-        let file = file as *const u8;
-        while *file.add(len) != 0 {
-            len += 1;
-        }
-        std::str::from_utf8_unchecked(std::slice::from_raw_parts(file, len)).to_string()
+    let filename = unsafe {
+        let cstr = core::ffi::CStr::from_ptr(file);
+        cstr.to_string_lossy().into_owned()
     };
     #[cfg(not(zend_error_observer_80))]
-    let file = unsafe { zend::zai_str_from_zstr(file.as_mut()).into_string() };
+    let filename = unsafe {
+        let zstr = zai_str_from_zstr(file.as_mut());
+        zstr.into_string_lossy().into_owned()
+    };
 
     let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
     if let Some(profiler) = Profiler::get() {
         let now = now.as_nanos() as i64;
-        profiler.collect_fatal(now, file, line, unsafe {
+        profiler.collect_fatal(now, filename, line, unsafe {
             zend::zai_str_from_zstr(message.as_mut()).into_string()
         });
     }

--- a/profiling/src/timeline.rs
+++ b/profiling/src/timeline.rs
@@ -204,15 +204,11 @@ unsafe extern "C" fn ddog_php_prof_zend_error_observer(
     }
 
     #[cfg(zend_error_observer_80)]
-    let filename = unsafe {
-        let cstr = core::ffi::CStr::from_ptr(file);
-        cstr.to_string_lossy().into_owned()
-    };
+    let filename_str = unsafe { core::ffi::CStr::from_ptr(file) };
     #[cfg(not(zend_error_observer_80))]
-    let filename = unsafe {
-        let zstr = zai_str_from_zstr(file.as_mut());
-        zstr.into_string_lossy().into_owned()
-    };
+    let filename_str = unsafe { zai_str_from_zstr(file.as_mut()) };
+
+    let filename = filename_str.into_string_lossy().into_owned();
 
     let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
     if let Some(profiler) = Profiler::get() {

--- a/profiling/src/timeline.rs
+++ b/profiling/src/timeline.rs
@@ -208,7 +208,7 @@ unsafe extern "C" fn ddog_php_prof_zend_error_observer(
     #[cfg(not(zend_error_observer_80))]
     let filename_str = unsafe { zai_str_from_zstr(file.as_mut()) };
 
-    let filename = filename_str.into_string_lossy().into_owned();
+    let filename = filename_str.to_string_lossy().into_owned();
 
     let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
     if let Some(profiler) = Profiler::get() {


### PR DESCRIPTION
### Description

Happens in timeline filename for zend_error_observer.

I found this mismatch while doing something else. I asked Florian about it and he prepared a different way to fix it in #2988. I thought I'd push mine up too so we can compare.

### Reviewer checklist
- [x] Test coverage seems ok.
- [x] Appropriate labels assigned.
