### PR TITLE
fix: `ObjectKVStore::put` on throwing `__set`

### DIFF
--- a/tests/Unit/Util/ObjectKVStoreTest.php
+++ b/tests/Unit/Util/ObjectKVStoreTest.php
@@ -157,4 +157,25 @@ final class ObjectKVStoreTest extends BaseTestCase
         ObjectKVStore::put($instance, 'key', 'value');
         $this->assertFalse(property_exists($instance, 'key'));
     }
+
+    public function testSetMagicMethodNotAllowed()
+    {
+        $firstInstance = new Foo();
+        ObjectKVStore::put($firstInstance, 'key', 'bar');
+        $this->assertFalse(property_exists($firstInstance, 'key'));
+        $this->assertSame('bar', ObjectKVStore::get($firstInstance, 'key'));
+
+        $secondInstance = new Foo();
+        ObjectKVStore::put($secondInstance, 'key', 'baz');
+        $this->assertFalse(property_exists($secondInstance, 'key'));
+        $this->assertSame('baz', ObjectKVStore::get($secondInstance, 'key'));
+    }
+}
+
+class Foo
+{
+    public function __set($name, $value)
+    {
+        throw new \RuntimeException('not allowed');
+    }
 }


### PR DESCRIPTION
### Motivation

In `predis/predis`, starting v2.1.2 w/ https://github.com/predis/predis/pull/1049, it is no longer possible to use [ObjectKVStore::put](https://github.com/DataDog/dd-trace-php/blob/c11372f59b0be0dcd1fe9042ad83ec8080e40d6c/src/DDTrace/Util/ObjectKVStore.php#L140) in versions 7.4 and below since [Predis\Client::__set will be throwing an exception](https://github.com/predis/predis/blob/52489ea703aeb182b7ee7981eac69655d8f084ec/src/Client.php#L362-L365).

Currently, PredisIntegration is throwing an exception on versions 2.1.2+, using a PHP runtime that is strictly less than 7.4. Current estimates are reporting that [~5% of orgs](https://docs.google.com/spreadsheets/d/1JaQIu-UwshIep_mH5SIyYRfyE_dA49SumTQSbtwZ3VM/edit?usp=sharing) using the predis integration are impacted.

### Description

Fallback to [spl_object_hash](https://github.com/php/php-src/blob/caf5e8a1673392d08f58a8c89a5b257a9a6387ac/ext/spl/php_spl.c#L670-L673) when it is not possible to use the weakmap nor `__set`.

This should allow to proceed with https://github.com/DataDog/dd-trace-php/pull/3065.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
