### PR TITLE
Add FakeApp for profiling benchmarking

### DIFF
--- a/profiling/benches/fakeapp/bench.sh
+++ b/profiling/benches/fakeapp/bench.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+
+# 3 is the number of unique samples triggered, it's just known statically for the app
+rm -v trigger-{0..2}.txt
+
+set -eu
+
+cargo build --release --features "allocation_profiling,exception_profiling,io_profiling,timeline,tracing-subscriber,trigger_time_sample"
+
+RUST_LOG=trace php -c . -dextension=$PWD/../../../target/release/libdatadog_php_profiling.so -S 0.0.0.0:8080 -t public &> output.txt &
+pid=$!
+
+# https://measuringu.com/sample-size-recommendations/
+# For 90% confidence with a margin of error lower than some percent:
+# 5%: 268
+# 4%: 421
+# 3%: 749
+# Their numbers are perhaps not an exact match for our use-case, but it's at
+# least better justified than pulling them out of the air.
+target=749
+
+sleep 1 # just because it takes time for the thing to be ready to serve requests
+
+i=0
+time (while [ $i -lt $target ]
+    do
+        i=$((i+1))
+        curl 0.0.0.0:8080/blog &>/dev/null
+    done;
+    echo "Ran $i iterations"
+)
+
+kill -n TERM "$pid"
+
+< output.txt awk -F'[ =]' '/collect_stack_sample/ { print $7 }' \
+    | awk '{ print $0 > "trigger-" (NR-1)%3 ".txt" }'
+
+wc -l trigger-{0..2}.txt
+

--- a/profiling/benches/fakeapp/bench.sh
+++ b/profiling/benches/fakeapp/bench.sh
@@ -1,5 +1,10 @@
 #!/bin/bash
 
+if [[ "$OSTYPE" != "linux-gnu"* ]]; then
+    echo "ERROR: This script only works on Linux."
+    exit 1
+fi
+
 # 3 is the number of unique samples triggered, it's just known statically for the app
 rm -v trigger-{0..2}.txt
 

--- a/profiling/benches/fakeapp/driver.sh
+++ b/profiling/benches/fakeapp/driver.sh
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+if [ -z "$TMPDIR" ]; then
+    export TMPDIR="/tmp"
+fi
+
+set -eu
+
+# The branch being tested.
+head="$1"
+
+# The baseline to compare against.
+target_branch="$2"
+
+merge_base=$(git merge-base "$head" "$target_branch")
+
+git checkout "$head"
+cp -v bench.sh "$TMPDIR/bench.sh"
+
+bash "$TMPDIR/bench.sh"
+mv -v trigger-*.txt "$TMPDIR/"
+
+git checkout "$merge_base"
+bash "$TMPDIR/bench.sh"
+
+git checkout "$head"

--- a/profiling/benches/fakeapp/php.ini
+++ b/profiling/benches/fakeapp/php.ini
@@ -1,0 +1,8 @@
+display_errors=off
+
+datadog.profiling.enabled=1
+datadog.profiling.allocation_enabled=0
+datadog.profiling.experimental_cpu_time_enabled=0
+datadog.profiling.exception_enabled=0
+datadog.profiling.timeline_enabled=0
+datadog.profiling.walltime_enabled=0

--- a/profiling/benches/fakeapp/public/index.php
+++ b/profiling/benches/fakeapp/public/index.php
@@ -1,0 +1,22 @@
+<?php declare(strict_types=1);
+
+// Composer is near ubiquitous, so we'll set up a composer-like app.
+require __DIR__ . "/../vendor/autoload.php";
+require __DIR__ . "/../src/functions.php";
+
+function main()
+{
+    $app = App\HttpApp::new();
+
+    $http_method = $_SERVER['REQUEST_METHOD'];
+    $uri = $_SERVER['REQUEST_URI'];
+
+    if (false !== $pos = \strpos($uri, '?')) {
+        $uri = \substr($uri, 0, $pos);
+    }
+    $uri = \rawurldecode($uri);
+
+    $app->run($http_method, $uri);
+}
+
+main();

