### PR TITLE
Fix SpanLink::fromHeaders() crash with no or invalid propagated tags

### DIFF
--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -870,7 +870,9 @@ ZEND_METHOD(DDTrace_SpanLink, fromHeaders) {
 
     zend_string *propagated_tags = ddtrace_format_propagated_tags(&result.propagated_tags, &result.meta_tags);
     zend_string *full_tracestate = ddtrace_format_tracestate(result.tracestate, 0, result.origin, result.priority_sampling, propagated_tags, &result.tracestate_unknown_dd_keys);
-    zend_string_release(propagated_tags);
+    if (propagated_tags) {
+        zend_string_release(propagated_tags);
+    }
     if (full_tracestate) {
         ZVAL_STR(&link->property_trace_state, full_tracestate);
     }

--- a/tests/ext/distributed_tracing/distributed_trace_span_link_from_headers_invalid_tags.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_span_link_from_headers_invalid_tags.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Setting custom distributed header information with invalid propagated tags
+--ENV--
+HTTP_X_DATADOG_TRACE_ID=42
+HTTP_X_DATADOG_PARENT_ID=10
+HTTP_X_DATADOG_TAGS=_dd.p.custom_tag?!
+--FILE--
+<?php
+
+print_r(DDTrace\SpanLink::fromHeaders([
+    "traceparent" => "00-0000000000000000000000000000002a-0000000000000001-01",
+    "tracestate" => "dd=foo:bar=baz",
+]));
+
+?>
+--EXPECTF--
+DDTrace\SpanLink Object
+(
+    [traceId] => 0000000000000000000000000000002a
+    [spanId] => 0000000000000001
+    [traceState] => dd=foo:bar=baz
+    [attributes] => Array
+        (
+            [_dd.parent_id] => 0000000000000000
+        )
+
+)


### PR DESCRIPTION
A simple NULL check missing.