### PR TITLE
Work around preloaded enums being broken on early PHP 8.4 versions with observers

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -112,7 +112,7 @@ $(BUILD_DIR)/run-tests.php: $(if $(ASSUME_COMPILED),, $(BUILD_DIR)/configure)
 	sed -i 's/\bdl(/(bool)(/' $(BUILD_DIR)/run-tests.php # this dl() stuff in run-tests.php is for --EXTENSIONS-- sections, which we don't use; just strip it away (see https://github.com/php/php-src/issues/15367)
 
 $(BUILD_DIR)/Makefile: $(BUILD_DIR)/configure
-	$(Q) (cd $(BUILD_DIR); ./configure --$(if $(RUST_DEBUG_BUILD),enable,disable)-ddtrace-rust-debug $(if $(ASAN), --enable-ddtrace-sanitize) $(EXTRA_CONFIGURE_OPTIONS))
+	$(Q) (cd $(BUILD_DIR); $(if $(ASAN),CFLAGS="${CFLAGS} -DZEND_TRACK_ARENA_ALLOC") ./configure --$(if $(RUST_DEBUG_BUILD),enable,disable)-ddtrace-rust-debug $(if $(ASAN), --enable-ddtrace-sanitize) $(EXTRA_CONFIGURE_OPTIONS))
 
 $(SO_FILE): $(if $(ASSUME_COMPILED),, $(ALL_OBJECT_FILES) $(BUILD_DIR)/compile_rust.sh)
 	$(if $(ASSUME_COMPILED),,$(Q) $(MAKE) -C $(BUILD_DIR) -j)

--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -1622,7 +1622,7 @@ static void dd_initialize_request(void) {
 static PHP_RINIT_FUNCTION(ddtrace) {
     UNUSED(module_number, type);
 
-#if PHP_VERSION_ID < 80000
+#if PHP_VERSION_ID < 80000 || (PHP_VERSION_ID >= 80400 && PHP_VERSION_ID < 80500)
     zai_interceptor_rinit();
 #endif
 

--- a/ext/live_debugger.c
+++ b/ext/live_debugger.c
@@ -27,7 +27,14 @@ static void clean_ctx(struct eval_ctx *ctx) {
         zend_arena *arena = ctx->arena;
         do {
             zend_arena *prev = arena->prev;
-            for (zval *cur = (zval *)((char *)arena + ZEND_MM_ALIGNED_SIZE(sizeof(zend_arena))); cur < (zval *)arena->ptr; ++cur) {
+#ifdef ZEND_TRACK_ARENA_ALLOC
+            for (zval **ptr = (zval **)arena->ptrs; ptr < (zval **)arena->ptr; ++ptr)
+            {
+                zval *cur = *ptr;
+#else
+            for (zval *cur = (zval *)((char *)arena + ZEND_MM_ALIGNED_SIZE(sizeof(zend_arena))); cur < (zval *)arena->ptr; ++cur)
+            {
+#endif
                 zval_ptr_dtor(cur);
             }
             arena = prev;

--- a/zend_abstract_interface/interceptor/php8/interceptor.h
+++ b/zend_abstract_interface/interceptor/php8/interceptor.h
@@ -12,5 +12,8 @@ void zai_interceptor_startup(void);
 void zai_interceptor_activate(void);
 void zai_interceptor_deactivate(void);
 void zai_interceptor_shutdown(void);
+#if PHP_VERSION_ID >= 80400 && PHP_VERSION_ID < 80500
+void zai_interceptor_rinit(void);
+#endif
 
 #endif  // ZAI_INTERCEPTOR_H


### PR DESCRIPTION
See also https://github.com/php/php-src/issues/17715.

Relatively simple fix: just initialize the cache slots on every request. Has a slight per request-overhead, but avoids crashes when SomePreloadedEnum::cases().

Not adding a test, it's covered by `preload_enum_observed.phpt` from php-src.