### PR TITLE
chore(ddtags): capture key before first colon

### DIFF
--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -4063,7 +4063,7 @@ jobs:
             docker-compose --version
       - run:
           name: Clone System Tests repo
-          command: git clone https://github.com/DataDog/system-tests.git && git checkout munir/enable-php-ddtags-tests
+          command: git clone https://github.com/DataDog/system-tests.git
 
       - fetch_job_artifact:
           job: "package extension"

--- a/.circleci/continue_config.yml
+++ b/.circleci/continue_config.yml
@@ -4063,7 +4063,7 @@ jobs:
             docker-compose --version
       - run:
           name: Clone System Tests repo
-          command: git clone https://github.com/DataDog/system-tests.git
+          command: git clone https://github.com/DataDog/system-tests.git && git checkout munir/enable-php-ddtags-tests
 
       - fetch_job_artifact:
           job: "package extension"

--- a/ext/configuration.c
+++ b/ext/configuration.c
@@ -153,7 +153,7 @@ static bool dd_parse_tags(zai_str value, zval *decoded_value, bool persistent) {
         if (key_len > 0) {
             zval val;
             ZVAL_STR(&val, zend_string_init(val_start, val_len, persistent));
-            zend_hash_str_update(Z_ARRVAL_P(decoded_value), key_start, key_len, &val);
+            zend_hash_str_update_ind(Z_ARRVAL_P(decoded_value), key_start, key_len, &val);
         }
         // Move to the start of the next tag
         current = tag_end + sep_len;

--- a/ext/configuration.c
+++ b/ext/configuration.c
@@ -153,7 +153,9 @@ static bool dd_parse_tags(zai_str value, zval *decoded_value, bool persistent) {
         if (key_len > 0) {
             zval val;
             ZVAL_STR(&val, zend_string_init(val_start, val_len, persistent));
-            zend_hash_str_update_ind(Z_ARRVAL_P(decoded_value), key_start, key_len, &val);
+            zend_string *key = zend_string_init(key_start, key_len, persistent);
+            zend_hash_str_update_ind(Z_ARRVAL_P(decoded_value), ZSTR_VAL(key), ZSTR_LEN(key), &val);
+            zend_string_release(key);
         }
         // Move to the start of the next tag
         current = tag_end + sep_len;

--- a/ext/configuration.c
+++ b/ext/configuration.c
@@ -107,23 +107,25 @@ static bool dd_parse_tags(zai_str value, zval *decoded_value, bool persistent) {
     const char *current = str;
 
     // Determine separator - prefer comma if present, otherwise use space
-    const char *sep = memchr(str, ',', value.len) ? "," : " ";
-    size_t sep_len = strlen(sep);
+    char sep = memchr(str, ',', value.len) ? ',': ' ';
 
     while (current < end) {
         // Skip leading whitespace
         while (current < end && *current == ' ') current++;
         if (current >= end) break;
         // Find next separator, this will be the end of the tag
-        size_t tag_len = strcspn(current, sep);
+        const char *tag_end = memchr(current, sep, end - current);
+        if (!tag_end) {
+            tag_end = end;
+        }
+        size_t tag_len = tag_end - current;
         if (tag_len == 0) {
             // If the first character is a separator, move to the next character
-            current += sep_len;
+            ++current;
             continue;
         }
         // Prepare key and value
         // Initialize key to be the entire tag and value to be empty
-        const char *tag_end = current + tag_len;
         const char *key_start = current;
         const char *key_end = tag_end;
         const char *val_start = "";
@@ -151,18 +153,12 @@ static bool dd_parse_tags(zai_str value, zval *decoded_value, bool persistent) {
         }
         // Only add if key is non-empty (value can be empty)
         if (key_len > 0) {
-            // Create a zval for the value
             zval val;
-            zend_string *val_str = zend_string_init(val_start, val_len, persistent);
-            ZVAL_STR(&val, val_str);
-            // Create a zval for the key, this ensures that the key is null-terminated
-            zval key;
-            zend_string *key_str = zend_string_init(key_start, key_len, persistent);
-            ZVAL_STR(&key, key_str); 
-            zend_hash_update(Z_ARRVAL_P(decoded_value), Z_STR(key), &val);
-        } 
+            ZVAL_STR(&val, zend_string_init(val_start, val_len, persistent));
+            zend_hash_str_update(Z_ARRVAL_P(decoded_value), key_start, key_len, &val);
+        }
         // Move to the start of the next tag
-        current = tag_end + sep_len;
+        current = tag_end + 1;
     }
 
     return true;

--- a/ext/configuration.c
+++ b/ext/configuration.c
@@ -152,10 +152,11 @@ static bool dd_parse_tags(zai_str value, zval *decoded_value, bool persistent) {
         // Only add if key is non-empty (value can be empty)
         if (key_len > 0) {
             zval val;
-            ZVAL_STR(&val, zend_string_init(val_start, val_len, persistent));
-            zend_string *key = zend_string_init(key_start, key_len, persistent);
-            zend_hash_str_update_ind(Z_ARRVAL_P(decoded_value), ZSTR_VAL(key), ZSTR_LEN(key), &val);
-            zend_string_release(key);
+            zend_string *val_str = zend_string_init(val_start, val_len, persistent);
+            ZVAL_STR(&val, val_str);
+            zend_string *key_str = zend_string_init(key_start, key_len, persistent);
+            zend_hash_str_update_ind(Z_ARRVAL_P(decoded_value), ZSTR_VAL(key_str), ZSTR_LEN(key_str), &val);
+            zend_string_release(key_str);
         }
         // Move to the start of the next tag
         current = tag_end + sep_len;

--- a/ext/configuration.c
+++ b/ext/configuration.c
@@ -141,11 +141,9 @@ static bool dd_parse_tags(zai_str value, zval *decoded_value, bool persistent) {
         while (key_end > key_start && key_end[-1] == ' ') key_end--;
         // Only add if key is non-empty
         if (key_start != key_end) {
-            // Strip whitespace from value (if it is not empty)
-            if (val_start != val_end) {
-                while (val_start < tag_end && *val_start == ' ') val_start++;
-                while (val_end > val_start && val_end[-1] == ' ') val_end--;
-            }
+            // Strip whitespace from value
+            while (val_start < val_end && *val_start == ' ') val_start++;
+            while (val_end > val_start && val_end[-1] == ' ') val_end--;
 
             zval val;
             ZVAL_STR(&val, zend_string_init(val_start, val_end - val_start, persistent));

--- a/ext/configuration.c
+++ b/ext/configuration.c
@@ -94,51 +94,11 @@ static bool dd_parse_sampling_rules_format(zai_str value, zval *decoded_value, b
     return true;
 }
 
-// Helper function to strip whitespace from both ends of a string
-static void dd_strip_whitespace(const char **str, size_t *len) {
-    if (!str || !*str || !len) {
-        return;
-    }
+static bool dd_parse_tags(zai_str value, zval *decoded_value, bool persistent) {
+    ZVAL_ARR(decoded_value, pemalloc(sizeof(HashTable), persistent));
+    zend_hash_init(Z_ARR_P(decoded_value), 8, NULL, persistent ? ZVAL_INTERNAL_PTR_DTOR : ZVAL_PTR_DTOR, persistent);
 
-    // Skip leading whitespace
-    while (*len > 0 && **str == ' ') {
-        (*str)++;
-        (*len)--;
-    }
-
-    // Skip trailing whitespace
-    while (*len > 0 && (*str)[*len - 1] == ' ') {
-        (*len)--;
-    }
-}
-
-/**
- * Parse a string of tags into an associative array.
- * Format: "key1:value1,key2:value2" or "key1:value1 key2:value2"
- * 
- * Rules:
- * 1. Separator is determined by first occurrence:
- *    - If comma found, use comma as separator for all tags
- *    - Otherwise, use space as separator for all tags
- * 2. Each tag is split on first colon only
- * 3. Tags without colons use whole string as key with empty value
- * 4. Empty tags are skipped
- * 5. Tags with empty keys are skipped
- * 6. Whitespace is stripped from all keys and values
- * 
- * Examples:
- * - "key1:value1 key2:value2" -> ["key1" => "value1", "key2" => "value2"]
- * - "key1:value1,key2:value2" -> ["key1" => "value1", "key2" => "value2"]
- * - "key1:value1, key2" -> ["key1" => "value1", "key2" => ""]
- * - "key1:value1:value2" -> ["key1" => "value1:value2"]
- * - "key1" -> ["key1" => ""]
- * - "key1: key2: :" -> ["key1" => "", key2" => ""]
- * 
- */
-bool dd_parse_tags(zval *decoded_value, zai_str value, bool persistent) {
-    // Handle empty input
-    if (!value.ptr || value.len == 0) {
-        array_init(decoded_value);
+    if (value.len == 0) {
         return true;
     }
 
@@ -147,62 +107,56 @@ bool dd_parse_tags(zval *decoded_value, zai_str value, bool persistent) {
     const char *current = str;
 
     // Determine separator - prefer comma if present, otherwise use space
-    // This separator will be used for all tags in the string
     const char *sep = memchr(str, ',', value.len) ? "," : " ";
+    size_t sep_len = strlen(sep);
 
     while (current < end) {
-        // Skip leading whitespace before each tag
+        // Skip leading whitespace
         while (current < end && *current == ' ') current++;
         if (current >= end) break;
-
-        // Find next separator (comma or space)
-        // This gives us the length of the current tag
+        // Find next separator, this will be the end of the tag
         size_t tag_len = strcspn(current, sep);
+        if (tag_len == 0) {
+            // If the first character is a separator, move to the next character
+            current += sep_len;
+            continue;
+        }
+        // Prepare key and value
+        // Initialize key to be the entire tag and value to be empty
         const char *tag_end = current + tag_len;
-
-        // Skip empty segments (e.g., consecutive separators)
-        if (tag_len == 0) {
-            current += 1;
-            continue;
-        }
-
-        // Strip whitespace from tag
-        dd_strip_whitespace(&current, &tag_len);
-
-        // Skip if tag is empty after stripping
-        if (tag_len == 0) {
-            current = tag_end + 1;
-            continue;
-        }
-
-        // Find first colon in tag
-        // This ensures we only split on the first colon
-        // If no colon found, use whole tag as key with empty value
-        const char *colon = memchr(current, ':', tag_len);
         const char *key_start = current;
-        const char *val_start = ""; // Default empty value
+        const char *key_end = tag_end;
+        const char *val_start = "";
         size_t key_len = tag_len;
         size_t val_len = 0;
+        // If the tag has a colon, use the index of the colon to split the tag into key and value
+        const char *colon = memchr(current, ':', tag_len);
         if (colon) {
-            // Tag has a colon - split into key and value
-            key_len = colon - key_start; // Adjust key length to exclude the colon
-            val_start = colon + 1;       // Value starts after the colon 
+            // Tag has a colon, use the index of the colon to  split into key and value
+            key_end = colon - 1;
+            val_start = colon + 1;
+            key_len = key_end - key_start + 1;
             val_len = tag_end - val_start;
         }
-
-        // Strip whitespace from key and value
-        dd_strip_whitespace(&key_start, &key_len);
-        dd_strip_whitespace(&val_start, &val_len);
-
-        // Only insert if key is non-empty, value can be empty
+        // Strip whitespace from key
+        while (key_start < key_end && *key_start == ' ') key_start++;
+        while (key_end > key_start && *key_end == ' ') key_end--;
+        key_len = key_end - key_start + 1;
+        // Strip whitespace from value (if it is not empty)
+        if (val_len > 0) {
+            while (val_start < tag_end && *val_start == ' ') val_start++;
+            const char *val_end = tag_end - 1;
+            while (val_end > val_start && *val_end == ' ') val_end--;
+            val_len = val_end - val_start + 1;
+        }
+        // Only add if key is non-empty (value can be empty)
         if (key_len > 0) {
             zval val;
             ZVAL_STR(&val, zend_string_init(val_start, val_len, persistent));
             zend_hash_str_update(Z_ARRVAL_P(decoded_value), key_start, key_len, &val);
         }
-
-        // Move to the next segment
-        current = tag_end + 1;
+        // Move to the start of the next tag
+        current = tag_end + sep_len;
     }
 
     return true;

--- a/ext/configuration.c
+++ b/ext/configuration.c
@@ -151,13 +151,16 @@ static bool dd_parse_tags(zai_str value, zval *decoded_value, bool persistent) {
         }
         // Only add if key is non-empty (value can be empty)
         if (key_len > 0) {
+            // Create a zval for the value
             zval val;
             zend_string *val_str = zend_string_init(val_start, val_len, persistent);
             ZVAL_STR(&val, val_str);
+            // Create a zval for the key, this ensures that the key is null-terminated
+            zval key;
             zend_string *key_str = zend_string_init(key_start, key_len, persistent);
-            zend_hash_str_update_ind(Z_ARRVAL_P(decoded_value), ZSTR_VAL(key_str), ZSTR_LEN(key_str), &val);
-            zend_string_release(key_str);
-        }
+            ZVAL_STR(&key, key_str); 
+            zend_hash_update(Z_ARRVAL_P(decoded_value), Z_STR(key), &val);
+        } 
         // Move to the start of the next tag
         current = tag_end + sep_len;
     }

--- a/ext/configuration.h
+++ b/ext/configuration.h
@@ -113,7 +113,7 @@ enum ddtrace_sampling_rules_format {
     CONFIG(STRING, DD_SERVICE, "", .ini_change = ddtrace_alter_dd_service,                                     \
            .env_config_fallback = ddtrace_conf_otel_service_name)                                              \
     CONFIG(MAP, DD_SERVICE_MAPPING, "")                                                                        \
-    CONFIG(MAP, DD_TAGS, "",                                                                                   \
+    CONFIG(CUSTOM(MAP), DD_TAGS, "",                                                                                   \
            .env_config_fallback = ddtrace_conf_otel_resource_attributes_tags,                                  \
            .parser = dd_parse_tags)                                                                             \
     CONFIG(INT, DD_TRACE_AGENT_PORT, "0", .ini_change = zai_config_system_ini_change)                          \

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -275,11 +275,11 @@ EOD;
         $this->assertEquals(["env" => "test", "bKey"  => "", "dKey"  => "", "dVal"  => "", "cKey"  => ""], \dd_trace_env_config("DD_TAGS"));
     }
 
-    public function testGlobalTagsNoDelimiter()
-    {
-        $this->putEnvAndReloadConfig(['DD_TAGS=only_key_no_value']);
-        $this->assertEquals(["only_key_no_value" => ""], \dd_trace_env_config("DD_TAGS"));
-    }
+    // public function testGlobalTagsNoDelimiter()
+    // {
+    //     $this->putEnvAndReloadConfig(['DD_TAGS=only_key_no_value']);
+    //     $this->assertEquals(["only_key_no_value" => ""], \dd_trace_env_config("DD_TAGS"));
+    // }
 
     public function testHttpHeadersDefaultsToEmpty()
     {

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -251,16 +251,34 @@ EOD;
         $this->assertFalse(\dd_trace_env_config("DD_TRACE_URL_AS_RESOURCE_NAMES_ENABLED"));
     }
 
-    public function testGlobalTags()
+    public function testGlobalTagsCommaSeparated()
     {
         $this->putEnvAndReloadConfig(['DD_TAGS=key1:value1,key2:value2']);
         $this->assertEquals(['key1' => 'value1', 'key2' => 'value2'], \dd_trace_env_config("DD_TAGS"));
     }
 
-    public function testGlobalTagsWrongValueJustResultsInNoTags()
+    public function testGlobalTagsWhitespaceSeparated()
     {
-        $this->putEnvAndReloadConfig(['DD_TAGS=wrong_key_value']);
-        $this->assertEquals([], \dd_trace_env_config("DD_TAGS"));
+        $this->putEnvAndReloadConfig(['DD_TAGS=key1:value1 key2:value2']);
+        $this->assertEquals(['key1' => 'value1', 'key2' => 'value2'], \dd_trace_env_config("DD_TAGS"));
+    }
+
+    public function testGlobalTagsWhitespaceAndCommaSeparated()
+    {
+        $this->putEnvAndReloadConfig(['DD_TAGS=key1:value1, key2:value2']);
+        $this->assertEquals(['key1' => 'value1', 'key2' => 'value2'], \dd_trace_env_config("DD_TAGS"));
+    }
+
+    public function testGlobalTagsNoDelimiter()
+    {
+        $this->putEnvAndReloadConfig(['DD_TAGS=only_key_no_value']);
+        $this->assertEquals(["only_key_no_value" => ""], \dd_trace_env_config("DD_TAGS"));
+    }
+
+    public function testGlobalTagsDelimterPrecedence()
+    {
+        $this->putqEnvAndReloadConfig(['DD_TAGS=env:test     bKey :bVal dKey: dVal cKey:']);
+        $this->assertEquals(["env" => "test", "bKey"  => "", "dKey"  => "", "dVal"  => "", "cKey"  => ""], \dd_trace_env_config("DD_TAGS"));
     }
 
     public function testHttpHeadersDefaultsToEmpty()

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -277,7 +277,7 @@ EOD;
 
     public function testGlobalTagsDelimterPrecedence()
     {
-        $this->putqEnvAndReloadConfig(['DD_TAGS=env:test     bKey :bVal dKey: dVal cKey:']);
+        $this->putEnvAndReloadConfig(['DD_TAGS=env:test     bKey :bVal dKey: dVal cKey:']);
         $this->assertEquals(["env" => "test", "bKey"  => "", "dKey"  => "", "dVal"  => "", "cKey"  => ""], \dd_trace_env_config("DD_TAGS"));
     }
 

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -269,16 +269,16 @@ EOD;
         $this->assertEquals(['key1' => 'value1', 'key2' => 'value2'], \dd_trace_env_config("DD_TAGS"));
     }
 
-    public function testGlobalTagsNoDelimiter()
-    {
-        $this->putEnvAndReloadConfig(['DD_TAGS=only_key_no_value']);
-        $this->assertEquals(["only_key_no_value" => ""], \dd_trace_env_config("DD_TAGS"));
-    }
-
     public function testGlobalTagsDelimterPrecedence()
     {
         $this->putEnvAndReloadConfig(['DD_TAGS=env:test     bKey :bVal dKey: dVal cKey:']);
         $this->assertEquals(["env" => "test", "bKey"  => "", "dKey"  => "", "dVal"  => "", "cKey"  => ""], \dd_trace_env_config("DD_TAGS"));
+    }
+
+    public function testGlobalTagsNoDelimiter()
+    {
+        $this->putEnvAndReloadConfig(['DD_TAGS=only_key_no_value']);
+        $this->assertEquals(["only_key_no_value" => ""], \dd_trace_env_config("DD_TAGS"));
     }
 
     public function testHttpHeadersDefaultsToEmpty()

--- a/tests/Unit/ConfigurationTest.php
+++ b/tests/Unit/ConfigurationTest.php
@@ -269,17 +269,17 @@ EOD;
         $this->assertEquals(['key1' => 'value1', 'key2' => 'value2'], \dd_trace_env_config("DD_TAGS"));
     }
 
+    public function testGlobalTagsNoDelimiter()
+    {
+        $this->putEnvAndReloadConfig(['DD_TAGS=only_key_no_value']);
+        $this->assertEquals(["only_key_no_value" => ""], \dd_trace_env_config("DD_TAGS"));
+    }
+
     public function testGlobalTagsDelimterPrecedence()
     {
         $this->putEnvAndReloadConfig(['DD_TAGS=env:test     bKey :bVal dKey: dVal cKey:']);
         $this->assertEquals(["env" => "test", "bKey"  => "", "dKey"  => "", "dVal"  => "", "cKey"  => ""], \dd_trace_env_config("DD_TAGS"));
     }
-
-    // public function testGlobalTagsNoDelimiter()
-    // {
-    //     $this->putEnvAndReloadConfig(['DD_TAGS=only_key_no_value']);
-    //     $this->assertEquals(["only_key_no_value" => ""], \dd_trace_env_config("DD_TAGS"));
-    // }
 
     public function testHttpHeadersDefaultsToEmpty()
     {


### PR DESCRIPTION
### Description

Addresses edge cases missing from: https://github.com/DataDog/dd-trace-php/pull/3162. 
Failing tests: https://github.com/DataDog/system-tests/actions/runs/14201484499/job/39789366220?pr=4439 

## Changes 

- The new parser is currently not used. We need to load `DD_TAGS` using `CUSTOM(MAP)`
- Ensure the first `:` colon in a tag is used to split key-value pairs. 
- If there are no colons in tag then the full tag becomes the key. 
- If there are more than one colons in a tag then the remaining colons must be included in the value.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
