### PR TITLE
Upgrade libddwaf to v1.22.0

### DIFF
--- a/appsec/tests/helper/client_test.cpp
+++ b/appsec/tests/helper/client_test.cpp
@@ -2760,7 +2760,7 @@ TEST(ClientTest, RaspCalls)
             dynamic_cast<network::request_shutdown::response *>(res.get());
 
         EXPECT_EQ(msg_res->metrics.size(), 3);
-        EXPECT_GT(msg_res->metrics[metrics::waf_duration], 0.0);
+        EXPECT_GE(msg_res->metrics[metrics::waf_duration], 0.0);
         EXPECT_EQ(msg_res->metrics[metrics::rasp_rule_eval], 1);
         EXPECT_GE(msg_res->metrics[metrics::rasp_duration], 0.0);
     }

--- a/appsec/tests/helper/waf_test.cpp
+++ b/appsec/tests/helper/waf_test.cpp
@@ -117,8 +117,10 @@ TEST(WafTest, RunWithTimeout)
 
         EXPECT_CALL(submitm, submit_span_metric(metrics::rasp_timeout, 1));
         EXPECT_CALL(submitm, submit_span_metric(metrics::rasp_rule_eval, 1.0));
-        EXPECT_CALL(submitm, submit_span_metric(metrics::waf_duration, 0.0));
-        EXPECT_CALL(submitm, submit_span_metric(metrics::rasp_duration, 0.0));
+        // Since v1.22.0 libddwaf will still attempt to run denylists, which
+        // will cause the duration to be non-zero
+        EXPECT_CALL(submitm, submit_span_metric(metrics::waf_duration, _));
+        EXPECT_CALL(submitm, submit_span_metric(metrics::rasp_duration, _));
         parameter_view pv(p);
         dds::event e;
         bool is_rasp = true;

--- a/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/CommonTests.groovy
+++ b/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/CommonTests.groovy
@@ -181,7 +181,7 @@ trait CommonTests {
 
     @Test
     void 'test blocking and stack generation'() {
-        HttpRequest req = container.buildReq('/generate_stack.php?id=user2020').GET().build()
+        HttpRequest req = container.buildReq('/generate_stack.php?id=stack_user').GET().build()
         def trace = container.traceFromRequest(req, ofString()) { HttpResponse<String> re ->
             assert re.statusCode() == 403
             assert re.body().contains('blocked')

--- a/appsec/tests/integration/src/test/waf/recommended.json
+++ b/appsec/tests/integration/src/test/waf/recommended.json
@@ -44,7 +44,7 @@
                 "address": "usr.id"
               }
             ],
-            "data": "blocked_users"
+            "data": "blocked_users_with_stack"
           },
           "operator": "exact_match"
         }
@@ -6894,6 +6894,17 @@
         }
       ]
     },
+    {
+      "id": "blocked_users_with_stack",
+      "type": "data_with_expiration",
+      "data": [
+        {
+          "value": "stack_user",
+          "expiration": 0
+        }
+      ]
+    },
+
     {
       "id": "redirected_users",
       "type": "data_with_expiration",


### PR DESCRIPTION
### Description

This PR upgrades libddwaf to v1.22.0 and fixes a few tests:
- Failures due to the fact that the WAF will evaluate some rules even with a timeout of 0 (denylists).
- Failures due to rule order expectations in the integration tests.

Related Jiras: [APPSEC-56195]
<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.


[APPSEC-56195]: https://datadoghq.atlassian.net/browse/APPSEC-56195?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