### PR TITLE
style: cargo clippy --fix and fmt on Rust v1.84

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -548,7 +548,7 @@ commands:
                 -v $(pwd)/tests/snapshots:/snapshots \
                 --name test-agent ghcr.io/datadog/dd-apm-test-agent/ddapm-test-agent:latest
               retry_docker run --detach --rm --net net \
-                --name httpbin_integration kong/httpbin
+                --name httpbin_integration kong/httpbin:0.2.2
               retry_docker run --detach --rm --net net \
                 -e DD_REQUEST_DUMPER_FILE=dump.json \
                 --name request-replayer datadog/dd-trace-ci:php-request-replayer-2.0

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -40,7 +40,7 @@ aliases:
       - ES_JAVA_OPTS=-Xms1g -Xmx1g
 
   - &IMAGE_DOCKER_HTTPBIN
-    image: kong/httpbin
+    image: kong/httpbin:0.2.2
     name: httpbin_integration
 
   - &IMAGE_DOCKER_KAFKA

--- a/config.w32
+++ b/config.w32
@@ -8,8 +8,10 @@ if (PHP_DDTRACE != 'no') {
 
 	var versionpath = configure_module_dirname + "/ext/version.h";
 	var versionfile = FSO.CreateTextFile(versionpath, true);
+	var versionContent = FSO.OpenTextFile(configure_module_dirname + "/VERSION", 1).ReadAll();
+	versionContent = versionContent.replace(/[\r\n]+$/, '');
 	versionfile.WriteLine("#ifndef PHP_DDTRACE_VERSION");
-	versionfile.WriteLine('#define PHP_DDTRACE_VERSION "' + FSO.OpenTextFile(configure_module_dirname + "/VERSION", 1).ReadAll() + '"');
+	versionfile.WriteLine('#define PHP_DDTRACE_VERSION "' + versionContent  + '"');
 	versionfile.WriteLine("#endif");
 	versionfile.Close();
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -215,7 +215,7 @@ services:
     image: "memcached:1.5-alpine"
 
   httpbin_integration:
-    image: kong/httpbin
+    image: kong/httpbin:0.2.2
     ports:
       - "8765:80"
 

--- a/profiling/src/allocation.rs
+++ b/profiling/src/allocation.rs
@@ -10,9 +10,9 @@ use log::{debug, error, trace, warn};
 use rand::rngs::ThreadRng;
 use rand_distr::{Distribution, Poisson};
 use std::cell::{RefCell, UnsafeCell};
+use std::ptr;
 use std::sync::atomic::AtomicU64;
 use std::sync::atomic::Ordering::{Relaxed, SeqCst};
-use std::{ffi, ptr};
 
 static mut GC_MEM_CACHES_HANDLER: zend::InternalFunctionHandler = None;
 
@@ -318,7 +318,7 @@ pub fn alloc_prof_rshutdown() {
 pub fn alloc_prof_startup() {
     unsafe {
         let handle = datadog_php_zif_handler::new(
-            ffi::CStr::from_bytes_with_nul_unchecked(b"gc_mem_caches\0"),
+            c"gc_mem_caches",
             ptr::addr_of_mut!(GC_MEM_CACHES_HANDLER),
             Some(alloc_prof_gc_mem_caches),
         );

--- a/profiling/src/bindings/mod.rs
+++ b/profiling/src/bindings/mod.rs
@@ -568,7 +568,7 @@ impl<'a> From<&'a str> for ZaiStr<'a> {
     }
 }
 
-impl<'a> Default for ZaiStr<'a> {
+impl Default for ZaiStr<'_> {
     fn default() -> Self {
         Self::new()
     }

--- a/profiling/src/exception.rs
+++ b/profiling/src/exception.rs
@@ -4,7 +4,6 @@ use crate::REQUEST_LOCALS;
 use log::{error, info};
 use rand::rngs::ThreadRng;
 use std::cell::RefCell;
-use std::ffi::CStr;
 use std::ptr;
 use std::sync::atomic::AtomicU32;
 use std::sync::atomic::Ordering;
@@ -136,8 +135,8 @@ pub fn exception_profiling_minit() {
         zend::zend_throw_exception_hook = Some(exception_profiling_throw_exception_hook);
 
         let method_handlers = [zend::datadog_php_zim_handler::new(
-            CStr::from_bytes_with_nul_unchecked(b"generator\0"),
-            CStr::from_bytes_with_nul_unchecked(b"throw\0"),
+            c"generator",
+            c"throw",
             ptr::addr_of_mut!(GENERATOR_THROW_HANDLER),
             Some(ddog_php_prof_generator_throw),
         )];

--- a/profiling/src/profiling/stack_walking.rs
+++ b/profiling/src/profiling/stack_walking.rs
@@ -95,7 +95,7 @@ mod detail {
         string_set: &'a mut StringSet,
     }
 
-    impl<'a> StringCache<'a> {
+    impl StringCache<'_> {
         /// Makes a copy of the string in the cache slot. If there isn't a
         /// string in the slot currently, then create one by calling the
         /// provided function, store it in the string cache and cache slot,

--- a/profiling/src/sapi.rs
+++ b/profiling/src/sapi.rs
@@ -62,7 +62,7 @@ impl Sapi {
                     // Safety: It's not null; the VM should do the rest.
                     let cstr = unsafe { CStr::from_ptr(*sapi_request_info.argv) };
                     let bytes = cstr.to_bytes();
-                    return if !bytes.is_empty() {
+                    if !bytes.is_empty() {
                         let osstr = OsStr::from_bytes(bytes);
                         Path::new(osstr)
                             .file_name()
@@ -82,7 +82,7 @@ impl Sapi {
                             })
                     } else {
                         None
-                    };
+                    }
                 } else {
                     None
                 }

--- a/profiling/src/thin_str.rs
+++ b/profiling/src/thin_str.rs
@@ -55,7 +55,7 @@ impl<'a> ThinStr<'a> {
     }
 }
 
-impl<'a> Deref for ThinStr<'a> {
+impl Deref for ThinStr<'_> {
     type Target = str;
 
     fn deref(&self) -> &Self::Target {
@@ -75,21 +75,21 @@ impl<'a> Deref for ThinStr<'a> {
     }
 }
 
-impl<'a> hash::Hash for ThinStr<'a> {
+impl hash::Hash for ThinStr<'_> {
     fn hash<H: hash::Hasher>(&self, state: &mut H) {
         self.deref().hash(state)
     }
 }
 
-impl<'a> PartialEq for ThinStr<'a> {
+impl PartialEq for ThinStr<'_> {
     fn eq(&self, other: &Self) -> bool {
         self.deref().eq(other.deref())
     }
 }
 
-impl<'a> Eq for ThinStr<'a> {}
+impl Eq for ThinStr<'_> {}
 
-impl<'a> Borrow<str> for ThinStr<'a> {
+impl Borrow<str> for ThinStr<'_> {
     fn borrow(&self) -> &str {
         self.deref()
     }

--- a/tests/randomized/lib/docker-compose.yml
+++ b/tests/randomized/lib/docker-compose.yml
@@ -11,7 +11,7 @@ services:
 
   httpbin:
     container_name: httpbin
-    image: kong/httpbin
+    image: kong/httpbin:0.2.2
 
   memcached:
     container_name: memcached


### PR DESCRIPTION
### Description

I think there are some `static mut` uses and other things clippy should be complaining about in CI, but it's not. While investigating why we aren't getting more clippy errors, I figured I'd run `cargo +1.84 clippy fix` while I was at it.

We also fix some other small things with the build so that tests pass. Thanks Bob and Florian for contributing those.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
