### PR TITLE
fix trailing whitespace

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -3,8 +3,11 @@ root = true
 [*]
 charset = utf-8
 indent_style = space
-insert_final_newline = false
+insert_final_newline = true
 trim_trailing_whitespace = true
+
+[VERSION]
+insert_final_newline = false
 
 [*.{c,h}]
 indent_size = none


### PR DESCRIPTION
### Description

AFAIK there is only a small number of files where we do want to have no final newline at the end of the file, so far I know it is the `VERSION` file, but all other files should have a final newline character.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
