### PR TITLE
[Profiling] Accept `auto` as valid value for DD_PROFILING_ENABLED

### DIFF
--- a/profiling/src/bindings/mod.rs
+++ b/profiling/src/bindings/mod.rs
@@ -323,6 +323,9 @@ extern "C" {
     #[cfg(php7)]
     pub fn zend_register_extension(extension: &ZendExtension, handle: *mut c_void) -> ZendResult;
 
+    /// Writes a string to the output.
+    pub static zend_write: Option<unsafe extern "C" fn(*const c_char, usize) -> usize>;
+
     /// Converts the `zstr` into a `zai_str`. A None as well as empty
     /// strings will be converted into a string view to a static empty string
     /// (single byte of null, len of 0).
@@ -659,6 +662,7 @@ pub struct ZaiConfigEntry {
     pub aliases_count: u8,
     pub ini_change: zai_config_apply_ini_change,
     pub parser: zai_custom_parse,
+    pub displayer: zai_custom_display,
     pub env_config_fallback: zai_env_config_fallback,
 }
 
@@ -673,6 +677,7 @@ pub struct ZaiConfigMemoizedEntry {
     pub name_index: i16,
     pub ini_change: zai_config_apply_ini_change,
     pub parser: zai_custom_parse,
+    pub displayer: zai_custom_display,
     pub env_config_fallback: zai_env_config_fallback,
     pub original_on_modify: Option<
         unsafe extern "C" fn(

--- a/profiling/src/config.rs
+++ b/profiling/src/config.rs
@@ -762,14 +762,18 @@ unsafe extern "C" fn parse_profiling_enabled(
     decoded_value: *mut zval,
     _persistent: bool,
 ) -> bool {
-    if value.is_empty() || decoded_value.is_null() {
+    if decoded_value.is_null() {
         return false;
     }
 
     let decoded_value = &mut *decoded_value;
     match value.into_utf8() {
         Ok(value) => {
-            if value == "1" || value == "on" || value == "yes" || value == "true" || value == "auto"
+            if value.eq_ignore_ascii_case("1")
+                || value.eq_ignore_ascii_case("on")
+                || value.eq_ignore_ascii_case("yes")
+                || value.eq_ignore_ascii_case("true")
+                || value.eq_ignore_ascii_case("auto")
             {
                 decoded_value.u1.type_info = IS_TRUE as u32;
             } else {
@@ -799,9 +803,10 @@ unsafe extern "C" fn display_profiling_enabled(ini_entry: *mut zend_ini_entry, t
     let mut value: bool = false;
     if !tmp_value.is_null() {
         let str_val = zai_str_from_zstr(tmp_value.as_mut()).into_string();
-        value = if str_val.eq_ignore_ascii_case("true")
-            || str_val.eq_ignore_ascii_case("yes")
+        value = if str_val.eq_ignore_ascii_case("1")
             || str_val.eq_ignore_ascii_case("on")
+            || str_val.eq_ignore_ascii_case("yes")
+            || str_val.eq_ignore_ascii_case("true")
             || str_val.eq_ignore_ascii_case("auto")
         {
             true

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -627,7 +627,7 @@ zval *ddog_php_prof_get_memoized_config(uint16_t config_id) {
     return &zai_config_memoized_entries[config_id].decoded_value;
 }
 
-#if CFG_TEST
+#if defined(__aarch64__) && defined(CFG_TEST)
 // dummy symbol for tests, so that they can be run without being linked into PHP
 __attribute__((weak)) zend_write_func_t zend_write;
 #endif

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -626,3 +626,8 @@ const zend_function_entry* ddog_php_prof_functions = functions;
 zval *ddog_php_prof_get_memoized_config(uint16_t config_id) {
     return &zai_config_memoized_entries[config_id].decoded_value;
 }
+
+#if CFG_TEST
+// dummy symbol for tests, so that they can be run without being linked into PHP
+__attribute__((weak)) zend_write_func_t zend_write;
+#endif

--- a/profiling/tests/phpt/phpinfo_08.phpt
+++ b/profiling/tests/phpt/phpinfo_08.phpt
@@ -1,0 +1,52 @@
+--TEST--
+[profiling] test profiler's extension info with disabled profiling
+--DESCRIPTION--
+The profiler's phpinfo section contains important debugging information. This
+test verifies that certain information is present.
+--SKIPIF--
+<?php
+if (!extension_loaded('datadog-profiling'))
+    echo "skip: test requires Datadog Continuous Profiler\n";
+?>
+--ENV--
+DD_PROFILING_ENABLED=auto
+--INI--
+assert.exception=1
+--FILE--
+<?php
+
+ob_start();
+$extension = new ReflectionExtension('datadog-profiling');
+$extension->info();
+$output = ob_get_clean();
+
+$lines = preg_split("/\R/", $output);
+$values = [];
+foreach ($lines as $line) {
+    $pair = explode("=>", $line);
+    if (count($pair) != 2) {
+        continue;
+    }
+    $values[trim($pair[0])] = trim($pair[1]);
+}
+
+// Check that Version exists, but not its value
+assert(isset($values["Version"]));
+
+// Check exact values for this set
+$sections = [
+    ["Profiling Enabled", "true"],
+];
+
+foreach ($sections as [$key, $expected]) {
+    assert(
+        $values[$key] === $expected,
+        "Expected '{$expected}', found '{$values[$key]}', for key '{$key}'"
+    );
+}
+
+echo "Done.";
+
+?>
+--EXPECT--
+Done.

--- a/profiling/tests/phpt/phpinfo_ini_02.phpt
+++ b/profiling/tests/phpt/phpinfo_ini_02.phpt
@@ -1,0 +1,51 @@
+--TEST--
+[profiling] test profiler's extension info (.ini version)
+--DESCRIPTION--
+The profiler's phpinfo section contains important debugging information. This
+test verifies that certain information is present when configured by .ini.
+--SKIPIF--
+<?php
+if (!extension_loaded('datadog-profiling'))
+    echo "skip: test requires Datadog Continuous Profiler\n";
+?>
+--INI--
+assert.exception=1
+datadog.profiling.enabled=auto
+--FILE--
+<?php
+
+ob_start();
+$extension = new ReflectionExtension('datadog-profiling');
+$extension->info();
+$output = ob_get_clean();
+
+$lines = preg_split("/\R/", $output);
+$values = [];
+foreach ($lines as $line) {
+    $pair = explode("=>", $line, 2);
+    if (count($pair) != 2) {
+        continue;
+    }
+    $values[trim($pair[0])] = trim($pair[1]);
+}
+
+// Check that Version exists, but not its value
+assert(isset($values["Version"]));
+
+// Check exact values for this set
+$sections = [
+    ["Profiling Enabled", "true"],
+];
+
+foreach ($sections as [$key, $expected]) {
+    assert(
+        $values[$key] === $expected,
+        "Expected '{$expected}', found '{$values[$key]}', for key '{$key}'"
+    );
+}
+
+echo "Done.";
+
+?>
+--EXPECT--
+Done.

--- a/zend_abstract_interface/config/config.c
+++ b/zend_abstract_interface/config/config.c
@@ -102,6 +102,7 @@ static zai_config_memoized_entry *zai_config_memoize_entry(zai_config_entry *ent
     memoized->type = entry->type;
     memoized->default_encoded_value = entry->default_encoded_value;
     memoized->parser = entry->parser;
+    memoized->displayer = entry->displayer;
 
     ZVAL_UNDEF(&memoized->decoded_value);
     if (!zai_config_decode_value(entry->default_encoded_value, memoized->type, memoized->parser, &memoized->decoded_value, /* persistent */ true)) {

--- a/zend_abstract_interface/config/config.h
+++ b/zend_abstract_interface/config/config.h
@@ -43,6 +43,7 @@ struct zai_config_entry_s {
     // Accept or reject ini changes, potentially apply to the currently running system
     zai_config_apply_ini_change ini_change;
     zai_custom_parse parser;
+    zai_custom_display displayer;
     zai_env_config_fallback env_config_fallback;
 };
 
@@ -64,6 +65,7 @@ struct zai_config_memoized_entry_s {
     int16_t name_index;
     zai_config_apply_ini_change ini_change;
     zai_custom_parse parser;
+    zai_custom_display displayer;
     zai_env_config_fallback env_config_fallback;
     ZEND_INI_MH((*original_on_modify)); // when some other extension has registered that INI
 };

--- a/zend_abstract_interface/config/config_decode.c
+++ b/zend_abstract_interface/config/config_decode.c
@@ -128,7 +128,7 @@ static bool zai_config_decode_map(zai_str value, zval *decoded_value, bool persi
                     if (*data == ':') {
                         has_colon = true;
                         data++;
-                        
+
                         while (*data == ' ' || *data == '\t' || *data == '\n') data++;
 
                         if (*data == ',' || !*data) {

--- a/zend_abstract_interface/config/config_decode.h
+++ b/zend_abstract_interface/config/config_decode.h
@@ -20,6 +20,7 @@ typedef enum {
 } zai_config_type;
 
 typedef bool (*zai_custom_parse)(zai_str value, zval *decoded_value, bool persistent);
+typedef void (*zai_custom_display)(zend_ini_entry *ini_entry, int type);
 
 bool zai_config_decode_value(zai_str value, zai_config_type type, zai_custom_parse custom_parser, zval *decoded_value, bool persistent);
 

--- a/zend_abstract_interface/config/config_ini.c
+++ b/zend_abstract_interface/config/config_ini.c
@@ -299,7 +299,10 @@ static void zai_config_add_ini_entry(zai_config_memoized_entry *memoized, zai_st
     entry->value_length = memoized->default_encoded_value.len;
     entry->on_modify = ZaiConfigOnUpdateIni;
     entry->modifiable = memoized->ini_change == zai_config_system_ini_change ? PHP_INI_SYSTEM : PHP_INI_ALL;
-    if (memoized->type == ZAI_CONFIG_TYPE_BOOL) {
+
+    if (memoized->displayer) {
+        entry->displayer = memoized->displayer;
+    } else if (memoized->type == ZAI_CONFIG_TYPE_BOOL) {
         entry->displayer = php_ini_boolean_displayer_cb;
     }
 


### PR DESCRIPTION
### Description

In the context of Single Step Instrumentation, all profilers must accept the value `auto` in the `DD_PROFILING_ENABLED` environment variable.
Treating it as `true` is adequate for the initial version.

This PR adds a new "displayer" function pointer to the zai entry structs, as it is needed to display "On" if the value is `auto` when the config is printed.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
