### PR TITLE
style(prof): use local_key_cell_methods

### DIFF
--- a/profiling/src/allocation/allocation_ge84.rs
+++ b/profiling/src/allocation/allocation_ge84.rs
@@ -359,10 +359,7 @@ unsafe extern "C" fn alloc_prof_malloc(len: size_t) -> *mut c_void {
         return ptr;
     }
 
-    ALLOCATION_PROFILING_STATS.with(|cell| {
-        let mut allocations = cell.borrow_mut();
-        allocations.track_allocation(len)
-    });
+    ALLOCATION_PROFILING_STATS.with_borrow_mut(|allocations| allocations.track_allocation(len));
 
     ptr
 }
@@ -427,10 +424,7 @@ unsafe extern "C" fn alloc_prof_realloc(prev_ptr: *mut c_void, len: size_t) -> *
         return ptr;
     }
 
-    ALLOCATION_PROFILING_STATS.with(|cell| {
-        let mut allocations = cell.borrow_mut();
-        allocations.track_allocation(len)
-    });
+    ALLOCATION_PROFILING_STATS.with_borrow_mut(|allocations| allocations.track_allocation(len));
 
     ptr
 }

--- a/profiling/src/allocation/allocation_le83.rs
+++ b/profiling/src/allocation/allocation_le83.rs
@@ -350,10 +350,7 @@ unsafe extern "C" fn alloc_prof_malloc(len: size_t) -> *mut c_void {
         return ptr;
     }
 
-    ALLOCATION_PROFILING_STATS.with(|cell| {
-        let mut allocations = cell.borrow_mut();
-        allocations.track_allocation(len)
-    });
+    ALLOCATION_PROFILING_STATS.with_borrow_mut(|allocations| allocations.track_allocation(len));
 
     ptr
 }
@@ -408,10 +405,7 @@ unsafe extern "C" fn alloc_prof_realloc(prev_ptr: *mut c_void, len: size_t) -> *
         return ptr;
     }
 
-    ALLOCATION_PROFILING_STATS.with(|cell| {
-        let mut allocations = cell.borrow_mut();
-        allocations.track_allocation(len)
-    });
+    ALLOCATION_PROFILING_STATS.with_borrow_mut(|allocations| allocations.track_allocation(len));
 
     ptr
 }

--- a/profiling/src/allocation/mod.rs
+++ b/profiling/src/allocation/mod.rs
@@ -18,7 +18,8 @@ pub mod allocation_le83;
 pub const DEFAULT_ALLOCATION_SAMPLING_INTERVAL: u64 = 1024 * 4096;
 
 /// Sampling distance feed into poison sampling algo
-pub static ALLOCATION_PROFILING_INTERVAL: AtomicU64 = AtomicU64::new(DEFAULT_ALLOCATION_SAMPLING_INTERVAL);
+pub static ALLOCATION_PROFILING_INTERVAL: AtomicU64 =
+    AtomicU64::new(DEFAULT_ALLOCATION_SAMPLING_INTERVAL);
 
 /// This will store the count of allocations (including reallocations) during
 /// a profiling period. This will overflow when doing more than u64::MAX
@@ -122,7 +123,10 @@ pub fn alloc_prof_first_rinit() {
 
     ALLOCATION_PROFILING_INTERVAL.store(sampling_distance as u64, Ordering::SeqCst);
 
-    trace!("Memory allocation profiling initialized with a sampling distance of {} bytes.", ALLOCATION_PROFILING_INTERVAL.load(Ordering::SeqCst));
+    trace!(
+        "Memory allocation profiling initialized with a sampling distance of {} bytes.",
+        ALLOCATION_PROFILING_INTERVAL.load(Ordering::SeqCst)
+    );
 }
 
 pub fn alloc_prof_rinit() {

--- a/profiling/src/config.rs
+++ b/profiling/src/config.rs
@@ -530,7 +530,6 @@ unsafe fn profiling_allocation_sampling_distance() -> u32 {
     )
 }
 
