### PR TITLE
Fix warnings on clang-tidy-17

### DIFF
--- a/appsec/src/helper/parameter_base.cpp
+++ b/appsec/src/helper/parameter_base.cpp
@@ -70,9 +70,13 @@ void debug_str_helper(std::string &res, const ddwaf_object &p)
 
 std::string parameter_base::debug_str() const noexcept
 {
-    std::string res;
-    debug_str_helper(res, *this);
-    return res;
+    try {
+        std::string res;
+        debug_str_helper(res, *this);
+        return res;
+    } catch (...) {} // NOLINT(bugprone-empty-catch)
+
+    return {};
 }
 
 } // namespace dds


### PR DESCRIPTION
### Description

This PR fixes some clang-tidy warnings on version 17.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
