### PR TITLE
fix: PackageUpdater failure

### DIFF
--- a/tests/PackageUpdater.php
+++ b/tests/PackageUpdater.php
@@ -180,6 +180,7 @@ class PackageUpdater
             foreach ($this->errors as $error) {
                 echo "- $error\n";
             }
+            exit(1);
         }
     }
 }

--- a/tests/PackageUpdater.php
+++ b/tests/PackageUpdater.php
@@ -68,7 +68,7 @@ class PackageUpdater
 
             $this->updatePackageVersion($library, $composer);
         } catch (Throwable $e) {
-            $this->errors[] = "Error processing $file: " . $e->getMessage();
+            $this->errors[] = "Error processing $file: " . $e->getMessage() . PHP_EOL . $e->getTraceAsString();
         }
     }
 
@@ -91,7 +91,9 @@ class PackageUpdater
     {
         foreach (['getAppIndexScript', 'getConsoleScript'] as $method) {
             if (method_exists($className, $method)) {
-                $dir = dirname(call_user_func([$className, $method]));
+                $scriptPath = call_user_func([$className, $method]);
+                if (!$scriptPath) continue;
+                $dir = dirname($scriptPath);
                 while (basename($dir) !== 'Frameworks') {
                     $possible = "$dir/composer.json";
                     if (file_exists($possible)) {


### PR DESCRIPTION
### Description

In #3062, `IntegrationTestCase` was updated to declare `getAppIndexScript` and `getConsoleScript`. Since these methods now exist on any test suite extending `IntegrationTestCase,` we had this type of failures:
```
- Error processing /home/circleci/app/tests/Integrations/AMQP/Latest/AMQPTest.php: dirname(): Argument #1 ($path) must be of type string, null given
#0 /home/circleci/app/tests/PackageUpdater.php(94): dirname(NULL)
#1 /home/circleci/app/tests/PackageUpdater.php(66): PackageUpdater->findComposerFile('DDTrace\\Tests\\I...', '/home/circleci/...')
#2 /home/circleci/app/tests/PackageUpdater.php(21): PackageUpdater->processFile('/home/circleci/...')
#3 /home/circleci/app/tests/PackageUpdater.php(185): PackageUpdater->run()
#4 {main}
```

This fix just proposes to check whether it's null + exit 1 when errors are encountered.


<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
