### PR TITLE
chore: Update phpstan/phpdoc-parser to v2

### DIFF
--- a/tests/Frameworks/Symfony/Latest/composer.json
+++ b/tests/Frameworks/Symfony/Latest/composer.json
@@ -12,7 +12,7 @@
         "doctrine/doctrine-migrations-bundle": "^3.3",
         "doctrine/orm": "^2.17",
         "phpdocumentor/reflection-docblock": "^5.6",
-        "phpstan/phpdoc-parser": "^1.0",
+        "phpstan/phpdoc-parser": "^2.0",
         "symfony/console": "7.2.5",
         "symfony/doctrine-messenger": "^7.1",
         "symfony/dotenv": "*",


### PR DESCRIPTION
### Description

<!---
Any description you feel is relevant and gives more background to this PR, if necessary.
-->

We currently have the following issue since https://github.com/DataDog/dd-trace-php/pull/2956:

```
In ConstExprParser.php line 32:

  PHPStan\PhpDocParser\Parser\ConstExprParser::__construct(): Argument #1 ($u
  nescapeStrings) must be of type bool, PHPStan\PhpDocParser\ParserConfig giv
  en, called in /home/circleci/datadog/tests/Frameworks/Symfony/Latest/vendor
  /symfony/property-info/Extractor/PhpStanExtractor.php on line 87
```

There is some weird interaction only when using xdebug.

Upgrading to v2 seems to address the issue.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
