### PR TITLE
fix: Update Hunter Version to 0.25.8

### DIFF
--- a/appsec/CMakeLists.txt
+++ b/appsec/CMakeLists.txt
@@ -7,9 +7,9 @@ option(HUNTER_STATUS_DEBUG "Print Hunter debug info" OFF)
 
 include("cmake/HunterGate.cmake")
 HunterGate(
-    URL "https://github.com/cpp-pm/hunter/archive/v0.25.3.tar.gz"
-    SHA1 "0dfbc2cb5c4cf7e83533733bdfd2125ff96680cb")
-
+    URL "https://github.com/cpp-pm/hunter/archive/v0.25.8.tar.gz"
+    SHA1 "26c79d587883ec910bce168e25f6ac4595f97033"
+)
 configure_file(${CMAKE_CURRENT_SOURCE_DIR}/hunter-cache.id.in ${CMAKE_CURRENT_SOURCE_DIR}/hunter-cache.id)
 
 file(READ "../VERSION" appsec_version)


### PR DESCRIPTION
### Description

`compile_appsec_helper` [jobs](https://app.circleci.com/pipelines/github/DataDog/dd-trace-php/18757/workflows/b8b6a505-6e61-4401-a505-b28760410ea5/jobs/5839325) are failing, hence preventing the `package extension` step from running.

<details>

<summary>Extend to see failure</summary>

```
CMake Deprecation Warning at CMakeLists.txt:1 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


CMake Warning (dev) at /usr/share/cmake/Modules/ExternalProject.cmake:3230 (message):
  The DOWNLOAD_EXTRACT_TIMESTAMP option was not given and policy CMP0135 is
  not set.  The policy's OLD behavior will be used.  When using a URL
  download, the timestamps of extracted files should preferably be that of
  the time of extraction, otherwise code that depends on the extracted
  contents might not be rebuilt if the URL changes.  The OLD behavior
  preserves the timestamps from the archive instead, but this is usually not
  what you want.  Update your project to the NEW behavior or specify the
  DOWNLOAD_EXTRACT_TIMESTAMP option with a value of true to avoid this
  robustness issue.
Call Stack (most recent call first):
  /usr/share/cmake/Modules/ExternalProject.cmake:4456 (_ep_add_download_command)
  CMakeLists.txt:4 (ExternalProject_Add)
This warning is for project developers.  Use -Wno-dev to suppress it.

-- [hunter] Initializing Hunter workspace (0dfbc2cb5c4cf7e83533733bdfd2125ff96680cb)
-- [hunter]   https://github.com/cpp-pm/hunter/archive/v0.25.3.tar.gz
-- [hunter]   -> /root/.hunter/_Base/Download/Hunter/0.25.3/0dfbc2c
-- The C compiler identification is Clang 17.0.6
-- The CXX compiler identification is Clang 17.0.6
-- Detecting C compiler ABI info
-- Detecting C compiler ABI info - done
-- Check for working C compiler: /usr/bin/clang-17 - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Detecting CXX compiler ABI info
-- Detecting CXX compiler ABI info - done
-- Check for working CXX compiler: /usr/bin/clang++-17 - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Project version: 1.22.0
-- Build type: RelWithDebInfo
-- Has recursive unordered_map    : TRUE
-- Has memory_resource test macro : TRUE
-- Has monotonic_resource         : TRUE
-- Build id is 990e73c55fb070225bdb853ab2334efe7c151dc2
CMake Deprecation Warning at build/_deps/googletest-src/CMakeLists.txt:4 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


CMake Deprecation Warning at build/_deps/googletest-src/googlemock/CMakeLists.txt:45 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


CMake Deprecation Warning at build/_deps/googletest-src/googletest/CMakeLists.txt:56 (cmake_minimum_required):
  Compatibility with CMake < 3.5 will be removed from a future version of
  CMake.

  Update the VERSION argument <min> value or use a ...<max> suffix to tell
  CMake that the project does not need compatibility with older versions.


-- Found Python: /usr/bin/python3.12 (found version "3.12.7") found components: Interpreter
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD
-- Performing Test CMAKE_HAVE_LIBC_PTHREAD - Success
-- Found Threads: TRUE
-- Build spdlog: 1.14.1
-- Build type: RelWithDebInfo
-- Looking for sys/types.h
-- Looking for sys/types.h - found
-- Looking for stdint.h
-- Looking for stdint.h - found
-- Looking for stddef.h
-- Looking for stddef.h - found
-- Check size of off64_t
-- Check size of off64_t - done
-- Looking for fseeko
-- Looking for fseeko - found
-- Looking for unistd.h
-- Looking for unistd.h - found
-- Renaming
--     /home/circleci/datadog/appsec/build/_deps/zlib-src/zconf.h
-- to 'zconf.h.included' because this file is included with zlib
-- but CMake generates it automatically in the build directory.
-- [hunter] Calculating Toolchain-SHA1
-- [hunter] Calculating Config-SHA1
-- [hunter] HUNTER_ROOT: /root/.hunter
-- [hunter] [ Hunter-ID: 0dfbc2c | Toolchain-ID: 23059d5 | Config-ID: b5bebf3 ]
-- [hunter] BOOST_ROOT: /root/.hunter/_Base/0dfbc2c/23059d5/b5bebf3/Install (ver.: 1.83.0)
-- [hunter] Building Boost
loading initial cache file /root/.hunter/_Base/0dfbc2c/23059d5/b5bebf3/cache.cmake
loading initial cache file /root/.hunter/_Base/0dfbc2c/23059d5/b5bebf3/Build/Boost/args.cmake
-- The C compiler identification is Clang 17.0.6
-- The CXX compiler identification is Clang 17.0.6
-- Check for working C compiler: /usr/bin/clang-17 - skipped
-- Detecting C compile features
-- Detecting C compile features - done
-- Check for working CXX compiler: /usr/bin/clang++-17 - skipped
-- Detecting CXX compile features
-- Detecting CXX compile features - done
-- Configuring done (0.2s)
-- Generating done (0.0s)
-- Build files have been written to: /root/.hunter/_Base/0dfbc2c/23059d5/b5bebf3/Build/Boost/Build
[ 12%] Creating directories for 'Boost'
[ 25%] Performing download step (download, verify and extract) for 'Boost'
-- Downloading...
   dst='/root/.hunter/_Base/Download/Boost/1.83.0/75b1f56/boost_1_83_0.tar.bz2'
   timeout='none'
   inactivity timeout='none'
-- Using src='https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.tar.bz2'
-- [download 100% complete]
-- verifying file...
       file='/root/.hunter/_Base/Download/Boost/1.83.0/75b1f56/boost_1_83_0.tar.bz2'
-- SHA1 hash of
    /root/.hunter/_Base/Download/Boost/1.83.0/75b1f56/boost_1_83_0.tar.bz2
  does not match expected value
    expected: '75b1f569134401d178ad2aaf97a2993898dd7ee3'
      actual: '7694f0b22c5217c4a12cd0fc1b4f74758b9d3fa3'
-- Hash mismatch, removing...
-- Using src='https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.tar.bz2'
-- [download 100% complete]
-- verifying file...
       file='/root/.hunter/_Base/Download/Boost/1.83.0/75b1f56/boost_1_83_0.tar.bz2'
-- SHA1 hash of
    /root/.hunter/_Base/Download/Boost/1.83.0/75b1f56/boost_1_83_0.tar.bz2
  does not match expected value
    expected: '75b1f569134401d178ad2aaf97a2993898dd7ee3'
      actual: '7694f0b22c5217c4a12cd0fc1b4f74758b9d3fa3'
-- Hash mismatch, removing...
-- Using src='https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.tar.bz2'
-- [download 100% complete]
-- verifying file...
       file='/root/.hunter/_Base/Download/Boost/1.83.0/75b1f56/boost_1_83_0.tar.bz2'
-- SHA1 hash of
    /root/.hunter/_Base/Download/Boost/1.83.0/75b1f56/boost_1_83_0.tar.bz2
  does not match expected value
    expected: '75b1f569134401d178ad2aaf97a2993898dd7ee3'
      actual: '7694f0b22c5217c4a12cd0fc1b4f74758b9d3fa3'
-- Hash mismatch, removing...
-- Using src='https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.tar.bz2'
-- [download 100% complete]
-- verifying file...
       file='/root/.hunter/_Base/Download/Boost/1.83.0/75b1f56/boost_1_83_0.tar.bz2'
-- SHA1 hash of
    /root/.hunter/_Base/Download/Boost/1.83.0/75b1f56/boost_1_83_0.tar.bz2
  does not match expected value
    expected: '75b1f569134401d178ad2aaf97a2993898dd7ee3'
      actual: '7694f0b22c5217c4a12cd0fc1b4f74758b9d3fa3'
-- Hash mismatch, removing...
-- Using src='https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.tar.bz2'
-- [download 100% complete]
-- verifying file...
       file='/root/.hunter/_Base/Download/Boost/1.83.0/75b1f56/boost_1_83_0.tar.bz2'
-- SHA1 hash of
    /root/.hunter/_Base/Download/Boost/1.83.0/75b1f56/boost_1_83_0.tar.bz2
  does not match expected value
    expected: '75b1f569134401d178ad2aaf97a2993898dd7ee3'
      actual: '7694f0b22c5217c4a12cd0fc1b4f74758b9d3fa3'
-- Hash mismatch, removing...
-- Using src='https://boostorg.jfrog.io/artifactory/main/release/1.83.0/source/boost_1_83_0.tar.bz2'
-- [download 100% complete]
-- verifying file...
       file='/root/.hunter/_Base/Download/Boost/1.83.0/75b1f56/boost_1_83_0.tar.bz2'
-- SHA1 hash of
    /root/.hunter/_Base/Download/Boost/1.83.0/75b1f56/boost_1_83_0.tar.bz2
  does not match expected value
    expected: '75b1f569134401d178ad2aaf97a2993898dd7ee3'
      actual: '7694f0b22c5217c4a12cd0fc1b4f74758b9d3fa3'
-- Hash mismatch, removing...
CMake Error at Build/Boost-prefix/src/Boost-stamp/download-Boost.cmake:162 (message):
  Each download failed!

    
    


gmake[2]: *** [CMakeFiles/Boost.dir/build.make:103: Boost-prefix/src/Boost-stamp/Boost-download] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:83: CMakeFiles/Boost.dir/all] Error 2
gmake: *** [Makefile:91: all] Error 2

[hunter ** FATAL ERROR **] Build step failed (dir: /root/.hunter/_Base/0dfbc2c/23059d5/b5bebf3/Build/Boost
[hunter ** FATAL ERROR **] [Directory:/root/.hunter/_Base/Download/Hunter/0.25.3/0dfbc2c/Unpacked/cmake/projects/Boost]

------------------------------ ERROR -----------------------------
    https://hunter.readthedocs.io/en/latest/reference/errors/error.external.build.failed.html
------------------------------------------------------------------

CMake Error at /root/.hunter/_Base/Download/Hunter/0.25.3/0dfbc2c/Unpacked/cmake/modules/hunter_error_page.cmake:12 (message):
Call Stack (most recent call first):
  /root/.hunter/_Base/Download/Hunter/0.25.3/0dfbc2c/Unpacked/cmake/modules/hunter_fatal_error.cmake:20 (hunter_error_page)
  /root/.hunter/_Base/Download/Hunter/0.25.3/0dfbc2c/Unpacked/cmake/modules/hunter_download.cmake:623 (hunter_fatal_error)
  /root/.hunter/_Base/Download/Hunter/0.25.3/0dfbc2c/Unpacked/cmake/projects/Boost/hunter.cmake:542 (hunter_download)
  /root/.hunter/_Base/Download/Hunter/0.25.3/0dfbc2c/Unpacked/cmake/modules/hunter_add_package.cmake:62 (include)
  cmake/helper.cmake:1 (hunter_add_package)
  CMakeLists.txt:46 (include)


-- Configuring incomplete, errors occurred!

```

</details>

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
