### PR TITLE
Reduce work done by stress test

### DIFF
--- a/dockerfiles/ci/buster/docker-compose.yml
+++ b/dockerfiles/ci/buster/docker-compose.yml
@@ -17,8 +17,8 @@ services:
       x-bake: *bake
       args:
         phpVersion: "8.4"
-        phpTarGzUrl: https://www.php.net/distributions/php-8.4.1.tar.gz
-        phpSha256Hash: "c3d1ce4157463ea43004289c01172deb54ce9c5894d8722f4e805461bf9feaec"
+        phpTarGzUrl: https://www.php.net/distributions/php-8.4.5.tar.gz
+        phpSha256Hash: "f05530d350f1ffe279e097c2af7a8d78cab046ef99d91f6b3151b06f0ab05d05"
 
   php-8.3:
     image: datadog/dd-trace-ci:php-8.3_buster
@@ -28,8 +28,8 @@ services:
       x-bake: *bake
       args:
         phpVersion: "8.3"
-        phpTarGzUrl: https://www.php.net/distributions/php-8.3.14.tar.gz
-        phpSha256Hash: "e4ee602c31e2f701c9f0209a2902dd4802727431246a9155bf56dda7bcf7fb4a"
+        phpTarGzUrl: https://www.php.net/distributions/php-8.3.19.tar.gz
+        phpSha256Hash: "bb21d1a5eb9a8b27668b2926fa9279a5878bb6fdee55450621f7865e062dcf3a"
 
   php-8.2:
     image: datadog/dd-trace-ci:php-8.2_buster
@@ -39,8 +39,8 @@ services:
       x-bake: *bake
       args:
         phpVersion: "8.2"
-        phpTarGzUrl: https://www.php.net/distributions/php-8.2.26.tar.gz
-        phpSha256Hash: "04e47b46b347ed6404dcc9e9989486710b075eafc8490500fd271aeeac5d83cb"
+        phpTarGzUrl: https://www.php.net/distributions/php-8.2.28.tar.gz
+        phpSha256Hash: "3318300888de5023720cc84efad5e005e53f30b5f0072fae65a750dabcaf6ec3"
 
   php-8.1:
     image: datadog/dd-trace-ci:php-8.1_buster
@@ -50,8 +50,8 @@ services:
       x-bake: *bake
       args:
         phpVersion: "8.1"
-        phpTarGzUrl: https://www.php.net/distributions/php-8.1.31.tar.gz
-        phpSha256Hash: "618923b407c4575bfee085f00c4aaa16a5cc86d4b1eb893c0f352d61541bbfb1"
+        phpTarGzUrl: https://www.php.net/distributions/php-8.1.32.tar.gz
+        phpSha256Hash: "4846836d1de27dbd28e89180f073531087029a77e98e8e019b7b2eddbdb1baff"
 
   php-8.0:
     image: datadog/dd-trace-ci:php-8.0_buster

--- a/dockerfiles/ci/buster/php-8.0/0001-Fix-memory-leak-in-zend_wrong_callback_error.patch
+++ b/dockerfiles/ci/buster/php-8.0/0001-Fix-memory-leak-in-zend_wrong_callback_error.patch
@@ -1,0 +1,29 @@
+From 0160b28d4ec5d2d6009590c99928625e0ae5ddff Mon Sep 17 00:00:00 2001
+From: Bob Weinand <bobwei9@hotmail.com>
+Date: Mon, 7 Apr 2025 12:16:21 +0200
+Subject: [PATCH] Fix memory leak in zend_wrong_callback_error
+
+---
+ Zend/zend_API.c | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/Zend/zend_API.c b/Zend/zend_API.c
+index b75dcc27004..339402866ce 100644
+--- a/Zend/zend_API.c
++++ b/Zend/zend_API.c
+@@ -329,10 +329,10 @@ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_parameter_class_or_string_or_nu
+ ZEND_API ZEND_COLD void ZEND_FASTCALL zend_wrong_callback_error(uint32_t num, char *error) /* {{{ */
+ {
+ 	if (EG(exception)) {
+-		return;
++		zend_argument_type_error(num, "must be a valid callback, %s", error);
+ 	}
+ 
+-	zend_argument_type_error(num, "must be a valid callback, %s", error);
++
+ 	efree(error);
+ }
+ /* }}} */
+-- 
+2.41.0
+

