### PR TITLE
Fix remote config applying with consecutive requests to the same resource

### DIFF
--- a/ext/sidecar.c
+++ b/ext/sidecar.c
@@ -383,6 +383,11 @@ void ddtrace_sidecar_submit_root_span_data_direct(ddtrace_root_span_data *root, 
     bool changed = true;
     if (DDTRACE_G(remote_config_state)) {
         changed = ddog_remote_configs_service_env_change(DDTRACE_G(remote_config_state), service_slice, env_slice, version_slice, &DDTRACE_G(active_global_tags));
+        if (!changed && root) {
+            // ddog_remote_configs_service_env_change() generally only processes configs if they changed. However, upon request initialization it may be identical to the previous request.
+            // However, at request shutdown some configs are unloaded. Explicitly forcing a processing step ensures these are re-loaded.
+            ddog_process_remote_configs(DDTRACE_G(remote_config_state));
+        }
     }
     if (changed || !root) {
         ddtrace_ffi_try("Failed sending remote config data", ddog_sidecar_set_remote_config_data(&ddtrace_sidecar, ddtrace_sidecar_instance_id, &DDTRACE_G(sidecar_queue_id), service_slice, env_slice, version_slice, &DDTRACE_G(active_global_tags)));

--- a/package.xml
+++ b/package.xml
@@ -83,7 +83,7 @@
 ### Fixed
 - Check server first before accessing in ddtrace_ip_extraction_find #3216
 - Fix assumptions around interned strings on PHP 7.3 #3224
-- Fix initial double remote config reading #3225
+- Fix initial double remote config reading #3225, #3238
 - Fix dropped trace payloads for the sidecar Datadog/libdatadog#1047
 - Fix Windows VirtualProtect call #3229
 
@@ -99,6 +99,10 @@
 
 ### Fixed
 - Fix empty internal metadata #3228
+- Follow PHP globals model in allocation profiler #3175
+
+### Internal changes
+- Bump libdatadog to version 18 #3229
 
 ## Application Security Management
 ### Added


### PR DESCRIPTION
This regressed in #3225. Fixing before the 1.9.0 release.