### PR TITLE
fix: WordPress integration hook handling for "static" and object methods

### DIFF
--- a/src/DDTrace/Integrations/WordPress/WordPressIntegrationLoader.php
+++ b/src/DDTrace/Integrations/WordPress/WordPressIntegrationLoader.php
@@ -690,11 +690,12 @@ class WordPressIntegrationLoader
                 $callback = $args[1];
                 $pluginName = end($plugins);
                 if (isset($interestingActions[$action]) && dd_trace_env_config('DD_TRACE_WORDPRESS_CALLBACKS')) {
-                    if (\is_array($callback)) {
-                        if (!method_exists($callback[0], $callback[1])) {
-                            $hookTarget = null; // Invalid callback
-                        } else {
-                            $hookTarget = (is_string($callback[0]) ? $callback[0] : get_class($callback[0])) . '::' . $callback[1]; // Static or instance method
+                    $hookTarget = null;
+                    if (is_array($callback)) {
+                        if (is_string($callback[0])) {
+                            $hookTarget = "{$callback[0]}::{$callback[1]}";
+                        } elseif (method_exists($callback[0], $callback[1])) {
+                            $hookTarget = $callback; // object method
                         }
                     } else {
                         $hookTarget = $callback; // Function or Closure


### PR DESCRIPTION
### Description

This PR improves the handling of WordPress action hooks in the integration by:

1. Properly handling static method callbacks (e.g., [WP_Block_Supports::init](https://github.com/WordPress/WordPress/blob/7faba13ae1a2bbad489d4bb4fa44036e44fd3690/wp-includes/class-wp-block-supports.php#L66-L69)) by creating the hook target string without early validation, since the class [might not be loaded yet during early WordPress bootstrap](https://github.com/WordPress/WordPress/blob/7faba13ae1a2bbad489d4bb4fa44036e44fd3690/wp-includes/default-filters.php#L367).
2. Adding explicit method existence checks for object method callbacks to prevent errors when methods don't exist (e.g., [ujic_Widget::load_textdomain](https://github.com/wp-plugins/uji-countdown/blob/ef5fd87190b2d0917e5a72902f27b50d3862a92a/classes/class-uji-widget.php#L31C53-L31C68)).
3. Simplifying the hook target creation logic to be more robust and handle both static and instance methods correctly.

This fixes issues with early WordPress action registration and prevents errors from non-existent methods.

```
Error : Error raised in ddtrace's closure defined at <redacted>/DDTrace/Integrations/WordPress/WordPressIntegrationLoader.php:688 for add_action(): DDTrace\install_hook(): Argument #1 must be of type string|callable|Generator|Closure, got array, but class 'ujic_Widget' does not have a method 'load_textdomain' in <redacted>/DDTrace/Integrations/WordPress/WordPressIntegrationLoader.php on line 728
```
<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
