### PR TITLE
Init ddtrace_coms_globals.tmp_stack

### DIFF
--- a/ext/coms.c
+++ b/ext/coms.c
@@ -170,6 +170,8 @@ bool ddtrace_coms_minit(size_t initial_stack_size, size_t max_stack_size, size_t
     atomic_store(&ddtrace_coms_globals.next_group_id, 1);
     atomic_store(&ddtrace_coms_globals.current_stack, stack);
 
+    ddtrace_coms_globals.tmp_stack = NULL;
+
     _dd_ptr_at_exit_callback = _dd_at_exit_callback;
     atexit(_dd_at_exit_hook);
 


### PR DESCRIPTION
### Description

In `ddtrace_coms_minit`, `ddtrace_coms_globals.tmp_stack` is never initialized. As a result, when `tmp_stack` differs from `current_stack` in `_dd_unsafe_cleanup_dirty_stack_area`, it may be freed—potentially causing a memory leak.
https://github.com/DataDog/dd-trace-php/blob/master/ext/coms.c#L207-L236

This is related to https://github.com/DataDog/dd-trace-php/issues/3208.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