--- a/profiling/benches/fakeapp/src/HttpApp.php
+++ b/profiling/benches/fakeapp/src/HttpApp.php
@@ -1,0 +1,72 @@
+<?php declare(strict_types=1);
+
+namespace App;
+
+use FakeApp\FakeRoute;
+use FakeApp\Http;
+
+final class HttpApp
+{
+
+    private function __construct(private FakeRoute\Dispatcher $dispatcher)
+    {
+    }
+
+    public static function new(): HttpApp
+    {
+        $dispatcher = FakeRoute\Dispatcher::new(
+            function (FakeRoute\Config $config) {
+                $config->add_route('GET', '/', 'App\\home');
+                $config->add_route('GET', '/blog', 'App\\blog_index');
+                $config->add_route('POST', '/about', 'App\\about_us');
+
+                // Our fake router sucks, can't do regexp or anything ^_^
+                $config->add_route('GET', '/blog/1', 'App\\blog_article');
+                $config->add_route('GET', '/blog/2', 'App\\blog_article');
+            });
+        return new HttpApp($dispatcher);
+    }
+
+    public function run(string $http_method, string $uri): void {
+        try {
+            $result = $this->dispatcher->dispatch($http_method, $uri);
+            if ($result instanceof FakeRoute\NotFound) {
+                $status = Http\Status::new('HTTP/1.1', 405, 'Method Not Allowed');
+                $body = "Not Found\n\n$http_method $uri\n";
+                $headers = Http\Headers::new()
+                    ->append('Content-Type', 'text/plain')
+                    ->append('Content-Length', (string)\strlen($body));
+                $response = Http\Response::new($status, $headers, $body);
+            } elseif ($result instanceof FakeRoute\MethodNotAllowed) {
+                $status = Http\Status::new('HTTP/1.1', 405, 'Method Not Allowed');
+                $body = "Method Not Allowed\n\nAllowed Methods:\n";
+                foreach ($result->allowed_methods as $method) {
+                    $body .= " - $method\n";
+                }
+                $headers = Http\Headers::new()
+                    ->append('Content-Type', 'text/plain')
+                    ->append('Content-Length', (string)\strlen($body));
+                $response = Http\Response::new($status, $headers, $body);
+            } else {            
+                assert($result instanceof FakeRoute\Found);
+                $response = ($result->handler)($http_method, $uri);
+            }
+        } catch (Throwable $err) {
+            $status = Http\Status::new('HTTP/1.1', 500, 'Internal Server Error');
+            $body = "Internal Server Error\n\n{$err}";
+            $headers = Http\Headers::new()
+                ->append('Content-Type', 'text/plain')
+                ->append('Content-Length', (string)\strlen($body));
+            $response = Http\Response::new($status, $headers, $body);
+        }
+
+        $status = $response->status;
+        \header("{$status->protocol} {$status->code} {$status->message}");
+
+        foreach ($response->headers as $header => $value) {
+            \header("{$header}: {$value}");
+        }
+
+        echo $response->body;
+    }
+}

--- a/profiling/benches/fakeapp/src/autoload.php
+++ b/profiling/benches/fakeapp/src/autoload.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace App;
+
+function autoload(string $class): void
+{
+    $prefix = 'App\\';
+    $base_dir = __DIR__ . '/../src/';
+
+    $len = \strlen($prefix);
+    if (\strncmp($prefix, $class, $len) !== 0) {
+        return;
+    }
+
+    $relative = \substr($class, $len);
+
+    $file = $base_dir . \str_replace('\\', '/', $relative) . '.php';
+
+    @include $file;
+}

