### PR TITLE
fix(prof): `fork()` call handling before rinit

### DIFF
--- a/profiling/src/allocation/allocation_ge84.rs
+++ b/profiling/src/allocation/allocation_ge84.rs
@@ -245,8 +245,12 @@ pub fn alloc_prof_rshutdown() {
         let mut custom_mm_gc: Option<zend::VmMmCustomGcFn> = None;
         let mut custom_mm_shutdown: Option<zend::VmMmCustomShutdownFn> = None;
 
-        // Safety: `unwrap()` is safe here, as `heap` is initialized in `MINIT`
+        if unsafe { (*zend_mm_state).heap.is_null() } {
+            return;
+        }
+
         let heap = unsafe { (*zend_mm_state).heap };
+
         unsafe {
             zend::zend_mm_get_custom_handlers_ex(
                 heap,

--- a/profiling/src/allocation/allocation_ge84.rs
+++ b/profiling/src/allocation/allocation_ge84.rs
@@ -245,7 +245,11 @@ pub fn alloc_prof_rshutdown() {
         let mut custom_mm_gc: Option<zend::VmMmCustomGcFn> = None;
         let mut custom_mm_shutdown: Option<zend::VmMmCustomShutdownFn> = None;
 
+        // SAFETY: UnsafeCell::get() ensures non-null, and the object should
+        // be valid for reads during rshutdown.
         let heap = unsafe { (*zend_mm_state).heap };
+
+        // The heap ptr can be null if a fork has happens outside the request.
         if heap.is_null() {
             return;
         }

--- a/profiling/src/allocation/allocation_ge84.rs
+++ b/profiling/src/allocation/allocation_ge84.rs
@@ -245,11 +245,10 @@ pub fn alloc_prof_rshutdown() {
         let mut custom_mm_gc: Option<zend::VmMmCustomGcFn> = None;
         let mut custom_mm_shutdown: Option<zend::VmMmCustomShutdownFn> = None;
 
-        if unsafe { (*zend_mm_state).heap.is_null() } {
+        let heap = unsafe { (*zend_mm_state).heap };
+        if heap.is_null() {
             return;
         }
-
-        let heap = unsafe { (*zend_mm_state).heap };
 
         unsafe {
             zend::zend_mm_get_custom_handlers_ex(

--- a/profiling/src/allocation/allocation_le83.rs
+++ b/profiling/src/allocation/allocation_le83.rs
@@ -181,7 +181,11 @@ pub fn alloc_prof_rshutdown() {
         let mut custom_mm_free: Option<zend::VmMmCustomFreeFn> = None;
         let mut custom_mm_realloc: Option<zend::VmMmCustomReallocFn> = None;
         // Safety: `unwrap()` is safe here, as `heap` is initialized in `RINIT`
-        let heap = unsafe { (*zend_mm_state).heap.unwrap() };
+        let heap = unsafe { (*zend_mm_state).heap };
+        if heap.is_none() {
+            return;
+        }
+        let heap = unsafe { heap.unwrap_unchecked() };
         unsafe {
             zend::zend_mm_get_custom_handlers(
                 heap,

--- a/profiling/src/allocation/allocation_le83.rs
+++ b/profiling/src/allocation/allocation_le83.rs
@@ -180,11 +180,13 @@ pub fn alloc_prof_rshutdown() {
         let mut custom_mm_malloc: Option<zend::VmMmCustomAllocFn> = None;
         let mut custom_mm_free: Option<zend::VmMmCustomFreeFn> = None;
         let mut custom_mm_realloc: Option<zend::VmMmCustomReallocFn> = None;
-        let heap = unsafe { (*zend_mm_state).heap };
-        if heap.is_none() {
+
+        // SAFETY: UnsafeCell::get() ensures non-null, and the object should
+        // be valid for reads during rshutdown.
+        let Some(heap) =  (unsafe { (*zend_mm_state).heap }) else {
             return;
-        }
-        let heap = unsafe { heap.unwrap_unchecked() };
+        };
+
         unsafe {
             zend::zend_mm_get_custom_handlers(
                 heap,

--- a/profiling/src/allocation/allocation_le83.rs
+++ b/profiling/src/allocation/allocation_le83.rs
@@ -180,7 +180,6 @@ pub fn alloc_prof_rshutdown() {
         let mut custom_mm_malloc: Option<zend::VmMmCustomAllocFn> = None;
         let mut custom_mm_free: Option<zend::VmMmCustomFreeFn> = None;
         let mut custom_mm_realloc: Option<zend::VmMmCustomReallocFn> = None;
-        // Safety: `unwrap()` is safe here, as `heap` is initialized in `RINIT`
         let heap = unsafe { (*zend_mm_state).heap };
         if heap.is_none() {
             return;


### PR DESCRIPTION
### Description

In case a `fork()` happens before the allocation profiler got initialised, the atfork handler in the child will try and shutdown the allocation profiler in the child and crash.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
