### PR TITLE
Add DDTrace\try_drop_span() API

### DIFF
--- a/ext/ddtrace.stub.php
+++ b/ext/ddtrace.stub.php
@@ -72,13 +72,13 @@ namespace DDTrace {
     class SpanLink implements \JsonSerializable {
         /**
          * @var string $traceId A 32-character, lower-case hexadecimal encoded string of the linked trace ID. This field
-         * shouldn't be directly assigned an id from SpanData. Use the SpanData::getLinks() method instead.
+         * shouldn't be directly assigned an id from SpanData. Use the SpanData::getLink() method instead.
          */
         public string $traceId;
 
         /**
          * @var string $spanId A 16-character, lower-case hexadecimal encoded string of the linked span ID. This field
-         * shouldn't be directly assigned an id from SpanData. Use the SpanData::getLinks() method instead.
+         * shouldn't be directly assigned an id from SpanData. Use the SpanData::getLink() method instead.
          */
         public string $spanId;
 
@@ -574,6 +574,18 @@ namespace DDTrace {
      * @return RootSpanData The newly created root span
      */
     function start_trace_span(float $startTime = 0): RootSpanData {}
+
+
+    /**
+     * Attempts to drop a span without breaking the trace.
+     * No metrics will be collected for that span, if successfully dropped.
+     * This means, the span is not dropped if any of the following were true before calling this function:
+     *  - the span has a non-dropped child span
+     *  - generate_distributed_tracing_headers() was called while this span was active
+     *  - a span link to this span was generated
+     * @return bool Whether the span was successfully dropped.
+     */
+    function try_drop_span(SpanData $span): bool {}
 
     /**
      * Get the active stack

--- a/ext/ddtrace_arginfo.h
+++ b/ext/ddtrace_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: f7e8f6a8052abd0404a3e01fa6b52d27024e6f1b */
+ * Stub hash: 21dd48a5e3e602ba3be010a325d2cb8b703907c7 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_trace_method, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, className, IS_STRING, 0)
@@ -63,6 +63,10 @@ ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_DDTrace_start_trace_span, 0, 0, DDTrace\\RootSpanData, 0)
 	ZEND_ARG_TYPE_INFO_WITH_DEFAULT_VALUE(0, startTime, IS_DOUBLE, 0, "0")
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_try_drop_span, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_OBJ_INFO(0, span, DDTrace\\SpanData, 0)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_OBJ_INFO_EX(arginfo_DDTrace_active_stack, 0, 0, DDTrace\\SpanStack, 1)
@@ -318,6 +322,7 @@ ZEND_FUNCTION(DDTrace_start_span);
 ZEND_FUNCTION(DDTrace_close_span);
 ZEND_FUNCTION(DDTrace_update_span_duration);
 ZEND_FUNCTION(DDTrace_start_trace_span);
+ZEND_FUNCTION(DDTrace_try_drop_span);
 ZEND_FUNCTION(DDTrace_active_stack);
 ZEND_FUNCTION(DDTrace_create_stack);
 ZEND_FUNCTION(DDTrace_switch_stack);
@@ -402,6 +407,7 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "close_span"), zif_DDTrace_close_span, arginfo_DDTrace_close_span, 0, NULL, NULL)
 	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "update_span_duration"), zif_DDTrace_update_span_duration, arginfo_DDTrace_update_span_duration, 0, NULL, NULL)
 	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "start_trace_span"), zif_DDTrace_start_trace_span, arginfo_DDTrace_start_trace_span, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "try_drop_span"), zif_DDTrace_try_drop_span, arginfo_DDTrace_try_drop_span, 0, NULL, NULL)
 	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "active_stack"), zif_DDTrace_active_stack, arginfo_DDTrace_active_stack, 0, NULL, NULL)
 	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "create_stack"), zif_DDTrace_create_stack, arginfo_DDTrace_create_stack, 0, NULL, NULL)
 	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "switch_stack"), zif_DDTrace_switch_stack, arginfo_DDTrace_switch_stack, 0, NULL, NULL)