-
 /// # Safety
 /// This function must only be called after config has been initialized in
 /// rinit, and before it is uninitialized in mshutdown.

--- a/profiling/src/exception.rs
+++ b/profiling/src/exception.rs
@@ -200,10 +200,8 @@ unsafe extern "C" fn exception_profiling_throw_exception_hook(
     // traversed. Fortunately, this behavior can be easily identified by checking for a NULL
     // pointer.
     if exception_profiling && !exception.is_null() {
-        EXCEPTION_PROFILING_STATS.with(|cell| {
-            let mut exceptions = cell.borrow_mut();
-            exceptions.track_exception(exception)
-        });
+        EXCEPTION_PROFILING_STATS
+            .with_borrow_mut(|exceptions| exceptions.track_exception(exception));
     }
 
     if let Some(prev) = PREV_ZEND_THROW_EXCEPTION_HOOK {

--- a/profiling/src/io.rs
+++ b/profiling/src/io.rs
@@ -245,30 +245,19 @@ unsafe extern "C" fn observed_poll(fds: *mut libc::pollfd, nfds: u64, timeout: c
     let duration = start.elapsed();
 
     if !fds.is_null() {
+        let duration_nanos = duration.as_nanos() as u64;
         if (*fds).revents & 1 == 1 {
             // requested events contains reading
-            SOCKET_READ_TIME_PROFILING_STATS.with(|cell| {
-                let mut io = cell.borrow_mut();
-                io.track(duration.as_nanos() as u64)
-            });
+            SOCKET_READ_TIME_PROFILING_STATS.with_borrow_mut(|io| io.track(duration_nanos));
         } else if (*fds).revents & 4 == 4 {
             // requested events contains writing
-            SOCKET_WRITE_TIME_PROFILING_STATS.with(|cell| {
-                let mut io = cell.borrow_mut();
-                io.track(duration.as_nanos() as u64)
-            });
+            SOCKET_WRITE_TIME_PROFILING_STATS.with_borrow_mut(|io| io.track(duration_nanos));
         } else if (*fds).events & 1 == 1 {
             // socket became readable
-            SOCKET_READ_TIME_PROFILING_STATS.with(|cell| {
-                let mut io = cell.borrow_mut();
-                io.track(duration.as_nanos() as u64)
-            });
+            SOCKET_READ_TIME_PROFILING_STATS.with_borrow_mut(|io| io.track(duration_nanos));
         } else if (*fds).events & 4 == 4 {
             // socket became writeable
-            SOCKET_WRITE_TIME_PROFILING_STATS.with(|cell| {
-                let mut io = cell.borrow_mut();
-                io.track(duration.as_nanos() as u64)
-            });
+            SOCKET_WRITE_TIME_PROFILING_STATS.with_borrow_mut(|io| io.track(duration_nanos));
         }
     }
 
@@ -287,15 +276,9 @@ unsafe extern "C" fn observed_recv(
     let len = ORIG_RECV(socket, buf, length, flags);
     let duration = start.elapsed();
 
-    SOCKET_READ_TIME_PROFILING_STATS.with(|cell| {
-        let mut io = cell.borrow_mut();
-        io.track(duration.as_nanos() as u64)
-    });
+    SOCKET_READ_TIME_PROFILING_STATS.with_borrow_mut(|io| io.track(duration.as_nanos() as u64));
     if len > 0 {
-        SOCKET_READ_SIZE_PROFILING_STATS.with(|cell| {
-            let mut io = cell.borrow_mut();
-            io.track(len as u64)
-        });
+        SOCKET_READ_SIZE_PROFILING_STATS.with_borrow_mut(|io| io.track(len as u64));
     }
 
     len
@@ -313,15 +296,9 @@ unsafe extern "C" fn observed_recvmsg(
     let len = ORIG_RECVMSG(socket, msg, flags);
     let duration = start.elapsed();
 
-    SOCKET_READ_TIME_PROFILING_STATS.with(|cell| {
-        let mut io = cell.borrow_mut();
-        io.track(duration.as_nanos() as u64)
-    });
+    SOCKET_READ_TIME_PROFILING_STATS.with_borrow_mut(|io| io.track(duration.as_nanos() as u64));
     if len > 0 {
-        SOCKET_READ_SIZE_PROFILING_STATS.with(|cell| {
-            let mut io = cell.borrow_mut();
-            io.track(len as u64);
-        });
+        SOCKET_READ_SIZE_PROFILING_STATS.with_borrow_mut(|io| io.track(len as u64));
     }
 
     len
@@ -348,15 +325,9 @@ unsafe extern "C" fn observed_recvfrom(
     let len = ORIG_RECVFROM(socket, buf, length, flags, address, address_len);
     let duration = start.elapsed();
 
-    SOCKET_READ_TIME_PROFILING_STATS.with(|cell| {
-        let mut io = cell.borrow_mut();
-        io.track(duration.as_nanos() as u64)
-    });
+    SOCKET_READ_TIME_PROFILING_STATS.with_borrow_mut(|io| io.track(duration.as_nanos() as u64));
     if len > 0 {
-        SOCKET_READ_SIZE_PROFILING_STATS.with(|cell| {
-            let mut io = cell.borrow_mut();
-            io.track(len as u64)
-        });
+        SOCKET_READ_SIZE_PROFILING_STATS.with_borrow_mut(|io| io.track(len as u64));
     }
 
     len
@@ -374,15 +345,9 @@ unsafe extern "C" fn observed_send(
     let len = ORIG_SEND(socket, buf, length, flags);
     let duration = start.elapsed();
 
-    SOCKET_WRITE_TIME_PROFILING_STATS.with(|cell| {
-        let mut io = cell.borrow_mut();
-        io.track(duration.as_nanos() as u64)
-    });
+    SOCKET_WRITE_TIME_PROFILING_STATS.with_borrow_mut(|io| io.track(duration.as_nanos() as u64));
     if len > 0 {
-        SOCKET_WRITE_SIZE_PROFILING_STATS.with(|cell| {
-            let mut io = cell.borrow_mut();
-            io.track(len as u64)
-        });
+        SOCKET_WRITE_SIZE_PROFILING_STATS.with_borrow_mut(|io| io.track(len as u64));
     }
 
     len
@@ -399,15 +364,9 @@ unsafe extern "C" fn observed_sendmsg(
     let len = ORIG_SENDMSG(socket, msg, flags);
     let duration = start.elapsed();
 
-    SOCKET_WRITE_TIME_PROFILING_STATS.with(|cell| {
-        let mut io = cell.borrow_mut();
-        io.track(duration.as_nanos() as u64)
-    });
+    SOCKET_WRITE_TIME_PROFILING_STATS.with_borrow_mut(|io| io.track(duration.as_nanos() as u64));
     if len > 0 {
-        SOCKET_WRITE_SIZE_PROFILING_STATS.with(|cell| {
-            let mut io = cell.borrow_mut();
-            io.track(len as u64)
-        });
+        SOCKET_WRITE_SIZE_PROFILING_STATS.with_borrow_mut(|io| io.track(len as u64));
     }
 
     len
@@ -429,15 +388,9 @@ unsafe extern "C" fn observed_fwrite(
     let len = ORIG_FWRITE(ptr, size, nobj, stream);
     let duration = start.elapsed();
 
-    FILE_WRITE_TIME_PROFILING_STATS.with(|cell| {
-        let mut io = cell.borrow_mut();
-        io.track(duration.as_nanos() as u64)
-    });
+    FILE_WRITE_TIME_PROFILING_STATS.with_borrow_mut(|io| io.track(duration.as_nanos() as u64));
     if len > 0 {
-        FILE_WRITE_SIZE_PROFILING_STATS.with(|cell| {
-            let mut io = cell.borrow_mut();
-            io.track(len as u64)
-        });
+        FILE_WRITE_SIZE_PROFILING_STATS.with_borrow_mut(|io| io.track(len as u64));
     }
 
     len
@@ -450,26 +403,15 @@ unsafe extern "C" fn observed_write(fd: c_int, buf: *const c_void, count: usize)
     let duration = start.elapsed();
 
     if fd_is_socket(fd) {
-        SOCKET_WRITE_TIME_PROFILING_STATS.with(|cell| {
-            let mut io = cell.borrow_mut();
-            io.track(duration.as_nanos() as u64)
-        });
+        SOCKET_WRITE_TIME_PROFILING_STATS
+            .with_borrow_mut(|io| io.track(duration.as_nanos() as u64));
         if len > 0 {
-            SOCKET_WRITE_SIZE_PROFILING_STATS.with(|cell| {
-                let mut io = cell.borrow_mut();
-                io.track(len as u64)
-            });
+            SOCKET_WRITE_SIZE_PROFILING_STATS.with_borrow_mut(|io| io.track(len as u64));
         }
     } else {
-        FILE_WRITE_TIME_PROFILING_STATS.with(|cell| {
-            let mut io = cell.borrow_mut();
-            io.track(duration.as_nanos() as u64)
-        });
+        FILE_WRITE_TIME_PROFILING_STATS.with_borrow_mut(|io| io.track(duration.as_nanos() as u64));
         if len > 0 {
-            FILE_WRITE_SIZE_PROFILING_STATS.with(|cell| {
-                let mut io = cell.borrow_mut();
-                io.track(len as u64)
-            });
+            FILE_WRITE_SIZE_PROFILING_STATS.with_borrow_mut(|io| io.track(len as u64));
         }
     }
 
@@ -491,14 +433,10 @@ unsafe extern "C" fn observed_fread(
     let len = ORIG_FREAD(ptr, size, nobj, stream);
     let duration = start.elapsed();
 
-    FILE_READ_TIME_PROFILING_STATS.with(|cell| {
-        let mut io = cell.borrow_mut();
-        io.track(duration.as_nanos() as u64)
-    });
-    FILE_READ_SIZE_PROFILING_STATS.with(|cell| {
-        let mut io = cell.borrow_mut();
-        io.track(len as u64)
-    });
+    FILE_READ_TIME_PROFILING_STATS.with_borrow_mut(|io| io.track(duration.as_nanos() as u64));
+    if len > 0 {
+        FILE_READ_SIZE_PROFILING_STATS.with_borrow_mut(|io| io.track(len as u64));
+    }
 
     len
 }
@@ -510,26 +448,14 @@ unsafe extern "C" fn observed_read(fd: c_int, buf: *mut c_void, count: usize) ->
     let duration = start.elapsed();
 
     if fd_is_socket(fd) {
-        SOCKET_READ_TIME_PROFILING_STATS.with(|cell| {
-            let mut io = cell.borrow_mut();
-            io.track(duration.as_nanos() as u64)
-        });
+        SOCKET_READ_TIME_PROFILING_STATS.with_borrow_mut(|io| io.track(duration.as_nanos() as u64));
         if len > 0 {
-            SOCKET_READ_SIZE_PROFILING_STATS.with(|cell| {
-                let mut io = cell.borrow_mut();
-                io.track(len as u64)
-            });
+            SOCKET_READ_SIZE_PROFILING_STATS.with_borrow_mut(|io| io.track(len as u64));
         }
     } else {
-        FILE_READ_TIME_PROFILING_STATS.with(|cell| {
-            let mut io = cell.borrow_mut();
-            io.track(duration.as_nanos() as u64)
-        });
+        FILE_READ_TIME_PROFILING_STATS.with_borrow_mut(|io| io.track(duration.as_nanos() as u64));
         if len > 0 {
-            FILE_READ_SIZE_PROFILING_STATS.with(|cell| {
-                let mut io = cell.borrow_mut();
-                io.track(len as u64)
-            });
+            FILE_READ_SIZE_PROFILING_STATS.with_borrow_mut(|io| io.track(len as u64));
         }
     }
 
@@ -723,11 +649,7 @@ impl<C: IOCollector> IOProfilingStats<C> {
     }
 
     fn track(&mut self, value: u64) {
-        let zend_thread = REQUEST_LOCALS.with(|cell| {
-            let locals = cell.borrow();
-            !locals.vm_interrupt_addr.is_null()
-        });
-        if !zend_thread {
+        if !REQUEST_LOCALS.with_borrow(|locals| !locals.vm_interrupt_addr.is_null()) {
             // `curl_exec()` for example will spawn a new thread for name resolution. GOT hooking
             // follows threads and as such we might sample from another (non PHP) thread even in a
             // NTS build of PHP. We have observed crashes for these cases, so instead of crashing

--- a/profiling/src/io.rs
+++ b/profiling/src/io.rs
@@ -649,7 +649,8 @@ impl<C: IOCollector> IOProfilingStats<C> {
     }
 
     fn track(&mut self, value: u64) {
-        if !REQUEST_LOCALS.with_borrow(|locals| !locals.vm_interrupt_addr.is_null()) {
+        let zend_thread = REQUEST_LOCALS.with_borrow(|locals| !locals.vm_interrupt_addr.is_null());
+        if !zend_thread {
             // `curl_exec()` for example will spawn a new thread for name resolution. GOT hooking
             // follows threads and as such we might sample from another (non PHP) thread even in a
             // NTS build of PHP. We have observed crashes for these cases, so instead of crashing

--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -17,7 +17,7 @@ use crate::bindings::ddog_php_prof_get_active_fiber_test as ddog_php_prof_get_ac
 
 use crate::bindings::{datadog_php_profiling_get_profiling_context, zend_execute_data};
 use crate::config::SystemSettings;
-use crate::{CLOCKS, TAGS};
+use crate::{Clocks, CLOCKS, TAGS};
 use chrono::Utc;
 use core::mem::forget;
 use crossbeam_channel::{Receiver, Sender, TrySendError};
@@ -916,7 +916,7 @@ impl Profiler {
         match result {
             Ok(frames) => {
                 let depth = frames.len();
-                let (wall_time, cpu_time) = CLOCKS.with(|cell| cell.borrow_mut().rotate_clocks());
+                let (wall_time, cpu_time) = CLOCKS.with_borrow_mut(Clocks::rotate_clocks);
 
                 let labels = Profiler::common_labels(0);
                 let n_labels = labels.len();
@@ -1537,7 +1537,7 @@ impl Profiler {
         let sample_types = self.sample_types_filter.sample_types();
         let sample_values = self.sample_types_filter.filter(samples);
 
-        let tags = TAGS.with(|cell| Arc::clone(&cell.borrow()));
+        let tags = TAGS.with_borrow(Arc::clone);
 
         SampleMessage {
             key: ProfileIndex { sample_types, tags },

--- a/profiling/src/profiling/stack_walking.rs
+++ b/profiling/src/profiling/stack_walking.rs
@@ -203,8 +203,7 @@ mod detail {
 
     #[inline]
     pub fn rshutdown() {
-        FUNCTION_CACHE_STATS.with(|cell| {
-            let stats = cell.borrow();
+        FUNCTION_CACHE_STATS.with_borrow(|stats| {
             let hit_rate = stats.hit_rate();
             debug!("Process cumulative {stats:?} hit_rate: {hit_rate}");
         });
@@ -240,8 +239,7 @@ mod detail {
         #[cfg(feature = "tracing")]
         let _span = tracing::trace_span!("collect_stack_sample").entered();
 
-        CACHED_STRINGS.with(|cell| {
-            let string_set: &mut StringSet = &mut cell.borrow_mut();
+        CACHED_STRINGS.with_borrow_mut(|string_set| {
             let max_depth = 512;
             let mut samples = Vec::with_capacity(max_depth >> 3);
             let mut execute_data_ptr = top_execute_data;
@@ -322,8 +320,7 @@ mod detail {
                 let (file, line) = handle_file_cache_slot(execute_data, &mut string_cache);
 
                 let cache_slots = string_cache.cache_slots;
-                FUNCTION_CACHE_STATS.with(|cell| {
-                    let mut stats = cell.borrow_mut();
+                FUNCTION_CACHE_STATS.with_borrow_mut(|stats| {
                     if cache_slots[0] == 0 {
                         stats.missed += 1;
                     } else {
@@ -335,10 +332,7 @@ mod detail {
             }
 
             None => {
-                FUNCTION_CACHE_STATS.with(|cell| {
-                    let mut stats = cell.borrow_mut();
-                    stats.not_applicable += 1;
-                });
+                FUNCTION_CACHE_STATS.with_borrow_mut(|stats| stats.not_applicable += 1);
                 let function = extract_function_name(func);
                 let (file, line) = extract_file_and_line(execute_data);
                 (function, file, line)

--- a/profiling/src/profiling/stack_walking.rs
+++ b/profiling/src/profiling/stack_walking.rs
@@ -209,21 +209,26 @@ mod detail {
             debug!("Process cumulative {stats:?} hit_rate: {hit_rate}");
         });
 
-        CACHED_STRINGS.with(|cell| {
-            let set: &StringSet = &cell.borrow();
-            let arena_used_bytes = set.arena_used_bytes();
-            // A slow ramp up to 2 MiB is probably _not_ going to look like
-            // a memory leak, whereas a higher threshold could make a user
-            // suspect a leak.
-            let threshold = 2 * 1024 * 1024;
-            if arena_used_bytes > threshold {
-                debug!("string cache arena is using {arena_used_bytes} bytes which exceeds the {threshold} byte threshold, resetting");
+        // PANIC: panics if the string arena is already borrowed. However, it
+        // should not be borrowed at this point, so we're likely going to fail.
+        // It's probably better to fail in rshutdown.
+        // Maybe in a new PHP version, we can have the engine check rshutdown
+        // failures, and stop serving requests from that process, and go into
+        // module shutdown instead.
+        CACHED_STRINGS.with_borrow_mut(|string_set| {
+            // A slow ramp up to 2 MiB is probably _not_ going to look like a
+            // memory leak. A higher threshold may make a user suspect a leak.
+            const THRESHOLD: usize = 2 * 1024 * 1024;
+
+            let used_bytes = string_set.arena_used_bytes();
+            if used_bytes > THRESHOLD {
+                debug!("string cache arena is using {used_bytes} bytes which exceeds the {THRESHOLD} byte threshold, resetting");
                 // Note that this cannot be done _during_ a request. The
                 // ThinStrs inside the run time cache need to remain valid
                 // during the request.
-                cell.replace(StringSet::new());
+                *string_set = StringSet::new();
             } else {
-                trace!("string cache arena is using {arena_used_bytes} bytes which is less than the {threshold} byte threshold");
+                trace!("string cache arena is using {used_bytes} bytes which is less than the {THRESHOLD} byte threshold");
             }
         });
     }

--- a/profiling/src/timeline.rs
+++ b/profiling/src/timeline.rs
@@ -583,9 +583,7 @@ pub(crate) fn timeline_ginit() {
     // During GINIT in "this" thread, the request locals are not initialized, which happens in
     // RINIT, so we currently do not know if profile is enabled at all and if, if timeline is
     // enabled. That's why we raise this flag here and read it in RINIT.
-    IS_NEW_THREAD.with(|cell| {
-        cell.set(true);
-    });
+    IS_NEW_THREAD.set(true);
 }
 
 #[cfg(php_zts)]


### PR DESCRIPTION
### Description

Rust added these in v1.73. Cleans up our code a bit. I didn't want mingle them in with a bug fix.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
