### PR TITLE
Fix stable config in profiling when ddtrace is not loaded

### DIFF
--- a/profiling/tests/phpt/stable_config.phpt
+++ b/profiling/tests/phpt/stable_config.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Check the library config files
+--SKIPIF--
+<?php
+copy(__DIR__.'/stable_config.yaml', '/tmp/test_profiling_stable_config.yaml');
+?>
+--ENV--
+_DD_TEST_LIBRARY_CONFIG_FLEET_FILE=/foo
+_DD_TEST_LIBRARY_CONFIG_LOCAL_FILE=/tmp/test_profiling_stable_config.yaml
+--FILE--
+<?php
+
+echo 'DD_SERVICE: '.ini_get("datadog.service")."\n";
+echo 'DD_ENV: '.ini_get("datadog.env")."\n";
+echo 'DD_PROFILING_ENABLED: '.ini_get("datadog.profiling.enabled")."\n";
+
+?>
+--EXPECT--
+DD_SERVICE: service_from_local_config
+DD_ENV: env_from_local_config
+DD_PROFILING_ENABLED: 0

--- a/profiling/tests/phpt/stable_config.yaml
+++ b/profiling/tests/phpt/stable_config.yaml
@@ -1,0 +1,4 @@
+apm_configuration_default:
+  DD_SERVICE: service_from_local_config
+  DD_ENV: env_from_local_config
+  DD_PROFILING_ENABLED: 0

--- a/zend_abstract_interface/config/config_stable_file.c
+++ b/zend_abstract_interface/config/config_stable_file.c
@@ -6,7 +6,7 @@
 #include "config_stable_file.h"
 
 #define RESOLVE_SYMBOL(name) \
-    _##name = (void *)DL_FETCH_SYMBOL(ddtrace_me->handle, #name); \
+    _##name = (void *)DL_FETCH_SYMBOL(ext->handle, #name); \
     if (!_##name) { \
         _ddog_library_configurator_new = NULL; \
         return; \
@@ -45,10 +45,13 @@ void zai_config_stable_file_minit(void) {
     // Resolve symbols at runtime, as they are not part of the AppSec extension
     // but are provided by ddtrace if it is loaded.
     if (!_ddog_library_configurator_new) {
-        zend_module_entry *ddtrace_me = NULL;
-        ddtrace_me = zend_hash_str_find_ptr(&module_registry, ZEND_STRL("ddtrace"));
-        if (!ddtrace_me) {
-            return;
+        zend_module_entry *ext = NULL;
+        ext = zend_hash_str_find_ptr(&module_registry, ZEND_STRL("ddtrace"));
+        if (!ext) {
+            ext = zend_hash_str_find_ptr(&module_registry, ZEND_STRL("datadog-profiling"));
+            if (!ext) {
+                return;
+            }
         }
 
         RESOLVE_SYMBOL(ddog_library_configurator_new);


### PR DESCRIPTION
### Description

Fix stable config when only the `datadog-profiling` is loaded, and not `ddtrace`

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
