### PR TITLE
feat(prof): add DD_TAGS support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1099,7 +1099,6 @@ dependencies = [
  "ciborium",
  "clap",
  "criterion-plot",
- "csv",
  "is-terminal",
  "itertools 0.10.5",
  "num-traits",
@@ -1273,22 +1272,23 @@ dependencies = [
  "arc-swap",
  "bytes",
  "criterion",
+ "data-pipeline",
  "datadog-ddsketch",
- "datadog-trace-normalization",
- "datadog-trace-obfuscation",
  "datadog-trace-protobuf",
  "datadog-trace-utils",
  "ddcommon 0.0.1",
+ "ddtelemetry",
  "dogstatsd-client",
  "either",
- "futures",
  "httpmock",
  "hyper 0.14.32",
  "log",
  "rand 0.8.5",
+ "regex",
  "rmp-serde",
  "serde",
  "serde_json",
+ "tempfile",
  "tinybytes",
  "tokio",
  "tokio-util",
@@ -1312,6 +1312,7 @@ dependencies = [
  "anyhow",
  "backtrace",
  "blazesym",
+ "cc",
  "chrono",
  "ddcommon 0.0.1",
  "ddtelemetry",
@@ -1319,6 +1320,8 @@ dependencies = [
  "hyper 0.14.32",
  "libc 0.2.169",
  "nix 0.27.1",
+ "num-derive",
+ "num-traits",
  "os_info",
  "page_size",
  "portable-atomic",
@@ -1544,8 +1547,6 @@ dependencies = [
  "arrayref",
  "base64 0.22.1",
  "bincode",
- "bytes",
- "cadence",
  "chrono",
  "console-subscriber",
  "data-pipeline",
@@ -1556,30 +1557,23 @@ dependencies = [
  "datadog-live-debugger",
  "datadog-remote-config",
  "datadog-sidecar-macros",
- "datadog-trace-normalization",
- "datadog-trace-protobuf",
  "datadog-trace-utils",
  "ddcommon 0.0.1",
  "ddtelemetry",
  "dogstatsd-client",
  "futures",
- "hashbrown 0.14.5",
  "http 0.2.12",
  "httpmock",
  "hyper 0.14.32",
- "io-lifetimes",
  "lazy_static",
  "libc 0.2.169",
  "manual_future",
  "memory-stats",
  "microseh",
  "nix 0.27.1",
- "pin-project",
  "prctl",
  "priority-queue",
  "rand 0.8.5",
- "regex",
- "rmp-serde",
  "sendfd",
  "serde",
  "serde_json",
@@ -1587,7 +1581,6 @@ dependencies = [
  "sha2",
  "simd-json",
  "spawn_worker",
- "sys-info",
  "tempfile",
  "tinybytes",
  "tokio",
@@ -1595,7 +1588,6 @@ dependencies = [
  "tracing",
  "tracing-log",
  "tracing-subscriber",
- "uuid",
  "winapi 0.3.9",
  "windows",
  "windows-sys 0.52.0",
@@ -1642,24 +1634,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "datadog-trace-obfuscation"
-version = "0.0.1"
-dependencies = [
- "anyhow",
- "criterion",
- "datadog-trace-protobuf",
- "datadog-trace-utils",
- "ddcommon 0.0.1",
- "duplicate",
- "log",
- "percent-encoding",
- "regex",
- "serde",
- "serde_json",
- "url",
-]
-
-[[package]]
 name = "datadog-trace-protobuf"
 version = "0.0.1"
 dependencies = [
@@ -1701,9 +1675,11 @@ dependencies = [
  "rmpv",
  "serde",
  "serde_json",
+ "tempfile",
  "testcontainers",
  "tinybytes",
  "tokio",
+ "urlencoding",
 ]
 
 [[package]]
@@ -1974,12 +1950,10 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "cadence",
- "datadog-ddsketch",
- "datadog-trace-normalization",
- "datadog-trace-protobuf",
  "ddcommon 0.0.1",
  "http 0.2.12",
  "serde",
+ "tokio",
  "tracing",
 ]
 
@@ -3457,6 +3431,17 @@ name = "num-conv"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+
+[[package]]
+name = "num-derive"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
+]
 
 [[package]]
 name = "num-integer"
@@ -5754,6 +5739,12 @@ dependencies = [
  "percent-encoding",
  "serde",
 ]
+
+[[package]]
+name = "urlencoding"
+version = "2.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
 
 [[package]]
 name = "utf16_iter"


### PR DESCRIPTION
### Description

"Fun" fact: the profiler once had `DD_TAGS` support, and this is why
there are tag parsing functions in libdatadog. I think it was lost when
the profiler adopted ZAI config, which was quite a long time ago.

Another "fun" fact: the profiler also had an INI entry for
`datadog.tags`, it just didn't use it anywhere.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
