### PR TITLE
Fix initial double remote config reading

### DIFF
--- a/components-rs/ddtrace.h
+++ b/components-rs/ddtrace.h
@@ -199,8 +199,6 @@ bool ddog_remote_config_alter_dynamic_config(struct ddog_RemoteConfigState *remo
 void ddog_setup_remote_config(ddog_DynamicConfigUpdate update_config,
                               const struct ddog_LiveDebuggerSetup *setup);
 
-void ddog_rinit_remote_config(struct ddog_RemoteConfigState *remote_config);
-
 void ddog_rshutdown_remote_config(struct ddog_RemoteConfigState *remote_config);
 
 void ddog_shutdown_remote_config(struct ddog_RemoteConfigState*);

--- a/components-rs/remote_config.rs
+++ b/components-rs/remote_config.rs
@@ -475,11 +475,6 @@ pub unsafe extern "C" fn ddog_setup_remote_config(
 }
 
 #[no_mangle]
-pub extern "C" fn ddog_rinit_remote_config(remote_config: &mut RemoteConfigState) {
-    ddog_process_remote_configs(remote_config);
-}
-
-#[no_mangle]
 pub extern "C" fn ddog_rshutdown_remote_config(remote_config: &mut RemoteConfigState) {
     remote_config.live_debugger.spans_map.clear();
     remote_config.dynamic_config.old_config_values.clear();

--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -1625,6 +1625,15 @@ static void dd_initialize_request(void) {
     // Do after env check, so that RC data is not updated before RC init
     DDTRACE_G(request_initialized) = true;
 
+    if (!DDTRACE_G(remote_config_state) && ddtrace_endpoint) {
+        DDTRACE_G(remote_config_state) = ddog_init_remote_config_state(ddtrace_endpoint);
+    }
+
+    // We need to init RC for the sidecar to write to it immediately
+    if (DDTRACE_G(remote_config_state)) {
+        ddtrace_rinit_remote_config();
+    }
+
     ddtrace_sidecar_rinit();
     ddtrace_asm_event_rinit();
 
@@ -1641,14 +1650,6 @@ static void dd_initialize_request(void) {
             ddog_agent_remote_config_reader_for_anon_shm(ddtrace_coms_agent_config_handle, &DDTRACE_G(agent_config_reader));
 #endif
         }
-    }
-
-    if (!DDTRACE_G(remote_config_state) && ddtrace_endpoint) {
-        DDTRACE_G(remote_config_state) = ddog_init_remote_config_state(ddtrace_endpoint);
-    }
-
-    if (DDTRACE_G(remote_config_state)) {
-        ddtrace_rinit_remote_config();
     }
 
     ddtrace_internal_handlers_rinit();

--- a/ext/remote_config.c
+++ b/ext/remote_config.c
@@ -121,7 +121,6 @@ void ddtrace_mshutdown_remote_config(void) {
 void ddtrace_rinit_remote_config(void) {
     zend_hash_init(&DDTRACE_G(active_rc_hooks), 8, NULL, NULL, 0);
     DDTRACE_G(reread_remote_configuration) = 0;
-    ddog_rinit_remote_config(DDTRACE_G(remote_config_state));
 }
 
 void ddtrace_rshutdown_remote_config(void) {

--- a/ext/sidecar.h
+++ b/ext/sidecar.h
@@ -17,6 +17,7 @@ void ddtrace_sidecar_submit_root_span_data(void);
 void ddtrace_sidecar_push_tag(ddog_Vec_Tag *vec, ddog_CharSlice key, ddog_CharSlice value);
 void ddtrace_sidecar_push_tags(ddog_Vec_Tag *vec, zval *tags);
 ddog_Endpoint *ddtrace_sidecar_agent_endpoint(void);
+void ddtrace_sidecar_submit_root_span_data_direct_defaults(ddtrace_root_span_data *root);
 void ddtrace_sidecar_submit_root_span_data_direct(ddtrace_root_span_data *root, zend_string *cfg_service, zend_string *cfg_env, zend_string *cfg_version);
 
 void ddtrace_sidecar_send_debugger_data(ddog_Vec_DebuggerPayload payloads);

--- a/tests/ext/live-debugger/debugger_span_probe_class.phpt
+++ b/tests/ext/live-debugger/debugger_span_probe_class.phpt
@@ -2,6 +2,7 @@
 Installing a live debugger span probe on a class
 --SKIPIF--
 <?php include __DIR__ . '/../includes/skipif_no_dev_env.inc'; ?>
+<?php if (getenv('USE_ZEND_ALLOC') === '0' && !getenv("SKIP_ASAN")) die('skip timing sensitive test - valgrind is too slow'); ?>
 --ENV--
 DD_AGENT_HOST=request-replayer
 DD_TRACE_AGENT_PORT=80

--- a/tests/ext/live-debugger/debugger_span_probe_class.phpt
+++ b/tests/ext/live-debugger/debugger_span_probe_class.phpt
@@ -50,11 +50,15 @@ $ordered = [];
 $events = 0;
 $time = time();
 do {
-    $log = $dlr->waitForDiagnosticsDataAndReplay();
-    foreach (json_decode($log["files"]["event"]["contents"], true) as $payload) {
-        $diagnostic = $payload["debugger"]["diagnostics"];
-        $ordered[$diagnostic["probeId"]][$payload["timestamp"]][] = $diagnostic["status"];
-        ++$events;
+    try {
+        $log = $dlr->waitForDiagnosticsDataAndReplay();
+        foreach (json_decode($log["files"]["event"]["contents"], true) as $payload) {
+            $diagnostic = $payload["debugger"]["diagnostics"];
+            $ordered[$diagnostic["probeId"]][$payload["timestamp"]][] = $diagnostic["status"];
+            ++$events;
+        }
+    } catch (Exception $e) {
+        // handle the timeout?
     }
 } while ($events < 5 && $time > time() - 10);
 ksort($ordered);


### PR DESCRIPTION
This also prevents an use-after-free given that only ddtrace_rinit_remote_config will initialize `DDTRACE_G(active_rc_hooks)`.

This use-after-free only manifests sometimes on consecutive requests where both requests end up using live-debugger resources.