### PR TITLE
Add RASP_SQLI remote config capability

### DIFF
--- a/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/RemoteConfigTests.groovy
+++ b/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/RemoteConfigTests.groovy
@@ -1,15 +1,15 @@
 package com.datadog.appsec.php.integration
 
-import com.datadog.appsec.php.model.Span
 import com.datadog.appsec.php.docker.AppSecContainer
 import com.datadog.appsec.php.docker.FailOnUnmatchedTraces
 import com.datadog.appsec.php.mock_agent.rem_cfg.Capability
 import com.datadog.appsec.php.mock_agent.rem_cfg.RemoteConfigRequest
 import com.datadog.appsec.php.mock_agent.rem_cfg.Target
+import com.datadog.appsec.php.model.Span
 import groovy.util.logging.Slf4j
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.Test
-import org.junit.jupiter.api.condition.DisabledIf
+import org.junit.jupiter.api.condition.EnabledIf
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
 
@@ -19,14 +19,13 @@ import java.net.http.HttpResponse
 import static com.datadog.appsec.php.integration.TestParams.getPhpVersion
 import static com.datadog.appsec.php.integration.TestParams.getVariant
 import static java.net.http.HttpResponse.BodyHandlers.ofString
-import static org.junit.jupiter.api.Assumptions.assumeTrue
 import static org.testcontainers.containers.Container.ExecResult
 
 @Testcontainers
 @Slf4j
-@DisabledIf('isDisabled')
+@EnabledIf('isEnabled')
 class RemoteConfigTests {
-    static boolean disabled = variant.contains('zts') || phpVersion != '8.3'
+    static boolean enabled = !variant.contains('zts') && phpVersion == '8.3'
 
     private static final Target INITIAL_TARGET = new Target('some-name', 'none', '')
 
@@ -87,6 +86,7 @@ class RemoteConfigTests {
                 Capability.ASM_TRUSTED_IPS,
                 Capability.ASM_RASP_LFI,
                 Capability.ASM_RASP_SSRF,
+                Capability.ASM_RASP_SQLI,
         ].each { assert it in capSet }
 
         doReq.call(403)

--- a/components-rs/remote_config.rs
+++ b/components-rs/remote_config.rs
@@ -14,7 +14,10 @@ use datadog_remote_config::{
 use datadog_sidecar::service::blocking::SidecarTransport;
 use datadog_sidecar::service::{InstanceId, QueueId};
 use datadog_sidecar::shm_remote_config::{RemoteConfigManager, RemoteConfigUpdate};
-use datadog_sidecar_ffi::{ddog_sidecar_send_debugger_data, ddog_sidecar_send_debugger_diagnostics};
+use datadog_sidecar_ffi::{
+    ddog_sidecar_send_debugger_data, ddog_sidecar_send_debugger_diagnostics,
+};
+use ddcommon::tag::Tag;
 use ddcommon::Endpoint;
 use ddcommon_ffi::slice::AsBytes;
 use ddcommon_ffi::{CharSlice, MaybeError};
@@ -28,7 +31,6 @@ use std::ffi::c_char;
 use std::mem;
 use std::sync::Arc;
 use tracing::debug;
-use ddcommon::tag::Tag;
 
 type DynamicConfigUpdate = for<'a> extern "C" fn(
     config: CharSlice,
@@ -124,6 +126,7 @@ pub unsafe extern "C" fn ddog_init_remote_config(
             RemoteConfigCapabilities::AsmTrustedIps,
             RemoteConfigCapabilities::AsmRaspLfi,
             RemoteConfigCapabilities::AsmRaspSsrf,
+            RemoteConfigCapabilities::AsmRaspSqli,
         ]
         .iter()
         .for_each(|c| DDTRACE_REMOTE_CONFIG_CAPABILITIES.push(*c));


### PR DESCRIPTION
### Description

Adds a missing remote config capability for sqli.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
