### PR TITLE
tests: Reduce AMQP & PCNTL Tests flakiness

### DIFF
--- a/tests/Common/IntegrationTestCase.php
+++ b/tests/Common/IntegrationTestCase.php
@@ -19,7 +19,7 @@ abstract class IntegrationTestCase extends BaseTestCase
     public static $database = "test";
     private static $createdDatabases = ["test" => true];
 
-    protected static $maxRetries = 3;
+    protected static $maxRetries = 5;
 
     public static function ddSetUpBeforeClass()
     {
@@ -124,8 +124,11 @@ abstract class IntegrationTestCase extends BaseTestCase
                 $testCase(...$args);
                 return; // Test passed, exit the loop.
             } catch (\Throwable $e) {
+                echo "Attempt $attempts failed: " . $e->getMessage() . PHP_EOL;
+                echo "Retrying..." . PHP_EOL;
                 $attempts++;
                 if ($attempts >= self::$maxRetries) {
+                    echo "Max retries reached." . PHP_EOL;
                     throw $e; // Re-throw after max retries.
                 }
             }

--- a/tests/Integrations/PCNTL/PCNTLTest.php
+++ b/tests/Integrations/PCNTL/PCNTLTest.php
@@ -8,7 +8,7 @@ use DDTrace\Tests\Common\SpanAssertion;
 final class PCNTLTest extends IntegrationTestCase
 {
     private static $acceptable_test_execution_time = 2;
-    private const MAX_RETRIES = 3;
+    const MAX_RETRIES = 3;
 
     protected function ddSetUp()
     {
@@ -17,6 +17,7 @@ final class PCNTLTest extends IntegrationTestCase
         }
 
         $this->resetRequestDumper();
+        \usleep(500000); // 500ms
         parent::ddSetUp();
     }
 

--- a/tests/Integrations/PCNTL/PCNTLTest.php
+++ b/tests/Integrations/PCNTL/PCNTLTest.php
@@ -20,22 +20,6 @@ final class PCNTLTest extends IntegrationTestCase
         parent::ddSetUp();
     }
 
-    private function retryTest(callable $testCase, ...$args)
-    {
-        $attempts = 0;
-        while ($attempts < self::MAX_RETRIES) {
-            try {
-                $testCase(...$args);
-                return; // Test passed, exit the loop.
-            } catch (\Throwable $e) {
-                $attempts++;
-                if ($attempts >= self::MAX_RETRIES) {
-                    throw $e; // Re-throw after max retries.
-                }
-            }
-        }
-    }
-
     /**
      * @dataProvider dataProviderAllScripts
      */

--- a/tests/Integrations/PCNTL/PCNTLTest.php
+++ b/tests/Integrations/PCNTL/PCNTLTest.php
@@ -8,7 +8,6 @@ use DDTrace\Tests\Common\SpanAssertion;
 final class PCNTLTest extends IntegrationTestCase
 {
     private static $acceptable_test_execution_time = 2;
-    const MAX_RETRIES = 3;
 
     protected function ddSetUp()
     {


### PR DESCRIPTION
### Description

I was getting a bit bored of these tests failing here and there in CI jobs... I believe this quick workaround could help us trust the CI a bit more.

The workaround simply consist in retrying the tests, up to five times.

This only affects `integration_snapshots-test_integrations`

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
