### PR TITLE
Fix crash with non-interned string in Trace attribute tags

### DIFF
--- a/ext/hook/uhook_attributes.c
+++ b/ext/hook/uhook_attributes.c
@@ -128,6 +128,7 @@ static void dd_fill_span_data(dd_uhook_def *def, ddtrace_span_data *span) {
         zval *value;
         ZEND_HASH_FOREACH_STR_KEY_VAL(def->tags, key, value) {
             if (key) {
+                Z_TRY_ADDREF_P(value);
                 zend_hash_update(meta, key, value);
             }
         } ZEND_HASH_FOREACH_END();

--- a/tests/ext/traced_attribute.phpt
+++ b/tests/ext/traced_attribute.phpt
@@ -11,7 +11,7 @@ DD_TRACE_GENERATE_ROOT_SPAN=0
 include __DIR__ . '/sandbox/dd_dumper.inc';
 
 class Foo {
-    #[DDTrace\Trace(name: "simplename", resource: "rsrc", type: "typeee", service: "test", tags: ["a" => "b", 1 => "ignored"])]
+    #[DDTrace\Trace(name: "simplename", resource: "rsrc", type: "typeee", service: "test", tags: ["a" => "b", "data" => "dog", 1 => "ignored"])]
     static function simple($arg) {}
 /*
     #[DDTrace\Trace(saveArgs: ["foo"])]
@@ -63,6 +63,7 @@ spans(\DDTrace\SpanData) (3) {
     _dd.p.tid => %s
     simplename (test, rsrc, typeee)
       a => b
+      data => dog
       _dd.base_service => traced_attribute.php
   recursion (traced_attribute.php, recursion, cli)
     _dd.p.dm => -0


### PR DESCRIPTION
Fixes #3246.