### PR TITLE
fix(prof) FrankenPHP idle phase

### DIFF
--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -941,9 +941,7 @@ extern "C" fn mshutdown(_type: c_int, _module_number: c_int) -> ZendResult {
 
     // SAFETY: being called before [config::shutdown].
     #[cfg(feature = "timeline")]
-    unsafe {
-        timeline::timeline_mshutdown()
-    };
+    timeline::timeline_mshutdown();
 
     #[cfg(feature = "exception_profiling")]
     exception::exception_profiling_mshutdown();

--- a/profiling/src/timeline.rs
+++ b/profiling/src/timeline.rs
@@ -133,13 +133,6 @@ create_sleeping_fn!(
     State::Sleeping
 );
 
-// Idle functions: these are functions which are like RSHUTDOWN -> RINIT
-create_sleeping_fn!(
-    ddog_php_prof_frankenphp_handle_request,
-    FRANKENPHP_HANDLE_REQUEST_HANDLER,
-    State::Idle
-);
-
 // Functions that are blocking on I/O
 create_sleeping_fn!(
     ddog_php_prof_stream_select,
@@ -313,11 +306,6 @@ pub unsafe fn timeline_startup() {
             cstr!("time_sleep_until"),
             ptr::addr_of_mut!(TIME_SLEEP_UNTIL_HANDLER),
             Some(ddog_php_prof_time_sleep_until),
-        ),
-        zend::datadog_php_zif_handler::new(
-            cstr!("frankenphp_handle_request"),
-            ptr::addr_of_mut!(FRANKENPHP_HANDLE_REQUEST_HANDLER),
-            Some(ddog_php_prof_frankenphp_handle_request),
         ),
         zend::datadog_php_zif_handler::new(
             cstr!("stream_select"),

--- a/profiling/src/timeline.rs
+++ b/profiling/src/timeline.rs
@@ -346,9 +346,14 @@ pub fn timeline_minit() {
         PREV_ZEND_COMPILE_STRING = zend::zend_compile_string;
         zend::zend_compile_string = Some(ddog_php_prof_compile_string);
 
-        // To detect idle phases in FrankenPHP in worker mode, we need to hook the
-        // `sapi_module.activate` / `sapi_module.deactivate`, as FrankenPHP worker request shutdown
-        // / startup will call these functions.
+        // To detect idle phases in FrankenPHP's worker mode, we hook the `sapi_module.activate` /
+        // `sapi_module.deactivate` function pointers, as FrankenPHP's worker call those via the
+        // `sapi_activate()` / `sapi_deactivate()` function calls from
+        // `frankenphp_worker_request_startup` / `frankenphp_worker_request_shutdown`. There is no
+        // special handling for the first idle phase needed, as FrankenPHP will initiate a dummy
+        // request upon startup of a FrankenPHP worker and run to the first
+        // `frankenphp_handle_request()` PHP function from which onward we'll collect the first idle
+        // phase.
         if *SAPI == Sapi::FrankenPHP {
             PREV_FRANKEN_PHP_SAPI_ACTIVATE = zend::sapi_module.activate;
             PREV_FRANKEN_PHP_SAPI_DEACTIVATE = zend::sapi_module.deactivate;


### PR DESCRIPTION
### Description

This PR fixes FrankenPHP idle phase detection in worker mode. Turns out, that `frankenphp_handle_request()` does also execute the closure given to it, so the current way of measuring the idle phase in worker mode is incorrect. So what I am doing now instead of hooking `frankenphp_handle_request()` is hooking into `sapi_module.activate`/ `sapi_module.deactivate` in case the detected SAPI is FrankenPHP. If one of those functions is being called while `frankenphp_handle_request()` is the current execute frame, we are indeed in the idle phase.

Why does this work?

FrankenPHP in `frankenphp_worker_request_shutdown()` calls into [`sapi_deactivate()`](https://github.com/dunglas/frankenphp/blob/d3589f97706eac585cdafddbc059cdd53711faf9/frankenphp.c#L141) and in `frankenphp_worker_request_startup()` it calls into [`sapi_activate()`](https://github.com/dunglas/frankenphp/blob/d3589f97706eac585cdafddbc059cdd53711faf9/frankenphp.c#L181).

There is also a small cleanup: I have extracted the idle phase start and stop code into their own functions.


### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
