### PR TITLE
test: print date/time in asan test_internal_api_randomized

### DIFF
--- a/tests/internal-api-stress-test.php
+++ b/tests/internal-api-stress-test.php
@@ -121,7 +121,7 @@ $minFunctionArgs = [];
 function call_function(ReflectionFunction $function)
 {
     global $minFunctionArgs;
-    print "Executing: {$function->name}\n";
+    print date('Y-m-d H:i:s') . " Executing: {$function->name}\n";
 
     $i = PHP_VERSION_ID >= 80100 ? $function->getNumberOfRequiredParameters() : ($minFunctionArgs[$function->name] ?? 0);
     $invocations = $i == 0 ? [[]] : [];


### PR DESCRIPTION
### Description

Print date/time in asan test_internal_api_randomized. This way I can see if all tests are slow or if it just gets "stuck." Locally they are all quite fast.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
