### PR TITLE
fix: fetch target branch before checkout in version update script

### DIFF
--- a/tooling/tested_versions/create_or_update_supported_versions_pr.sh
+++ b/tooling/tested_versions/create_or_update_supported_versions_pr.sh
@@ -17,6 +17,7 @@ git remote add origin https://$GITHUB_TOKEN@github.com/DataDog/dd-trace-php.git
 
 if git ls-remote --heads origin $TARGET_BRANCH | grep $TARGET_BRANCH; then
   echo "Branch exists, updating it..."
+  git fetch origin $TARGET_BRANCH
   git checkout $TARGET_BRANCH
   git pull origin $TARGET_BRANCH
 else


### PR DESCRIPTION
### Description

The script was failing when trying to checkout an existing remote branch because it wasn't being fetched first. This change ensures we fetch the specific target branch before attempting to checkout.

[Current failure on master](https://app.circleci.com/pipelines/github/DataDog/dd-trace-php/20575/workflows/ae13dac5-bbc9-445f-8a71-19353329186e/jobs/6771995?invite=true#step-106-0_25):
```
++ git status --porcelain
+ [[ -z  M aggregated_tested_versions.json
 M integration_versions.md ]]
+ git config --global user.email '41898282+github-actions[bot]@users.noreply.github.com'
+ git config --global user.name 'github-actions[bot]'
+ CURRENT_BRANCH=master
+ TARGET_BRANCH=update-supported-versions
+ git remote remove origin
+ git remote add origin https://****************************************@github.com/DataDog/dd-trace-php.git
+ git ls-remote --heads origin update-supported-versions
+ grep update-supported-versions
e7f6f8988ef6d31fe9931d7c5e51305d5cabb570        refs/heads/update-supported-versions
+ echo 'Branch exists, updating it...'
Branch exists, updating it...
+ git checkout update-supported-versions
error: pathspec 'update-supported-versions' did not match any file(s) known to git

Exited with code exit status 1
```

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