--- a/dockerfiles/ci/buster/php-8.0/Dockerfile
+++ b/dockerfiles/ci/buster/php-8.0/Dockerfile
@@ -3,6 +3,7 @@ ARG phpTarGzUrl
 ARG phpSha256Hash
 COPY 0001-Better-support-for-cross-compilation.patch /home/circleci
 COPY 0001-Fix-GH-10611-fpm_env_init_main-leaks-environ.patch /home/circleci
+COPY php-8.0/0001-Fix-memory-leak-in-zend_wrong_callback_error.patch /home/circleci
 COPY php-8.0/0001-Introduce-DD_IGNORE_ARGINFO_ZPP_CHECK-env-var-to-ski.patch /home/circleci
 RUN set -eux; \
     curl -fsSL -o /tmp/php.tar.gz "${phpTarGzUrl}"; \
@@ -12,6 +13,7 @@ RUN set -eux; \
     cd ${PHP_SRC_DIR}; \
     git apply /home/circleci/0001-Better-support-for-cross-compilation.patch; \
     git apply /home/circleci/0001-Introduce-DD_IGNORE_ARGINFO_ZPP_CHECK-env-var-to-ski.patch; \
+    git apply /home/circleci/0001-Fix-memory-leak-in-zend_wrong_callback_error.patch; \
     patch -p1 /home/circleci/0001-Fix-GH-10611-fpm_env_init_main-leaks-environ.patch; \
     ./buildconf --force
 

--- a/dockerfiles/ci/xfail_tests/8.0.list
+++ b/dockerfiles/ci/xfail_tests/8.0.list
@@ -213,6 +213,7 @@ ext/json/tests/pass001.phpt
 ext/mbstring/tests/zend_multibyte-01.phpt
 ext/mbstring/tests/zend_multibyte-02.phpt
 ext/mbstring/tests/zend_multibyte-06.phpt
+ext/mysqli/tests/ghsa-h35g-vwh6-m678-stmt-row-date.phpt
 ext/openssl/tests/bug46127.phpt
 ext/openssl/tests/bug48182.phpt
 ext/openssl/tests/bug54992.phpt

--- a/dockerfiles/ci/xfail_tests/8.1.list
+++ b/dockerfiles/ci/xfail_tests/8.1.list
@@ -52,6 +52,7 @@ ext/mbstring/tests/zend_multibyte-01.phpt
 ext/mbstring/tests/zend_multibyte-02.phpt
 ext/mbstring/tests/zend_multibyte-06.phpt
 ext/mysqli/tests/ghsa-h35g-vwh6-m678-stmt-row-double.phpt
+ext/mysqli/tests/ghsa-h35g-vwh6-m678-stmt-row-date.phpt
 ext/mysqli/tests/ghsa-h35g-vwh6-m678-stmt-row-time.phpt
 ext/mysqli/tests/protocol_stmt_row_fetch_data.phpt
 ext/opcache/tests/bug66251.phpt

--- a/dockerfiles/ci/xfail_tests/8.2.list
+++ b/dockerfiles/ci/xfail_tests/8.2.list
@@ -53,6 +53,7 @@ ext/mbstring/tests/zend_multibyte-01.phpt
 ext/mbstring/tests/zend_multibyte-02.phpt
 ext/mbstring/tests/zend_multibyte-06.phpt
 ext/mysqli/tests/ghsa-h35g-vwh6-m678-stmt-row-double.phpt
+ext/mysqli/tests/ghsa-h35g-vwh6-m678-stmt-row-date.phpt
 ext/mysqli/tests/ghsa-h35g-vwh6-m678-stmt-row-time.phpt
 ext/mysqli/tests/protocol_stmt_row_fetch_data.phpt
 ext/openssl/tests/bug46127.phpt

