### PR TITLE
Fix log fd opening on windows

### DIFF
--- a/components/atomic_win32_polyfill.h
+++ b/components/atomic_win32_polyfill.h
@@ -7,7 +7,8 @@
 #define atomic_fetch_sub(var, val) atomic_fetch_add(var, -(val))
 #define atomic_fetch_or _InterlockedOr64
 #define atomic_fetch_and _InterlockedAnd64
-#define atomic_compare_exchange_strong(var, expected, val) _InterlockedCompareExchange64(var, *(expected), val)
+#define atomic_compare_exchange_strong(var, expected, val) (_InterlockedCompareExchange64(var, val, *(expected)) == *(expected))
+#define atomic_compare_exchange_strong_int(var, expected, val) (_InterlockedCompareExchange(var, val, *(expected)) == *(expected))
 
 // "Simple reads and writes to properly aligned 64 bit [also 32 bit] variables are atomic on 64-bit windows"
 #define atomic_store(var, val) (*var = val)

--- a/ext/logging.c
+++ b/ext/logging.c
@@ -9,6 +9,10 @@
 #include "configuration.h"
 #include <main/SAPI.h>
 
+#ifndef _WIN32
+#define atomic_compare_exchange_strong_int atomic_compare_exchange_strong
+#endif
+
 
 static void dd_log_set_level(bool debug) {
     bool once = runtime_config_first_init ? get_DD_TRACE_ONCE_LOGS() : get_global_DD_TRACE_ONCE_LOGS();
@@ -83,7 +87,7 @@ void ddtrace_log_rinit(char *error_log) {
     time(&now);
     atomic_store(&dd_error_log_fd_rotated, (uintmax_t) now);
     int expected = -1;
-    if (!atomic_compare_exchange_strong(&ddtrace_error_log_fd, &expected, desired)) {
+    if (!atomic_compare_exchange_strong_int(&ddtrace_error_log_fd, &expected, desired)) {
         // if it didn't exchange, then we need to free it
         close(desired);
     }


### PR DESCRIPTION
This leaked the log file descriptors due to compare_exchange being a 64 bit operation, on 32 bit ints.