@@ -520,9 +526,7 @@ static zend_class_entry *register_class_DDTrace_SpanEvent(zend_class_entry *clas
 
 	zval property_name_default_value;
 	ZVAL_UNDEF(&property_name_default_value);
-	zend_string *property_name_name = zend_string_init("name", sizeof("name") - 1, 1);
-	zend_declare_typed_property(class_entry, property_name_name, &property_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
-	zend_string_release(property_name_name);
+	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_NAME), &property_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING));
 
 	zval property_attributes_default_value;
 	ZVAL_UNDEF(&property_attributes_default_value);
@@ -628,15 +632,11 @@ static zend_class_entry *register_class_DDTrace_SpanData(void)
 
 	zval property_name_default_value;
 	ZVAL_EMPTY_STRING(&property_name_default_value);
-	zend_string *property_name_name = zend_string_init("name", sizeof("name") - 1, 1);
-	zend_declare_typed_property(class_entry, property_name_name, &property_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
-	zend_string_release(property_name_name);
+	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_NAME), &property_name_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 
 	zval property_resource_default_value;
 	ZVAL_EMPTY_STRING(&property_resource_default_value);
-	zend_string *property_resource_name = zend_string_init("resource", sizeof("resource") - 1, 1);
-	zend_declare_typed_property(class_entry, property_resource_name, &property_resource_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
-	zend_string_release(property_resource_name);
+	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_RESOURCE), &property_resource_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 
 	zval property_service_default_value;
 	ZVAL_EMPTY_STRING(&property_service_default_value);
@@ -664,9 +664,7 @@ static zend_class_entry *register_class_DDTrace_SpanData(void)
 
 	zval property_type_default_value;
 	ZVAL_EMPTY_STRING(&property_type_default_value);
-	zend_string *property_type_name = zend_string_init("type", sizeof("type") - 1, 1);
-	zend_declare_typed_property(class_entry, property_type_name, &property_type_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
-	zend_string_release(property_type_name);
+	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_TYPE), &property_type_default_value, ZEND_ACC_PUBLIC, NULL, (zend_type) ZEND_TYPE_INIT_MASK(MAY_BE_STRING|MAY_BE_NULL));
 
 	zval property_meta_default_value;
 	ZVAL_EMPTY_ARRAY(&property_meta_default_value);
@@ -713,10 +711,8 @@ static zend_class_entry *register_class_DDTrace_SpanData(void)
 
 	zval property_parent_default_value;
 	ZVAL_UNDEF(&property_parent_default_value);
-	zend_string *property_parent_name = zend_string_init("parent", sizeof("parent") - 1, 1);
 	zend_string *property_parent_class_DDTrace_SpanData = zend_string_init("DDTrace\\SpanData", sizeof("DDTrace\\SpanData")-1, 1);
-	zend_declare_typed_property(class_entry, property_parent_name, &property_parent_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_parent_class_DDTrace_SpanData, 0, MAY_BE_NULL));
-	zend_string_release(property_parent_name);
+	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_PARENT), &property_parent_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_parent_class_DDTrace_SpanData, 0, MAY_BE_NULL));
 
 	zval property_stack_default_value;
 	ZVAL_UNDEF(&property_stack_default_value);
@@ -831,10 +827,8 @@ static zend_class_entry *register_class_DDTrace_SpanStack(void)
 
 	zval property_parent_default_value;
 	ZVAL_UNDEF(&property_parent_default_value);
-	zend_string *property_parent_name = zend_string_init("parent", sizeof("parent") - 1, 1);
 	zend_string *property_parent_class_DDTrace_SpanStack = zend_string_init("DDTrace\\SpanStack", sizeof("DDTrace\\SpanStack")-1, 1);
-	zend_declare_typed_property(class_entry, property_parent_name, &property_parent_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_parent_class_DDTrace_SpanStack, 0, MAY_BE_NULL));
-	zend_string_release(property_parent_name);
+	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_PARENT), &property_parent_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_parent_class_DDTrace_SpanStack, 0, MAY_BE_NULL));
 
 	zval property_active_default_value;
 	ZVAL_NULL(&property_active_default_value);

