### PR TITLE
fix(profiler) guard `VERSION` against CRLF characters

### DIFF
--- a/profiling/build.rs
+++ b/profiling/build.rs
@@ -1,6 +1,6 @@
 use bindgen::callbacks::IntKind;
 use std::collections::HashSet;
-use std::env;
+use std::{env, fs};
 use std::path::Path;
 use std::path::PathBuf;
 use std::process::Command;
@@ -20,6 +20,14 @@ fn main() {
             ),
         }
     }
+
+    // Read the version from the VERSION file
+    let version = fs::read_to_string("../VERSION")
+        .expect("Failed to read VERSION file")
+        .trim()
+        .to_string();
+    println!("cargo:rustc-env=PROFILER_VERSION={}", version);
+    println!("cargo:rerun-if-changed=../VERSION");
 
     let php_config_includes = std::str::from_utf8(php_config_includes_output.stdout.as_slice())
         .expect("`php-config`'s stdout to be valid utf8");

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -58,7 +58,7 @@ static PROFILER_NAME_CSTR: &CStr = unsafe { CStr::from_bytes_with_nul_unchecked(
 
 /// Version of the profiling module and zend_extension. Must not contain any
 /// interior null bytes and must be null terminated.
-static PROFILER_VERSION: &[u8] = concat!(include_str!("../../VERSION"), "\0").as_bytes();
+static PROFILER_VERSION: &[u8] = concat!(env!("PROFILER_VERSION"), "\0").as_bytes();
 
 /// Version ID of PHP at run-time, not the version it was built against at
 /// compile-time. Its value is overwritten during minit.
@@ -82,7 +82,7 @@ lazy_static! {
     static ref LAZY_STATICS_TAGS: Vec<Tag> = {
         vec![
             tag!("language", "php"),
-            tag!("profiler_version", include_str!("../../VERSION")),
+            tag!("profiler_version", env!("PROFILER_VERSION")),
             // Safety: calling getpid() is safe.
             Tag::new("process_id", unsafe { libc::getpid() }.to_string())
                 .expect("process_id tag to be valid"),


### PR DESCRIPTION
### Description

This fixes a bug on `master` where the profiler would not upload profiles anymore:
```
[WARN  datadog_php_profiling::profiling::uploader] Failed to upload profile: failed to parse header value
```
This error could happen when the `VERSION` file had a trailing CRLF sign. This got removed on `master` but profiling still relied on this not existing.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
