### PR TITLE
Fix remote config tests on pipeline

### DIFF
--- a/appsec/CMakeLists.txt
+++ b/appsec/CMakeLists.txt
@@ -25,6 +25,7 @@ configure_file(${CMAKE_CURRENT_SOURCE_DIR}/hunter-cache.id.in ${CMAKE_CURRENT_SO
 file(READ "../VERSION" appsec_version)
 string(STRIP "${appsec_version}" appsec_version)
 set(CMAKE_APPSEC_VERSION ${appsec_version})
+string(REGEX REPLACE "\n" "" appsec_version "${appsec_version}")
 string(REGEX MATCH "^[^+a-z]*" appsec_short_version "${appsec_version}")
 project(ddappsec VERSION ${appsec_short_version})
 


### PR DESCRIPTION
### Description

The file `VERSION` got added a new extra empty line and that was making the pipeline to fail

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
