### PR TITLE
ci(all) use workflow to add assets to release

### DIFF
--- a/.github/workflows/add-asset-to-gh-release.yml
+++ b/.github/workflows/add-asset-to-gh-release.yml
@@ -1,0 +1,25 @@
+name: Add assets to release
+
+on:
+  workflow_dispatch:
+    inputs:
+      packagesUrl:
+        description: 'URL for `packages.tar.gz` to add to release'
+        required: true
+      releaseVersion:
+        description: 'Version to add the assets to'
+        required: true
+
+jobs:
+  add-assets-to-release:
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          curl -L -o packages.tar.gz $PACKAGES_URL
+          tar -xvzf packages.tar.gz
+          cd build/packages/
+          gh release upload -R DataDog/dd-trace-php --clobber $RELEASE *
+        env:
+          PACKAGES_URL: ${{ inputs.packagesUrl }}
+          RELEASE: ${{ inputs.releaseVersion }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
### Description

This adds a manual workflow that we can use to add assets to a release. This is not magically finding the current draft release, nor is it magically downloading the correct assets from the latest CircleCI `ddtrace-$VERSION` workflow run, but it removes the need to download and re-upload assets.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
