### PR TITLE
fix(prof): combine thread timeout errors properly

### DIFF
--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -719,7 +719,7 @@ impl Profiler {
             }
 
             let num_failures = result1.is_err() as usize + result2.is_err() as usize;
-            result2.or(result1).map_err(|_| JoinError { num_failures })
+            result2.and(result1).map_err(|_| JoinError { num_failures })
         } else {
             Ok(())
         }


### PR DESCRIPTION
### Description

I used the wrong combinator before, need to use `Result::and`. From [Result::and documentation](https://doc.rust-lang.org/std/result/enum.Result.html#method.and):

```rs
let x: Result<u32, &str> = Ok(2);
let y: Result<&str, &str> = Err("late error");
assert_eq!(x.and(y), Err("late error"));

let x: Result<u32, &str> = Err("early error");
let y: Result<&str, &str> = Ok("foo");
assert_eq!(x.and(y), Err("early error"));

let x: Result<u32, &str> = Err("not a 2");
let y: Result<&str, &str> = Err("late error");
assert_eq!(x.and(y), Err("not a 2"));

let x: Result<u32, &str> = Ok(2);
let y: Result<&str, &str> = Ok("different result type");
assert_eq!(x.and(y), Ok("different result type"));
```

This is a follow-up to #3075.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
