### PR TITLE
fix(prof): crash in ZEND_INIT_ARRAY

### DIFF
--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -11,7 +11,8 @@
 #include <dlfcn.h> // for dlsym
 #endif
 
-#if PHP_VERSION_ID >= 70400 && PHP_VERSION_ID < 80400
+// todo: not all things are fixed upstream yet e.g. ZEND_INIT_ARRAY
+#if PHP_VERSION_ID >= 70400
 #define CFG_NEED_OPCODE_HANDLERS 1
 #else
 #define CFG_NEED_OPCODE_HANDLERS 0
@@ -168,6 +169,11 @@ static void ddog_php_prof_install_opcode_handlers(uint32_t php_version_id) {
         zend_set_user_opcode_handler(ZEND_FUNC_GET_ARGS, dispatch_handler);
     }
 #endif
+
+    // this is not yet patched upstream
+    if (zend_get_user_opcode_handler(ZEND_INIT_ARRAY) == NULL) {
+        zend_set_user_opcode_handler(ZEND_INIT_ARRAY, dispatch_handler);
+    }
 }
 #endif
 


### PR DESCRIPTION
[PROF-11814](https://datadoghq.atlassian.net/browse/PROF-11814)

### Description

A PHP application _may_ crash happen if:
 - Using PHP 7.4+
 - The allocation profiler is enabled
 - And the ZEND_INIT_ARRAY opcode is executed

The engine currently does not save the opline in ZEND_INIT_ARRAY. Usually if it's out-dated and the line-number is a bit stale, it's not a big deal. But in some cases the opline will be dangling, and in those cases we read invalid memory. This is a bug in the PHP VM that needs to also be fixed upstream: php/php-src#18578. Since PHP 8.1 and 8.2 are in security fixes only, this will go into PHP 8.3 and 8.4, and we'll have to mitigate it on <8.3.

The fix works because by having a user opcode handler the engine will save the opline before it calls the user opcode handler. This has a small performance penalty for this specific opcode.

I do not have a reproducer for this one yet, but we've hit this issue before in other opcodes. I'm fairly confident this needs to be done until there is an upstream fix in PHP, then we can restrict this mitigation to version-specific ranges.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [x] Appropriate labels assigned.


[PROF-11814]: https://datadoghq.atlassian.net/browse/PROF-11814?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