### PR TITLE
fix: Don't open Draft PR when updating supported versions

### DIFF
--- a/tooling/tested_versions/create_or_update_supported_versions_pr.sh
+++ b/tooling/tested_versions/create_or_update_supported_versions_pr.sh
@@ -42,8 +42,7 @@ if [[ -z $PR_NUMBER ]]; then
     --base $CURRENT_BRANCH \
     --head $TARGET_BRANCH \
     --title "chore: update supported versions" \
-    --body "This PR updates the tested versions list automatically." \
-  	--draft
+    --body "This PR updates the tested versions list automatically."
 else
   echo "A PR already exists."
 fi


### PR DESCRIPTION
### Description

I forgot to remove `--draft` before pushing the PR to master 🤦 

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
