### PR TITLE
Initialize baggage in RINIT

### DIFF
--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -1578,6 +1578,7 @@ static void dd_initialize_request(void) {
     zend_hash_init(&DDTRACE_G(root_span_tags_preset), 8, unused, ZVAL_PTR_DTOR, 0);
     zend_hash_init(&DDTRACE_G(propagated_root_span_tags), 8, unused, ZVAL_PTR_DTOR, 0);
     zend_hash_init(&DDTRACE_G(tracestate_unknown_dd_keys), 8, unused, ZVAL_PTR_DTOR, 0);
+    zend_hash_init(&DDTRACE_G(baggage), 8, unused, ZVAL_PTR_DTOR, 0);
 
     // Check for the env first, before the first RC
     ddtrace_check_agent_info_env();

--- a/ext/handlers_http.h
+++ b/ext/handlers_http.h
@@ -144,18 +144,19 @@ static inline zend_string *ddtrace_percent_encode(zend_string *string, bool is_k
 static inline zend_string *ddtrace_serialize_baggage(HashTable *baggage) {
     smart_str serialized_baggage = {0};
     zend_string *key;
+    zend_long numkey;
     zval *value;
     uint64_t max_bytes = get_DD_TRACE_BAGGAGE_MAX_BYTES();
     uint64_t max_items = get_DD_TRACE_BAGGAGE_MAX_ITEMS();
     size_t size = 0;
     size_t item_count = 0;
 
-    ZEND_HASH_FOREACH_STR_KEY_VAL(baggage, key, value) {
-        if (!key || ZSTR_LEN(key) == 0 || Z_TYPE_P(value) != IS_STRING || Z_STRLEN_P(value) == 0) {
+    ZEND_HASH_FOREACH_KEY_VAL(baggage, numkey, key, value) {
+        if ((key && ZSTR_LEN(key) == 0) || Z_TYPE_P(value) != IS_STRING || Z_STRLEN_P(value) == 0) {
             continue; // Skip invalid entries
         }
 
-        zend_string *encoded_key = ddtrace_percent_encode(key, true);
+        zend_string *encoded_key = key ? ddtrace_percent_encode(key, true) : zend_long_to_str(numkey);
         zend_string *encoded_value = ddtrace_percent_encode(Z_STR_P(value), false);
 
         if (item_count++ >= max_items) {


### PR DESCRIPTION
Fixes segfault from system tests.

And properly supports numeric keys in serialization.