### PR TITLE
chore(statsd): support DD_DOGSTATSD_HOST configuration

### DIFF
--- a/ext/configuration.h
+++ b/ext/configuration.h
@@ -102,6 +102,7 @@ enum ddtrace_sampling_rules_format {
     CONFIG(STRING, DD_TRACE_AGENT_URL, "", .ini_change = zai_config_system_ini_change)                         \
     CONFIG(STRING, DD_AGENT_HOST, "", .ini_change = zai_config_system_ini_change)                              \
     CONFIG(STRING, DD_DOGSTATSD_URL, "")                                                                       \
+    CONFIG(STRING, DD_DOGSTATSD_HOST, "")                                                                      \
     CONFIG(STRING, DD_API_KEY, "", .ini_change = zai_config_system_ini_change)                                 \
     CONFIG(BOOL, DD_DISTRIBUTED_TRACING, "true")                                                               \
     CONFIG(STRING, DD_DOGSTATSD_PORT, "8125")                                                                  \

--- a/ext/dogstatsd_client.c
+++ b/ext/dogstatsd_client.c
@@ -70,7 +70,12 @@ void ddtrace_dogstatsd_client_rinit(void) {
             host = url;
             port = NULL;
         } else {
-            host = ZSTR_VAL(get_DD_AGENT_HOST());
+            zend_string *dogstatsd_host = get_DD_DOGSTATSD_HOST();
+            if (ZSTR_LEN(dogstatsd_host) > 0) {
+                host = ZSTR_VAL(dogstatsd_host);
+            } else {
+                host = ZSTR_VAL(get_DD_AGENT_HOST());
+            }
             port = ZSTR_VAL(get_DD_DOGSTATSD_PORT());
 
             if (!*host) {

--- a/tests/ext/dogstatsd/metrics_host_config.phpt
+++ b/tests/ext/dogstatsd/metrics_host_config.phpt
@@ -1,0 +1,57 @@
+--TEST--
+Test DogStatsD configuration with DD_DOGSTATSD_HOST and DD_DOGSTATSD_PORT
+--SKIPIF--
+<?php if (!extension_loaded('sockets')) die('skip: the sockets extension is required for this test'); ?>
+--ENV--
+DD_DOGSTATSD_HOST=192.168.1.1
+DD_DOGSTATSD_PORT=9876
+--FILE--
+<?php
+
+class UDPServer {
+    private $socket;
+
+    public function __construct($addr, $port) {
+        if (!($this->socket = socket_create(AF_INET, SOCK_DGRAM, 0))) {
+            $errorcode = socket_last_error();
+            $errormsg = socket_strerror($errorcode);
+            die("Couldn't create socket: [$errorcode] $errormsg\n");
+        }
+
+        if (!socket_bind($this->socket, $addr, $port)) {
+            $errorcode = socket_last_error();
+            $errormsg = socket_strerror($errorcode);
+            die("Could not bind socket : [$errorcode] $errormsg\n");
+        }
+    }
+
+    public function dump($expected, $iter = 5000) {
+        $lines = [];
+        for ($i = 0; $i < $iter; ++$i) {
+            usleep(100);
+            if (socket_recvfrom($this->socket, $buf, 2048, MSG_DONTWAIT, $remote_ip, $remote_port)) {
+                $lines[] = "$buf\n";
+                if (count($lines) == $expected) {
+                    sort($lines, SORT_STRING);
+                    echo implode($lines);
+                    return;
+                }
+            }
+        }
+    }
+
+    public function close() {
+        socket_close($this->socket);
+    }
+}
+
+$server = new UDPServer('192.168.1.1', 9876);
+
+\DDTrace\dogstatsd_count("test.host.port.config", 42, ['test' => 'host_port']);
+
+$server->dump(1);
+$server->close();
+
+?>
+--EXPECT--
+test.host.port.config:42|c|#service:metrics_host_config.php,test:host_port 


### PR DESCRIPTION
### Description

Adds support for `DD_DOGSTATSD_HOST`. This configuration is supported by other ddtrace sdks

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
