### PR TITLE
Fix #3191: crash due to double close of span

### DIFF
--- a/ext/span.c
+++ b/ext/span.c
@@ -883,7 +883,7 @@ void ddtrace_close_span(ddtrace_span_data *span) {
         }
         zval_ptr_dtor(&on_close_zv);
 
-        if (span->duration == DDTRACE_SILENTLY_DROPPED_SPAN || span->duration == DDTRACE_DROPPED_SPAN) {
+        if (span->duration == DDTRACE_SILENTLY_DROPPED_SPAN || span->duration == DDTRACE_DROPPED_SPAN || span->type == DDTRACE_SPAN_CLOSED) {
             return; // It was dropped in onClose handler
         }
     }

--- a/tests/ext/try_drop_span_root.phpt
+++ b/tests/ext/try_drop_span_root.phpt
@@ -1,0 +1,21 @@
+--TEST--
+Test try_drop_span() on root span
+--INI--
+datadog.trace.generate_root_span=0
+datadog.trace.auto_flush_enabled=1
+--FILE--
+<?php
+
+$extraRef = $span = DDTrace\start_span();
+$span->onClose[] = function($span) {
+    var_dump(DDTrace\try_drop_span($span));
+};
+DDTrace\close_span();
+
+foreach (dd_trace_serialize_closed_spans() as $span) {
+    echo $span["service"], "\n";
+}
+
+?>
+--EXPECT--
+bool(true)


### PR DESCRIPTION
Recursion in ddtrace_close_span is not that great.