--- a/profiling/benches/fakeapp/src/functions.php
+++ b/profiling/benches/fakeapp/src/functions.php
@@ -1,0 +1,49 @@
+<?php declare(strict_types=1);
+
+namespace App;
+
+use FakeApp\Http\{Headers, Response, Status};
+
+function home(string $http_method, string $uri): Response
+{
+    $status = Status::new('HTTP/1.1', 200, 'Found');
+    $body = "Welcome to /\n";
+    $headers = Headers::new()
+        ->append('Content-Type', 'text/plain')
+        ->append('Content-Length', (string)\strlen($body));
+    return Response::new($status, $headers, $body);
+}
+
+function blog_index(string $http_method, string $uri): Response
+{
+    $status = Status::new('HTTP/1.1', 200, 'Found');
+    $body = "Blog Index\n - 1\n - 2\n";
+    $headers = Headers::new()
+        ->append('Content-Type', 'text/plain')
+        ->append('Content-Length', (string)\strlen($body));
+    return Response::new($status, $headers, $body);
+}
+
+function blog_article(string $http_method, string $uri): Response
+{
+    $status = Status::new('HTTP/1.1', 200, 'Found');
+    $body = "Blog Article\n";
+    $headers = Headers::new()
+        ->append('Content-Type', 'text/plain')
+        ->append('Content-Length', (string)\strlen($body));
+    return Response::new($status, $headers, $body);
+}
+
+function about_us(string $http_method, string $uri): Response
+{
+    $status = Status::new('HTTP/1.1', 200, 'Found');
+    $body = "About Us\n\nTODO\n";
+    $headers = Headers::new()
+        ->append('Content-Type', 'text/plain')
+        ->append('Content-Length', (string)\strlen($body));
+    return Response::new($status, $headers, $body);
+}
+
+if (\function_exists('Datadog\\Profiling\\trigger_time_sample')) {
+    \Datadog\Profiling\trigger_time_sample();
+}

--- a/profiling/benches/fakeapp/vendor/FakeApp/FakeRoute/autoload.php
+++ b/profiling/benches/fakeapp/vendor/FakeApp/FakeRoute/autoload.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace FakeApp\FakeRoute;
+
+function autoload(string $class): void
+{
+    $prefix = 'FakeApp\\FakeRoute\\';
+    $base_dir = __DIR__ . '/src/';
+
+    $len = \strlen($prefix);
+    if (\strncmp($prefix, $class, $len) !== 0) {
+        return;
+    }
+
+    $relative = \substr($class, $len);
+
+    $file = $base_dir . \str_replace('\\', '/', $relative) . '.php';
+
+    include $file;
+}

--- a/profiling/benches/fakeapp/vendor/FakeApp/FakeRoute/src/Config.php
+++ b/profiling/benches/fakeapp/vendor/FakeApp/FakeRoute/src/Config.php
@@ -1,0 +1,32 @@
+<?php declare(strict_types=1);
+
+namespace FakeApp\FakeRoute;
+
+final class Config
+{
+
+    private function __construct(private array $routes)
+    {
+    }
+
+    public static function new(): Config
+    {
+        return new Config([]);
+    }
+
+    public function add_route(
+        string $http_method,
+        string $path,
+        callable $handler,
+    ): void {
+        $endpoint = $this->routes[$path]
+            ?? ($this->routes[$path] = ConfigRoute::new($path));
+	
+        $endpoint->add_handler($http_method, $handler);
+    }
+
+    public function get_route(string $route): ?ConfigRoute
+    {
+        return $this->routes[$route] ?? null;
+    }
+}

--- a/profiling/benches/fakeapp/vendor/FakeApp/FakeRoute/src/ConfigRoute.php
+++ b/profiling/benches/fakeapp/vendor/FakeApp/FakeRoute/src/ConfigRoute.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace FakeApp\FakeRoute;
+
+use Closure;
+
+final class ConfigRoute
+{
+    private array $handlers = [];
+
+    private function __construct(private string $route)
+    {
+    }
+
+    public static function new(string $route): ConfigRoute
+    {
+        return new ConfigRoute($route);
+    }
+
+    public function add_handler(string $http_method, callable $handler): void
+    {
+        $this->handlers[$http_method] = \Closure::fromCallable($handler);
+    }
+
+    public function get_handlers(): array
+    {
+        return $this->handlers;
+    }
+
+    public function allowed_methods(): array
+    {
+        return \array_keys($this->handlers);
+    }
+
+    public function get_handler(string $http_method): ?Closure
+    {
+        return $this->handlers[$http_method] ?? null;
+    }
+
+}

