### PR TITLE
feat(profiling) re-enable allocation profiling with JIT for PHP 8.4.7

### DIFF
--- a/profiling/src/allocation/allocation_ge84.rs
+++ b/profiling/src/allocation/allocation_ge84.rs
@@ -143,8 +143,8 @@ lazy_static! {
 }
 
 pub fn first_rinit_should_disable_due_to_jit() -> bool {
-    if *JIT_ENABLED && zend::PHP_VERSION_ID >= 80400 {
-        error!("Memory allocation profiling will be disabled as long as JIT is active. To enable allocation profiling disable JIT. See https://github.com/DataDog/dd-trace-php/pull/3199");
+    if *JIT_ENABLED && zend::PHP_VERSION_ID >= 80400 && zend::PHP_VERSION_ID < 80407 {
+        error!("Memory allocation profiling will be disabled as long as JIT is active. To enable allocation profiling disable JIT or upgrade PHP to at least version 8.4.7. See https://github.com/DataDog/dd-trace-php/pull/3199");
         true
     } else {
         false

--- a/profiling/src/allocation/allocation_ge84.rs
+++ b/profiling/src/allocation/allocation_ge84.rs
@@ -7,6 +7,7 @@ use core::{cell::Cell, ptr};
 use lazy_static::lazy_static;
 use libc::{c_char, c_void, size_t};
 use log::{debug, error, trace, warn};
+use std::sync::atomic::Ordering::Relaxed;
 use std::sync::atomic::Ordering::SeqCst;
 
 #[derive(Copy, Clone)]
@@ -143,7 +144,10 @@ lazy_static! {
 }
 
 pub fn first_rinit_should_disable_due_to_jit() -> bool {
-    if *JIT_ENABLED && zend::PHP_VERSION_ID >= 80400 && zend::PHP_VERSION_ID < 80407 {
+    if *JIT_ENABLED
+        && zend::PHP_VERSION_ID >= 80400
+        && (80400..80406).contains(&crate::RUNTIME_PHP_VERSION_ID.load(Relaxed))
+    {
         error!("Memory allocation profiling will be disabled as long as JIT is active. To enable allocation profiling disable JIT or upgrade PHP to at least version 8.4.7. See https://github.com/DataDog/dd-trace-php/pull/3199");
         true
     } else {

--- a/profiling/tests/phpt/jit_03.phpt
+++ b/profiling/tests/phpt/jit_03.phpt
@@ -8,6 +8,8 @@ we make sure to disable allocation profiling when we detect the JIT is enabled.
 <?php
 if (PHP_VERSION_ID < 80400)
     echo "skip: PHP Version < 8.4 are not affected", PHP_EOL;
+if (PHP_VERSION_ID >= 80407)
+    echo "skip: fixed since PHP version 8.4.7", PHP_EOL;
 if (!extension_loaded('datadog-profiling'))
     echo "skip: test requires datadog-profiling", PHP_EOL;
 if (php_uname("s") === "Darwin")
@@ -27,5 +29,5 @@ opcache.jit_buffer_size=4M
 echo "Done.", PHP_EOL;
 ?>
 --EXPECTF--
-%aMemory allocation profiling will be disabled as long as JIT is active. To enable allocation profiling disable JIT. See https://github.com/DataDog/dd-trace-php/pull/3199
+%aMemory allocation profiling will be disabled as long as JIT is active. To enable allocation profiling disable JIT or upgrade PHP to at least version 8.4.7. See https://github.com/DataDog/dd-trace-php/pull/3199
 %ADone.%a


### PR DESCRIPTION
### Description

With #3199 we've disable allocation profiling when an active JIT was detected on PHP 8.4. The [upstream fix](https://github.com/php/php-src/pull/18289) landed in PHP 8.4.7 and was confirmed to fix the issue, so we can allow allocation profiling even when an active JIT is detected on PHP >= 8.4.7  

### Reviewer checklist
- [x] Test coverage seems ok.
- [x] Appropriate labels assigned.
