### PR TITLE
Add span creation and close handlers

### DIFF
--- a/ext/compatibility.h
+++ b/ext/compatibility.h
@@ -432,6 +432,8 @@ static zend_always_inline int zend_compare(zval *op1, zval *op2) {
 #define Z_OBJPROP_P(zv) Z_OBJPROP(*(zval *)(zv))
 #undef Z_OBJDEBUG_P
 #define Z_OBJDEBUG_P(zv, is_temp) Z_OBJDEBUG(*(zval *)(zv), is_temp)
+
+#define ZEND_TYPE_CONTAINS_CODE(type, code) ((code) == IS_NULL ? ZEND_TYPE_ALLOW_NULL(type) : ZEND_TYPE_CODE(type) == (code))
 #endif
 
 #if PHP_VERSION_ID < 80100

--- a/ext/ddtrace_arginfo.h
+++ b/ext/ddtrace_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 5053d17ed0824b80591563b6f27fbc6ba18d0a3f */
+ * Stub hash: 683415b6ad6f59c7f8412ae4b2142b9c548c222a */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_trace_method, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, className, IS_STRING, 0)
@@ -85,7 +85,7 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_get_priority_sampling, 0
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_get_sanitized_exception_trace, 0, 1, IS_STRING, 0)
-	ZEND_ARG_OBJ_TYPE_MASK(0, exception, Exception|Throwable, 0, NULL)
+	ZEND_ARG_OBJ_INFO(0, exception, Throwable, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, skipFrames, IS_LONG, 0, "0")
 ZEND_END_ARG_INFO()
 
@@ -715,6 +715,12 @@ static zend_class_entry *register_class_DDTrace_SpanData(void)
 	zend_declare_typed_property(class_entry, property_stack_name, &property_stack_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_stack_class_DDTrace_SpanStack, 0, 0));
 	zend_string_release(property_stack_name);
 
+	zval property_onClose_default_value;
+	ZVAL_EMPTY_ARRAY(&property_onClose_default_value);
+	zend_string *property_onClose_name = zend_string_init("onClose", sizeof("onClose") - 1, 1);
+	zend_declare_typed_property(class_entry, property_onClose_name, &property_onClose_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY));
+	zend_string_release(property_onClose_name);
+
 	return class_entry;
 }
 
@@ -801,6 +807,12 @@ static zend_class_entry *register_class_DDTrace_SpanStack(void)
 	zend_string *property_active_class_DDTrace_SpanData = zend_string_init("DDTrace\\SpanData", sizeof("DDTrace\\SpanData")-1, 1);
 	zend_declare_typed_property(class_entry, property_active_name, &property_active_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_active_class_DDTrace_SpanData, 0, MAY_BE_NULL));
 	zend_string_release(property_active_name);
+
+	zval property_spanCreationObservers_default_value;
+	ZVAL_EMPTY_ARRAY(&property_spanCreationObservers_default_value);
+	zend_string *property_spanCreationObservers_name = zend_string_init("spanCreationObservers", sizeof("spanCreationObservers") - 1, 1);
+	zend_declare_typed_property(class_entry, property_spanCreationObservers_name, &property_spanCreationObservers_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_ARRAY));
+	zend_string_release(property_spanCreationObservers_name);
 
 	return class_entry;
 }

