### PR TITLE
fix(prof): PHP 8.4 crash with opcache optimizer

### DIFF
--- a/profiling/src/profiling/stack_walking.rs
+++ b/profiling/src/profiling/stack_walking.rs
@@ -209,8 +209,14 @@ mod detail {
                 // allowed because it's only used on the frameless path
                 #[allow(unused_variables)]
                 if let Some(func) = unsafe { execute_data.func.as_ref() } {
+                    // It's possible that this is a fake frame put there by
+                    // the engine, see accel_preload on PHP 8.4 and the local
+                    // variable `fake_execute_data`. The frame is zeroed in
+                    // this case, so we can check for null.
                     #[cfg(php_frameless)]
-                    if !func.is_internal() {
+                    if !func.is_internal() && !execute_data.opline.is_null() {
+                        // SAFETY: if it's not null, then it should be valid
+                        // or something else has messed up already.
                         let opline = unsafe { &*execute_data.opline };
                         match opline.opcode as u32 {
                             ZEND_FRAMELESS_ICALL_0


### PR DESCRIPTION
### Description

The profiler may crash when:

1. The profiler is enabled,
2. Allocation profiling is enabled (on by default),
3. The application is on PHP 8.4,
4. and Opcache is enabled and used (strongly recommended for production).

If allocation profiling triggers at a precise spot in the optimizer, then it will dereference a null pointer. The reason is that the optimizer puts a fake frame with a zeroed opline in `accel_preload`, and the profiler does not check for null at this location.

There are other access in the profiler to the opline such as `extract_file_and_line`, but they already guard against a null pointer. This specific bit of code that did not guard was added for PHP 8.4 to handle frameless functions, a new optimization in PHP 8.4.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
