### PR TITLE
Try to fix crash with uninitialized priority_header_map

### DIFF
--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -1432,6 +1432,9 @@ static PHP_MINIT_FUNCTION(ddtrace) {
         ddtrace_module = Z_PTR_P(ddtrace_module_zv);
     }
 
+    // Make sure it's available for appsec, before any early returns
+    dd_ip_extraction_startup();
+
     // config initialization needs to be at the top
     // This also initialiyzed logging, so no logs may be emitted before this.
     ddtrace_log_init();
@@ -1465,9 +1468,6 @@ static PHP_MINIT_FUNCTION(ddtrace) {
     }
     mod_ptr->handle = NULL;
     /* }}} */
-
-    // Make sure it's available for appsec, i.e. before disabling
-    dd_ip_extraction_startup();
 
     if (ddtrace_disable) {
         return SUCCESS;


### PR DESCRIPTION
### Description

Try to fix this kind of crash:

```json
  {
    "symbol_address": "0x64207d58657f",
    "function": "zend_hash_find",
    "ip": "0x64207d5865d5",
    "sp": "0x7fff1479f4d0"
  },
  {
    "symbol_address": "0x75096545b970",
    "function": "ddtrace_ip_extraction_find",
    "ip": "0x75096545b9ed",
    "sp": "0x7fff1479f550"
  },
  {
    "symbol_address": "0x750961814ff0",
    "file": "/home/circleci/datadog/appsec/src/extension/request_lifecycle.c",
    "line": 436,
    "function": "_extract_ip_from_autoglobal",
    "ip": "0x750961815035",
    "sp": "0x7fff1479f5c0"
  }
```

pointing to an NULL zend_string* passed to zend_hash_find.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
