### PR TITLE
Validate DD_TRACE_AGENT_URL

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1860,6 +1860,7 @@ dependencies = [
  "ddtelemetry",
  "ddtelemetry-ffi",
  "env_logger 0.10.2",
+ "http 0.2.11",
  "itertools 0.11.0",
  "lazy_static",
  "log",

--- a/components-rs/Cargo.toml
+++ b/components-rs/Cargo.toml
@@ -43,6 +43,7 @@ tracing-subscriber = { version = "0.3", default-features = false, features = [
 serde_json = "1.0.113"
 regex = "1.10.5"
 regex-automata = "0.4.5"
+http = "0.2.11"
 
 [build-dependencies]
 cbindgen = "0.27"

--- a/components-rs/ddtrace.h
+++ b/components-rs/ddtrace.h
@@ -153,6 +153,8 @@ char *ddtrace_strip_invalid_utf8(const char *input, uintptr_t *len);
 
 void ddtrace_drop_rust_string(char *input, uintptr_t len);
 
+struct ddog_Endpoint *ddtrace_parse_agent_url(ddog_CharSlice url);
+
 bool ddog_shall_log(enum ddog_Log category);
 
 void ddog_set_error_log_level(bool once);

--- a/ext/signals.c
+++ b/ext/signals.c
@@ -117,6 +117,9 @@ static void ddtrace_init_crashtracker() {
     socket_path.ptr = crashtracker_socket_path;
 
     ddog_Endpoint *agent_endpoint = ddtrace_sidecar_agent_endpoint();
+    if (!agent_endpoint) {
+        return;
+    }
 
     ddog_crasht_Config config = {
         .endpoint = agent_endpoint,

--- a/tests/ext/background-sender/sidecar_handles_invalid_agent_url.phpt
+++ b/tests/ext/background-sender/sidecar_handles_invalid_agent_url.phpt
@@ -1,0 +1,15 @@
+--TEST--
+The sidecar properly handles invalid agent urls
+--SKIPIF--
+<?php include __DIR__ . '/../includes/skipif_no_dev_env.inc'; ?>
+<?php if (getenv('USE_ZEND_ALLOC') === '0' && !getenv("SKIP_ASAN")) die('skip: valgrind reports sendmsg(msg.msg_control) points to uninitialised byte(s), but it is unproblematic and outside our control in rust code'); ?>
+--ENV--
+DD_TRACE_AGENT_URL=/invalid
+DD_TRACE_SIDECAR_TRACE_SENDER=1
+DD_CRASHTRACKING_ENABLED=0
+--FILE--
+<?php
+
+?>
+--EXPECTF--
+[ddtrace] [error] Invalid DD_TRACE_AGENT_URL: /invalid. A proper agent URL must be unix:///path/to/agent.sock or http://hostname:port/.


### PR DESCRIPTION
This avoids panics in the sidecar and crashes in crashtracker initialization.