### PR TITLE
Well ...

### DIFF
--- a/.github/workflows/add-asset-to-gh-release.yml
+++ b/.github/workflows/add-asset-to-gh-release.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   add-assets-to-release:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-latest-8core
     steps:
       - run: |
           curl -L -o packages.tar.gz $PACKAGES_URL

--- a/.github/workflows/add-asset-to-gh-release.yml
+++ b/.github/workflows/add-asset-to-gh-release.yml
@@ -12,7 +12,7 @@ on:
 
 jobs:
   add-assets-to-release:
-    runs-on: ubuntu-latest-8core
+    runs-on: ubuntu-latest-8-cores
     steps:
       - run: |
           curl -L -o packages.tar.gz $PACKAGES_URL


### PR DESCRIPTION
### Description

[Doc](https://docs.github.com/de/actions/using-github-hosted-runners/using-larger-runners/running-jobs-on-larger-runners) suggests it should be called `ubuntu-latest-8core`, other resources would suggest it is `ubuntu-latest-8-cores`...

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
