### PR TITLE
add a job that check all other job status

### DIFF
--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -19,3 +19,12 @@ jobs:
         uses: DataDog/ensure-ci-success@v1
         with:
           initial-delay-seconds: "100"  # what is the longest job that always run ?
+          max-retries: "60"
+          ignored-name-patterns: |
+            dd-gitlab/build
+            ci/circleci: test-test_extension_ci-8.4-medium+
+            ci/circleci: integration_snapshots-test_integrations-8.1
+            ci/circleci: integration_snapshots-test_integrations-8.2
+            ci/circleci: integration_snapshots-test_integrations-8.3
+            ci/circleci: integration_snapshots-test_integrations_coverage-8.2
+

--- a/.github/workflows/all-green.yml
+++ b/.github/workflows/all-green.yml
@@ -1,0 +1,21 @@
+name: Check Pull Request CI Status
+
+on:
+  pull_request:
+    types:
+      - opened
+      - synchronize
+      - reopened
+
+permissions:
+  checks: read
+  statuses: read
+
+jobs:
+  all-jobs-are-green:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Run Ensure CI Success
+        uses: DataDog/ensure-ci-success@v1
+        with:
+          initial-delay-seconds: "100"  # what is the longest job that always run ?


### PR DESCRIPTION
### Description

Add a job in the CI that runs in PR. The job will be a success if all other jobs are skipped/success, and fails otherwise

### Motivation

While it's possible to enforce a green CI policy using GitHub's native "required status checks" feature, doing so requires explicitly listing all job names under branch protection rules. This approach has two key drawbacks:

- It does not support optional jobs
- It introduces ongoing maintenance overhead as the job list evolves

This jobs will check ALL other job, and we'll be able to set this as a requirement. The action used offers a `ignored-name-patterns` parameters`, I added few job that failed on that PR, let me know if others should be added.

the plan is to merge this PR, wait few days to be sure that everything is fine. Then add it as a requirement.


### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
