### PR TITLE
Enable RASP by default also in the tracer

### DIFF
--- a/appsec/CMakeLists.txt
+++ b/appsec/CMakeLists.txt
@@ -37,6 +37,12 @@ set(CMAKE_CXX_STANDARD 17)
 set(CMAKE_CXX_STANDARD_REQUIRED ON)
 
 cmake_policy(SET CMP0083 NEW) # make PIE executables when PIC property is set
+if(POLICY CMP0144)
+    cmake_policy(SET CMP0144 NEW) # consider RAPIDJSON_ROOT, not just RapidJSON_ROOT
+endif()
+if(POLICY CMP0153)
+    cmake_policy(SET CMP0153 OLD) # allow exec_program
+endif()
 
 option(DD_APPSEC_BUILD_HELPER "Whether to builder the helper" ON)
 option(DD_APPSEC_BUILD_EXTENSION "Whether to builder the extension" ON)
@@ -48,12 +54,24 @@ add_subdirectory(third_party EXCLUDE_FROM_ALL)
 
 include("cmake/patchelf.cmake")
 
-if (DD_APPSEC_BUILD_EXTENSION)
+if(DD_APPSEC_BUILD_EXTENSION OR DD_APPSEC_DDTRACE_ALT)
+    find_package(PhpConfig REQUIRED)
+    message(STATUS "PHP version: ${PhpConfig_VERSION}")
+    message(STATUS "PHP include directories: ${PhpConfig_INCLUDE_DIRS}")
+    message(STATUS "PHP libraries: ${PhpConfig_LIBRARIES}")
+    include("cmake/ext_asan.cmake")
+endif()
+
+if(DD_APPSEC_BUILD_EXTENSION)
     include("cmake/extension.cmake")
 endif()
 
-if (DD_APPSEC_BUILD_HELPER)
+if(DD_APPSEC_BUILD_HELPER)
     include ("cmake/helper.cmake")
+endif()
+
+if(DD_APPSEC_DDTRACE_ALT)
+    include(cmake/ddtrace.cmake)
 endif()
 
 include(cmake/clang-tidy.cmake)

--- a/appsec/cmake/ddtrace.cmake
+++ b/appsec/cmake/ddtrace.cmake
@@ -115,8 +115,10 @@ endif()
 if (PhpConfig_VERNUM LESS 80100)
     list(REMOVE_ITEM FILES_DDTRACE "${CMAKE_SOURCE_DIR}/../ext/handlers_fiber.c")
 endif()
+list(REMOVE_ITEM FILES_DDTRACE "${CMAKE_SOURCE_DIR}/../ext/crashtracking_windows.c")
 
 find_package(CURL REQUIRED)
+message(STATUS "CURL version: ${CURL_VERSION_STRING}")
 
 add_library(ddtrace SHARED ${FILES_DDTRACE})
 set_target_properties(ddtrace PROPERTIES

--- a/appsec/cmake/ext_asan.cmake
+++ b/appsec/cmake/ext_asan.cmake
@@ -1,0 +1,25 @@
+find_program(READELF_PROGRAM readelf)
+set(ENABLE_ASAN FALSE CACHE BOOL "Enable ASAN")
+if(READELF_PROGRAM)
+    execute_process(COMMAND ${READELF_PROGRAM} -d ${PhpConfig_PHP_BINARY}
+                    COMMAND grep NEEDED
+                    COMMAND grep asan
+                    RESULT_VARIABLE result
+                    OUTPUT_QUIET
+                    ERROR_QUIET)
+    if(result EQUAL 0)
+        set(ENABLE_ASAN TRUE CACHE BOOL "Enable ASAN" FORCE)
+    endif()
+else()
+    message(WARNING "readelf unavailable. Cannot detect ASAN")
+endif()
+
+if(ENABLE_ASAN)
+    message(STATUS "Enabling ASAN")
+    target_compile_options(PhpConfig INTERFACE -fsanitize=address)
+    target_compile_definitions(PhpConfig INTERFACE ZEND_TRACK_ARENA_ALLOC)
+    target_link_options(PhpConfig INTERFACE -fsanitize=address)
+else()
+    message(STATUS "ASAN is disabled")
+endif()
+

--- a/appsec/cmake/run_tests.cmake
+++ b/appsec/cmake/run_tests.cmake
@@ -1,5 +1,4 @@
 if(DD_APPSEC_DDTRACE_ALT)
-    include(cmake/ddtrace.cmake)
     set(DD_APPSEC_TRACER_EXT_FILE $<TARGET_FILE:ddtrace>)
 else()
     get_filename_component(DD_APPSEC_TRACER_EXT_FILE "${CMAKE_SOURCE_DIR}/../tmp/build_extension/modules/ddtrace.so" REALPATH)

--- a/appsec/src/extension/commands_helpers.c
+++ b/appsec/src/extension/commands_helpers.c
@@ -150,8 +150,10 @@ static dd_result _dd_command_exec(dd_conn *nonnull conn,
             return dd_helper_error;
         } else {
             mlog(dd_log_debug,
-                "Received message for command %.*s unexpected: %.*s\n", NAME_L,
-                (int)mpack_node_strlen(type), mpack_node_str(type));
+                "Received message for command %.*s unexpected: \"%.*s\". "
+                "Expected \"config_features\", \"error\" or \"%.*s\"",
+                NAME_L, (int)mpack_node_strlen(type), mpack_node_str(type),
+                NAME_L);
             return dd_error;
         }
 

