### PR TITLE
fix(prof): disable allocation profiling when JIT is enabled on PHP 8.4

### DIFF
--- a/profiling/src/allocation/allocation_ge84.rs
+++ b/profiling/src/allocation/allocation_ge84.rs
@@ -102,7 +102,7 @@ lazy_static! {
 
 pub fn first_rinit_should_disable_due_to_jit() -> bool {
     if *JIT_ENABLED && zend::PHP_VERSION_ID >= 80400 {
-        error!("Memory allocation profiling will be disabled as long as JIT is active. To enable allocation profiling disable JIT");
+        error!("Memory allocation profiling will be disabled as long as JIT is active. To enable allocation profiling disable JIT. See https://github.com/DataDog/dd-trace-php/pull/3199");
         true
     } else {
         false

--- a/profiling/src/allocation/mod.rs
+++ b/profiling/src/allocation/mod.rs
@@ -9,7 +9,7 @@ use std::cell::RefCell;
 use std::sync::atomic::AtomicU64;
 
 #[cfg(php_zend_mm_set_custom_handlers_ex)]
-mod allocation_ge84;
+pub mod allocation_ge84;
 #[cfg(not(php_zend_mm_set_custom_handlers_ex))]
 pub mod allocation_le83;
 

--- a/profiling/src/config.rs
+++ b/profiling/src/config.rs
@@ -1,4 +1,3 @@
-#[cfg(not(php_zend_mm_set_custom_handlers_ex))]
 use crate::allocation;
 use crate::bindings::zai_config_type::*;
 use crate::bindings::{
@@ -111,6 +110,10 @@ impl SystemSettings {
         // Work around version-specific issues.
         #[cfg(not(php_zend_mm_set_custom_handlers_ex))]
         if allocation::allocation_le83::first_rinit_should_disable_due_to_jit() {
+            system_settings.profiling_allocation_enabled = false;
+        }
+        #[cfg(php_zend_mm_set_custom_handlers_ex)]
+        if allocation::allocation_ge84::first_rinit_should_disable_due_to_jit() {
             system_settings.profiling_allocation_enabled = false;
         }
         swap(&mut system_settings, SYSTEM_SETTINGS.assume_init_mut());

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -791,7 +791,12 @@ unsafe extern "C" fn minfo(module_ptr: *mut zend::ModuleEntry) {
                     if system_settings.profiling_allocation_enabled {
                         yes
                     } else if zend::ddog_php_jit_enabled() {
-                        b"Not available due to JIT being active, see https://github.com/DataDog/dd-trace-php/pull/2088 for more information.\0"
+                        // Work around version-specific issues.
+                        if cfg!(not(php_zend_mm_set_custom_handlers_ex)) {
+                            b"Not available due to JIT being active, see https://github.com/DataDog/dd-trace-php/pull/2088 for more information.\0"
+                        } else {
+                            b"Not available due to JIT being active, see https://github.com/DataDog/dd-trace-php/pull/9999 for more information.\0"
+                        }
                     } else if system_settings.profiling_enabled {
                         no
                     } else {

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -795,7 +795,7 @@ unsafe extern "C" fn minfo(module_ptr: *mut zend::ModuleEntry) {
                         if cfg!(not(php_zend_mm_set_custom_handlers_ex)) {
                             b"Not available due to JIT being active, see https://github.com/DataDog/dd-trace-php/pull/2088 for more information.\0"
                         } else {
-                            b"Not available due to JIT being active, see https://github.com/DataDog/dd-trace-php/pull/9999 for more information.\0"
+                            b"Not available due to JIT being active, see https://github.com/DataDog/dd-trace-php/pull/3199 for more information.\0"
                         }
                     } else if system_settings.profiling_enabled {
                         no

--- a/profiling/tests/phpt/jit_01.phpt
+++ b/profiling/tests/phpt/jit_01.phpt
@@ -10,6 +10,8 @@ if (PHP_VERSION_ID >= 80208 || PHP_VERSION_ID >= 80121 && PHP_VERSION_ID < 80200
     echo "skip: PHP Version >= 8.1.21 and >= 8.2.8 have a fix for this";
 if (PHP_VERSION_ID < 80000)
     echo "skip: JIT requires PHP >= 8.0", PHP_EOL;
+if (PHP_VERSION_ID >= 80300)
+    echo "skip: not affected version", PHP_EOL;
 if (!extension_loaded('datadog-profiling'))
     echo "skip: test requires datadog-profiling", PHP_EOL;
 $arch = php_uname('m');

--- a/profiling/tests/phpt/jit_02.phpt
+++ b/profiling/tests/phpt/jit_02.phpt
@@ -9,6 +9,8 @@ if (PHP_VERSION_ID < 80120 || PHP_VERSION_ID >= 80200 && PHP_VERSION_ID < 80207)
     echo "skip: unpatched PHP version, so JIT should be inactive";
 if (PHP_VERSION_ID < 80000)
     echo "skip: JIT requires PHP >= 8.0", PHP_EOL;
+if (PHP_VERSION_ID >= 80300)
+    echo "skip: not affected version", PHP_EOL;
 if (!extension_loaded('datadog-profiling'))
     echo "skip: test requires datadog-profiling", PHP_EOL;
 $arch = php_uname('m');

--- a/profiling/tests/phpt/jit_03.phpt
+++ b/profiling/tests/phpt/jit_03.phpt
@@ -1,0 +1,29 @@
+--TEST--
+[profiling] Allocation profiling should be disabled when JIT is active on PHP 8.4
+--DESCRIPTION--
+We did find a crash in PHP when collecting a stack sample in allocation
+profiling when JIT is activated while a function becomes hot. For the time being
+we make sure to disable allocation profiling when we detect the JIT is enabled.
+--SKIPIF--
+<?php
+if (PHP_VERSION_ID < 80400)
+    echo "skip: PHP Version < 8.4 are not affected", PHP_EOL;
+if (!extension_loaded('datadog-profiling'))
+    echo "skip: test requires datadog-profiling", PHP_EOL;
+?>
+--INI--
+datadog.profiling.enabled=yes
+datadog.profiling.log_level=debug
+datadog.profiling.allocation_enabled=yes
+datadog.profiling.experimental_cpu_time_enabled=no
+zend_extension=opcache
+opcache.enable_cli=1
+opcache.jit=tracing
+opcache.jit_buffer_size=4M
+--FILE--
+<?php
+echo "Done.", PHP_EOL;
+?>
+--EXPECTF--
+%aMemory allocation profiling will be disabled as long as JIT is active. To enable allocation profiling disable JIT. See https://github.com/DataDog/dd-trace-php/pull/3199
+%ADone.%a

--- a/profiling/tests/phpt/phpinfo_04.phpt
+++ b/profiling/tests/phpt/phpinfo_04.phpt
@@ -5,7 +5,7 @@ The profiler's phpinfo section contains important debugging information. This
 test verifies that certain information is present.
 --SKIPIF--
 <?php
-if (PHP_VERSION_ID < 80120 || PHP_VERSION_ID >= 80200 && PHP_VERSION_ID < 80207)
+if (PHP_VERSION_ID < 80120 || PHP_VERSION_ID >= 80200 && PHP_VERSION_ID < 80207 || PHP_VERSION_ID >= 80400)
     echo "skip: unpatched PHP version, so JIT should be inactive";
 if (PHP_VERSION_ID < 80000)
     echo "skip: JIT requires PHP >= 8.0", PHP_EOL;


### PR DESCRIPTION
### Description

A customer reached out in #3197 with a crash while collecting a stack frame for an allocation that is done while hot function is compiled. This code seems to be there since the new JIT in PHP 8.4. So for now we are disabling allocation profiling when an active JIT is detected in PHP 8.4.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
