### PR TITLE
fix(prof)!: avoid some OOM panics and avoid long strings

### DIFF
--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -23,6 +23,7 @@ mod exception;
 
 #[cfg(feature = "timeline")]
 mod timeline;
+mod vec_ext;
 
 use crate::config::{SystemSettings, INITIAL_SYSTEM_SETTINGS};
 use crate::zend::datadog_sapi_globals_request_info;

--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -305,10 +305,8 @@ impl TimeCollector {
 
         // check if we have the `alloc-size` and `alloc-samples` sample types
         #[cfg(feature = "allocation_profiling")]
-        let (alloc_samples_offset, alloc_size_offset) = (
-            get_offset("alloc-samples"),
-            get_offset("alloc-size"),
-        );
+        let (alloc_samples_offset, alloc_size_offset) =
+            (get_offset("alloc-samples"), get_offset("alloc-size"));
 
         // check if we have the IO sample types
         #[cfg(all(target_os = "linux", feature = "io_profiling"))]
@@ -383,25 +381,30 @@ impl TimeCollector {
             }
         }
 
-       #[cfg(all(target_os = "linux", feature = "io_profiling"))]
+        #[cfg(all(target_os = "linux", feature = "io_profiling"))]
         {
-            let add_io_upscaling_rule = |profile: &mut InternalProfile,
-                                         sum_value_offset: Option<usize>,
-                                         count_value_offset: Option<usize>,
-                                         sampling_distance: u64,
-                                         metric_name: &str| {
-                if let (Some(sum_value_offset), Some(count_value_offset)) = (sum_value_offset, count_value_offset) {
-                    let upscaling_info = UpscalingInfo::Poisson {
-                        sum_value_offset,
-                        count_value_offset,
-                        sampling_distance,
-                    };
-                    let values_offset = [sum_value_offset, count_value_offset];
-                    if let Err(err) = profile.add_upscaling_rule(&values_offset, "", "", upscaling_info) {
-                       warn!("Failed to add upscaling rule for {metric_name}, {metric_name} reported will be wrong: {err}")
+            let add_io_upscaling_rule =
+                |profile: &mut InternalProfile,
+                 sum_value_offset: Option<usize>,
+                 count_value_offset: Option<usize>,
+                 sampling_distance: u64,
+                 metric_name: &str| {
+                    if let (Some(sum_value_offset), Some(count_value_offset)) =
+                        (sum_value_offset, count_value_offset)
+                    {
+                        let upscaling_info = UpscalingInfo::Poisson {
+                            sum_value_offset,
+                            count_value_offset,
+                            sampling_distance,
+                        };
+                        let values_offset = [sum_value_offset, count_value_offset];
+                        if let Err(err) =
+                            profile.add_upscaling_rule(&values_offset, "", "", upscaling_info)
+                        {
+                            warn!("Failed to add upscaling rule for {metric_name}, {metric_name} reported will be wrong: {err}")
+                        }
                     }
-                }
-            };
+                };
 
             add_io_upscaling_rule(
                 &mut profile,

--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -1084,7 +1084,7 @@ impl Profiler {
         match self.prepare_and_send_message(
             vec![ZendFrame {
                 function: COW_EVAL,
-                file: Some(filename),
+                file: Some(Cow::Owned(filename)),
                 line,
             }],
             SampleValues {
@@ -1202,7 +1202,7 @@ impl Profiler {
         match self.prepare_and_send_message(
             vec![ZendFrame {
                 function: "[fatal]".into(),
-                file: Some(file),
+                file: Some(Cow::Owned(file)),
                 line,
             }],
             SampleValues {
@@ -1249,7 +1249,7 @@ impl Profiler {
         match self.prepare_and_send_message(
             vec![ZendFrame {
                 function: "[opcache restart]".into(),
-                file: Some(file),
+                file: Some(Cow::Owned(file)),
                 line,
             }],
             SampleValues {
@@ -1508,7 +1508,7 @@ impl Profiler {
             if let Some(functionname) = extract_function_name(func) {
                 labels.push(Label {
                     key: "fiber",
-                    value: LabelValue::Str(functionname.into()),
+                    value: LabelValue::Str(functionname),
                 });
             }
         }

--- a/profiling/src/profiling/stack_walking.rs
+++ b/profiling/src/profiling/stack_walking.rs
@@ -1,4 +1,5 @@
 use crate::bindings::{zai_str_from_zstr, zend_execute_data, zend_function};
+use crate::vec_ext::VecExt;
 use std::borrow::Cow;
 use std::collections::TryReserveError;
 use std::str::Utf8Error;
@@ -14,12 +15,18 @@ use crate::bindings::{
 const COW_PHP_OPEN_TAG: Cow<str> = Cow::Borrowed("<?php");
 const COW_TRUNCATED: Cow<str> = Cow::Borrowed("[truncated]");
 
+/// The profiler is not meant to handle such large strings--if a file or
+/// function name exceeds this size, it will fail in some manner, or be
+/// replaced by a shorter string, etc.
+const STR_LEN_LIMIT: usize = u16::MAX as usize;
+const COW_LARGE_STRING: Cow<str> = Cow::Borrowed("[large string]");
+
 #[derive(Default, Debug)]
 pub struct ZendFrame {
     // Most tools don't like frames that don't have function names, so use a
     // fake name if you need to like "<?php".
     pub function: Cow<'static, str>,
-    pub file: Option<String>,
+    pub file: Option<Cow<'static, str>>,
     pub line: u32, // use 0 for no line info
 }
 
@@ -40,7 +47,7 @@ pub enum CollectStackSampleError {
 /// Namespaces are part of the class_name or function_name respectively.
 /// Closures and anonymous classes get reformatted by the backend (or maybe
 /// frontend, either way it's not our concern, at least not right now).
-pub fn extract_function_name(func: &zend_function) -> Option<String> {
+pub fn extract_function_name(func: &zend_function) -> Option<Cow<'static, str>> {
     let method_name: &[u8] = func.name().unwrap_or(b"");
 
     /* The top of the stack seems to reasonably often not have a function, but
@@ -69,15 +76,31 @@ pub fn extract_function_name(func: &zend_function) -> Option<String> {
 
     buffer.extend_from_slice(method_name);
 
-    Some(String::from_utf8_lossy(buffer.as_slice()).into_owned())
+    // Rather than fail, we use a short string to represent a long string.
+    if buffer.len() <= STR_LEN_LIMIT {
+        // When replacing the string to make it valid utf-8, it may get a bit
+        // longer, but this usually doesn't happen. This limit is a soft-limit
+        // at the moment anyway, so this is okay.
+        let string = String::from_utf8_lossy(buffer.as_slice()).into_owned();
+        Some(Cow::Owned(string))
+    } else {
+        Some(COW_LARGE_STRING)
+    }
 }
 
-unsafe fn extract_file_and_line(execute_data: &zend_execute_data) -> (Option<String>, u32) {
+unsafe fn extract_file_and_line(
+    execute_data: &zend_execute_data,
+) -> (Option<Cow<'static, str>>, u32) {
     // This should be Some, just being cautious.
     match execute_data.func.as_ref() {
         Some(func) if !func.is_internal() => {
             // Safety: zai_str_from_zstr will return a valid ZaiStr.
-            let file = zai_str_from_zstr(func.op_array.filename.as_mut()).into_string();
+            let bytes = zai_str_from_zstr(func.op_array.filename.as_mut()).as_bytes();
+            let file = if bytes.len() <= STR_LEN_LIMIT {
+                Cow::Owned(std::string::String::from_utf8_lossy(bytes).to_string())
+            } else {
+                COW_LARGE_STRING
+            };
             let lineno = match execute_data.opline.as_ref() {
                 Some(opline) => opline.lineno,
                 None => 0,
@@ -93,7 +116,6 @@ mod detail {
     use super::*;
     use crate::string_set::StringSet;
     use crate::thin_str::ThinStr;
-    use crate::vec_ext::VecExt;
     use log::{debug, trace};
     use std::cell::RefCell;
     use std::ptr::NonNull;
@@ -241,7 +263,7 @@ mod detail {
                                     &**zend_flf_functions.offset(opline.extended_value as isize)
                                 };
                                 samples.try_push(ZendFrame {
-                                    function: extract_function_name(func).map(Cow::Owned).unwrap(),
+                                    function: extract_function_name(func).unwrap(),
                                     file: None,
                                     line: 0,
                                 })?;
@@ -304,7 +326,7 @@ mod detail {
                     }
                 });
 
-                (function, file, line)
+                (function, file.map(Cow::Owned), line)
             }
 
             None => {
@@ -312,7 +334,7 @@ mod detail {
                     let mut stats = cell.borrow_mut();
                     stats.not_applicable += 1;
                 });
-                let function = extract_function_name(func).map(Cow::Owned);
+                let function = extract_function_name(func);
                 let (file, line) = extract_file_and_line(execute_data);
                 (function, file, line)
             }
@@ -333,7 +355,8 @@ mod detail {
         func: &zend_function,
         string_cache: &mut StringCache,
     ) -> Option<Cow<'static, str>> {
-        let fname = string_cache.get_or_insert(0, || extract_function_name(func))?;
+        let fname =
+            string_cache.get_or_insert(0, || extract_function_name(func).map(Cow::into_owned))?;
         Some(Cow::Owned(fname))
     }
 
@@ -424,7 +447,7 @@ mod detail {
             // Only create a new frame if there's file or function info.
             if file.is_some() || function.is_some() {
                 // If there's no function name, use a fake name.
-                let function = function.map(Cow::Owned).unwrap_or(COW_PHP_OPEN_TAG);
+                let function = function.unwrap_or(COW_PHP_OPEN_TAG);
                 return Some(ZendFrame {
                     function,
                     file,

--- a/profiling/src/vec_ext.rs
+++ b/profiling/src/vec_ext.rs
@@ -1,0 +1,34 @@
+// Copyright 2025-Present Datadog, Inc. https://www.datadoghq.com/
+// SPDX-License-Identifier: Apache-2.0 OR BSD-3-Clause
+
+use std::collections::TryReserveError;
+use std::ptr;
+
+mod sealed {
+    pub trait Sealed {}
+
+    impl<T> Sealed for Vec<T> {}
+}
+
+pub trait VecExt<T>: sealed::Sealed {
+    fn try_push(&mut self, val: T) -> Result<(), TryReserveError>;
+}
+
+impl<T> VecExt<T> for Vec<T> {
+    /// Use [Vec::try_reserve] to reserve space for the additional item, and
+    /// then write the item in the new slot. This is similar to [Vec::push]
+    /// except it will fail on if the collection cannot grow.
+    fn try_push(&mut self, value: T) -> Result<(), TryReserveError> {
+        let len = self.len();
+        self.try_reserve(1)?;
+        // SAFETY: try_reserve ensures there is at least one item of capacity.
+        let end = unsafe { self.as_mut_ptr().add(len) };
+        // SAFETY: ensured by the Vec's own invariants, and that we are
+        // writing into an initialized slot.
+        unsafe { ptr::write(end, value) };
+        // SAFETY: the len is less than or equal to the capacity due to the
+        // try_reserve, and we initialized the new slot with the ptr::write.
+        unsafe { self.set_len(len + 1) };
+        Ok(())
+    }
+}

--- a/profiling/src/vec_ext.rs
+++ b/profiling/src/vec_ext.rs
@@ -17,7 +17,7 @@ pub trait VecExt<T>: sealed::Sealed {
 impl<T> VecExt<T> for Vec<T> {
     /// Use [Vec::try_reserve] to reserve space for the additional item, and
     /// then write the item in the new slot. This is similar to [Vec::push]
-    /// except it will fail on if the collection cannot grow.
+    /// except it will fail if the collection cannot grow rather than panic.
     fn try_push(&mut self, value: T) -> Result<(), TryReserveError> {
         let len = self.len();
         self.try_reserve(1)?;


### PR DESCRIPTION
### Description

Some customer crash reports indicate that we can hit a Rust OOM panic when stack walking and try to allocate a filename. Based on a quick reading of the code, this can fail if the length exceeds `isize::MAX` or some other fringe conditions. Usually it's not because the system returned `NULL` as this generally doesn't happen on Linux, due to memory overcommit. However, some customers may disable overcommit.

This PR has some steps to be cautious around large strings, notably ones that are longer than `u16::MAX`, or 65,535. It also is a bit more cautious around some Vec operations. However, this is not a full implementation to handle allocation failures--it's just a step in the right direction.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