--- a/ext/ddtrace.stub.php
+++ b/ext/ddtrace.stub.php
@@ -205,7 +205,7 @@ namespace DDTrace {
         /**
          * @var SpanData|null The parent span, or 'null' if there is none
          */
-        public readonly SpanData|null $parent;
+        public readonly SpanData|null $parent = null;
 
         /**
          * @var SpanStack The span's stack trace
@@ -321,7 +321,7 @@ namespace DDTrace {
         /**
          * @var SpanStack|null The parent stack, or 'null' if there is none
          */
-        public readonly SpanStack|null $parent;
+        public readonly SpanStack|null $parent = null;
 
         /**
          * @var SpanData|null The active span

--- a/ext/ddtrace_arginfo.h
+++ b/ext/ddtrace_arginfo.h
@@ -1,5 +1,5 @@
 /* This is a generated file, edit the .stub.php file instead.
- * Stub hash: 21dd48a5e3e602ba3be010a325d2cb8b703907c7 */
+ * Stub hash: a0151c34f00ffc69945f366d81cafd27e9e1167d */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_trace_method, 0, 3, _IS_BOOL, 0)
 	ZEND_ARG_TYPE_INFO(0, className, IS_STRING, 0)
@@ -710,7 +710,7 @@ static zend_class_entry *register_class_DDTrace_SpanData(void)
 	zend_string_release(property_peerServiceSources_name);
 
 	zval property_parent_default_value;
-	ZVAL_UNDEF(&property_parent_default_value);
+	ZVAL_NULL(&property_parent_default_value);
 	zend_string *property_parent_class_DDTrace_SpanData = zend_string_init("DDTrace\\SpanData", sizeof("DDTrace\\SpanData")-1, 1);
 	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_PARENT), &property_parent_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_parent_class_DDTrace_SpanData, 0, MAY_BE_NULL));
 
@@ -826,7 +826,7 @@ static zend_class_entry *register_class_DDTrace_SpanStack(void)
 	class_entry = zend_register_internal_class_with_flags(&ce, NULL, 0);
 
 	zval property_parent_default_value;
-	ZVAL_UNDEF(&property_parent_default_value);
+	ZVAL_NULL(&property_parent_default_value);
 	zend_string *property_parent_class_DDTrace_SpanStack = zend_string_init("DDTrace\\SpanStack", sizeof("DDTrace\\SpanStack")-1, 1);
 	zend_declare_typed_property(class_entry, ZSTR_KNOWN(ZEND_STR_PARENT), &property_parent_default_value, ZEND_ACC_PUBLIC|ZEND_ACC_READONLY, NULL, (zend_type) ZEND_TYPE_INIT_CLASS(property_parent_class_DDTrace_SpanStack, 0, MAY_BE_NULL));
 

--- a/tests/ext/request-replayer/dd_trace_agent_env.phpt
+++ b/tests/ext/request-replayer/dd_trace_agent_env.phpt
@@ -3,7 +3,7 @@ Assert that the default environment can be read from agent info
 --SKIPIF--
 <?php include __DIR__ . '/../includes/skipif_no_dev_env.inc'; ?>
 <?php
-if (PHP_OS === "WINNT" && PHP_VERSION_ID < 70400) die("skip: Windows on PHP 7.2 and 7.3 have permission issues with synchronous access to sidecar data");
+if (PHP_VERSION_ID < 70400) die("skip: Before PHP 7.4, the skip-task would cause the sidecar to fetch the info already.");
 if (PHP_VERSION_ID >= 80100) {
     echo "nocache\n";
 }