--- a/profiling/benches/fakeapp/vendor/FakeApp/FakeRoute/src/Dispatcher.php
+++ b/profiling/benches/fakeapp/vendor/FakeApp/FakeRoute/src/Dispatcher.php
@@ -1,0 +1,42 @@
+<?php declare(strict_types=1);
+
+namespace FakeApp\FakeRoute;
+
+final class Dispatcher
+{
+    private function __construct(private Config $config)
+    {
+    }
+
+    public static function new(callable $callable): Dispatcher
+    {
+        $config = Config::new(); 
+        $callable($config);
+        return new Dispatcher($config);
+    }
+
+    public function dispatch(
+        string $http_method,
+        string $path,
+    ): Found|NotFound|MethodNotAllowed {
+        if (\function_exists('Datadog\\Profiling\\trigger_time_sample')) {
+            \Datadog\Profiling\trigger_time_sample();
+        }
+        $route = $this->config->get_route($path);
+        if ($route === null) {
+            return NotFound::new($http_method, $path);
+        }
+
+        $handler = $route->get_handler($http_method);
+        if ($handler === null) {
+            return MethodNotAllowed::new(
+                $http_method,
+                $path,
+                $route->allowed_methods()
+            );
+        }
+
+        return Found::new($http_method, $path, $handler);
+        
+    }
+}

--- a/profiling/benches/fakeapp/vendor/FakeApp/FakeRoute/src/Found.php
+++ b/profiling/benches/fakeapp/vendor/FakeApp/FakeRoute/src/Found.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace FakeApp\FakeRoute;
+
+use Closure;
+
+final class Found
+{
+    private function __construct(
+        public readonly string $http_method,
+        public readonly string $path,
+        public readonly Closure $handler,
+    ) {   
+    }   
+
+    public static function new(
+        string $http_method,
+        string $path,
+        Closure $handler,
+    ): Found {
+        return new Found($http_method, $path, $handler);
+    }
+}

--- a/profiling/benches/fakeapp/vendor/FakeApp/FakeRoute/src/MatchedRoute.php
+++ b/profiling/benches/fakeapp/vendor/FakeApp/FakeRoute/src/MatchedRoute.php
@@ -1,0 +1,35 @@
+<?php declare(strict_types=1);
+
+namespace FakeApp\FakeRoute;
+
+final class MatchedRoute
+{
+
+    private function __construct(private array $handlers)
+    {
+    }
+
+    public static function new(array $handlers): Config
+    {
+        foreach ($handlers as $http_method => $handler) {
+            Self::validate_handler($handlers);
+        }
+        return new Config($handlers);
+    }
+
+    private static function validate_handler(
+        string $http_method,
+        Closure $handler
+    ): void {
+    }
+
+    public function get_handler(mixed $http_method): ?Closure
+    {
+        return $this->handlers[$http_method] ?? null;
+    }
+
+    public function allowed_methods(): array
+    {
+        return \array_keys($this->handlers);
+    }
+}

--- a/profiling/benches/fakeapp/vendor/FakeApp/FakeRoute/src/MethodNotAllowed.php
+++ b/profiling/benches/fakeapp/vendor/FakeApp/FakeRoute/src/MethodNotAllowed.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace FakeApp\FakeRoute;
+
+final class MethodNotAllowed
+{
+
+    private function __construct(
+        public readonly string $http_method,
+        public readonly string $path,
+        public readonly array $allowed_methods,
+    ) {
+    }
+
+    public static function new(
+        string $http_method,
+        string $path,
+        array $allowed_methods,
+    ): MethodNotAllowed
+    {
+        foreach ($allowed_methods as $method) {
+            Self::validate_string($method);
+        }
+        return new MethodNotAllowed($http_method, $path, $allowed_methods);
+    }
+
+    private static function validate_string(string $s): void {}
+}

--- a/profiling/benches/fakeapp/vendor/FakeApp/FakeRoute/src/NotFound.php
+++ b/profiling/benches/fakeapp/vendor/FakeApp/FakeRoute/src/NotFound.php
@@ -1,0 +1,18 @@
+<?php declare(strict_types=1);
+
+namespace FakeApp\FakeRoute;
+
+final class NotFound
+{
+
+    private function __construct(
+        public readonly string $http_method,
+        public readonly string $path,
+    ) {
+    }
+
+    public static function new(string $http_method, string $path): NotFound
+    {
+        return new NotFound($http_method, $path);
+    }
+}

