### PR TITLE
Implement SSRF

### DIFF
--- a/appsec/src/extension/ddappsec.c
+++ b/appsec/src/extension/ddappsec.c
@@ -126,7 +126,7 @@ static void ddappsec_sort_modules(void *base, size_t count, size_t siz,
 
     // Reorder ddappsec to ensure it's always after ddtrace
     for (Bucket *module = base, *end = module + count, *ddappsec_module = NULL;
-        module < end; ++module) {
+         module < end; ++module) {
         zend_module_entry *m = (zend_module_entry *)Z_PTR(module->val);
         if (m->name == ddappsec_module_entry.name) {
             ddappsec_module = module;

--- a/appsec/src/extension/ddappsec.c
+++ b/appsec/src/extension/ddappsec.c
@@ -126,7 +126,7 @@ static void ddappsec_sort_modules(void *base, size_t count, size_t siz,
 
     // Reorder ddappsec to ensure it's always after ddtrace
     for (Bucket *module = base, *end = module + count, *ddappsec_module = NULL;
-         module < end; ++module) {
+        module < end; ++module) {
         zend_module_entry *m = (zend_module_entry *)Z_PTR(module->val);
         if (m->name == ddappsec_module_entry.name) {
             ddappsec_module = module;
@@ -474,7 +474,7 @@ static PHP_FUNCTION(datadog_appsec_testing_request_exec)
     RETURN_TRUE;
 }
 
-static PHP_FUNCTION(datadog_appsec_push_address)
+static PHP_FUNCTION(datadog_appsec_push_addresses)
 {
     struct timespec start;
     struct timespec end;
@@ -482,15 +482,14 @@ static PHP_FUNCTION(datadog_appsec_push_address)
     long elapsed = 0;
     UNUSED(return_value);
     if (!DDAPPSEC_G(active)) {
-        mlog(dd_log_debug, "Trying to access to push_address "
+        mlog(dd_log_debug, "Trying to access to push_addresses "
                            "function while appsec is disabled");
         return;
     }
 
-    zend_string *key = NULL;
-    zval *value = NULL;
+    HashTable *addresses = NULL;
     bool rasp = false;
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "Sz|b", &key, &value, &rasp) ==
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "h|b", &addresses, &rasp) ==
         FAILURE) {
         RETURN_FALSE;
     }
@@ -499,16 +498,32 @@ static PHP_FUNCTION(datadog_appsec_push_address)
         return;
     }
 
+    if (addresses == NULL) {
+        return;
+    }
+
+    zend_array *parameters_arr =
+        zend_new_array(zend_hash_num_elements(addresses));
     zval parameters_zv;
-    zend_array *parameters_arr = zend_new_array(1);
     ZVAL_ARR(&parameters_zv, parameters_arr);
-    zend_hash_add(Z_ARRVAL(parameters_zv), key, value);
-    Z_TRY_ADDREF_P(value);
+
+    zend_string *key;
+    zval *value;
+    ZEND_HASH_FOREACH_STR_KEY_VAL(addresses, key, value)
+    {
+        if (!key) {
+            continue;
+        }
+
+        zend_hash_add(Z_ARRVAL(parameters_zv), key, value);
+        Z_TRY_ADDREF_P(value);
+    }
+    ZEND_HASH_FOREACH_END();
 
     dd_conn *conn = dd_helper_mgr_cur_conn();
     if (conn == NULL) {
         zval_ptr_dtor(&parameters_zv);
-        mlog_g(dd_log_debug, "No connection; skipping push_address");
+        mlog_g(dd_log_debug, "No connection; skipping push_addresses");
         return;
     }
 
@@ -549,16 +564,16 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(request_exec_arginfo, 0, 1, _IS_BOOL, 0)
 ZEND_ARG_INFO(0, "data")
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(push_address_arginfo, 0, 0, IS_VOID, 1)
-ZEND_ARG_INFO(0, key)
-ZEND_ARG_INFO(0, value)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(
+    push_addresses_arginfo, 0, 0, IS_VOID, 1)
+ZEND_ARG_INFO(0, addresses)
 ZEND_ARG_INFO(0, rasp)
 ZEND_END_ARG_INFO()
 
 // clang-format off
 static const zend_function_entry functions[] = {
     ZEND_RAW_FENTRY(DD_APPSEC_NS "is_enabled", PHP_FN(datadog_appsec_is_enabled), void_ret_bool_arginfo, 0, NULL, NULL)
-    ZEND_RAW_FENTRY(DD_APPSEC_NS "push_address", PHP_FN(datadog_appsec_push_address), push_address_arginfo, 0, NULL, NULL)
+    ZEND_RAW_FENTRY(DD_APPSEC_NS "push_addresses", PHP_FN(datadog_appsec_push_addresses), push_addresses_arginfo, 0, NULL, NULL)
     PHP_FE_END
 };
 static const zend_function_entry testing_functions[] = {

--- a/appsec/src/extension/ddappsec.c
+++ b/appsec/src/extension/ddappsec.c
@@ -498,23 +498,9 @@ static PHP_FUNCTION(datadog_appsec_push_addresses)
         return;
     }
 
-    zend_array *parameters_arr =
-        zend_new_array(zend_hash_num_elements(addresses));
     zval parameters_zv;
-    ZVAL_ARR(&parameters_zv, parameters_arr);
-
-    zend_string *key;
-    zval *value;
-    ZEND_HASH_FOREACH_STR_KEY_VAL(addresses, key, value)
-    {
-        if (!key) {
-            continue;
-        }
-
-        zend_hash_add(Z_ARRVAL(parameters_zv), key, value);
-        Z_TRY_ADDREF_P(value);
-    }
-    ZEND_HASH_FOREACH_END();
+    ZVAL_ARR(&parameters_zv, addresses);
+    Z_TRY_ADDREF_P(&parameters_zv);
 
     dd_conn *conn = dd_helper_mgr_cur_conn();
     if (conn == NULL) {

--- a/appsec/src/extension/ddappsec.c
+++ b/appsec/src/extension/ddappsec.c
@@ -500,7 +500,6 @@ static PHP_FUNCTION(datadog_appsec_push_addresses)
 
     zval parameters_zv;
     ZVAL_ARR(&parameters_zv, addresses);
-    Z_TRY_ADDREF_P(&parameters_zv);
 
     dd_conn *conn = dd_helper_mgr_cur_conn();
     if (conn == NULL) {
@@ -510,7 +509,6 @@ static PHP_FUNCTION(datadog_appsec_push_addresses)
     }
 
     dd_result res = dd_request_exec(conn, &parameters_zv, rasp);
-    zval_ptr_dtor(&parameters_zv);
 
     if (rasp) {
         clock_gettime(CLOCK_MONOTONIC_RAW, &end);

--- a/appsec/src/extension/ddappsec.c
+++ b/appsec/src/extension/ddappsec.c
@@ -498,10 +498,6 @@ static PHP_FUNCTION(datadog_appsec_push_addresses)
         return;
     }
 
-    if (addresses == NULL) {
-        return;
-    }
-
     zend_array *parameters_arr =
         zend_new_array(zend_hash_num_elements(addresses));
     zval parameters_zv;

--- a/appsec/src/helper/remote_config/listeners/engine_listener.hpp
+++ b/appsec/src/helper/remote_config/listeners/engine_listener.hpp
@@ -34,7 +34,7 @@ public:
     [[nodiscard]] std::unordered_set<product> get_supported_products() override
     {
         return {known_products::ASM, known_products::ASM_DD,
-            known_products::ASM_DATA, known_products::ASM_RASP_LFI, known_products::ASM_RASP_SSRF};
+            known_products::ASM_DATA};
     }
 
 protected:

--- a/appsec/src/helper/remote_config/listeners/engine_listener.hpp
+++ b/appsec/src/helper/remote_config/listeners/engine_listener.hpp
@@ -34,7 +34,7 @@ public:
     [[nodiscard]] std::unordered_set<product> get_supported_products() override
     {
         return {known_products::ASM, known_products::ASM_DD,
-            known_products::ASM_DATA, known_products::ASM_RASP_LFI};
+            known_products::ASM_DATA, known_products::ASM_RASP_LFI, known_products::ASM_RASP_SSRF};
     }
 
 protected:

--- a/appsec/src/helper/remote_config/product.hpp
+++ b/appsec/src/helper/remote_config/product.hpp
@@ -31,6 +31,8 @@ struct known_products {
         std::string_view{"ASM_FEATURES"}};
     static inline constexpr product ASM_RASP_LFI{
         std::string_view{"ASM_RASP_LFI"}};
+    static inline constexpr product ASM_RASP_SSRF{
+        std::string_view{"ASM_RASP_SSRF"}};
     static inline constexpr product UNKNOWN{std::string_view{"UNKOWN"}};
 
     static product for_name(std::string_view name)
@@ -49,6 +51,9 @@ struct known_products {
         }
         if (name == ASM_RASP_LFI.name()) {
             return ASM_RASP_LFI;
+        }
+        if (name == ASM_RASP_SSRF.name()) {
+            return ASM_RASP_SSRF;
         }
 
         return UNKNOWN;

--- a/appsec/src/helper/remote_config/product.hpp
+++ b/appsec/src/helper/remote_config/product.hpp
@@ -29,10 +29,6 @@ struct known_products {
     static inline constexpr product ASM_DATA{std::string_view{"ASM_DATA"}};
     static inline constexpr product ASM_FEATURES{
         std::string_view{"ASM_FEATURES"}};
-    static inline constexpr product ASM_RASP_LFI{
-        std::string_view{"ASM_RASP_LFI"}};
-    static inline constexpr product ASM_RASP_SSRF{
-        std::string_view{"ASM_RASP_SSRF"}};
     static inline constexpr product UNKNOWN{std::string_view{"UNKOWN"}};
 
     static product for_name(std::string_view name)
@@ -49,13 +45,6 @@ struct known_products {
         if (name == ASM_FEATURES.name()) {
             return ASM_FEATURES;
         }
-        if (name == ASM_RASP_LFI.name()) {
-            return ASM_RASP_LFI;
-        }
-        if (name == ASM_RASP_SSRF.name()) {
-            return ASM_RASP_SSRF;
-        }
-
         return UNKNOWN;
     }
 };

--- a/appsec/tests/extension/actions_handling_01.phpt
+++ b/appsec/tests/extension/actions_handling_01.phpt
@@ -6,7 +6,7 @@ datadog.appsec.enabled=1
 --FILE--
 <?php
 use function datadog\appsec\testing\{rinit,rshutdown};
-use function datadog\appsec\push_address;
+use function datadog\appsec\push_addresses;
 
 include __DIR__ . '/inc/mock_helper.php';
 
@@ -17,7 +17,7 @@ $helper = Helper::createInitedRun([
 ]);
 
 var_dump(rinit());
-push_address("server.request.path_params", ["some" => "params", "more" => "parameters"]);
+push_addresses(["server.request.path_params" => ["some" => "params", "more" => "parameters"]]);
 var_dump(rshutdown());
 
 var_dump($helper->get_command("request_exec"));

--- a/appsec/tests/extension/push_params_block.phpt
+++ b/appsec/tests/extension/push_params_block.phpt
@@ -6,7 +6,7 @@ datadog.appsec.enabled=1
 --FILE--
 <?php
 use function datadog\appsec\testing\{rinit,rshutdown};
-use function datadog\appsec\push_address;
+use function datadog\appsec\push_addresses;
 
 include __DIR__ . '/inc/mock_helper.php';
 
@@ -16,7 +16,7 @@ $helper = Helper::createInitedRun([
 ]);
 
 rinit();
-push_address("server.request.path_params", ["some" => "params", "more" => "parameters"]);
+push_addresses(["server.request.path_params" => ["some" => "params", "more" => "parameters"]]);
 
 var_dump("THIS SHOULD NOT GET IN THE OUTPUT");
 
@@ -26,4 +26,4 @@ Status: 404 Not Found
 Content-type: application/json
 --EXPECTF--
 {"errors": [{"title": "You've been blocked", "detail": "Sorry, you cannot access this page. Please contact the customer service team. Security provided by Datadog."}]}
-Warning: datadog\appsec\push_address(): Datadog blocked the request and presented a static error page in %s on line %d
+Warning: datadog\appsec\push_addresses(): Datadog blocked the request and presented a static error page in %s on line %d

--- a/appsec/tests/extension/push_params_block_02.phpt
+++ b/appsec/tests/extension/push_params_block_02.phpt
@@ -6,7 +6,7 @@ datadog.appsec.enabled=1
 --FILE--
 <?php
 use function datadog\appsec\testing\{rinit,rshutdown};
-use function datadog\appsec\push_address;
+use function datadog\appsec\push_addresses;
 
 include __DIR__ . '/inc/mock_helper.php';
 
@@ -25,7 +25,7 @@ class SomeIntegration {
     private static function hooked_function()
     {
         return static function (DDTrace\HookData $hook) {
-              push_address("server.request.path_params", ["some" => "params", "more" => "parameters"]);
+              push_addresses(["server.request.path_params", ["some" => "params", "more" => "parameters"]]);
               var_dump("This should be executed");
         };
     }

--- a/appsec/tests/extension/push_params_block_03.phpt
+++ b/appsec/tests/extension/push_params_block_03.phpt
@@ -6,7 +6,7 @@ datadog.appsec.enabled=1
 --FILE--
 <?php
 use function datadog\appsec\testing\{rinit,rshutdown};
-use function datadog\appsec\push_address;
+use function datadog\appsec\push_addresses;
 
 include __DIR__ . '/inc/mock_helper.php';
 
@@ -25,7 +25,7 @@ class SomeIntegration {
     private static function hooked_function()
     {
         return static function (DDTrace\HookData $hook) {
-              push_address("server.request.path_params", ["some" => "params", "more" => "parameters"]);
+              push_addresses(["server.request.path_params", ["some" => "params", "more" => "parameters"]]);
               var_dump("This should be executed");
         };
     }

--- a/appsec/tests/extension/push_params_ok_02.phpt
+++ b/appsec/tests/extension/push_params_ok_02.phpt
@@ -6,7 +6,7 @@ datadog.appsec.enabled=1
 --FILE--
 <?php
 use function datadog\appsec\testing\{rinit,rshutdown};
-use function datadog\appsec\push_address;
+use function datadog\appsec\push_addresses;
 
 include __DIR__ . '/inc/mock_helper.php';
 
@@ -17,7 +17,7 @@ $helper = Helper::createInitedRun([
 ]);
 
 var_dump(rinit());
-push_address("server.request.path_params", "some string");
+push_addresses(["server.request.path_params" => "some string"]);
 var_dump(rshutdown());
 
 var_dump($helper->get_command("request_exec"));

--- a/appsec/tests/extension/push_params_ok_03.phpt
+++ b/appsec/tests/extension/push_params_ok_03.phpt
@@ -6,7 +6,7 @@ datadog.appsec.enabled=1
 --FILE--
 <?php
 use function datadog\appsec\testing\{rinit,rshutdown};
-use function datadog\appsec\push_address;
+use function datadog\appsec\push_addresses;
 
 include __DIR__ . '/inc/mock_helper.php';
 
@@ -17,7 +17,7 @@ $helper = Helper::createInitedRun([
 ]);
 
 var_dump(rinit());
-push_address("server.request.path_params", 1234);
+push_addresses(["server.request.path_params" => 1234]);
 var_dump(rshutdown());
 
 var_dump($helper->get_command("request_exec"));

--- a/appsec/tests/extension/push_params_ok_04.phpt
+++ b/appsec/tests/extension/push_params_ok_04.phpt
@@ -7,7 +7,7 @@ datadog.appsec.rasp_enabled=1
 --FILE--
 <?php
 use function datadog\appsec\testing\{rinit,rshutdown, root_span_get_metrics};
-use function datadog\appsec\push_address;
+use function datadog\appsec\push_addresses;
 
 include __DIR__ . '/inc/mock_helper.php';
 
@@ -19,7 +19,7 @@ $helper = Helper::createInitedRun([
 
 var_dump(rinit());
 $is_rasp = true;
-push_address("server.request.path_params", 1234, $is_rasp);
+push_addresses(["server.request.path_params" => 1234], $is_rasp);
 var_dump(rshutdown());
 print_r(root_span_get_metrics());
 

--- a/appsec/tests/extension/push_params_ok_05.phpt
+++ b/appsec/tests/extension/push_params_ok_05.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_RASP_ENABLED=false
 --FILE--
 <?php
 use function datadog\appsec\testing\{rinit,rshutdown,root_span_get_metrics};
-use function datadog\appsec\push_address;
+use function datadog\appsec\push_addresses;
 
 include __DIR__ . '/inc/mock_helper.php';
 
@@ -19,7 +19,7 @@ $helper = Helper::createInitedRun([
 
 var_dump(rinit());
 $is_rasp = true;
-push_address("server.request.path_params", 1234, $is_rasp);
+push_addresses(["server.request.path_params" => 1234], $is_rasp);
 var_dump(rshutdown());
 print_r(root_span_get_metrics());
 

--- a/appsec/tests/extension/push_params_ok_06.phpt
+++ b/appsec/tests/extension/push_params_ok_06.phpt
@@ -6,7 +6,7 @@ datadog.appsec.enabled=1
 --FILE--
 <?php
 use function datadog\appsec\testing\{rinit,rshutdown,root_span_get_metrics};
-use function datadog\appsec\push_address;
+use function datadog\appsec\push_addresses;
 
 include __DIR__ . '/inc/mock_helper.php';
 
@@ -17,7 +17,7 @@ $helper = Helper::createInitedRun([
 
 var_dump(rinit());
 $is_rasp = true;
-push_address("server.request.path_params", 1234, $is_rasp);
+push_addresses(["server.request.path_params" => 1234], $is_rasp);
 var_dump(rshutdown());
 print_r(root_span_get_metrics());
 

--- a/appsec/tests/extension/push_params_ok_07.phpt
+++ b/appsec/tests/extension/push_params_ok_07.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Push address are sent on request_exec - array
+Multiple addresses can be sent at once
 --INI--
 extension=ddtrace.so
 datadog.appsec.enabled=1
@@ -17,7 +17,7 @@ $helper = Helper::createInitedRun([
 ]);
 
 var_dump(rinit());
-push_addresses(["server.request.path_params" => ["some" => "params", "more" => "parameters"]]);
+push_addresses(["server.request.path_params" => ["some" => "params", "more" => "parameters"], "some.other" => 12345]);
 var_dump(rshutdown());
 
 var_dump($helper->get_command("request_exec"));
@@ -34,7 +34,7 @@ array(2) {
     [0]=>
     bool(false)
     [1]=>
-    array(1) {
+    array(2) {
       ["server.request.path_params"]=>
       array(2) {
         ["some"]=>
@@ -42,6 +42,8 @@ array(2) {
         ["more"]=>
         string(10) "parameters"
       }
+      ["some.other"]=>
+      int(12345)
     }
   }
 }

--- a/appsec/tests/extension/push_params_redirect_01.phpt
+++ b/appsec/tests/extension/push_params_redirect_01.phpt
@@ -6,7 +6,7 @@ datadog.appsec.enabled=1
 --FILE--
 <?php
 use function datadog\appsec\testing\{rinit,rshutdown};
-use function datadog\appsec\push_address;
+use function datadog\appsec\push_addresses;
 
 include __DIR__ . '/inc/mock_helper.php';
 
@@ -16,7 +16,7 @@ $helper = Helper::createInitedRun([
 ]);
 
 rinit();
-push_address("server.request.path_params", ["some" => "params", "more" => "parameters"]);
+push_addresses(["server.request.path_params" => ["some" => "params", "more" => "parameters"]]);
 
 var_dump("THIS SHOULD NOT GET IN THE OUTPUT");
 
@@ -25,4 +25,4 @@ var_dump("THIS SHOULD NOT GET IN THE OUTPUT");
 Status: 303 See Other
 Content-type: text/html; charset=UTF-8
 --EXPECTF--
-Warning: datadog\appsec\push_address(): Datadog blocked the request and attempted a redirection to https://datadoghq.com in %s on line %d
+Warning: datadog\appsec\push_addresses(): Datadog blocked the request and attempted a redirection to https://datadoghq.com in %s on line %d

--- a/appsec/tests/extension/push_params_redirect_02.phpt
+++ b/appsec/tests/extension/push_params_redirect_02.phpt
@@ -6,7 +6,7 @@ datadog.appsec.enabled=1
 --FILE--
 <?php
 use function datadog\appsec\testing\{rinit,rshutdown};
-use function datadog\appsec\push_address;
+use function datadog\appsec\push_addresses;
 
 include __DIR__ . '/inc/mock_helper.php';
 
@@ -25,7 +25,7 @@ class SomeIntegration {
     private static function hooked_function()
     {
         return static function (DDTrace\HookData $hook) {
-              push_address("server.request.path_params", ["some" => "params", "more" => "parameters"]);
+              push_addresses(["server.request.path_params", ["some" => "params", "more" => "parameters"]]);
               var_dump("This should be executed");
         };
     }

--- a/appsec/tests/extension/report_backtrace_05.phpt
+++ b/appsec/tests/extension/report_backtrace_05.phpt
@@ -9,7 +9,7 @@ datadog.appsec.enabled=1
 --FILE--
 <?php
 use function datadog\appsec\testing\{rinit,rshutdown};
-use function datadog\appsec\push_address;
+use function datadog\appsec\push_addresses;
 use function datadog\appsec\testing\{decode_msgpack};
 include __DIR__ . '/inc/ddtrace_version.php';
 include __DIR__ . '/inc/mock_helper.php';
@@ -21,7 +21,7 @@ $helper = Helper::createInitedRun([
 
 function two($param01, $param02)
 {
-    push_address("irrelevant", ["some" => "params", "more" => "parameters"]);
+    push_addresses(["irrelevant" => ["some" => "params", "more" => "parameters"]]);
 }
 
 function one($param01)

--- a/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/RemoteConfigTests.groovy
+++ b/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/RemoteConfigTests.groovy
@@ -84,6 +84,8 @@ class RemoteConfigTests {
                 Capability.ASM_CUSTOM_RULES,
                 Capability.ASM_CUSTOM_BLOCKING_RESPONSE,
                 Capability.ASM_TRUSTED_IPS,
+                Capability.ASM_RASP_LFI,
+                Capability.ASM_RASP_SSRF,
         ].each { assert it in capSet }
 
         doReq.call(403)

--- a/appsec/tests/integration/src/test/waf/recommended.json
+++ b/appsec/tests/integration/src/test/waf/recommended.json
@@ -86,6 +86,54 @@
       ]
     },
     {
+      "id": "rasp-934-100",
+      "name": "Server-side request forgery exploit",
+      "tags": {
+        "type": "ssrf",
+        "category": "vulnerability_trigger",
+        "cwe": "918",
+        "capec": "1000/225/115/664",
+        "confidence": "1",
+        "module": "rasp"
+      },
+      "conditions": [
+        {
+          "parameters": {
+            "resource": [
+              {
+                "address": "server.io.net.url"
+              }
+            ],
+            "params": [
+              {
+                "address": "server.request.query"
+              },
+              {
+                "address": "server.request.body"
+              },
+              {
+                "address": "server.request.path_params"
+              },
+              {
+                "address": "grpc.server.request.message"
+              },
+              {
+                "address": "graphql.server.all_resolvers"
+              },
+              {
+                "address": "graphql.server.resolver"
+              }
+            ]
+          },
+          "operator": "ssrf_detector"
+        }
+      ],
+      "transformers": [],
+      "on_match": [
+        "stack_trace"
+      ]
+    },
+    {
       "id": "blk-001-003",
       "name": "Block User Addresses",
       "tags": {

--- a/appsec/tests/integration/src/test/www/base/public/ssrf.php
+++ b/appsec/tests/integration/src/test/www/base/public/ssrf.php
@@ -1,0 +1,28 @@
+<?php
+
+function one() {
+    $function = $_GET['function'];
+    $path = 'http://'. $_GET['domain'] .'/somewhere/in/the/app';
+
+    switch ($function) {
+        case 'fopen':
+                fopen($path, 'r');
+                break;
+        default:
+            $function($path);
+            break;
+    }
+}
+
+function two() {
+    one();
+}
+
+function three() {
+    two();
+}
+
+three();
+
+
+echo "OK";

--- a/components-rs/remote_config.rs
+++ b/components-rs/remote_config.rs
@@ -120,6 +120,8 @@ pub unsafe extern "C" fn ddog_init_remote_config(
             RemoteConfigCapabilities::AsmCustomRules,
             RemoteConfigCapabilities::AsmCustomBlockingResponse,
             RemoteConfigCapabilities::AsmTrustedIps,
+            RemoteConfigCapabilities::AsmRaspLfi,
+            RemoteConfigCapabilities::AsmRaspSsrf,
         ]
         .iter()
         .for_each(|c| DDTRACE_REMOTE_CONFIG_CAPABILITIES.push(*c));

--- a/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
+++ b/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
@@ -66,9 +66,8 @@ class FilesystemIntegration extends Integration
            }
 
            if (in_array($variant, ['file_get_contents', 'fopen']) &&
-                (empty($protocol) || in_array($protocol, ['http', 'https', 'ftp', 'ftps']))) {
+           in_array($protocol, ['http', 'https', 'ftp', 'ftps'])) {
                 $addresses["server.io.net.url"] = $hook->args[0];
-
            }
 
             if (empty($addresses)) {

--- a/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
+++ b/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
@@ -16,7 +16,7 @@ class FilesystemIntegration extends Integration
             return Integration::NOT_LOADED;
         }
 
-        if (!function_exists('datadog\appsec\push_address')) {
+        if (!function_exists('datadog\appsec\push_addresses')) {
             //Dont load Appsec wrappers is not available
             return Integration::NOT_LOADED;
         }
@@ -59,13 +59,22 @@ class FilesystemIntegration extends Integration
            $uri_parsed = preg_match('/^([a-z]+)\:\/\//', $hook->args[0], $protocol);
            $protocol = isset($protocol[1]) ? $protocol[1]: "";
 
+           $addresses = [];
+
            if (empty($protocol) || $protocol === 'file') {
-                \datadog\appsec\push_address("server.io.fs.file", $hook->args[0], true);
+                $addresses["server.io.fs.file"] = $hook->args[0];
            }
 
            if (in_array($variant, ['file_get_contents', 'fopen']) && (empty($protocol) || $protocol === 'http')) {
-               \datadog\appsec\push_address("server.io.net.url", $hook->args[0], true);
+                $addresses["server.io.net.url"] = $hook->args[0];
+
            }
+
+            if (empty($addresses)) {
+                return;
+            }
+
+            \datadog\appsec\push_addresses($addresses, true);
         };
     }
 

--- a/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
+++ b/src/DDTrace/Integrations/Filesystem/FilesystemIntegration.php
@@ -65,7 +65,8 @@ class FilesystemIntegration extends Integration
                 $addresses["server.io.fs.file"] = $hook->args[0];
            }
 
-           if (in_array($variant, ['file_get_contents', 'fopen']) && (empty($protocol) || $protocol === 'http')) {
+           if (in_array($variant, ['file_get_contents', 'fopen']) &&
+                (empty($protocol) || in_array($protocol, ['http', 'https', 'ftp', 'ftps']))) {
                 $addresses["server.io.net.url"] = $hook->args[0];
 
            }

--- a/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
+++ b/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
@@ -136,10 +136,10 @@ class LaravelIntegration extends Integration
                 if (\method_exists($route, 'uri')) {
                     $rootSpan->meta[Tag::HTTP_ROUTE] = $route->uri();
                 }
-                if (\method_exists($route, 'parameters') && function_exists('\datadog\appsec\push_address')) {
+                if (\method_exists($route, 'parameters') && function_exists('\datadog\appsec\push_addresses')) {
                     $parameters = $route->parameters();
                     if (count($parameters) > 0) {
-                        \datadog\appsec\push_address("server.request.path_params", $parameters);
+                        \datadog\appsec\push_addresses(["server.request.path_params" => $parameters]);
                     }
                 }
                 $rootSpan->meta[Tag::HTTP_METHOD] = $request->method();

--- a/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
@@ -401,8 +401,8 @@ class SymfonyIntegration extends Integration
                 $parameters = $request->get('_route_params');
                 if (!empty($parameters) &&
                     is_array($parameters) &&
-                    function_exists('\datadog\appsec\push_address')) {
-                    \datadog\appsec\push_address("server.request.path_params", $parameters);
+                    function_exists('\datadog\appsec\push_addresses')) {
+                    \datadog\appsec\push_addresses(["server.request.path_params" => $parameters]);
                 }
 
                 $route = $request->get('_route');

--- a/src/DDTrace/Integrations/WordPress/WordPressIntegration.php
+++ b/src/DDTrace/Integrations/WordPress/WordPressIntegration.php
@@ -55,12 +55,12 @@ class WordPressIntegration extends Integration
 
         \DDTrace\hook_method('WP', 'main',  null, function ($This, $scope, $args) {
             if (\property_exists($This, 'did_permalink') && $This->did_permalink === true) {
-                if (function_exists('\datadog\appsec\push_address') &&
+                if (function_exists('\datadog\appsec\push_addresses') &&
                     \property_exists($This, 'query_vars') &&
                     function_exists('is_404') && is_404() === false) {
                     $parameters = $This->query_vars;
                     if (count($parameters) > 0) {
-                        \datadog\appsec\push_address("server.request.path_params", $parameters);
+                        \datadog\appsec\push_addresses(["server.request.path_params" => $parameters]);
                     }
                 }
             }

--- a/tests/Appsec/Mock.php
+++ b/tests/Appsec/Mock.php
@@ -77,7 +77,7 @@ if (!class_exists('datadog\appsec\AppsecStatus')) {
             foreach ($events as $event) {
                 $new = json_decode($event['event'], true);
                 if (empty($names) || in_array($new['eventName'], $names) &&
-                    (empty($addresses) || !empty(array_intersect($addresses, array_keys($new))))) {
+                    (empty($addresses) || !empty(array_intersect($addresses, array_keys($new[0]))))) {
                     $result[] = $new;
                 }
             }

--- a/tests/Appsec/Mock.php
+++ b/tests/Appsec/Mock.php
@@ -205,16 +205,15 @@ if (!function_exists('datadog\appsec\track_user_signup_event')) {
     }
 }
 
-if (!function_exists('datadog\appsec\push_address')) {
+if (!function_exists('datadog\appsec\push_addresses')) {
     /**
      * This function is exposed by appsec but here we are mocking it for tests
      * @param array $params
      */
-    function push_address($key, $value, $rasp = false)
-    {
-        if (!appsecMockEnabled()) {
-            return;
+    function push_addresses($addresses, $rasp = false) {
+        if(!appsecMockEnabled()) {
+           return;
         }
-        AppsecStatus::getInstance()->addEvent(['rasp' => $rasp, $key => $value], 'push_address');
+        AppsecStatus::getInstance()->addEvent(['rasp' => $rasp, $addresses], 'push_addresses');
     }
 }

--- a/tests/Integrations/Filesystem/FilesystemTest.php
+++ b/tests/Integrations/Filesystem/FilesystemTest.php
@@ -25,12 +25,13 @@ final class FilesystemTest extends AppsecTestCase
     protected function assertEvent(string $value, $traces, $also_ssrf = false)
     {
        $events = AppsecStatus::getInstance()->getEvents();
-       $this->assertEquals($also_ssrf ? 2 : 1, count($events));
-       $this->assertEquals($value, $events[0]["server.io.fs.file"]);
+       $this->assertEquals(1, count($events));
+       $this->assertEquals($also_ssrf ? 2 : 1, count($events[0][0]));
+       $this->assertEquals($value, $events[0][0]["server.io.fs.file"]);
        if ($also_ssrf) {
-        $this->assertEquals($value, $events[1]["server.io.net.url"]);
+        $this->assertEquals($value, $events[0][0]["server.io.net.url"]);
        }
-       $this->assertEquals('push_address', $events[0]['eventName']);
+       $this->assertEquals('push_addresses', $events[0]['eventName']);
        $this->assertTrue($events[0]['rasp']);
     }
 
@@ -65,8 +66,8 @@ final class FilesystemTest extends AppsecTestCase
 
        $events = AppsecStatus::getInstance()->getEvents();
        $this->assertEquals(1, count($events));
-       $this->assertEquals($file, $events[0]["server.io.net.url"]);
-       $this->assertEquals('push_address', $events[0]['eventName']);
+       $this->assertEquals($file, $events[0][0]["server.io.net.url"]);
+       $this->assertEquals('push_addresses', $events[0]['eventName']);
        $this->assertTrue($events[0]['rasp']);
     }
 

--- a/tests/Integrations/Filesystem/index.php
+++ b/tests/Integrations/Filesystem/index.php
@@ -7,13 +7,13 @@ $path = $_GET['path'];
 
 switch ($function) {
     case 'file_put_contents':
-            file_put_contents($path, 'some content');
+            @file_put_contents($path, 'some content');
             break;
     case 'fopen':
-            fopen($path, 'r');
+            @fopen($path, 'r');
             break;
     default:
-        $function($path);
+        @$function($path);
         break;
 }
 

--- a/tests/Integrations/Laravel/PathParamsTestSuite.php
+++ b/tests/Integrations/Laravel/PathParamsTestSuite.php
@@ -15,10 +15,10 @@ class PathParamsTestSuite extends AppsecTestCase
         $this->call(
             GetSpec::create('Call to dynamic route', "/dynamic_route/$param01/static/$param02")
         );
-        $events = AppsecStatus::getInstance()->getEvents(['push_address'], ['server.request.path_params']);
+        $events = AppsecStatus::getInstance()->getEvents(['push_addresses'], ['server.request.path_params']);
         $this->assertEquals(1, count($events));
-        $this->assertEquals($param01, $events[0]["server.request.path_params"]['param01']);
-        $this->assertEquals($param02, $events[0]["server.request.path_params"]['param02']);
+        $this->assertEquals($param01, $events[0][0]["server.request.path_params"]['param01']);
+        $this->assertEquals($param02, $events[0][0]["server.request.path_params"]['param02']);
     }
 
     public function testDynamicRouteWithOptionalParametersNotGiven()
@@ -27,10 +27,10 @@ class PathParamsTestSuite extends AppsecTestCase
         $this->call(
             GetSpec::create('Call to dynamic route', "/dynamic_route/$param01/static")
         );
-        $events = AppsecStatus::getInstance()->getEvents(['push_address'], ['server.request.path_params']);
+        $events = AppsecStatus::getInstance()->getEvents(['push_addresses'], ['server.request.path_params']);
         $this->assertEquals(1, count($events));
-        $this->assertCount(1, $events[0]["server.request.path_params"]);
-        $this->assertEquals($param01, $events[0]["server.request.path_params"]['param01']);
+        $this->assertCount(1, $events[0][0]["server.request.path_params"]);
+        $this->assertEquals($param01, $events[0][0]["server.request.path_params"]['param01']);
     }
 
     public function testStaticRouteDoesNotGenerateEvent()
@@ -38,7 +38,7 @@ class PathParamsTestSuite extends AppsecTestCase
         $this->call(
             GetSpec::create('Call to static route', "/simple")
         );
-        $events = AppsecStatus::getInstance()->getEvents(['push_address'], ['server.request.path_params']);
+        $events = AppsecStatus::getInstance()->getEvents(['push_addresses'], ['server.request.path_params']);
         $this->assertEquals(0, count($events));
     }
 }

--- a/tests/Integrations/Symfony/PathParamsTestSuite.php
+++ b/tests/Integrations/Symfony/PathParamsTestSuite.php
@@ -17,26 +17,26 @@ class PathParamsTestSuite extends AppsecTestCase
         $param01 = 'first_param';
         $param02 = 'second_param';
         $this->call(GetSpec::create('dynamic', "/dynamic_route/$param01/$param02"));
-        $events = AppsecStatus::getInstance()->getEvents(['push_address'], ['server.request.path_params']);
+        $events = AppsecStatus::getInstance()->getEvents(['push_addresses'], ['server.request.path_params']);
         $this->assertEquals(1, count($events));
-        $this->assertEquals($param01, $events[0]["server.request.path_params"]['param01']);
-        $this->assertEquals($param02, $events[0]["server.request.path_params"]['param02']);
+        $this->assertEquals($param01, $events[0][0]["server.request.path_params"]['param01']);
+        $this->assertEquals($param02, $events[0][0]["server.request.path_params"]['param02']);
     }
 
     public function testDynamicRouteWithOptionalsNotFilled()
     {
         $param01 = 'first_param';
         $this->call(GetSpec::create('dynamic', "/dynamic_route/$param01"));
-        $events = AppsecStatus::getInstance()->getEvents(['push_address'], ['server.request.path_params']);
+        $events = AppsecStatus::getInstance()->getEvents(['push_addresses'], ['server.request.path_params']);
         $this->assertEquals(1, count($events));
-        $this->assertEquals($param01, $events[0]["server.request.path_params"]['param01']);
-        $this->assertEmpty($events[0]["server.request.path_params"]['param02']);
+        $this->assertEquals($param01, $events[0][0]["server.request.path_params"]['param01']);
+        $this->assertEmpty($events[0][0]["server.request.path_params"]['param02']);
     }
 
     public function testStaticRoute()
     {
         $this->call(GetSpec::create('static', "/simple"));
-        $events = AppsecStatus::getInstance()->getEvents(['push_address'], ['server.request.path_params']);
+        $events = AppsecStatus::getInstance()->getEvents(['push_addresses'], ['server.request.path_params']);
         $this->assertEquals(0, count($events));
     }
 }

--- a/tests/Integrations/WordPress/PathParamsTestSuite.php
+++ b/tests/Integrations/WordPress/PathParamsTestSuite.php
@@ -17,9 +17,9 @@ class PathParamsTestSuite extends AppsecTestCase
             )
         );
 
-        $events = AppsecStatus::getInstance()->getEvents(['push_address'], ['server.request.path_params']);
+        $events = AppsecStatus::getInstance()->getEvents(['push_addresses'], ['server.request.path_params']);
         $this->assertEquals(1, count($events));
-        $this->assertEquals('hello-world', $events[0]["server.request.path_params"]['name']);
+        $this->assertEquals('hello-world', $events[0][0]["server.request.path_params"]['name']);
     }
 
     public function testCategory()
@@ -31,9 +31,9 @@ class PathParamsTestSuite extends AppsecTestCase
             )
         );
 
-        $events = AppsecStatus::getInstance()->getEvents(['push_address'], ['server.request.path_params']);
+        $events = AppsecStatus::getInstance()->getEvents(['push_addresses'], ['server.request.path_params']);
         $this->assertEquals(1, count($events));
-        $this->assertEquals('uncategorized', $events[0]["server.request.path_params"]['category_name']);
+        $this->assertEquals('uncategorized', $events[0][0]["server.request.path_params"]['category_name']);
     }
 
     public function testAuthor()
@@ -45,9 +45,9 @@ class PathParamsTestSuite extends AppsecTestCase
             )
         );
 
-        $events = AppsecStatus::getInstance()->getEvents(['push_address'], ['server.request.path_params']);
+        $events = AppsecStatus::getInstance()->getEvents(['push_addresses'], ['server.request.path_params']);
         $this->assertEquals(1, count($events));
-        $this->assertEquals('test', $events[0]["server.request.path_params"]['author_name']);
+        $this->assertEquals('test', $events[0][0]["server.request.path_params"]['author_name']);
     }
 
     public function testNonExistingPost()
@@ -59,7 +59,7 @@ class PathParamsTestSuite extends AppsecTestCase
             )
         );
 
-        $events = AppsecStatus::getInstance()->getEvents(['push_address'], ['server.request.path_params']);
+        $events = AppsecStatus::getInstance()->getEvents(['push_addresses'], ['server.request.path_params']);
         $this->assertEquals(0, count($events));
     }
 }


### PR DESCRIPTION
### Description

Adds server-side request forgery (SSRF) detection on top of the RASP architecture introduced in #2770.

The functional change is wrapping outbound HTTP calls  through`file_get_contents`, `file_put_contents`, `fopen`, and `readfile` with HTTP URLs and pushing the target URL and protocol to the WAF before the request is made. If the WAF determines the target is suspicious, the request is blocked and the exploit is reported on the span.

The more significant change in this PR is an API refactor: `push_address()` is replaced by `push_addresses()`, which takes a map of `address:value` pairs and pushes them all in a single WAF call. This was required for SSRF because the WAF rule needs both the URL and the protocol to evaluate correctly. With the old API, you'd have to call it twice, which would trigger two independent WAF evaluations per request. Batching them into a single call is more efficient.

[APPSEC-52930]

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.


[APPSEC-52930]: https://datadoghq.atlassian.net/browse/APPSEC-52930?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