### PR TITLE
Avoid repeated processing of internal functions

### DIFF
--- a/zend_abstract_interface/hook/hook.c
+++ b/zend_abstract_interface/hook/hook.c
@@ -816,10 +816,13 @@ static inline void zai_hook_resolve(HashTable *base_ht, zend_class_entry *ce, ze
 
     if (function->common.scope == ce || !ZEND_USER_CODE(function->type)) {
         zai_hook_resolve_lookup_inherited(hooks, ce, function, lcname);
-#if PHP_VERSION_ID >= 80000
-        zai_hook_on_function_resolve(function);
-#endif
     }
+
+#if PHP_VERSION_ID >= 80000
+    if (function->common.scope == ce) {
+        zai_hook_on_function_resolve(function);
+    }
+#endif
 }
 
 /* {{{ */
@@ -840,10 +843,13 @@ void zai_hook_resolve_class(zend_class_entry *ce, zend_string *lcname) {
             zai_store_func_location(function);
             if (function->common.scope == ce || !ZEND_USER_CODE(function->type)) {
                 zai_hook_resolve_lookup_inherited(NULL, ce, function, fnname);
-#if PHP_VERSION_ID >= 80000
-                zai_hook_on_function_resolve(function);
-#endif
             }
+
+#if PHP_VERSION_ID >= 80000
+            if (function->common.scope == ce) {
+                zai_hook_on_function_resolve(function);
+            }
+#endif
         } ZEND_HASH_FOREACH_END();
         return;
     }


### PR DESCRIPTION
Internal functions, when inherited, may (on PHP 8.1 with opcache at least) have pointers which are into heap memory which is local to a given process (e.g. attributes), not present on the target process. Thus accessing the attributes of a duplicated internal functions will crash there.

And on top of that, we anyway don't want to process these twice.