--- a/appsec/tests/extension/helper_bad_response_01.phpt
+++ b/appsec/tests/extension/helper_bad_response_01.phpt
@@ -17,10 +17,10 @@ $helper = Helper::createInitedRun([
 
 var_dump(rinit());
 
-match_log('/Received message for command config_sync unexpected: client_init/');
+match_log('/Received message for command config_sync unexpected: "client_init"/');
 
 
 ?>
 --EXPECTF--
 bool(true)
-found message in log matching /Received message for command config_sync unexpected: client_init/
+found message in log matching /Received message for command config_sync unexpected: "client_init"/

--- a/appsec/tests/extension/push_params_ok_04.phpt
+++ b/appsec/tests/extension/push_params_ok_04.phpt
@@ -3,7 +3,6 @@ Some addresses are rasp requests when rasp enabled
 --INI--
 extension=ddtrace.so
 datadog.appsec.enabled=1
-datadog.appsec.rasp_enabled=1
 --FILE--
 <?php
 use function datadog\appsec\testing\{rinit,rshutdown, root_span_get_metrics};

--- a/appsec/tests/extension/push_params_ok_06.phpt
+++ b/appsec/tests/extension/push_params_ok_06.phpt
@@ -1,8 +1,9 @@
 --TEST--
-Rasp addresses are not sent to the helper if RASP disabled. Rasp disabled by default
+Rasp addresses are not sent to the helper if RASP disabled.
 --INI--
 extension=ddtrace.so
 datadog.appsec.enabled=1
+datadog.appsec.rasp_enabled=0
 --FILE--
 <?php
 use function datadog\appsec\testing\{rinit,rshutdown,root_span_get_metrics};

--- a/appsec/tests/extension/push_params_ok_08.phpt
+++ b/appsec/tests/extension/push_params_ok_08.phpt
@@ -3,7 +3,6 @@ LFI Rule can be sent
 --INI--
 extension=ddtrace.so
 datadog.appsec.enabled=1
-datadog.appsec.rasp_enabled=1
 --FILE--
 <?php
 use function datadog\appsec\testing\{rinit,rshutdown};

--- a/appsec/tests/extension/push_params_ok_09.phpt
+++ b/appsec/tests/extension/push_params_ok_09.phpt
@@ -3,7 +3,6 @@ SSRF Rule can be sent
 --INI--
 extension=ddtrace.so
 datadog.appsec.enabled=1
-datadog.appsec.rasp_enabled=1
 --FILE--
 <?php
 use function datadog\appsec\testing\{rinit,rshutdown};

--- a/appsec/tests/mock_helper/CMakeLists.txt
+++ b/appsec/tests/mock_helper/CMakeLists.txt
@@ -1,6 +1,10 @@
 cmake_minimum_required(VERSION 3.11)
 project(mock_helper)
 
+if(POLICY CMP0153)
+cmake_policy(SET CMP0153 OLD) # allow exec_program
+endif()
+
 hunter_add_package(Boost COMPONENTS coroutine context program_options system thread stacktrace)
 
 find_package(Boost CONFIG REQUIRED

--- a/ext/configuration.h
+++ b/ext/configuration.h
@@ -146,7 +146,7 @@ enum ddtrace_sampling_rules_format {
     CONFIG(BOOL, DD_TRACE_SYMFONY_MESSENGER_MIDDLEWARES, "false")                                              \
     CONFIG(BOOL, DD_TRACE_REMOVE_ROOT_SPAN_LARAVEL_QUEUE, "true")                                              \
     CONFIG(BOOL, DD_TRACE_REMOVE_ROOT_SPAN_SYMFONY_MESSENGER, "true")                                          \
-    CONFIG(BOOL, DD_APPSEC_RASP_ENABLED , "false")                                                             \
+    CONFIG(BOOL, DD_APPSEC_RASP_ENABLED , "true")                                                              \
     CONFIG(BOOL, DD_TRACE_REMOVE_AUTOINSTRUMENTATION_ORPHANS, "false")                                         \
     CONFIG(SET, DD_TRACE_RESOURCE_URI_FRAGMENT_REGEX, "")                                                      \
     CONFIG(SET, DD_TRACE_RESOURCE_URI_MAPPING_INCOMING, "")                                                    \

--- a/tests/Common/WebFrameworkTestCase.php
+++ b/tests/Common/WebFrameworkTestCase.php
@@ -132,8 +132,11 @@ abstract class WebFrameworkTestCase extends IntegrationTestCase
             // to work setting it both in docker-compose.yml and in `getEnvs()` above, but that should be the best
             // option.
             'xdebug.remote_enable' => 1,
+            'xdebug.mode' => 'debug',
             'xdebug.remote_host' => 'host.docker.internal',
+            'xdebug.client_host' => 'host.docker.internal',
             'xdebug.remote_autostart' => 1,
+            'xdebug.start_with_request' => 'yes',
         ] + ($enableOpcache ? ["zend_extension" => "opcache.so"] : []);
     }
 

--- a/tests/Integrations/Custom/Autoloaded/InstrumentationTest.php
+++ b/tests/Integrations/Custom/Autoloaded/InstrumentationTest.php
@@ -130,13 +130,6 @@ final class InstrumentationTest extends WebFrameworkTestCase
                 'auto_enabled' => null,
             ],
             [
-                "name" => "filesystem",
-                "enabled" => false,
-                "version" => "",
-                'compatible' => null,
-                'auto_enabled' => null,
-            ],
-            [
                 "name" => "logs",
                 "enabled" => false,
                 "version" => "",

--- a/tests/ext/telemetry/integration.phpt
+++ b/tests/ext/telemetry/integration.phpt
@@ -69,7 +69,7 @@ PUBLIC STATIC METHOD
 test_access hook
 array(1) {
   ["integrations"]=>
-  array(3) {
+  array(2) {
     [0]=>
     array(5) {
       ["name"]=>
@@ -84,19 +84,6 @@ array(1) {
       NULL
     }
     [1]=>
-    array(5) {
-      ["name"]=>
-      string(10) "filesystem"
-      ["enabled"]=>
-      bool(false)
-      ["version"]=>
-      string(0) ""
-      ["compatible"]=>
-      NULL
-      ["auto_enabled"]=>
-      NULL
-    }
-    [2]=>
     array(5) {
       ["name"]=>
       string(4) "logs"

--- a/tests/ext/telemetry/integration_filesystem_01.phpt
+++ b/tests/ext/telemetry/integration_filesystem_01.phpt
@@ -11,6 +11,7 @@ require __DIR__ . '/../includes/clear_skipif_telemetry.inc'
 DD_TRACE_GENERATE_ROOT_SPAN=0
 _DD_LOAD_TEST_INTEGRATIONS=1
 DD_INSTRUMENTATION_TELEMETRY_ENABLED=1
+DD_APPSEC_RASP_ENABLED=0
 --INI--
 datadog.trace.agent_url="file://{PWD}/integration-telemetry-01.out"
 --FILE--

--- a/tests/ext/telemetry/integration_filesystem_02.phpt
+++ b/tests/ext/telemetry/integration_filesystem_02.phpt
@@ -11,7 +11,6 @@ require __DIR__ . '/../includes/clear_skipif_telemetry.inc'
 DD_TRACE_GENERATE_ROOT_SPAN=0
 _DD_LOAD_TEST_INTEGRATIONS=1
 DD_INSTRUMENTATION_TELEMETRY_ENABLED=1
-DD_APPSEC_RASP_ENABLED=1
 --INI--
 datadog.trace.agent_url="file://{PWD}/integration-telemetry-02.out"
 --FILE--

--- a/tests/ext/telemetry/integration_filesystem_03.phpt
+++ b/tests/ext/telemetry/integration_filesystem_03.phpt
@@ -11,7 +11,6 @@ require __DIR__ . '/../includes/clear_skipif_telemetry.inc'
 DD_TRACE_GENERATE_ROOT_SPAN=0
 _DD_LOAD_TEST_INTEGRATIONS=1
 DD_INSTRUMENTATION_TELEMETRY_ENABLED=1
-DD_APPSEC_RASP_ENABLED=1
 --INI--
 datadog.trace.agent_url="file://{PWD}/integration-telemetry-03.out"
 --FILE--

--- a/tests/ext/telemetry/integration_filesystem_04.phpt
+++ b/tests/ext/telemetry/integration_filesystem_04.phpt
@@ -11,7 +11,6 @@ require __DIR__ . '/../includes/clear_skipif_telemetry.inc'
 DD_TRACE_GENERATE_ROOT_SPAN=0
 _DD_LOAD_TEST_INTEGRATIONS=1
 DD_INSTRUMENTATION_TELEMETRY_ENABLED=1
-DD_APPSEC_RASP_ENABLED=1
 DD_TRACE_FILESYSTEM_ENABLED=0
 --INI--
 datadog.trace.agent_url="file://{PWD}/integration-telemetry-04.out"


### PR DESCRIPTION
### Description

RASP configuration needs to be also default on the tracer

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
