### PR TITLE
fix runner size

### DIFF
--- a/.github/workflows/add-asset-to-gh-release.yml
+++ b/.github/workflows/add-asset-to-gh-release.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   add-assets-to-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8core
     steps:
       - run: |
           curl -L -o packages.tar.gz $PACKAGES_URL


### PR DESCRIPTION
### Description

Update to use a 8core machine, should have 32 GB memory and 300 GB disk

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
