### PR TITLE
fix(prof): borrow error in request shutdown

### DIFF
--- a/profiling/src/profiling/stack_walking.rs
+++ b/profiling/src/profiling/stack_walking.rs
@@ -209,21 +209,26 @@ mod detail {
             debug!("Process cumulative {stats:?} hit_rate: {hit_rate}");
         });
 
-        CACHED_STRINGS.with(|cell| {
-            let set: &StringSet = &cell.borrow();
-            let arena_used_bytes = set.arena_used_bytes();
-            // A slow ramp up to 2 MiB is probably _not_ going to look like
-            // a memory leak, whereas a higher threshold could make a user
-            // suspect a leak.
-            let threshold = 2 * 1024 * 1024;
-            if arena_used_bytes > threshold {
-                debug!("string cache arena is using {arena_used_bytes} bytes which exceeds the {threshold} byte threshold, resetting");
+        // PANIC: panics if the string arena is already borrowed. However, it
+        // should not be borrowed at this point, so we're likely going to fail.
+        // It's probably better to fail in rshutdown.
+        // Maybe in a new PHP version, we can have the engine check rshutdown
+        // failures, and stop serving requests from that process, and go into
+        // module shutdown instead.
+        CACHED_STRINGS.with_borrow_mut(|string_set| {
+            // A slow ramp up to 2 MiB is probably _not_ going to look like a
+            // memory leak. A higher threshold may make a user suspect a leak.
+            const THRESHOLD: usize = 2 * 1024 * 1024;
+
+            let used_bytes = string_set.arena_used_bytes();
+            if used_bytes > THRESHOLD {
+                debug!("string cache arena is using {used_bytes} bytes which exceeds the {THRESHOLD} byte threshold, resetting");
                 // Note that this cannot be done _during_ a request. The
                 // ThinStrs inside the run time cache need to remain valid
                 // during the request.
-                cell.replace(StringSet::new());
+                *string_set = StringSet::new();
             } else {
-                trace!("string cache arena is using {arena_used_bytes} bytes which is less than the {threshold} byte threshold");
+                trace!("string cache arena is using {used_bytes} bytes which is less than the {THRESHOLD} byte threshold");
             }
         });
     }


### PR DESCRIPTION
### Description

This affects PHP 8.0+ and web SAPIs. The string arena was borrowed to check how much space the arena uses, and then it gets replaced. Unfortunately, the first borrow was not released, probably because of a lifetime extension.

It's hard to make a test case that triggers this edge, because you have to accumulate over 2 MiB in the string cache. This is also why few customers have hit it. In web SAPIs, the worker will often be rotated out for various before this happens. I verified it manually locally with a lower threshold to make sure it's fine now.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [x] Appropriate labels assigned.
