### PR TITLE
Avoid using db.statement in favor of sql.query

### DIFF
--- a/src/DDTrace/Integrations/SQLSRV/SQLSRVIntegration.php
+++ b/src/DDTrace/Integrations/SQLSRV/SQLSRVIntegration.php
@@ -167,10 +167,6 @@ class SQLSRVIntegration extends Integration
         $span->meta[Tag::COMPONENT] = SQLSRVIntegration::NAME;
         $span->meta[Tag::DB_SYSTEM] = SQLSRVIntegration::SYSTEM;
 
-        if ($query) {
-            $span->meta[Tag::DB_STMT] = $query;
-        }
-
         foreach ($storedConnectionInfo as $tag => $value) {
             $span->meta[$tag] = $value;
         }

--- a/src/api/Tag.php
+++ b/src/api/Tag.php
@@ -19,7 +19,7 @@ class Tag
     const MANUAL_DROP = 'manual.drop';
     const PID = 'process_id';
     const RESOURCE_NAME = 'resource.name';
-    const DB_STATEMENT = 'sql.query';
+    const DB_STATEMENT = self::DB_STMT;
     const ERROR = 'error';
     const ERROR_MSG = 'error.message'; // string representing the error message
     const ERROR_TYPE = 'error.type'; // string representing the type of the error
@@ -57,7 +57,7 @@ class Tag
     const DB_TYPE = 'db.type';
     const DB_SYSTEM = 'db.system';
     const DB_ROW_COUNT = 'db.row_count';
-    const DB_STMT = 'db.statement';
+    const DB_STMT = 'sql.query';
     const DB_USER = 'db.user';
 
     // Kafka

--- a/src/ddtrace_php_api.stubs.php
+++ b/src/ddtrace_php_api.stubs.php
@@ -2206,7 +2206,7 @@ namespace DDTrace {
         const MANUAL_DROP = 'manual.drop';
         const PID = 'process_id';
         const RESOURCE_NAME = 'resource.name';
-        const DB_STATEMENT = 'sql.query';
+        const DB_STATEMENT = self::DB_STMT;
         const ERROR = 'error';
         const ERROR_MSG = 'error.message';
         // string representing the error message
@@ -2246,7 +2246,7 @@ namespace DDTrace {
         const DB_TYPE = 'db.type';
         const DB_SYSTEM = 'db.system';
         const DB_ROW_COUNT = 'db.row_count';
-        const DB_STMT = 'db.statement';
+        const DB_STMT = 'sql.query';
         const DB_USER = 'db.user';
         // Kafka
         const KAFKA_CLIENT_ID = 'messaging.kafka.client_id';

--- a/tests/Integrations/SQLSRV/SQLSRVTest.php
+++ b/tests/Integrations/SQLSRV/SQLSRVTest.php
@@ -490,7 +490,7 @@ class SQLSRVTest extends IntegrationTestCase
             Tag::DB_USER => self::$user,
             Tag::TARGET_HOST => self::$host,
             Tag::TARGET_PORT => self::$port,
-        ] + ($query ? [Tag::DB_STMT => $query] : []);
+        ];
 
         if ($expectPeerService) {
             $tags['peer.service'] = 'master';

--- a/tests/api/Unit/UserAvailableConstantsTest.php
+++ b/tests/api/Unit/UserAvailableConstantsTest.php
@@ -136,7 +136,7 @@ class UserAvailableConstantsTest extends BaseTestCase
             [Tag::DB_TYPE, 'db.type'],
             [Tag::DB_SYSTEM, 'db.system'],
             [Tag::DB_ROW_COUNT, 'db.row_count'],
-            [Tag::DB_STMT, 'db.statement'],
+            [Tag::DB_STMT, 'sql.query'],
             [Tag::DB_USER, 'db.user'],
             [Tag::KAFKA_CLIENT_ID, 'messaging.kafka.client_id'],
             [Tag::KAFKA_GROUP_ID, 'messaging.kafka.group_id'],


### PR DESCRIPTION
db.statement is not normalized while sql.query is. Also sending sql.query in SQLSRVIntegration is redundant.