--- a/ext/handlers_http.h
+++ b/ext/handlers_http.h
@@ -202,6 +202,8 @@ static inline void ddtrace_inject_distributed_headers_config(zend_array *array, 
     zend_string *tracestate = DDTRACE_G(tracestate);
     zend_array *baggage = &DDTRACE_G(baggage);
     if (root) {
+        SPANDATA(DDTRACE_G(active_stack)->active)->flags |= DDTRACE_SPAN_FLAG_NOT_DROPPABLE;
+
         if (Z_TYPE(root->property_origin) == IS_STRING && Z_STRLEN(root->property_origin)) {
             origin = Z_STR(root->property_origin);
         } else {

--- a/ext/span.c
+++ b/ext/span.c
@@ -48,6 +48,9 @@ static void dd_drop_span_nodestroy(ddtrace_span_data *span, bool silent) {
         ddtrace_root_span_data *root = ROOTSPANDATA(&span->std);
         LOG(SPAN_TRACE, "Dropping root span: trace_id=%s, span_id=%" PRIu64, Z_STRVAL(root->property_trace_id), span->span_id);
     } else {
+        if (span->parent) {
+            --SPANDATA(span->parent)->active_child_spans;
+        }
         LOG(SPAN_TRACE, "Dropping span: trace_id=%s, span_id=%" PRIu64, Z_STRVAL(span->root->property_trace_id), span->span_id);
     }
 }
@@ -289,6 +292,8 @@ ddtrace_span_data *ddtrace_open_span(enum ddtrace_span_dataype type) {
 
         ddtrace_set_root_span_properties(root);
     } else {
+        ++parent_span->active_child_spans;
+
         // do not copy the parent, it was active span before, just transfer that reference
         ZVAL_OBJ(&span->property_parent, &parent_span->std);
         ddtrace_inherit_span_properties(span, parent_span);
@@ -898,7 +903,10 @@ void ddtrace_close_top_span_without_stack_swap(ddtrace_span_data *span) {
     stack->active = span->parent;
     // The top span is always referenced by the span stack
     if (stack->active) {
-        GC_ADDREF(&stack->active->std);
+        ddtrace_span_data *parent = SPANDATA(stack->active);
+        GC_ADDREF(&parent->std);
+        parent->flags |= DDTRACE_SPAN_FLAG_NOT_DROPPABLE;
+        --parent->active_child_spans;
     } else {
         ZVAL_NULL(&stack->property_active);
     }

--- a/ext/span.h
+++ b/ext/span.h
@@ -17,6 +17,7 @@
 
 #define DDTRACE_SPAN_FLAG_OPENTELEMETRY (1 << 0)
 #define DDTRACE_SPAN_FLAG_OPENTRACING (1 << 1)
+#define DDTRACE_SPAN_FLAG_NOT_DROPPABLE (1 << 2)
 
 struct ddtrace_span_stack;
 
@@ -88,6 +89,7 @@ struct ddtrace_span_data {
     uint8_t flags;
     enum ddtrace_span_dataype type : 8;
     bool notify_user_req_end;
+    uint32_t active_child_spans;
     struct ddtrace_span_data *next;
     struct ddtrace_root_span_data *root;
 

--- a/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
@@ -578,6 +578,7 @@ class SymfonyIntegration extends Integration
          */
         foreach (['Symfony\Component\Console\Terminal::hasSttyAvailable', 'Symfony\Component\Console\Helper\QuestionHelper::isInteractiveInput'] as $method) {
             \DDTrace\install_hook($method, function (HookData $hook) {
+                $hook->data = false;
                 \DDTrace\active_stack()->spanCreationObservers[] = function (SpanData $span) use ($hook) {
                     if ($hook->data) {
                         return false;

--- a/tests/Common/TracerTestTrait.php
+++ b/tests/Common/TracerTestTrait.php
@@ -227,10 +227,10 @@ trait TracerTestTrait
     /**
      * This method executes a single script with the provided configuration.
      */
-    public function inCli($scriptPath, $customEnvs = [], $customInis = [], $arguments = '', $withOutput = false, $until = null, $throw = true)
+    public function inCli($scriptPath, $customEnvs = [], $customInis = [], $arguments = '', $withOutput = false, $until = null, $throw = true, $checkTty = false)
     {
         $this->resetRequestDumper();
-        $output = $this->executeCli($scriptPath, $customEnvs, $customInis, $arguments, $withOutput);
+        $output = $this->executeCli($scriptPath, $customEnvs, $customInis, $arguments, $withOutput, false, false, $checkTty);
         usleep(100000); // Add a slight delay to give the request-replayer time to handle and store all requests.
         $out = [$this->parseTracesFromDumpedData($until, $throw)];
         if ($withOutput) {
@@ -239,7 +239,7 @@ trait TracerTestTrait
         return $out;
     }
 
-    public function executeCli($scriptPath, $customEnvs = [], $customInis = [], $arguments = '', $withOutput = false, $skipSyncFlush = false, $withExitCode = false)
+    public function executeCli($scriptPath, $customEnvs = [], $customInis = [], $arguments = '', $withOutput = false, $skipSyncFlush = false, $withExitCode = false, $checkTty = false)
     {
         $envs = (string) new EnvSerializer(array_merge(
             [
@@ -277,7 +277,11 @@ trait TracerTestTrait
         } elseif (\is_array($arguments)) {
             $arguments = implode(' ', array_map('escapeshellarg', $arguments));
         }
-        $commandToExecute = "$envs " . PHP_BINARY . " $inis $script $arguments";
+        if ($checkTty && !posix_isatty(STDOUT)) {
+            $commandToExecute = "script -q -c \"$envs " . PHP_BINARY . " $inis $script $arguments\" /dev/null";
+        } else {
+            $commandToExecute = "$envs " . PHP_BINARY . " $inis $script $arguments";
+        }
         $output = [];
         $exitCode = 0;
         $createHook = \DDTrace\install_hook('DDTrace\Integrations\Exec\ExecIntegration::createSpan', function (HookData $hook) {

--- a/tests/Frameworks/Symfony/Latest/src/Command/SttyCommand.php
+++ b/tests/Frameworks/Symfony/Latest/src/Command/SttyCommand.php
@@ -1,0 +1,23 @@
+<?php
+
+namespace App\Command;
+
+use Symfony\Component\Console\Attribute\AsCommand;
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Terminal;
+
+#[AsCommand(
+    name: 'app:stty'
+)]
+class SttyCommand extends Command
+{
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $terminal = new Terminal();
+        $terminal->hasSttyAvailable();
+
+        return Command::SUCCESS;
+    }
+}

--- a/tests/Frameworks/Symfony/Version_4_4/src/Command/SttyCommand.php
+++ b/tests/Frameworks/Symfony/Version_4_4/src/Command/SttyCommand.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Terminal;
+
+class SttyCommand extends Command
+{
+    protected static $defaultName = 'app:stty';
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $terminal = new Terminal();
+        $terminal->hasSttyAvailable();
+
+        return 0; // success
+    }
+}

--- a/tests/Frameworks/Symfony/Version_5_2/src/Command/SttyCommand.php
+++ b/tests/Frameworks/Symfony/Version_5_2/src/Command/SttyCommand.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Terminal;
+
+class SttyCommand extends Command
+{
+    protected static $defaultName = 'app:stty';
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $terminal = new Terminal();
+        $terminal->hasSttyAvailable();
+
+        return Command::SUCCESS;
+    }
+}

--- a/tests/Frameworks/Symfony/Version_6_2/src/Command/SttyCommand.php
+++ b/tests/Frameworks/Symfony/Version_6_2/src/Command/SttyCommand.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace App\Command;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Console\Terminal;
+
+class SttyCommand extends Command
+{
+    protected static $defaultName = 'app:stty';
+
+    protected function execute(InputInterface $input, OutputInterface $output): int
+    {
+        $terminal = new Terminal();
+        $terminal->hasSttyAvailable();
+
+        return Command::SUCCESS;
+    }
+}

--- a/tests/Integrations/CLI/Symfony/V4_4/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/Symfony/V4_4/CommonScenariosTest.php
@@ -8,9 +8,30 @@ use DDTrace\Tests\Common\SpanAssertion;
 
 class CommonScenariosTest extends IntegrationTestCase
 {
+    const FIELDS_TO_IGNORE = [
+        'metrics.php.compilation.total_time_ms',
+        'metrics.php.memory.peak_usage_bytes',
+        'metrics.php.memory.peak_real_usage_bytes',
+        'meta.error.stack',
+        'meta._dd.p.tid',
+        'meta.cmd.exit_code',
+    ];
+
     public static function getConsoleScript()
     {
         return __DIR__ . '/../../../../Frameworks/Symfony/Version_4_4/bin/console';
+    }
+
+    public function testSilencedSpansAreDropped()
+    {
+        list($traces) = $this->inCli(static::getConsoleScript(), [
+            'DD_TRACE_CLI_ENABLED' => 'true',
+            'DD_TRACE_GENERATE_ROOT_SPAN' => 'true',
+            'DD_TRACE_AUTO_FLUSH_ENABLED' => 'true',
+            'DD_TRACE_EXEC_ENABLED' => 'true',
+        ], [], 'app:stty', false, null, true, true);
+
+        $this->snapshotFromTraces($traces, self::FIELDS_TO_IGNORE);
     }
 
     public function testThrowCommand()

--- a/tests/Integrations/CLI/Symfony/V5_2/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/Symfony/V5_2/CommonScenariosTest.php
@@ -8,9 +8,30 @@ use DDTrace\Tests\Common\SpanAssertion;
 
 class CommonScenariosTest extends IntegrationTestCase
 {
+    const FIELDS_TO_IGNORE = [
+        'metrics.php.compilation.total_time_ms',
+        'metrics.php.memory.peak_usage_bytes',
+        'metrics.php.memory.peak_real_usage_bytes',
+        'meta.error.stack',
+        'meta._dd.p.tid',
+        'meta.cmd.exit_code',
+    ];
+
     public static function getConsoleScript()
     {
         return __DIR__ . '/../../../../Frameworks/Symfony/Version_5_2/bin/console';
+    }
+
+    public function testSilencedSpansAreDropped()
+    {
+        list($traces) = $this->inCli(static::getConsoleScript(), [
+            'DD_TRACE_CLI_ENABLED' => 'true',
+            'DD_TRACE_GENERATE_ROOT_SPAN' => 'true',
+            'DD_TRACE_AUTO_FLUSH_ENABLED' => 'true',
+            'DD_TRACE_EXEC_ENABLED' => 'true',
+        ], [], 'app:stty', false, null, true, true);
+
+        $this->snapshotFromTraces($traces, self::FIELDS_TO_IGNORE);
     }
 
     public function testThrowCommand()

--- a/tests/Integrations/CLI/Symfony/V6_2/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/Symfony/V6_2/CommonScenariosTest.php
@@ -8,6 +8,15 @@ use DDTrace\Tests\Common\SpanAssertion;
 
 class CommonScenariosTest extends IntegrationTestCase
 {
+    const FIELDS_TO_IGNORE = [
+        'metrics.php.compilation.total_time_ms',
+        'metrics.php.memory.peak_usage_bytes',
+        'metrics.php.memory.peak_real_usage_bytes',
+        'meta.error.stack',
+        'meta._dd.p.tid',
+        'meta.cmd.exit_code',
+    ];
+
     public static function getConsoleScript()
     {
         return __DIR__ . '/../../../../Frameworks/Symfony/Version_6_2/bin/console';
@@ -16,6 +25,18 @@ class CommonScenariosTest extends IntegrationTestCase
     public static function getTestedLibrary()
     {
         return 'symfony/console';
+    }
+
+    public function testSilencedSpansAreDropped()
+    {
+        list($traces) = $this->inCli(static::getConsoleScript(), [
+            'DD_TRACE_CLI_ENABLED' => 'true',
+            'DD_TRACE_GENERATE_ROOT_SPAN' => 'true',
+            'DD_TRACE_AUTO_FLUSH_ENABLED' => 'true',
+            'DD_TRACE_EXEC_ENABLED' => 'true',
+        ], [], 'app:stty', false, null, true, true);
+
+        $this->snapshotFromTraces($traces, self::FIELDS_TO_IGNORE);
     }
 
     public function testThrowCommand()

--- a/tests/ext/try_drop_span.phpt
+++ b/tests/ext/try_drop_span.phpt
@@ -1,0 +1,80 @@
+--TEST--
+Test try_drop_span()
+--FILE--
+<?php
+
+$span = DDTrace\start_span();
+var_dump(DDTrace\try_drop_span($span));
+
+$span = DDTrace\start_span();
+$span->name = "root span with child span retained";
+DDTrace\start_span()->name = "child span";
+DDTrace\close_span();
+var_dump(DDTrace\try_drop_span($span));
+DDTrace\close_span();
+
+$span = DDTrace\start_span();
+DDTrace\create_stack();
+var_dump(DDTrace\try_drop_span($span));
+DDTrace\start_span()->name = "retained on dropped stack";
+DDTrace\close_span();
+DDTrace\switch_stack();
+
+$span = DDTrace\start_span();
+$span->name = "root span with child stack retained";
+DDTrace\create_stack();
+DDTrace\start_span()->name = "retained on dropped stack";
+var_dump(DDTrace\try_drop_span($span));
+DDTrace\close_span();
+DDTrace\switch_stack();
+DDTrace\close_span();
+
+$span = DDTrace\start_span();
+$span->name = "root span dropped after child span dropped";
+DDTrace\create_stack();
+$childSpan = DDTrace\start_span();
+$childSpan->name = "dropped on stack";
+var_dump(DDTrace\try_drop_span($childSpan));
+var_dump(DDTrace\try_drop_span($span));
+DDTrace\switch_stack();
+
+$span = DDTrace\start_span();
+$span->name = "distributed tracing headers inhibit dropping";
+DDTrace\generate_distributed_tracing_headers();
+DDTrace\close_span();
+var_dump(DDTrace\try_drop_span($span));
+
+$span = DDTrace\start_span();
+DDTrace\create_stack();
+$span->name = "distributed tracing headers inhibit dropping, even on span stacks";
+DDTrace\generate_distributed_tracing_headers();
+var_dump(DDTrace\try_drop_span($span));
+DDTrace\close_span();
+DDTrace\switch_stack();
+
+$span = DDTrace\start_span();
+$span->name = "span link generation inhibits dropping";
+$span->getLink();
+DDTrace\close_span();
+var_dump(DDTrace\try_drop_span($span));
+
+foreach (dd_trace_serialize_closed_spans() as $span) {
+    echo $span["name"], "\n";
+}
+
+?>
+--EXPECT--
+bool(true)
+bool(false)
+bool(true)
+bool(false)
+bool(true)
+bool(true)
+bool(false)
+bool(false)
+bool(false)
+distributed tracing headers inhibit dropping, even on span stacks
+distributed tracing headers inhibit dropping
+root span with child stack retained
+root span with child span retained
+child span

--- a/tests/snapshots/tests.integrations.cli.symfony.latest.common_scenarios_test.test_silenced_spans_are_dropped.json
+++ b/tests/snapshots/tests.integrations.cli.symfony.latest.common_scenarios_test.test_silenced_spans_are_dropped.json
@@ -1,0 +1,99 @@
+[[
+  {
+    "name": "console",
+    "service": "console",
+    "resource": "console",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "cli",
+    "meta": {
+      "_dd.p.dm": "0",
+      "_dd.p.tid": "67dd820c00000000",
+      "runtime-id": "70a85d5f-2b3f-45ee-8fa6-493f858df4d9"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1,
+      "_sampling_priority_v1": 1
+    }
+  },
+     {
+       "name": "command_execution",
+       "service": "console",
+       "resource": "stty",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "system",
+       "meta": {
+         "cmd.exec": "[\"stty\",\"-a\"]",
+         "cmd.exit_code": "0",
+         "component": "subprocess"
+       }
+     },
+     {
+       "name": "symfony.httpkernel.kernel.boot",
+       "service": "symfony",
+       "resource": "App\\Kernel",
+       "trace_id": 0,
+       "span_id": 3,
+       "parent_id": 1,
+       "type": "web",
+       "meta": {
+         "_dd.base_service": "console",
+         "component": "symfony"
+       }
+     },
+     {
+       "name": "command_execution",
+       "service": "console",
+       "resource": "sh",
+       "trace_id": 0,
+       "span_id": 4,
+       "parent_id": 1,
+       "type": "system",
+       "meta": {
+         "cmd.shell": "stty -g",
+         "component": "subprocess"
+       }
+     },
+     {
+       "name": "symfony.console.command",
+       "service": "symfony",
+       "resource": "symfony.console.command",
+       "trace_id": 0,
+       "span_id": 5,
+       "parent_id": 1,
+       "type": "cli",
+       "meta": {
+         "_dd.base_service": "console",
+         "component": "symfony"
+       }
+     },
+     {
+       "name": "symfony.console.command.run",
+       "service": "symfony",
+       "resource": "app:stty",
+       "trace_id": 0,
+       "span_id": 6,
+       "parent_id": 1,
+       "type": "cli",
+       "meta": {
+         "_dd.base_service": "console",
+         "component": "symfony",
+         "symfony.console.command.class": "App\\Command\\SttyCommand"
+       }
+     },
+     {
+       "name": "symfony.console.terminate",
+       "service": "symfony",
+       "resource": "symfony.console.terminate",
+       "trace_id": 0,
+       "span_id": 7,
+       "parent_id": 1,
+       "type": "cli",
+       "meta": {
+         "_dd.base_service": "console",
+         "component": "symfony"
+       }
+     }]]

--- a/tests/snapshots/tests.integrations.cli.symfony.v4_4.common_scenarios_test.test_silenced_spans_are_dropped.json
+++ b/tests/snapshots/tests.integrations.cli.symfony.v4_4.common_scenarios_test.test_silenced_spans_are_dropped.json
@@ -1,0 +1,86 @@
+[[
+  {
+    "name": "console",
+    "service": "console",
+    "resource": "console",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "cli",
+    "meta": {
+      "_dd.p.dm": "0",
+      "_dd.p.tid": "67dd847d00000000",
+      "runtime-id": "912cfa64-a941-41e9-a07c-4b770d603d12"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1,
+      "_sampling_priority_v1": 1
+    }
+  },
+     {
+       "name": "command_execution",
+       "service": "console",
+       "resource": "sh",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "system",
+       "meta": {
+         "cmd.exit_code": "0",
+         "cmd.shell": "stty -a | grep columns",
+         "component": "subprocess"
+       }
+     },
+     {
+       "name": "symfony.httpkernel.kernel.boot",
+       "service": "symfony",
+       "resource": "App\\Kernel",
+       "trace_id": 0,
+       "span_id": 3,
+       "parent_id": 1,
+       "type": "web",
+       "meta": {
+         "_dd.base_service": "console",
+         "component": "symfony"
+       }
+     },
+     {
+       "name": "symfony.console.command",
+       "service": "symfony",
+       "resource": "symfony.console.command",
+       "trace_id": 0,
+       "span_id": 4,
+       "parent_id": 1,
+       "type": "cli",
+       "meta": {
+         "_dd.base_service": "console",
+         "component": "symfony"
+       }
+     },
+     {
+       "name": "symfony.console.command.run",
+       "service": "symfony",
+       "resource": "app:stty",
+       "trace_id": 0,
+       "span_id": 5,
+       "parent_id": 1,
+       "type": "cli",
+       "meta": {
+         "_dd.base_service": "console",
+         "component": "symfony",
+         "symfony.console.command.class": "App\\Command\\SttyCommand"
+       }
+     },
+     {
+       "name": "symfony.console.terminate",
+       "service": "symfony",
+       "resource": "symfony.console.terminate",
+       "trace_id": 0,
+       "span_id": 6,
+       "parent_id": 1,
+       "type": "cli",
+       "meta": {
+         "_dd.base_service": "console",
+         "component": "symfony"
+       }
+     }]]

--- a/tests/snapshots/tests.integrations.cli.symfony.v5_2.common_scenarios_test.test_silenced_spans_are_dropped.json
+++ b/tests/snapshots/tests.integrations.cli.symfony.v5_2.common_scenarios_test.test_silenced_spans_are_dropped.json
@@ -1,0 +1,86 @@
+[[
+  {
+    "name": "console",
+    "service": "console",
+    "resource": "console",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "cli",
+    "meta": {
+      "_dd.p.dm": "0",
+      "_dd.p.tid": "67dd827100000000",
+      "runtime-id": "b15c24a7-2f9c-4e47-920c-606eb8d2727a"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1,
+      "_sampling_priority_v1": 1
+    }
+  },
+     {
+       "name": "command_execution",
+       "service": "console",
+       "resource": "sh",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "system",
+       "meta": {
+         "cmd.exit_code": "0",
+         "cmd.shell": "stty -a | grep columns",
+         "component": "subprocess"
+       }
+     },
+     {
+       "name": "symfony.httpkernel.kernel.boot",
+       "service": "symfony",
+       "resource": "App\\Kernel",
+       "trace_id": 0,
+       "span_id": 3,
+       "parent_id": 1,
+       "type": "web",
+       "meta": {
+         "_dd.base_service": "console",
+         "component": "symfony"
+       }
+     },
+     {
+       "name": "symfony.console.command",
+       "service": "symfony",
+       "resource": "symfony.console.command",
+       "trace_id": 0,
+       "span_id": 4,
+       "parent_id": 1,
+       "type": "cli",
+       "meta": {
+         "_dd.base_service": "console",
+         "component": "symfony"
+       }
+     },
+     {
+       "name": "symfony.console.command.run",
+       "service": "symfony",
+       "resource": "app:stty",
+       "trace_id": 0,
+       "span_id": 5,
+       "parent_id": 1,
+       "type": "cli",
+       "meta": {
+         "_dd.base_service": "console",
+         "component": "symfony",
+         "symfony.console.command.class": "App\\Command\\SttyCommand"
+       }
+     },
+     {
+       "name": "symfony.console.terminate",
+       "service": "symfony",
+       "resource": "symfony.console.terminate",
+       "trace_id": 0,
+       "span_id": 6,
+       "parent_id": 1,
+       "type": "cli",
+       "meta": {
+         "_dd.base_service": "console",
+         "component": "symfony"
+       }
+     }]]

--- a/tests/snapshots/tests.integrations.cli.symfony.v6_2.common_scenarios_test.test_silenced_spans_are_dropped.json
+++ b/tests/snapshots/tests.integrations.cli.symfony.v6_2.common_scenarios_test.test_silenced_spans_are_dropped.json
@@ -1,0 +1,99 @@
+[[
+  {
+    "name": "console",
+    "service": "console",
+    "resource": "console",
+    "trace_id": 0,
+    "span_id": 1,
+    "parent_id": 0,
+    "type": "cli",
+    "meta": {
+      "_dd.p.dm": "0",
+      "_dd.p.tid": "67dd810000000000",
+      "runtime-id": "c026dcba-fec2-46c3-8d22-f27b66f52e19"
+    },
+    "metrics": {
+      "_dd.agent_psr": 1,
+      "_sampling_priority_v1": 1
+    }
+  },
+     {
+       "name": "command_execution",
+       "service": "console",
+       "resource": "stty",
+       "trace_id": 0,
+       "span_id": 2,
+       "parent_id": 1,
+       "type": "system",
+       "meta": {
+         "cmd.exec": "[\"stty\",\"-a\"]",
+         "cmd.exit_code": "0",
+         "component": "subprocess"
+       }
+     },
+     {
+       "name": "symfony.httpkernel.kernel.boot",
+       "service": "symfony",
+       "resource": "App\\Kernel",
+       "trace_id": 0,
+       "span_id": 3,
+       "parent_id": 1,
+       "type": "web",
+       "meta": {
+         "_dd.base_service": "console",
+         "component": "symfony"
+       }
+     },
+     {
+       "name": "command_execution",
+       "service": "console",
+       "resource": "sh",
+       "trace_id": 0,
+       "span_id": 4,
+       "parent_id": 1,
+       "type": "system",
+       "meta": {
+         "cmd.shell": "stty -g",
+         "component": "subprocess"
+       }
+     },
+     {
+       "name": "symfony.console.command",
+       "service": "symfony",
+       "resource": "symfony.console.command",
+       "trace_id": 0,
+       "span_id": 5,
+       "parent_id": 1,
+       "type": "cli",
+       "meta": {
+         "_dd.base_service": "console",
+         "component": "symfony"
+       }
+     },
+     {
+       "name": "symfony.console.command.run",
+       "service": "symfony",
+       "resource": "app:stty",
+       "trace_id": 0,
+       "span_id": 6,
+       "parent_id": 1,
+       "type": "cli",
+       "meta": {
+         "_dd.base_service": "console",
+         "component": "symfony",
+         "symfony.console.command.class": "App\\Command\\SttyCommand"
+       }
+     },
+     {
+       "name": "symfony.console.terminate",
+       "service": "symfony",
+       "resource": "symfony.console.terminate",
+       "trace_id": 0,
+       "span_id": 7,
+       "parent_id": 1,
+       "type": "cli",
+       "meta": {
+         "_dd.base_service": "console",
+         "component": "symfony"
+       }
+     }]]


### PR DESCRIPTION
Allow dropping top-of-stack (i.e. active) spans in a safe manner.