### PR TITLE
Fix unhandled dd_network; fix log message; fix handling of helper errors

### DIFF
--- a/appsec/src/extension/network.c
+++ b/appsec/src/extension/network.c
@@ -282,9 +282,12 @@ dd_result dd_conn_recv(dd_conn *nonnull conn, char *nullable *nonnull data,
 
     if (memcmp(h.code, "dds", 4) != 0) {
         mlog(dd_log_warning,
-            "Invalid message header from helper. First four bytes are "
-            "0x%02X%02X%02X%02x",
-            h.code[0], h.code[1], h.code[2], h.code[3]);
+            "Invalid message header from helper. First eight bytes are "
+            "%02X%02X%02X%02x%02X%02X%02X%02x",
+            ((unsigned char *)&h)[0], ((unsigned char *)&h)[1],
+            ((unsigned char *)&h)[2], ((unsigned char *)&h)[3],
+            ((unsigned char *)&h)[4], ((unsigned char *)&h)[5],
+            ((unsigned char *)&h)[6], ((unsigned char *)&h)[7]);
         // to force the connection closed. It may be we half-read a previous
         // message, so a reconnection can help
         return dd_network;

--- a/appsec/src/extension/request_lifecycle.c
+++ b/appsec/src/extension/request_lifecycle.c
@@ -278,7 +278,12 @@ void dd_req_lifecycle_rshutdown(bool ignore_verdict, bool force)
         } else {
             dd_result res = dd_config_sync(conn,
                 &(struct config_sync_data){.rem_cfg_path = _last_rem_cfg_path});
-            if (res) {
+            if (res == dd_network) {
+                mlog_g(dd_log_info, "request_init/config_sync failed with "
+                                    "dd_network; closing "
+                                    "connection to helper");
+                dd_helper_close_conn();
+            } else if (res) {
                 mlog_g(dd_log_info,
                     "Failed to sync remote config path on rshutdown: %s",
                     dd_result_to_string(res));

--- a/appsec/src/extension/user_tracking.c
+++ b/appsec/src/extension/user_tracking.c
@@ -132,6 +132,12 @@ void dd_find_and_apply_verdict_for_user(zend_string *nonnull user_id)
         Z_ARRVAL(data_zv), "usr.id", sizeof("usr.id") - 1, &user_id_zv);
 
     dd_result res = dd_request_exec(conn, &data_zv, false);
+    if (res == dd_network) {
+        mlog_g(dd_log_info, "request_exec failed with dd_network; closing "
+                            "connection to helper");
+        dd_helper_close_conn();
+    }
+
     zval_ptr_dtor(&data_zv);
 
     dd_tags_set_event_user_id(user_id);

--- a/appsec/tests/extension/helper_error_message.phpt
+++ b/appsec/tests/extension/helper_error_message.phpt
@@ -1,0 +1,27 @@
+--TEST--
+Test when helper responds with error
+--INI--
+datadog.appsec.log_file=/tmp/php_appsec_test.log
+datadog.appsec.log_level=debug
+--FILE--
+<?php
+use function datadog\appsec\testing\rinit;
+
+include __DIR__ . '/inc/mock_helper.php';
+require __DIR__ . '/inc/logging.php';
+
+$helper = Helper::createInitedRun([
+    response_list(response("error", []))
+]);
+
+var_dump(rinit());
+
+match_log("/Helper responded with an error\. Check helper logs/");
+match_log("/request init failed: dd_helper_error/");
+
+?>
+--EXPECTF--
+bool(true)
+found message in log matching /Helper responded with an error\. Check helper logs/
+found message in log matching /request init failed: dd_helper_error/
+


### PR DESCRIPTION
### Description

* Fix unhandled dd_network in newer calls (dd_network not handled)
* Fix log message (signed char -> integer promotion when printing)
* Fix handling of helper errors (extension took as errors messages with size 1 which were then leaked; actually helper sends an "error" message)

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