--- a/tests/internal-api-stress-test.php
+++ b/tests/internal-api-stress-test.php
@@ -31,18 +31,24 @@ $return_span = [
 // Otherwise we grow var_dump() graphs exponentially...
 function ensure_bounded_nesting_depth()
 {
-    $span = DDTrace\active_span();
     $depth = 0;
+    $stack = DDTrace\active_stack();
+    while (!$stack->active && $stack->parent) {
+        ++$depth;
+        $stack = $stack->parent;
+    }
+
+    $span = DDTrace\active_span();
     while ($span) {
         ++$depth;
-        if ($span->parent) {
+        if ($span->parent && $span->parent->stack == $span->stack) {
             $span = $span->parent;
         } else {
             $stack = $span->stack;
             do {
                 ++$depth;
                 $stack = $stack->parent;
-            } while ($stack && $stack->active);
+            } while ($stack && !$stack->active);
             $span = $stack ? $stack->active : null;
         }
     }
@@ -50,6 +56,7 @@ function ensure_bounded_nesting_depth()
     if ($depth >= 5) {
         ini_set("datadog.trace.enabled", "0");
         ini_set("datadog.trace.enabled", "1");
+        DDTrace\switch_stack(new DDTrace\SpanStack);
     }
 }
 
@@ -89,14 +96,22 @@ function generate_garbage()
         ["nonempty" => new stdClass()],
         new stdClass(),
         function ($hook = null) {
-            ob_start();
-            var_dump(func_get_args());
-            ob_end_clean();
+            $args = func_get_args();
+            if (is_array($args[2] ?? null)) {
+                if (rand(1, 10) != 1) {
+                    return; // Otel hooks cannot be removed
+                }
+            }
+            if (rand(1, 3) == 1) {
+                ob_start();
+                var_dump($args);
+                ob_end_clean();
+            }
             if ($hook instanceof DDTrace\HookData) {
-                if (rand(1, 3) != 1) {
+                if (rand(1, 2) != 1) {
                     DDTrace\remove_hook($hook->id);
                 }
-            } elseif (rand(1, 6) == 1) {
+            } elseif (rand(1, 5) == 1) {
                 dd_untrace('DDTrace\hook_method');
                 dd_untrace('call_function');
             }
@@ -125,12 +140,27 @@ function call_function(ReflectionFunction $function)
 
     $i = PHP_VERSION_ID >= 80100 ? $function->getNumberOfRequiredParameters() : ($minFunctionArgs[$function->name] ?? 0);
     $invocations = $i == 0 ? [[]] : [];
+    $invocationTypeMap = [];
+    $invNum = 0;
+    $existingGarbage = [generate_garbage()];
     for (; $i < $function->getNumberOfParameters(); ++$i) {
         foreach ($invocations as $invocation) {
-            foreach (generate_garbage() as $garbage) {
+            if (rand(1, max(1, ceil(2 ** $i))) == 1) {
+                $useGarbage = $existingGarbage[] = generate_garbage();
+            } else {
+                $useGarbage = $existingGarbage[array_rand($existingGarbage)];
+            }
+            foreach ($useGarbage as $garbage) {
                 $newInvocation = $invocation;
                 $newInvocation[] = $garbage;
-                $invocations[] = $newInvocation;
+                $invocations[++$invNum] = $newInvocation;
+                foreach ($newInvocation as $arg => $val) {
+                    $invocationTypeMap[$arg][gettype($val)][] = $invNum;
+                    if (is_object($val)) {
+                        $c = get_class($val);
+                        $invocationTypeMap[$arg][strrchr($c, '\\') ?: $c][] = $invNum;
+                    }
+                }
             }
         }
     }
@@ -146,6 +176,16 @@ function call_function(ReflectionFunction $function)
                 }
             }
         } catch (TypeError $e) {
+            # Fatal error: Uncaught TypeError: DDTrace\hook_method(): Argument #1 ($className) must be of type string, array given
+            if (preg_match('(Argument #(\d+).*?(?|got ([a-z]+)|([a-z]+) given))i', $e->getMessage(), $m)) {
+                $arg = $m[1];
+                $argNum = $arg - 1;
+                $type = $m[2];
+                $found = $invocationTypeMap[$arg - 1][$type] ?? $invocationTypeMap[$arg - 1]['\\' . $type] ?? [];
+                foreach ($found as $k) {
+                    unset($invocations[$k]);
+                }
+            }
         }
     }
 }


### PR DESCRIPTION
A bit, so that it doesn't frequently time out.

This test was effectively always red due to the timeout.