### PR TITLE
fix(Appsec Tests) Trim CRLF chars on version file on Remote Config

### DIFF
--- a/components-rs/remote_config.rs
+++ b/components-rs/remote_config.rs
@@ -134,7 +134,7 @@ pub unsafe extern "C" fn ddog_init_remote_config_state(
     Box::new(RemoteConfigState {
         manager: RemoteConfigManager::new(ConfigInvariants {
             language: "php".to_string(),
-            tracer_version: include_str!("../VERSION").into(),
+            tracer_version: include_str!("../VERSION").trim().into(),
             endpoint: endpoint.clone(),
             products: DDTRACE_REMOTE_CONFIG_PRODUCTS.to_vec(),
             capabilities: DDTRACE_REMOTE_CONFIG_CAPABILITIES.to_vec(),


### PR DESCRIPTION
### Description

Since `VERSION` file was created. Appsec remote config tests where failing. This PR fixes this issue

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