--- a/profiling/benches/fakeapp/vendor/FakeApp/Http/autoload.php
+++ b/profiling/benches/fakeapp/vendor/FakeApp/Http/autoload.php
@@ -1,0 +1,20 @@
+<?php declare(strict_types=1);
+
+namespace FakeApp\Http;
+
+function autoload(string $class): void
+{
+    $prefix = 'FakeApp\Http\\';
+    $base_dir = __DIR__ . '/src/';
+
+    $len = \strlen($prefix);
+    if (\strncmp($prefix, $class, $len) !== 0) {
+        return;
+    }
+
+    $relative = \substr($class, $len);
+
+    $file = $base_dir . \str_replace('\\', '/', $relative) . '.php';
+
+    include $file;
+}

--- a/profiling/benches/fakeapp/vendor/FakeApp/Http/src/Headers.php
+++ b/profiling/benches/fakeapp/vendor/FakeApp/Http/src/Headers.php
@@ -1,0 +1,34 @@
+<?php declare(strict_types=1);
+
+namespace FakeApp\Http;
+
+final class Headers
+    implements \Countable, \IteratorAggregate
+{
+
+    private function __construct(private array $headers)
+    {
+    }
+
+    public static function new(): Headers
+    {
+        return new Headers([]);
+    }
+
+    public function append(string $name, string $value): Headers {
+        $this->headers[] = [$name, $value];
+	return $this;
+    }
+
+    public function count(): int
+    {
+        return \count($this->headers);
+    }
+
+    public function getIterator(): \Iterator
+    {
+        foreach ($this->headers as [$name, $value]) {
+            yield $name => $value;
+        }
+    }
+}

--- a/profiling/benches/fakeapp/vendor/FakeApp/Http/src/Response.php
+++ b/profiling/benches/fakeapp/vendor/FakeApp/Http/src/Response.php
@@ -1,0 +1,27 @@
+<?php declare(strict_types=1);
+
+namespace FakeApp\Http;
+
+// Really only suitable for simple HTTP 1.0/1.1. Up to the user to get all of
+// the headers correct.
+final class Response
+{
+
+    public function __construct(
+        public readonly Status $status,
+        public readonly Headers $headers,
+        public readonly string $body,
+    ) {
+        if (\function_exists('Datadog\\Profiling\\trigger_time_sample')) {
+            \Datadog\Profiling\trigger_time_sample();
+        }
+    }
+
+    public static function new(
+        Status $status,
+        Headers $headers,
+        string $body,
+    ): Response {
+        return new Response($status, $headers, $body);
+    }
+}

--- a/profiling/benches/fakeapp/vendor/FakeApp/Http/src/Status.php
+++ b/profiling/benches/fakeapp/vendor/FakeApp/Http/src/Status.php
@@ -1,0 +1,21 @@
+<?php declare(strict_types=1);
+
+namespace FakeApp\Http;
+
+final class Status
+{
+    private function __construct(
+        public readonly string $protocol,
+        public readonly int $code,
+        public readonly string $message,
+    ) {
+    }
+
+    public static function new(
+	string $protocol,
+        int $code,
+        string $message = "",
+    ): Status {
+        return new Status($protocol, $code, $message);
+    }
+}

--- a/profiling/benches/fakeapp/vendor/autoload.php
+++ b/profiling/benches/fakeapp/vendor/autoload.php
@@ -1,0 +1,9 @@
+<?php
+
+require __DIR__ . '/../src/autoload.php';
+require __DIR__ . '/FakeApp/FakeRoute/autoload.php';
+require __DIR__ . '/FakeApp/Http/autoload.php';
+
+spl_autoload_register('App\\autoload');
+spl_autoload_register('FakeApp\\FakeRoute\\autoload');
+spl_autoload_register('FakeApp\\Http\\autoload');


### PR DESCRIPTION
### Description

This adds an app for benchmarking purposes which is somewhat similar to real world things, but gathers stack samples at deterministic points.

The benchmarking script are here but not being run in CI. You'd roughly do:

```sh
cd 'profiling/benches/fakeapp'
bash +x driver.sh "$(git rev-parse --abbrev-ref HEAD)" "master"
```

The driver still needs to compare the output from `$TMPDIR/trigger-*.txt` to the ones in `./trigger-*.txt`.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
