### PR TITLE
Amend bug on ip collection not happening

### DIFF
--- a/appsec/src/extension/request_lifecycle.c
+++ b/appsec/src/extension/request_lifecycle.c
@@ -406,8 +406,8 @@ static void _reset_globals()
 
     if (_client_ip && _client_ip != CLIENT_IP_LOOKUP_FAILED) {
         zend_string_release(_client_ip);
-        _client_ip = NULL;
     }
+    _client_ip = NULL;
 
     if (Z_TYPE(_blocking_function) != IS_UNDEF) {
         zval_ptr_dtor(&_blocking_function);


### PR DESCRIPTION
### Description

There was a bug on IP collection. Whenever a process could not get an IP for valid reasons, like IP not provided, that process would get stuck on an state that IP collection would never happen again. The reason was that the `_client_ip` was not set to null

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
