### PR TITLE
fix: root span name in Slim V4

### DIFF
--- a/src/DDTrace/Integrations/Slim/SlimIntegration.php
+++ b/src/DDTrace/Integrations/Slim/SlimIntegration.php
@@ -34,6 +34,7 @@ class SlimIntegration extends Integration
                 // Overwrite root span info
                 $rootSpan = \DDTrace\root_span();
                 $integration->addTraceAnalyticsIfEnabled($rootSpan);
+                $rootSpan->name = 'slim.request';
                 $rootSpan->service = $appName;
                 $rootSpan->meta[Tag::SPAN_KIND] = 'server';
                 $rootSpan->meta[Tag::COMPONENT] = SlimIntegration::NAME;
@@ -70,8 +71,6 @@ class SlimIntegration extends Integration
                 }
 
                 if ('3' === $majorVersion) {
-                    $rootSpan->name = 'slim.request';
-
                     // Hook into the router to extract the proper route name
                     \DDTrace\hook_method(
                         'Slim\\Router',

--- a/tests/Integrations/Slim/V4/CommonScenariosTest.php
+++ b/tests/Integrations/Slim/V4/CommonScenariosTest.php
@@ -104,7 +104,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
             [
                 'A simple GET request returning a string' => [
                     SpanAssertion::build(
-                        'web.request',
+                        'slim.request',
                         'slim_test_app',
                         'web',
                         'GET /simple'
@@ -133,7 +133,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                 ],
                 'A simple GET request with a view' => [
                     SpanAssertion::build(
-                        'web.request',
+                        'slim.request',
                         'slim_test_app',
                         'web',
                         'GET /simple_view'
@@ -170,7 +170,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                 ],
                 'A GET request with an exception' => [
                     SpanAssertion::build(
-                        'web.request',
+                        'slim.request',
                         'slim_test_app',
                         'web',
                         'GET /error'
@@ -204,7 +204,7 @@ final class CommonScenariosTest extends WebFrameworkTestCase
                 ],
                 'A GET request to a route with a parameter' => [
                     SpanAssertion::build(
-                        'web.request',
+                        'slim.request',
                         'slim_test_app',
                         'web',
                         'GET /parameterized/paramValue'


### PR DESCRIPTION
### Description

I couldn't find a reason for the root span name to differ in Slim 3 compared to Slim 4. Furthermore, setting it to `slim.request` is consistent with all other integrations.

This behavior was identified in the linked escalation.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
