### PR TITLE
repo: mandatory issue templates (AIDM-427)

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yaml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yaml
@@ -1,5 +1,5 @@
-name: Bug report
-description: Create a report to help us improve
+name: "Bug Report (Low Priority)"
+description: "Create a public Bug Report. Note that these may not be addressed as quickly as the helpdesk and that looking up account information will be difficult."
 title: "[Bug]: "
 labels: ["\U0001F41B bug"]
 body:

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
-blank_issues_enabled: true
+blank_issues_enabled: false
 contact_links:
-  - name: Check the docs
-    url: https://docs.datadoghq.com/tracing/trace_collection/dd_libraries/php/
-    about: In case you need help with setup and configuration you might find help in the offical documentation
+  - name: Bug Report (High Priority)
+    url: https://help.datadoghq.com/hc/en-us/requests/new?tf_1260824651490=pt_product_type:apm&tf_1900004146284=pt_apm_language:php
+    about: Create an expedited Bug Report via the helpdesk (no login required). This will allow us to look up your account and allows you to provide additional information in private. Please do not create a GitHub issue to report a bug.
+  - name: Feature Request (High Priority)
+    url: https://help.datadoghq.com/hc/en-us/requests/new?tf_1260824651490=pt_product_type:apm&tf_1900004146284=pt_apm_language:php&tf_1260825272270=pt_apm_category_feature_request
+    about: Create an expedited Feature Request via the helpdesk (no login required). This helps with prioritization and allows you to provide additional information in private. Please do not create a GitHub issue to request a feature.

--- a/.github/ISSUE_TEMPLATE/feature_request.yaml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yaml
@@ -1,7 +1,7 @@
-name: Feature request
-description: Suggest an idea
+name: Feature Request (Low Priority)
+description: Create a public Feature Request. Note that these may not be addressed as quickly as the helpdesk and that looking up account information will be difficult.
 title: "[Feature] "
-labels: ["feature-request"]
+labels: feature-request
 body:
   - type: textarea
     attributes:

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,15 @@
+# Security Policy
+
+This document outlines the security policy for the Datadog PHP client library (aka PHP tracer) and what to do if you discover a security vulnerability in the project.
+Most notably, please do not share the details in a public forum (such as in a discussion, issue, or pull request) but instead reach out to us with the details.
+This gives us an opportunity to release a fix for others to benefit from by the time details are made public.
+
+## Supported Versions
+
+We accept vulnerability submissions for the [currently maintained release](https://github.com/DataDog/dd-trace-php/releases).
+
+## Reporting a Vulnerability
+
+If you discover a vulnerability in the Datadog PHP client library (or any Datadog product for that matter) please submit details to the following email address:
+
+* [security@datadoghq.com](mailto:security@datadoghq.com)


### PR DESCRIPTION
### Description
- makes using issue templates mandatory
- adds a security document
- standardizes the issue creation experience across all tracers
- see the [node.js create issue screen](https://github.com/DataDog/dd-trace-js/issues/new/choose) for an example of what this looks like

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
