### PR TITLE
fix(prof): crash on PHP 8.4

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,12 +14,12 @@ debug = 2 # full debug info
 
 [profile.release]
 codegen-units = 1
-debug = "line-tables-only"
+debug = "full" #"line-tables-only"
 incremental = false
 lto = "fat"
 
 [profile.tracer-release]
-debug = 1 # line tables only
+debug = "full" # 1 # line tables only
 lto = true
 codegen-units = 1
 panic = "abort"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,7 +14,7 @@ debug = 2 # full debug info
 
 [profile.release]
 codegen-units = 1
-debug = "full" #"line-tables-only"
+debug = "line-tables-only"
 incremental = false
 lto = "fat"
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ incremental = false
 lto = "fat"
 
 [profile.tracer-release]
-debug = "full" # 1 # line tables only
+debug = 1 # line tables only
 lto = true
 codegen-units = 1
 panic = "abort"

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -343,7 +343,7 @@ void ddog_php_prof_function_run_time_cache_init(const char *module_name) {
     // On PHP 8.4+, the internal cache slots need to be registered separately
     // from the user ones.
     _internal_run_time_cache_handle =
-        zend_get_op_array_extension_handles(module_name, 2);
+        zend_get_internal_function_extension_handles(module_name, 2);
 #endif
 
 #endif

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -315,12 +315,12 @@ zend_fiber* ddog_php_prof_get_active_fiber_test()
 #endif
 
 #if CFG_RUN_TIME_CACHE // defined by build.rs
-static int ddog_php_prof_run_time_cache_handle = -1;
+static int _user_run_time_cache_handle = -1;
 
 // On PHP 8.4+, the internal cache slots need to be registered separately from
 // the user ones.
 #if PHP_VERSION_ID >= 80400
-static int ddog_php_prof_internal_run_time_cache_handle = -1;
+static int _internal_run_time_cache_handle = -1;
 #endif
 
 #endif
@@ -331,18 +331,18 @@ void ddog_php_prof_function_run_time_cache_init(const char *module_name) {
     // Grab 1 slot for caching filename, as it turns out the utf-8 validity
     // check is worth caching.
 #if PHP_VERSION_ID < 80200
-    ddog_php_prof_run_time_cache_handle =
+    _user_run_time_cache_handle =
         zend_get_op_array_extension_handle(module_name);
     int second = zend_get_op_array_extension_handle(module_name);
-    ZEND_ASSERT(ddog_php_prof_run_time_cache_handle + 1 == second);
+    ZEND_ASSERT(_user_run_time_cache_handle + 1 == second);
 #else
-    ddog_php_prof_run_time_cache_handle =
+    _user_run_time_cache_handle =
         zend_get_op_array_extension_handles(module_name, 2);
 
 #if PHP_VERSION_ID >= 80400
     // On PHP 8.4+, the internal cache slots need to be registered separately
     // from the user ones.
-    ddog_php_prof_internal_run_time_cache_handle =
+    _internal_run_time_cache_handle =
         zend_get_op_array_extension_handles(module_name, 2);
 #endif
 
@@ -361,7 +361,21 @@ void ddog_php_prof_function_run_time_cache_init(const char *module_name) {
 // defined by build.rs
 #if CFG_RUN_TIME_CACHE && !CFG_STACK_WALKING_TESTS
 static bool has_invalid_run_time_cache(zend_function const *func) {
-    if (UNEXPECTED(_ignore_run_time_cache) || UNEXPECTED(ddog_php_prof_run_time_cache_handle < 0))
+    bool ignore_cache = _ignore_run_time_cache;
+    bool inv_user_handle = _user_run_time_cache_handle < 0;
+
+    // The bitwise-ors are intentional here. We don't expect any of these
+    // things to be true, except if we're on CLI and in that case it's okay
+    // to pessimize since it'll predict well after it gets it wrong the first
+    // time.
+#if PHP_VERSION_ID < 80400
+    bool fast_skip = ignore_cache | inv_user_handle;
+#else
+    bool inv_internal_handle = _internal_run_time_cache_handle < 0;
+    bool fast_skip = ignore_cache | inv_user_handle | inv_internal_handle;
+#endif
+
+    if (UNEXPECTED(fast_skip))
         return true;
 
     // during an `include()`/`require()` with enabled OPcache, OPcache is
@@ -407,11 +421,11 @@ uintptr_t *ddog_php_prof_function_run_time_cache(zend_function const *func) {
     ZEND_ASSERT(cache_addr);
 
 #if PHP_VERSION_ID < 80400
-    int handle_offset = ddog_php_prof_run_time_cache_handle;
+    int handle_offset = _user_run_time_cache_handle;
 #else
     int handle_offset = func->type == ZEND_USER_FUNCTION
-        ? ddog_php_prof_run_time_cache_handle
-        : ddog_php_prof_internal_run_time_cache_handle;
+        ? _user_run_time_cache_handle
+        : _internal_run_time_cache_handle;
 #endif
     return cache_addr + handle_offset;
 


### PR DESCRIPTION
### Description

Fixes #3012. The profiler can crash on PHP 8.4 when walking the stack for any kind of sample type. The internals upgrading guide says:

```
* zend_get_internal_function_extension_handle[s]() must now be used over
  zend_get_op_array_extension_handle[s]() when registering run_time_cache slots
  for internal functions. If you need a cache slot for both internal and user
  functions, you may obtain a slot for each through the corresponding function.
```

So we call this now as well and use that handle instead of the user handle for internal functions.

~Note that there is a piece in this PR which shouldn't ship: an increase to the debug level. I did this so I can inspect variables and such with the artifacts from CI. This should be reverted before merging.~ Reverted. PR is ready for review.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [x] Appropriate labels assigned.
