### PR TITLE
Handle flushing of multiple traces at once

### DIFF
--- a/ext/asm_event.c
+++ b/ext/asm_event.c
@@ -12,8 +12,12 @@ DDTRACE_PUBLIC void ddtrace_emit_asm_event() {
     if (!DDTRACE_G(active_stack)) {
         return;
     }
-    DDTRACE_G(asm_event_emitted) = true;
-    ddtrace_trace_source_set_asm_source();
+    if (DDTRACE_G(active_stack)->root_span) {
+        DDTRACE_G(active_stack)->root_span->asm_event_emitted = true;
+        ddtrace_trace_source_set_asm_source();
+    } else {
+        DDTRACE_G(asm_event_emitted) = true;
+    }
     if (!get_DD_APM_TRACING_ENABLED()) {
         ddtrace_set_priority_sampling_on_root(PRIORITY_SAMPLING_USER_KEEP, DD_MECHANISM_ASM);
     }
@@ -28,7 +32,7 @@ PHP_FUNCTION(DDTrace_Testing_emit_asm_event) {
 }
 
 bool ddtrace_asm_event_emitted() {
-    return DDTRACE_G(asm_event_emitted);
+    return DDTRACE_G(asm_event_emitted) || (DDTRACE_G(active_stack) && DDTRACE_G(active_stack)->root_span && DDTRACE_G(active_stack)->root_span->asm_event_emitted);
 }
 
 void ddtrace_asm_event_rinit() {

--- a/ext/auto_flush.c
+++ b/ext/auto_flush.c
@@ -21,56 +21,27 @@ ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 ZEND_RESULT_CODE ddtrace_flush_tracer(bool force_on_startup, bool collect_cycles) {
     bool success = true;
 
-    zval trace, traces;
-    array_init(&trace);
+    zval traces;
+    array_init(&traces);
     if (collect_cycles) {
-        ddtrace_serialize_closed_spans_with_cycle(&trace);
+        ddtrace_serialize_closed_spans_with_cycle(&traces);
     } else {
-        ddtrace_serialize_closed_spans(&trace);
+        ddtrace_serialize_closed_spans(&traces);
     }
 
     // Prevent traces from requests not executing any PHP code:
     // PG(during_request_startup) will only be set to 0 upon execution of any PHP code.
     // e.g. php-fpm call with uri pointing to non-existing file, fpm status page, ...
     if (!force_on_startup && PG(during_request_startup)) {
-        zend_array_destroy(Z_ARR(trace));
+        zend_array_destroy(Z_ARR(traces));
         return SUCCESS;
     }
 
-    if (zend_hash_num_elements(Z_ARR(trace)) == 0) {
-        zend_array_destroy(Z_ARR(trace));
+    if (zend_hash_num_elements(Z_ARR(traces)) == 0) {
+        zend_array_destroy(Z_ARR(traces));
         LOG(INFO, "No finished traces to be sent to the agent");
         return SUCCESS;
     }
-
-    if (!get_global_DD_APM_TRACING_ENABLED()) {
-        if (!ddtrace_asm_event_emitted() && !ddtrace_trace_source_is_trace_asm_sourced(&trace) && !ddtrace_standalone_limiter_allow()) {
-            zval *root_span = zend_hash_index_find(Z_ARR(trace), 0);
-            if (!root_span || Z_TYPE_P(root_span) != IS_ARRAY) {
-                LOG(ERROR, "Root span not found. Dropping trace");
-                return SUCCESS;
-            }
-
-            zval *metrics = zend_hash_str_find(Z_ARR_P(root_span), ZEND_STRL("metrics"));
-            if (!metrics || Z_TYPE_P(metrics) != IS_ARRAY) {
-                LOG(ERROR, "Metrics not found. Dropping trace");
-                return SUCCESS;
-            }
-
-            zval *sampling_priority = zend_hash_str_find(Z_ARR_P(metrics), ZEND_STRL("_sampling_priority_v1"));
-            if (!sampling_priority || (Z_TYPE_P(sampling_priority) != IS_DOUBLE && Z_TYPE_P(sampling_priority) != IS_LONG)) {
-                LOG(ERROR, "Invalid sampling priority. Dropping trace");
-                return SUCCESS;
-            }
-            ZVAL_LONG(sampling_priority, PRIORITY_SAMPLING_AUTO_REJECT);
-        } else {
-            ddtrace_standalone_limiter_hit();
-        }
-    }
-
-    // background sender only wants a singular trace
-    array_init(&traces);
-    zend_hash_index_add(Z_ARR(traces), 0, &trace);
 
     size_t limit = get_global_DD_TRACE_AGENT_MAX_PAYLOAD_SIZE();
     if (get_global_DD_TRACE_SIDECAR_TRACE_SENDER()) {
@@ -125,8 +96,12 @@ ZEND_RESULT_CODE ddtrace_flush_tracer(bool force_on_startup, bool collect_cycles
 
                             LOGEV(INFO, {
                                 char *url = ddtrace_agent_url();
-                                log("Flushing trace of size %d to send-queue for %s",
-                                    zend_hash_num_elements(Z_ARR(trace)), url);
+                                zval *trace;
+                                int num_spans = 0;
+                                ZEND_HASH_FOREACH_VAL(Z_ARR(traces), trace) {
+                                    num_spans += zend_hash_num_elements(Z_ARR_P(trace));
+                                } ZEND_HASH_FOREACH_END();
+                                log("Flushing trace of size %d to send-queue for %s", num_spans, url);
                                 free(url);
                             });
                         } while (0);
@@ -136,36 +111,57 @@ ZEND_RESULT_CODE ddtrace_flush_tracer(bool force_on_startup, bool collect_cycles
                 }
             }
         } else {
-            LOG(INFO, "Skipping flushing trace of size %d as connection to sidecar failed",
-                               zend_hash_num_elements(Z_ARR(trace)));
+            LOGEV(INFO, {
+                zval *trace;
+                int num_spans = 0;
+                ZEND_HASH_FOREACH_VAL(Z_ARR(traces), trace) {
+                    num_spans += zend_hash_num_elements(Z_ARR_P(trace));
+                } ZEND_HASH_FOREACH_END();
+                log("Skipping flushing trace of size %d as connection to sidecar failed", num_spans);
+            });
         }
     } else {
 #ifndef _WIN32
-        char *payload;
-        size_t size;
-        if (ddtrace_serialize_simple_array_into_c_string(&traces, &payload, &size)) {
-            if (size > limit) {
-                LOG(ERROR, "Agent request payload of %zu bytes exceeds configured %zu byte limit; dropping request", size, limit);
-                success = false;
-            } else {
-                success = ddtrace_send_traces_via_thread(1, payload, size);
-                if (success) {
-                    LOGEV(INFO, {
-                        char *url = ddtrace_agent_url();
-                        log("Flushing trace of size %d to send-queue for %s",
-                                        zend_hash_num_elements(Z_ARR(trace)), url);
-                        free(url);
-                    });
-                }
-                dd_prepare_for_new_trace();
-            }
+        success = true;
+        zval sender_trace_container, *trace;
+        // background sender only wants a singular trace
+        array_init(&sender_trace_container);
+        zval *spans = zend_hash_index_add(Z_ARR(sender_trace_container), 0, &traces);
 
-            free(payload);
-        } else
+        // send in 1-trace chunks to make background sender happy
+        ZEND_HASH_FOREACH_VAL(Z_ARR(traces), trace) {
+            ZVAL_COPY_VALUE(spans, trace);
+
+            char *payload;
+            size_t size;
+            if (ddtrace_serialize_simple_array_into_c_string(&sender_trace_container, &payload, &size)) {
+                if (size > limit) {
+                    LOG(ERROR, "Agent request payload of %zu bytes exceeds configured %zu byte limit; dropping request", size, limit);
+                    success = false;
+                } else {
+                    success = ddtrace_send_traces_via_thread(1, payload, size);
+                    if (success) {
+                        LOGEV(INFO, {
+                            char *url = ddtrace_agent_url();
+                            log("Flushing trace of size %d to send-queue for %s",
+                                zend_hash_num_elements(Z_ARR_P(trace)), url);
+                            free(url);
+                        });
+                    }
+                    dd_prepare_for_new_trace();
+                }
+
+                free(payload);
+            } else {
+                success = false;
+            }
+        } ZEND_HASH_FOREACH_END();
+
+        ZVAL_UNDEF(spans);
+        zval_ptr_dtor(&sender_trace_container);
+#else
+        success = false;
 #endif
-        {
-            success = false;
-        }
     }
 
     zval_ptr_dtor(&traces);

--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -2120,8 +2120,25 @@ PHP_FUNCTION(dd_trace_serialize_closed_spans) {
 
     ddtrace_mark_all_span_stacks_flushable();
 
-    array_init(return_value);
-    ddtrace_serialize_closed_spans_with_cycle(return_value);
+    zval traces;
+    array_init(&traces);
+    ddtrace_serialize_closed_spans_with_cycle(&traces);
+
+    if (zend_hash_num_elements(Z_ARR(traces)) == 1) {
+        ZVAL_COPY(return_value, zend_hash_get_current_data(Z_ARR(traces)));
+    } else {
+        array_init(return_value);
+        zval *spans;
+        ZEND_HASH_FOREACH_VAL(Z_ARR(traces), spans) {
+            zval *span;
+            ZEND_HASH_FOREACH_VAL(Z_ARR_P(spans), span) {
+                Z_ADDREF_P(span);
+                zend_hash_next_index_insert_new(Z_ARR_P(return_value), span);
+            } ZEND_HASH_FOREACH_END();
+        } ZEND_HASH_FOREACH_END();
+    }
+
+    zval_ptr_dtor(&traces);
 
     ddtrace_free_span_stacks(false);
     ddtrace_init_span_stacks();

--- a/ext/serializer.c
+++ b/ext/serializer.c
@@ -855,6 +855,11 @@ void ddtrace_set_root_span_properties(ddtrace_root_span_data *span) {
             ddtrace_set_priority_sampling_on_span(span, DDTRACE_G(default_priority_sampling), DD_MECHANISM_MANUAL);
         }
 
+        if (DDTRACE_G(asm_event_emitted)) {
+            span->asm_event_emitted = DDTRACE_G(asm_event_emitted);
+            DDTRACE_G(asm_event_emitted) = false; // we attach this to the first root span after the asm event was detected (if there was none while emitted)
+        }
+
         ddtrace_integration *web_integration = &ddtrace_integrations[DDTRACE_INTEGRATION_WEB];
         if (get_DD_TRACE_ANALYTICS_ENABLED() || web_integration->is_analytics_enabled()) {
             zval sample_rate;

--- a/ext/span.h
+++ b/ext/span.h
@@ -123,6 +123,7 @@ struct ddtrace_root_span_data {
     uint64_t parent_id;
     ddtrace_rule_result sampling_rule;
     bool explicit_sampling_priority;
+    bool asm_event_emitted;
     enum ddtrace_trace_limited trace_is_limited;
 
     union {

--- a/ext/trace_source.c
+++ b/ext/trace_source.c
@@ -79,24 +79,3 @@ bool ddtrace_trace_source_is_meta_asm_sourced(zend_array *meta) {
 
     return source & TRACE_SOURCE_ASM;
 }
-
-bool ddtrace_trace_source_is_trace_asm_sourced(zval *trace) {
-    if (!trace || Z_TYPE_P(trace) != IS_ARRAY) {
-        return false;
-    }
-
-    zval *root_span = zend_hash_index_find(Z_ARR_P(trace), 0);
-    if (!root_span || Z_TYPE_P(root_span) != IS_ARRAY) {
-        return false;
-    }
-
-    zval *meta = zend_hash_str_find(Z_ARR_P(root_span), ZEND_STRL("meta"));
-
-    if (!meta || Z_TYPE_P(meta) != IS_ARRAY) {
-        return false;
-    }
-
-    return ddtrace_trace_source_is_meta_asm_sourced(Z_ARR_P(meta));
-}
-
-

--- a/ext/trace_source.h
+++ b/ext/trace_source.h
@@ -5,10 +5,10 @@
 
 #define DD_P_TS_KEY "_dd.p.ts"
 
-void ddtrace_trace_source_minit();
-zend_string *ddtrace_trace_source_get_encoded();
+void ddtrace_trace_source_minit(void);
+zend_string *ddtrace_trace_source_get_encoded(uint32_t source);
 void ddtrace_trace_source_set_from_hexadecimal(zend_string *hexadecimal, zend_array *meta);
-void ddtrace_trace_source_set_asm_source();
+void ddtrace_trace_source_set_asm_source(void);
 bool ddtrace_trace_source_is_trace_asm_sourced(zval *trace);
 bool ddtrace_trace_source_is_meta_asm_sourced(zend_array *meta);
 

--- a/package.xml
+++ b/package.xml
@@ -88,7 +88,8 @@
 - Implement Disable APM Tracing #3080
 
 ### Fixed
-- support both ENOTSUP and ENOSYS in shm_open fallback Datadog/libdatadog#969
+- Support both ENOTSUP and ENOSYS in shm_open fallback Datadog/libdatadog#969
+- Handle flushing of multiple traces at once #3176
 
 ### Internal
 - Show actual file and line for occurrence of exceptions as well #3172

--- a/tests/Integrations/PCNTL/scripts/long-running-manual-flush.php
+++ b/tests/Integrations/PCNTL/scripts/long-running-manual-flush.php
@@ -23,6 +23,9 @@ for ($iteration = 0; $iteration < ITERATIONS; $iteration++) {
     } else if ($forkPid === 0) {
         // Child
         call_httpbin('ip');
+// TODO: comment this to make PCNTLTest::testCliLongRunningMultipleForksManualFlush fail in NON-sidecar configuration
+        \DDTrace\flush();
+        dd_trace_synchronous_flush();
     } else {
         error_log('Error');
         exit(-1);
@@ -30,6 +33,4 @@ for ($iteration = 0; $iteration < ITERATIONS; $iteration++) {
     call_httpbin('user-agent');
     $scope->close();
     $tracer->flush();
-// TODO: comment this to make PCNTLTest::testCliLongRunningMultipleForksManualFlush fail in NON-sidecar configuration
-    dd_trace_synchronous_flush();
 }

--- a/tests/ext/force_flush_traces.phpt
+++ b/tests/ext/force_flush_traces.phpt
@@ -43,5 +43,5 @@ var_dump(dd_trace_serialize_closed_spans()); // Spans should be flushed, so this
 --EXPECTF--
 tracing process
 process
-[ddtrace] [info] Flushing trace of size 3 to send-queue for %s
+[ddtrace] [info] Flushing trace of size %r2.*\n.*1|3%r to send-queue for %s
 kill%r\n*(Killed\n*)?(Termsig=9)?%r


### PR DESCRIPTION
Working around the agent complaining about "foreign_span". With the agent each array of spans must have the same trace id.
This is already naturally separated with the closed_stack logic, but it was never actually split into different arrays.

This needs to also move the asm logic as now there's definitely no longer one single trace returned from ddtrace_serialize_closed_spans.

The asm logic for event emitted is instead stored on the root span where the event happens (or inherited from global scope if there was no root span at emission time). And the priority sampling / rate limiting applied when the root span is closed. Moving it to the root span close also simplifies the logic and allows possibly straightforwardly dropping the whole trace in future. This also fixes the asm event accidentally persisting in worker modes.