### PR TITLE
improve the Application::bootstrapWith hook to find Laravel's application name

### DIFF
--- a/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
+++ b/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
@@ -91,7 +91,12 @@ class LaravelIntegration extends Integration
                     $configPath = realpath($app->configPath());
                     if (file_exists($configPath . '/app.php')) {
                         $config = require $configPath . '/app.php';
-                        $integration->serviceName = $config['name'];
+                        if (isset($config['name'])) {
+                            $integration->serviceName = $config['name'];
+                        }                        
+                    }
+                    if (empty($integration->serviceName)) {
+                        $integration->serviceName = isset($_ENV['APP_NAME']) ? $_ENV['APP_NAME'] : 'Laravel';
                     }
                 }
             }


### PR DESCRIPTION
### Description

As per #3034 this fixes the scenario in which a Laravel 11+ application does not have the config/app.php file and when in this file is not specified the "name" key (using the default from vendor/laravel/framework/config/app.php).

I was trying to cover my code with test but I cannot execute the test suite, it cannot execute some build using make due to lack of permissions :man_shrugging: .

The new behaviour from Laravel config loader is here: https://github.com/laravel/framework/blob/11.x/src/Illuminate/Foundation/Bootstrap/LoadConfiguration.php#L189

This is the default config:
https://github.com/laravel/framework/blob/11.x/config/app.php#L19

Fixes #3034 

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