--- a/ext/handlers_curl.c
+++ b/ext/handlers_curl.c
@@ -138,6 +138,7 @@ static void dd_multi_inject_headers(zend_object *mh) {
             if (DDTRACE_G(curl_multi_injecting_spans) && Z_TYPE(DDTRACE_G(curl_multi_injecting_spans)->val) == IS_ARRAY) {
                 ddtrace_span_data *span = ddtrace_open_span(DDTRACE_INTERNAL_SPAN);
                 dd_inject_distributed_tracing_headers(ch);
+                ddtrace_observe_opened_span(span);
                 ddtrace_close_span(span);
                 span->duration = 1;
 

--- a/ext/hook/uhook.c
+++ b/ext/hook/uhook.c
@@ -145,7 +145,7 @@ void dd_uhook_report_sandbox_error(zend_execute_data *execute_data, zend_object 
         char *scope = "";
         char *colon = "";
         char *name = "(unknown function)";
-        if (execute_data->func && execute_data->func->common.function_name) {
+        if (execute_data && execute_data->func && execute_data->func->common.function_name) {
             zend_function *fbc = execute_data->func;
             name = ZSTR_VAL(fbc->common.function_name);
             if (fbc->common.scope) {

--- a/ext/hook/uhook_attributes.c
+++ b/ext/hook/uhook_attributes.c
@@ -199,9 +199,13 @@ static bool dd_uhook_begin(zend_ulong invocation, zend_execute_data *execute_dat
     def->active = true; // recursion protection
     dyn->was_primed = false;
 
-    dyn->span = ddtrace_alloc_execute_data_span(invocation, execute_data);
+    bool new_span;
+    dyn->span = ddtrace_alloc_execute_data_span_ex(invocation, execute_data, &new_span);
     dd_fill_span_data(def, dyn->span);
     dd_uhook_fill_args_in_meta(def, ddtrace_property_array(&dyn->span->property_meta), execute_data);
+    if (new_span) {
+        ddtrace_observe_opened_span(dyn->span);
+    }
 
     return true;
 }
@@ -223,12 +227,16 @@ static void dd_uhook_generator_resumption(zend_ulong invocation, zend_execute_da
         return;
     }
 
-    dyn->span = ddtrace_alloc_execute_data_span(invocation, execute_data);
+    bool new_span;
+    dyn->span = ddtrace_alloc_execute_data_span_ex(invocation, execute_data, &new_span);
     dd_fill_span_data(def, dyn->span);
     if (def->retval) {
         zend_array *meta = ddtrace_property_array(&dyn->span->property_meta);
         zval val = dd_uhook_save_value(value);
         zend_hash_str_update(meta, ZEND_STRL("send_value"), &val);
+    }
+    if (new_span) {
+        ddtrace_observe_opened_span(dyn->span);
     }
 }
 

--- a/ext/live_debugger.c
+++ b/ext/live_debugger.c
@@ -232,7 +232,8 @@ static bool dd_span_probe_begin(zend_ulong invocation, zend_execute_data *execut
 
     dd_probe_mark_active(def);
 
-    dyn->span = ddtrace_alloc_execute_data_span(invocation, execute_data);
+    bool new_span;
+    dyn->span = ddtrace_alloc_execute_data_span_ex(invocation, execute_data, &new_span);
 
     zval garbage;
     ZVAL_COPY_VALUE(&garbage, &dyn->span->property_resource);
@@ -243,6 +244,10 @@ static bool dd_span_probe_begin(zend_ulong invocation, zend_execute_data *execut
     zval probe_id;
     ZVAL_STR_COPY(&probe_id, def->probe_id);
     zend_hash_str_update(ddtrace_property_array(&dyn->span->property_meta), ZEND_STRL("debugger.probeid"), &probe_id);
+
+    if (new_span) {
+        ddtrace_observe_opened_span(dyn->span);
+    }
 
     return true;
 }

--- a/ext/span.c
+++ b/ext/span.c
@@ -18,6 +18,8 @@
 #include "user_request.h"
 #include "zend_types.h"
 #include "sidecar.h"
+#include "sandbox/sandbox.h"
+#include "hook/uhook.h"
 
 #define USE_REALTIME_CLOCK 0
 #define USE_MONOTONIC_CLOCK 1
@@ -228,14 +230,162 @@ ddtrace_span_data *ddtrace_open_span(enum ddtrace_span_dataype type) {
     return span;
 }
 
+static inline void dd_make_span_creation_observers_ref(zval *observers) {
+    if (!Z_ISREF_P(observers)) {
+        ZVAL_NEW_REF(observers, observers);
+#if PHP_VERSION_ID >= 80000
+        zend_property_info *prop = ddtrace_ce_span_stack->properties_info_table[(XtOffsetOf(ddtrace_span_stack, property_span_creation_observers) - (sizeof(zend_object) - sizeof(zval))) / sizeof(zval)];
+        ZEND_REF_ADD_TYPE_SOURCE(Z_REF_P(observers), prop);
+#endif
+    }
+}
+
+/* This function, written in PHP, would look like:
+ * foreach ($stack->spanCreationObservers as $key => &$observer) {
+ *     if ($observer instanceof \Closure && $observer($span) === false) {
+ *         $observer = null;
+ *         unset($stack->spanCreationObservers[$key]);
+ *     }
+ * }
+ */
+void ddtrace_observe_opened_span(ddtrace_span_data *span) {
+    ddtrace_span_stack *stack = span->stack;
+    zval *observers = &stack->property_span_creation_observers;
+    if (Z_TYPE_P(observers) == IS_ARRAY && zend_hash_num_elements(Z_ARR_P(observers)) == 0) {
+        return;  // fast path
+    }
+    // to be safe, we have to essentially foreach-by-ref
+    dd_make_span_creation_observers_ref(observers);
+    zend_reference *ref = Z_REF_P(observers);
+    observers = Z_REFVAL_P(observers);
+    if (Z_TYPE_P(observers) == IS_ARRAY && zend_hash_num_elements(Z_ARR_P(observers))) {
+        GC_ADDREF(ref);
+        uint32_t it = zend_hash_iterator_add(Z_ARR_P(observers), 0);
+        HashTableIterator *iter = EG(ht_iterators) + it;
+        zval *closure_zv, span_zv;
+        ZVAL_OBJ(&span_zv, &span->std);
+        for (;;) {
+            HashPosition pos = zend_hash_iterator_pos_ex(it, observers);
+            if ((closure_zv = zend_hash_get_current_data_ex(iter->ht, &pos))) {
+                bool cleanup = true;
+
+                zend_string *str_key;
+                zend_ulong num_key;
+                int key_type = zend_hash_get_current_key_ex(iter->ht, &str_key, &num_key, &pos);
+                if (key_type == HASH_KEY_IS_STRING) {
+                    str_key = zend_string_copy(str_key);
+                }
+
+                zend_hash_move_forward_ex(iter->ht, &pos);
+                iter->pos = pos;
+
+                zend_reference *closure_ref = NULL;
+                if (Z_TYPE_P(closure_zv) == IS_REFERENCE) {
+                    closure_ref = Z_REF_P(closure_zv);
+                    closure_zv = &closure_ref->val;
+                }
+                if (Z_TYPE_P(closure_zv) == IS_OBJECT && Z_OBJCE_P(closure_zv) == zend_ce_closure) {
+                    if (closure_ref) {
+                        GC_ADDREF(closure_ref);
+                    }
+
+                    zval rv;
+                    zai_sandbox sandbox;
+                    zai_sandbox_open(&sandbox);
+                    bool success = zai_symbol_call(ZAI_SYMBOL_SCOPE_GLOBAL, NULL,
+                                                   ZAI_SYMBOL_FUNCTION_CLOSURE, closure_zv,
+                                                   &rv, 1 | ZAI_SYMBOL_SANDBOX, &sandbox, &span_zv);
+                    if (!success || PG(last_error_message)) {
+                        dd_uhook_report_sandbox_error(sandbox.engine_state.current_execute_data, Z_OBJ_P(closure_zv));
+                    }
+                    zai_sandbox_close(&sandbox);
+                    zval_ptr_dtor(&rv);
+
+                    cleanup = Z_TYPE(rv) == IS_FALSE;
+
+                    if (closure_ref) {
+                        if (cleanup) {
+#if PHP_VERSION_ID >= 70400
+                            bool assignable = true;
+                            if (UNEXPECTED(ZEND_REF_HAS_TYPE_SOURCES(closure_ref))) {
+                                const zend_property_info *prop;
+                                ZEND_REF_FOREACH_TYPE_SOURCES(closure_ref, prop) {
+                                    if (!EXPECTED(ZEND_TYPE_CONTAINS_CODE(prop->type, IS_NULL))) {
+                                        assignable = false;
+                                    }
+                                } ZEND_REF_FOREACH_TYPE_SOURCES_END();
+                            }
+                            if (assignable)
+#endif
+                            {
+                                zval garbage;
+                                ZVAL_COPY_VALUE(&garbage, closure_zv);
+                                ZVAL_NULL(closure_zv);
+                                zval_ptr_dtor(&garbage);
+                            }
+                        }
+                        if (GC_DELREF(closure_ref) == 0) {
+                            zval_ptr_dtor(closure_zv);
+                            efree(closure_ref);
+                        }
+                    }
+
+                    observers = &stack->property_span_creation_observers;
+                    dd_make_span_creation_observers_ref(observers);
+                    observers = Z_REFVAL_P(observers);
+                    if (Z_TYPE_P(observers) != IS_ARRAY) {
+                        if (key_type == HASH_KEY_IS_STRING) {
+                            zend_string_release(str_key);
+                        }
+                        break;
+                    }
+                }
+
+                if (cleanup) {
+#if PHP_VERSION_ID < 80300 // work around https://github.com/php/php-src/issues/11244
+                    bool is_same_ht = Z_ARR_P(observers) == iter->ht;
+                    SEPARATE_ARRAY(observers);
+                    if (is_same_ht && Z_ARR_P(observers) != iter->ht) {
+                        --iter->ht->u.v.nIteratorsCount;
+                        iter->ht = Z_ARR_P(observers);
+                        ++iter->ht->u.v.nIteratorsCount;
+                    }
+#else
+                    SEPARATE_ARRAY(observers);
+#endif
+                    if (key_type == HASH_KEY_IS_STRING) {
+                        zend_hash_del(Z_ARR_P(observers), str_key);
+                    } else {
+                        zend_hash_index_del(Z_ARR_P(observers), num_key);
+                    }
+                }
+                if (key_type == HASH_KEY_IS_STRING) {
+                    zend_string_release(str_key);
+                }
+            } else {
+                break;
+            }
+        }
+
+        zend_hash_iterator_del(it);
+
+        if (GC_DELREF(ref) == 0) {
+            zval_ptr_dtor(&ref->val);
+            efree(ref);
+        }
+    }
+}
+
 // += 2 increment to avoid zval type ever being 0
-ddtrace_span_data *ddtrace_alloc_execute_data_span(zend_ulong index, zend_execute_data *execute_data) {
+ddtrace_span_data *ddtrace_alloc_execute_data_span_ex(zend_ulong index, zend_execute_data *execute_data, bool *new_span) {
     zval *span_zv = zend_hash_index_find(&DDTRACE_G(traced_spans), index);
     ddtrace_span_data *span;
     if (span_zv) {
+        *new_span = false;
         span = Z_PTR_P(span_zv);
         Z_TYPE_INFO_P(span_zv) += 2;
     } else {
+        *new_span = true;
         span = ddtrace_open_span(DDTRACE_INTERNAL_SPAN);
 
         // SpanData::$name defaults to fully qualified called name
@@ -292,6 +442,15 @@ ddtrace_span_data *ddtrace_alloc_execute_data_span(zend_ulong index, zend_execut
     return span;
 }
 
+ddtrace_span_data *ddtrace_alloc_execute_data_span(zend_ulong index, zend_execute_data *execute_data) {
+    bool new_span;
+    ddtrace_span_data *span = ddtrace_alloc_execute_data_span_ex(index, execute_data, &new_span);
+    if (new_span) {
+        ddtrace_observe_opened_span(span);
+    }
+    return span;
+}
+
 void ddtrace_clear_execute_data_span(zend_ulong index, bool keep) {
     zval *span_zv = zend_hash_index_find(&DDTRACE_G(traced_spans), index);
     ddtrace_span_data *span = Z_PTR_P(span_zv);
@@ -339,10 +498,33 @@ static ddtrace_span_stack *dd_alloc_span_stack(void) {
     return span_stack;
 }
 
+static void dd_inherit_span_stack(ddtrace_span_stack *span_stack, ddtrace_span_stack *active_stack) {
+    ZVAL_OBJ_COPY(&span_stack->property_parent, &active_stack->std);
+    // promote all values inside to reference, then copy
+    zval *observers = &active_stack->property_span_creation_observers;
+    if (Z_TYPE_P(observers) != IS_ARRAY || zend_hash_num_elements(Z_ARR_P(observers))) {
+        ZVAL_DEREF(observers);
+        if (Z_TYPE_P(observers) == IS_ARRAY) {
+            zval *value;
+            ZEND_HASH_REVERSE_FOREACH_VAL(Z_ARR_P(observers), value) {
+                if (!Z_ISREF_P(value)) {
+                    SEPARATE_ARRAY(observers);
+                    ZEND_HASH_FOREACH_VAL(Z_ARR_P(observers), value) {
+                        ZVAL_MAKE_REF(value);
+                    } ZEND_HASH_FOREACH_END();
+                    break;
+                }
+            } ZEND_HASH_FOREACH_END();
+            zval_ptr_dtor(&span_stack->property_span_creation_observers);
+            ZVAL_COPY(&span_stack->property_span_creation_observers, observers);
+        }
+    }
+}
+
 ddtrace_span_stack *ddtrace_init_root_span_stack(void) {
     ddtrace_span_stack *span_stack = dd_alloc_span_stack();
     if (DDTRACE_G(active_stack)) {
-        ZVAL_OBJ_COPY(&span_stack->property_parent, &DDTRACE_G(active_stack)->std);
+        dd_inherit_span_stack(span_stack, DDTRACE_G(active_stack));
     } else {
         ZVAL_NULL(&span_stack->property_parent);
         span_stack->parent_stack = NULL;
@@ -357,11 +539,11 @@ ddtrace_span_stack *ddtrace_init_root_span_stack(void) {
 }
 
 ddtrace_span_stack *ddtrace_init_span_stack(void) {
-    ddtrace_span_stack *span_stack = dd_alloc_span_stack();
-    ZVAL_OBJ_COPY(&span_stack->property_parent, &DDTRACE_G(active_stack)->std);
-    ZVAL_COPY(&span_stack->property_active, &DDTRACE_G(active_stack)->property_active);
-    span_stack->root_stack = DDTRACE_G(active_stack)->root_stack;
-    span_stack->root_span = DDTRACE_G(active_stack)->root_span;
+    ddtrace_span_stack *span_stack = dd_alloc_span_stack(), *active_stack = DDTRACE_G(active_stack);
+    dd_inherit_span_stack(span_stack, active_stack);
+    ZVAL_COPY(&span_stack->property_active, &active_stack->property_active);
+    span_stack->root_stack = active_stack->root_stack;
+    span_stack->root_span = active_stack->root_span;
 
     LOG(SPAN_TRACE, "Creating new SpanStack: %d, parent_stack: %d", span_stack->std.handle, span_stack->parent_stack ? span_stack->parent_stack->std.handle : 0);
 
@@ -372,6 +554,7 @@ void ddtrace_push_root_span(void) {
     ddtrace_span_data *span = ddtrace_open_span(DDTRACE_AUTOROOT_SPAN);
     // We opened the span, but are not going to hold a reference to it directly - the stack will manage it.
     GC_DELREF(&span->std);
+    ddtrace_observe_opened_span(span);
 }
 
 DDTRACE_PUBLIC zend_object *ddtrace_get_root_span()
@@ -496,12 +679,20 @@ static void dd_mark_closed_spans_flushable(ddtrace_span_stack *stack) {
             GC_ADDREF(&stack->std);
 
             if (stack->root_span && (stack->root_span->stack == stack || stack->root_span->type == DDTRACE_SPAN_CLOSED)) {
-                stack->next = DDTRACE_G(top_closed_stack);
-                DDTRACE_G(top_closed_stack) = stack;
+                if (!stack->top_closed_stack) {
+                    stack->next = DDTRACE_G(top_closed_stack);
+                    DDTRACE_G(top_closed_stack) = stack;
+                }
             } else {
                 // we'll just attach it so that it'll be flushed together (i.e. chunks are not flushed _before_ the root stack)
-                stack->next = stack->root_stack->top_closed_stack;
-                stack->root_stack->top_closed_stack = stack;
+                ddtrace_span_stack *root_stack = stack->root_stack;
+                // but handle the case where no closed spans exist yet on the primary stack
+                if (!root_stack->closed_ring_flush && !root_stack->top_closed_stack) {
+                    root_stack->next = DDTRACE_G(top_closed_stack);
+                    DDTRACE_G(top_closed_stack) = root_stack;
+                }
+                stack->next = root_stack->top_closed_stack;
+                root_stack->top_closed_stack = stack;
             }
         }
         stack->closed_ring = NULL;
@@ -546,6 +737,35 @@ void ddtrace_close_span(ddtrace_span_data *span) {
     // Closing a span (esp. when leaving a traced function) autoswitches the stacks if necessary
     if (span->stack != DDTRACE_G(active_stack)) {
         ddtrace_switch_span_stack(span->stack);
+    }
+
+    if (Z_TYPE(span->property_on_close) != IS_ARRAY || zend_hash_num_elements(Z_ARR(span->property_on_close))) {
+        zval on_close_zv, *on_close = &on_close_zv;
+        ZVAL_COPY_VALUE(&on_close_zv, &span->property_on_close);
+        ZVAL_EMPTY_ARRAY(&span->property_on_close);
+
+        ZVAL_DEREF(on_close);
+        if (Z_TYPE_P(on_close) == IS_ARRAY) {
+            zval *closure_zv, span_zv;
+            ZVAL_OBJ(&span_zv, &span->std);
+            ZEND_HASH_REVERSE_FOREACH_VAL(Z_ARR_P(on_close), closure_zv) {
+                ZVAL_DEREF(closure_zv);
+                if (Z_TYPE_P(closure_zv) == IS_OBJECT && Z_OBJCE_P(closure_zv) == zend_ce_closure) {
+                    zval rv;
+                    zai_sandbox sandbox;
+                    zai_sandbox_open(&sandbox);
+                    bool success = zai_symbol_call(ZAI_SYMBOL_SCOPE_GLOBAL, NULL,
+                                                   ZAI_SYMBOL_FUNCTION_CLOSURE, closure_zv,
+                                                   &rv, 1 | ZAI_SYMBOL_SANDBOX, &sandbox, &span_zv);
+                    if (!success || PG(last_error_message)) {
+                        dd_uhook_report_sandbox_error(sandbox.engine_state.current_execute_data, Z_OBJ_P(closure_zv));
+                    }
+                    zai_sandbox_close(&sandbox);
+                    zval_ptr_dtor(&rv);
+                }
+            } ZEND_HASH_FOREACH_END();
+        }
+        zval_ptr_dtor(&on_close_zv);
     }
 
     // Telemetry: increment the spans_created counter
@@ -732,6 +952,11 @@ void ddtrace_serialize_closed_spans(zval *serialized) {
             rootstack = rootstack->next;
             ddtrace_span_stack *next_stack = stack->top_closed_stack;
             stack->top_closed_stack = NULL;
+            if (!stack->closed_ring_flush) {
+                // stacks might be on the close-queue, but not have stacks on their own, only other attached closed stacks
+                stack = next_stack;
+                next_stack = stack->next;
+            }
             do {
                 // Note this ->next: We always splice in new spans at next, so start at next to mostly preserve order
                 ddtrace_span_data *span = stack->closed_ring_flush->next, *end = span;

--- a/ext/span.h
+++ b/ext/span.h
@@ -67,6 +67,7 @@ typedef union ddtrace_span_properties {
             struct ddtrace_span_stack *stack;
             zval property_stack;
         };
+        zval property_on_close;
     };
 } ddtrace_span_properties;
 
@@ -141,6 +142,7 @@ struct ddtrace_span_stack {
                 zval property_active;
                 ddtrace_span_properties *active;
             };
+            zval property_span_creation_observers;
         };
     };
     struct ddtrace_root_span_data *root_span;
@@ -207,6 +209,7 @@ void ddtrace_free_span_stacks(bool silent);
 void ddtrace_switch_span_stack(ddtrace_span_stack *target_stack);
 
 ddtrace_span_data *ddtrace_open_span(enum ddtrace_span_dataype type);
+void ddtrace_observe_opened_span(ddtrace_span_data *span);
 ddtrace_span_data *ddtrace_init_dummy_span(void);
 ddtrace_span_stack *ddtrace_init_span_stack(void);
 ddtrace_span_stack *ddtrace_init_root_span_stack(void);
@@ -218,6 +221,7 @@ static inline ddtrace_span_properties *ddtrace_active_span_props(void) {
     return span ? &span->props : NULL;
 }
 
+ddtrace_span_data *ddtrace_alloc_execute_data_span_ex(zend_ulong invocation, zend_execute_data *execute_data, bool *new_span);
 ddtrace_span_data *ddtrace_alloc_execute_data_span(zend_ulong invocation, zend_execute_data *execute_data);
 void ddtrace_clear_execute_data_span(zend_ulong invocation, bool keep);
 

--- a/tests/ext/active_span.phpt
+++ b/tests/ext/active_span.phpt
@@ -28,7 +28,7 @@ var_dump(DDTrace\active_span() == DDTrace\active_span());
 Hello, Datadog.
 greet tracer.
 bool(true)
-object(DDTrace\RootSpanData)#%d (21) {
+object(DDTrace\RootSpanData)#%d (22) {
   ["name"]=>
   string(15) "active_span.php"
   ["resource"]=>
@@ -70,16 +70,25 @@ object(DDTrace\RootSpanData)#%d (21) {
   ["parent"]=>
   NULL
   ["stack"]=>
-  object(DDTrace\SpanStack)#%d (2) {
+  object(DDTrace\SpanStack)#%d (3) {
     ["parent"]=>
-    object(DDTrace\SpanStack)#%d (2) {
+    object(DDTrace\SpanStack)#%d (3) {
       ["parent"]=>
       NULL
       ["active"]=>
       NULL
+      ["spanCreationObservers"]=>
+      array(0) {
+      }
     }
     ["active"]=>
     *RECURSION*
+    ["spanCreationObservers"]=>
+    array(0) {
+    }
+  }
+  ["onClose"]=>
+  array(0) {
   }%r(\s*\["origin"\]=>\s+uninitialized\(string\))?%r
   ["propagatedTags"]=>
   array(0) {

--- a/tests/ext/sandbox/span_clone.phpt
+++ b/tests/ext/sandbox/span_clone.phpt
@@ -25,7 +25,7 @@ var_dump(dd_trace_serialize_closed_spans());
 
 ?>
 --EXPECTF--
-object(DDTrace\RootSpanData)#%d (21) {
+object(DDTrace\RootSpanData)#%d (22) {
   ["name"]=>
   string(3) "foo"
   ["resource"]=>
@@ -67,16 +67,25 @@ object(DDTrace\RootSpanData)#%d (21) {
   ["parent"]=>
   NULL
   ["stack"]=>
-  object(DDTrace\SpanStack)#%d (2) {
+  object(DDTrace\SpanStack)#%d (3) {
     ["parent"]=>
-    object(DDTrace\SpanStack)#%d (2) {
+    object(DDTrace\SpanStack)#%d (3) {
       ["parent"]=>
       NULL
       ["active"]=>
       NULL
+      ["spanCreationObservers"]=>
+      array(0) {
+      }
     }
     ["active"]=>
     *RECURSION*
+    ["spanCreationObservers"]=>
+    array(0) {
+    }
+  }
+  ["onClose"]=>
+  array(0) {
   }%r(\s*\["origin"\]=>\s+uninitialized\(string\))?%r
   ["propagatedTags"]=>
   array(0) {
@@ -91,7 +100,7 @@ object(DDTrace\RootSpanData)#%d (21) {
   ["gitMetadata"]=>
   NULL
 }
-object(DDTrace\RootSpanData)#%d (21) {
+object(DDTrace\RootSpanData)#%d (22) {
   ["name"]=>
   string(5) "dummy"
   ["resource"]=>
@@ -133,16 +142,19 @@ object(DDTrace\RootSpanData)#%d (21) {
   ["parent"]=>
   NULL
   ["stack"]=>
-  object(DDTrace\SpanStack)#%d (2) {
+  object(DDTrace\SpanStack)#%d (3) {
     ["parent"]=>
-    object(DDTrace\SpanStack)#%d (2) {
+    object(DDTrace\SpanStack)#%d (3) {
       ["parent"]=>
       NULL
       ["active"]=>
       NULL
+      ["spanCreationObservers"]=>
+      array(0) {
+      }
     }
     ["active"]=>
-    object(DDTrace\RootSpanData)#%d (21) {
+    object(DDTrace\RootSpanData)#%d (22) {
       ["name"]=>
       string(3) "foo"
       ["resource"]=>
@@ -184,7 +196,10 @@ object(DDTrace\RootSpanData)#%d (21) {
       ["parent"]=>
       NULL
       ["stack"]=>
-      *RECURSION*%r(\s*\["origin"\]=>\s+uninitialized\(string\))?%r
+      *RECURSION*
+      ["onClose"]=>
+      array(0) {
+      }%r(\s*\["origin"\]=>\s+uninitialized\(string\))?%r
       ["propagatedTags"]=>
       array(0) {
       }
@@ -198,6 +213,12 @@ object(DDTrace\RootSpanData)#%d (21) {
       ["gitMetadata"]=>
       NULL
     }
+    ["spanCreationObservers"]=>
+    array(0) {
+    }
+  }
+  ["onClose"]=>
+  array(0) {
   }%r(\s*\["origin"\]=>\s+uninitialized\(string\))?%r
   ["propagatedTags"]=>
   array(0) {

--- a/tests/ext/span_create_observer.phpt
+++ b/tests/ext/span_create_observer.phpt
@@ -1,0 +1,99 @@
+--TEST--
+Test observing span creation
+--INI--
+datadog.trace.generate_root_span=0
+--FILE--
+<?php
+
+DDTrace\active_stack()->spanCreationObservers[] = function($span) {
+    $span->name = "hey";
+    echo "Observed\n";
+};
+
+DDTrace\start_span();
+$span = DDTrace\start_span();
+print "Got assigned a name: $span->name\n";
+DDTrace\close_span();
+DDTrace\close_span();
+
+DDTrace\create_stack();
+DDTrace\start_span();
+DDTrace\close_span();
+
+DDTrace\active_stack()->spanCreationObservers = [];
+DDTrace\start_span();
+DDTrace\close_span();
+
+DDTrace\switch_stack();
+
+print "Back to root\n";
+
+DDTrace\active_stack()->spanCreationObservers[] = function($span) {
+    echo "Observed and removed: 1\n";
+    return false;
+};
+DDTrace\start_span();
+DDTrace\start_span();
+DDTrace\close_span();
+DDTrace\close_span();
+
+// inherited and propagated back (removing original "observed" function too)
+DDTrace\active_stack()->spanCreationObservers = [function($span) {
+    echo "Observed and removed: 2\n";
+    return false;
+}];
+DDTrace\create_stack();
+DDTrace\start_span();
+DDTrace\close_span();
+DDTrace\start_span();
+DDTrace\close_span();
+DDTrace\switch_stack();
+DDTrace\start_span();
+DDTrace\close_span();
+
+DDTrace\start_span(); // on top of a root span
+DDTrace\active_stack()->spanCreationObservers = [function($span) {
+    echo "Observed, added and removed\n";
+    DDTrace\active_stack()->spanCreationObservers[] = function($span) {
+        echo "Inner-observed\n";
+    };
+    return false;
+}, 2];
+DDTrace\start_span();
+DDTrace\close_span();
+DDTrace\start_span();
+DDTrace\close_span();
+DDTrace\close_span();
+
+echo "Observed is count: ", count(array_filter(DDTrace\active_stack()->spanCreationObservers)), "\n";
+
+DDTrace\active_stack()->spanCreationObservers = [function($span) {
+    echo "Observed and cleared\n";
+    // root spans create a stack, hence parent
+    DDTrace\active_stack()->spanCreationObservers = [];
+    DDTrace\active_stack()->parent->spanCreationObservers = [];
+}, function($span) {
+    echo "Not visited\n";
+}];
+DDTrace\start_span();
+DDTrace\close_span();
+DDTrace\start_span();
+DDTrace\close_span();
+
+
+?>
+--EXPECT--
+Observed
+Observed
+Got assigned a name: hey
+Observed
+Back to root
+Observed
+Observed and removed: 1
+Observed
+Observed and removed: 2
+Observed, added and removed
+Inner-observed
+Inner-observed
+Observed is count: 0
+Observed and cleared

--- a/tests/ext/span_on_close.phpt
+++ b/tests/ext/span_on_close.phpt
@@ -1,0 +1,32 @@
+--TEST--
+Test onClose SpanData handler
+--INI--
+datadog.trace.debug=true
+datadog.autofinish_spans=true
+--FILE--
+<?php
+
+DDTrace\active_span()->onClose[] = function($span) {
+    $span->name = "root span";
+};
+
+$span = DDTrace\start_span();
+$span->onClose = [
+    function($span) {
+        print "First\n";
+        $span->name = "inner span";
+    },
+    function($span) {
+        print "Second\n";
+        $span->resource = "datadogs are awesome";
+    },
+];
+
+?>
+--EXPECTF--
+Second
+First
+[ddtrace] [span] Encoding span %s name='root span'%sresource: 'root span'%s
+[ddtrace] [span] Encoding span %s name='inner span',%sresource: 'datadogs are awesome'%s
+[ddtrace] [info] Flushing trace of size 2 to send-queue for %s
+[ddtrace] [info] No finished traces to be sent to the agent


### PR DESCRIPTION
The span creation handler is, in particular, needed to attach data dynamically to spans created within a context. E.g. attaching span links from a promises completion span to the promise awaiting span.

It is also beneficial for compression of spans; e.g. an eloquent integration may now opt to no longer create its own span, but manipulate the span created by the mysql integration instead - by first attaching a spanCreationObserver and then in that one attaching an onClose handler, gaining access to the final contents and able to manipulate it.

Span creation handlers are inherited via create_stack(). This can be essentially considered a form of context propagation without having a context with arbitrary metadata. These handlers can be globally removed by returning false (it resets the reference to null, effectively nulling it). That strategy ultimately allows full control over when the handlers are invoked. Also they are internally only called after the span was constructed with internal metadata, so that users never see spans in early construction stages, but before any user callbacks are invoked.

Span close handlers are executed in reverse order so that integrations (or users which ultimately end up calling integrations) may layer nicely (given that adding onClose handlers will generally happen with `$span->onClose[] = ...;` appending assignments).

It's also an alternative to an all-powerful post-processing handler.