### PR TITLE
fix(prof): fewer borrows, less panics on borrows

### DIFF
--- a/profiling/src/allocation/allocation_ge84.rs
+++ b/profiling/src/allocation/allocation_ge84.rs
@@ -3,7 +3,7 @@ use crate::allocation::{
     ALLOCATION_PROFILING_STATS,
 };
 use crate::bindings::{self as zend};
-use crate::PROFILER_NAME;
+use crate::{RefCellExt, PROFILER_NAME};
 use core::{cell::Cell, ptr};
 use lazy_static::lazy_static;
 use libc::{c_char, c_void, size_t};
@@ -365,7 +365,8 @@ unsafe extern "C" fn alloc_prof_malloc(len: size_t) -> *mut c_void {
     }
 
     if ALLOCATION_PROFILING_STATS
-        .with_borrow_mut(|allocations| allocations.should_collect_allocation(len))
+        .try_with_borrow_mut(|allocations| allocations.should_collect_allocation(len))
+        .unwrap_or(false)
     {
         collect_allocation(len);
     }
@@ -434,7 +435,8 @@ unsafe extern "C" fn alloc_prof_realloc(prev_ptr: *mut c_void, len: size_t) -> *
     }
 
     if ALLOCATION_PROFILING_STATS
-        .with_borrow_mut(|allocations| allocations.should_collect_allocation(len))
+        .try_with_borrow_mut(|allocations| allocations.should_collect_allocation(len))
+        .unwrap_or(false)
     {
         collect_allocation(len);
     }

--- a/profiling/src/allocation/allocation_ge84.rs
+++ b/profiling/src/allocation/allocation_ge84.rs
@@ -365,8 +365,7 @@ unsafe extern "C" fn alloc_prof_malloc(len: size_t) -> *mut c_void {
     }
 
     if ALLOCATION_PROFILING_STATS
-        .try_with_borrow_mut(|allocations| allocations.should_collect_allocation(len))
-        .unwrap_or(false)
+        .borrow_mut_or_false(|allocations| allocations.should_collect_allocation(len))
     {
         collect_allocation(len);
     }
@@ -435,8 +434,7 @@ unsafe extern "C" fn alloc_prof_realloc(prev_ptr: *mut c_void, len: size_t) -> *
     }
 
     if ALLOCATION_PROFILING_STATS
-        .try_with_borrow_mut(|allocations| allocations.should_collect_allocation(len))
-        .unwrap_or(false)
+        .borrow_mut_or_false(|allocations| allocations.should_collect_allocation(len))
     {
         collect_allocation(len);
     }

--- a/profiling/src/allocation/allocation_ge84.rs
+++ b/profiling/src/allocation/allocation_ge84.rs
@@ -1,14 +1,14 @@
-use crate::allocation::ALLOCATION_PROFILING_COUNT;
-use crate::allocation::ALLOCATION_PROFILING_SIZE;
-use crate::allocation::ALLOCATION_PROFILING_STATS;
+use crate::allocation::{
+    collect_allocation, ALLOCATION_PROFILING_COUNT, ALLOCATION_PROFILING_SIZE,
+    ALLOCATION_PROFILING_STATS,
+};
 use crate::bindings::{self as zend};
 use crate::PROFILER_NAME;
 use core::{cell::Cell, ptr};
 use lazy_static::lazy_static;
 use libc::{c_char, c_void, size_t};
 use log::{debug, error, trace, warn};
-use std::sync::atomic::Ordering::Relaxed;
-use std::sync::atomic::Ordering::SeqCst;
+use std::sync::atomic::Ordering::{Relaxed, SeqCst};
 
 #[derive(Copy, Clone)]
 struct ZendMMState {
@@ -364,7 +364,11 @@ unsafe extern "C" fn alloc_prof_malloc(len: size_t) -> *mut c_void {
         return ptr;
     }
 
-    ALLOCATION_PROFILING_STATS.with_borrow_mut(|allocations| allocations.track_allocation(len));
+    if ALLOCATION_PROFILING_STATS
+        .with_borrow_mut(|allocations| allocations.should_collect_allocation(len))
+    {
+        collect_allocation(len);
+    }
 
     ptr
 }
@@ -429,7 +433,11 @@ unsafe extern "C" fn alloc_prof_realloc(prev_ptr: *mut c_void, len: size_t) -> *
         return ptr;
     }
 
-    ALLOCATION_PROFILING_STATS.with_borrow_mut(|allocations| allocations.track_allocation(len));
+    if ALLOCATION_PROFILING_STATS
+        .with_borrow_mut(|allocations| allocations.should_collect_allocation(len))
+    {
+        collect_allocation(len);
+    }
 
     ptr
 }

--- a/profiling/src/allocation/allocation_le83.rs
+++ b/profiling/src/allocation/allocation_le83.rs
@@ -318,10 +318,9 @@ unsafe extern "C" fn alloc_prof_gc_mem_caches(
     execute_data: *mut zend::zend_execute_data,
     return_value: *mut zend::zval,
 ) {
+    // Not logging here to avoid potentially overwhelming logs.
     let allocation_profiling: bool = REQUEST_LOCALS
-        .try_with_borrow(|locals| locals.system_settings().profiling_allocation_enabled)
-        // Not logging here to avoid potentially overwhelming logs.
-        .unwrap_or(false);
+        .borrow_or_false(|locals| locals.system_settings().profiling_allocation_enabled);
 
     if let Some(func) = GC_MEM_CACHES_HANDLER {
         if allocation_profiling {
@@ -351,8 +350,7 @@ unsafe extern "C" fn alloc_prof_malloc(len: size_t) -> *mut c_void {
     }
 
     if ALLOCATION_PROFILING_STATS
-        .try_with_borrow_mut(|allocations| allocations.should_collect_allocation(len))
-        .unwrap_or(false)
+        .borrow_mut_or_false(|allocations| allocations.should_collect_allocation(len))
     {
         collect_allocation(len);
     }
@@ -411,8 +409,7 @@ unsafe extern "C" fn alloc_prof_realloc(prev_ptr: *mut c_void, len: size_t) -> *
     }
 
     if ALLOCATION_PROFILING_STATS
-        .try_with_borrow_mut(|allocations| allocations.should_collect_allocation(len))
-        .unwrap_or(false)
+        .borrow_mut_or_false(|allocations| allocations.should_collect_allocation(len))
     {
         collect_allocation(len);
     }

--- a/profiling/src/allocation/allocation_le83.rs
+++ b/profiling/src/allocation/allocation_le83.rs
@@ -351,7 +351,8 @@ unsafe extern "C" fn alloc_prof_malloc(len: size_t) -> *mut c_void {
     }
 
     if ALLOCATION_PROFILING_STATS
-        .with_borrow_mut(|allocations| allocations.should_collect_allocation(len))
+        .try_with_borrow_mut(|allocations| allocations.should_collect_allocation(len))
+        .unwrap_or(false)
     {
         collect_allocation(len);
     }
@@ -410,7 +411,8 @@ unsafe extern "C" fn alloc_prof_realloc(prev_ptr: *mut c_void, len: size_t) -> *
     }
 
     if ALLOCATION_PROFILING_STATS
-        .with_borrow_mut(|allocations| allocations.should_collect_allocation(len))
+        .try_with_borrow_mut(|allocations| allocations.should_collect_allocation(len))
+        .unwrap_or(false)
     {
         collect_allocation(len);
     }

--- a/profiling/src/allocation/allocation_le83.rs
+++ b/profiling/src/allocation/allocation_le83.rs
@@ -6,7 +6,7 @@ use crate::bindings::{
     self as zend, datadog_php_install_handler, datadog_php_zif_handler,
     ddog_php_prof_copy_long_into_zval,
 };
-use crate::{RefCellExt, RefCellExtError, PROFILER_NAME, REQUEST_LOCALS};
+use crate::{RefCellExt, PROFILER_NAME, REQUEST_LOCALS};
 use core::{cell::Cell, ptr};
 use lazy_static::lazy_static;
 use libc::{c_char, c_int, c_void, size_t};

--- a/profiling/src/allocation/mod.rs
+++ b/profiling/src/allocation/mod.rs
@@ -56,25 +56,29 @@ impl AllocationProfilingStats {
         self.next_sample = self.poisson.sample(&mut self.rng) as i64;
     }
 
-    fn track_allocation(&mut self, len: size_t) {
+    fn should_collect_allocation(&mut self, len: size_t) -> bool {
         self.next_sample -= len as i64;
 
         if self.next_sample > 0 {
-            return;
+            return false;
         }
 
         self.next_sampling_interval();
 
-        if let Some(profiler) = Profiler::get() {
-            // Safety: execute_data was provided by the engine, and the profiler doesn't mutate it.
-            unsafe {
-                profiler.collect_allocations(
-                    zend::ddog_php_prof_get_current_execute_data(),
-                    1_i64,
-                    len as i64,
-                )
-            };
-        }
+        true
+    }
+}
+
+pub fn collect_allocation(len: size_t) {
+    if let Some(profiler) = Profiler::get() {
+        // Safety: execute_data was provided by the engine, and the profiler doesn't mutate it.
+        unsafe {
+            profiler.collect_allocations(
+                zend::ddog_php_prof_get_current_execute_data(),
+                1_i64,
+                len as i64,
+            )
+        };
     }
 }
 

--- a/profiling/src/allocation/mod.rs
+++ b/profiling/src/allocation/mod.rs
@@ -69,6 +69,7 @@ impl AllocationProfilingStats {
     }
 }
 
+#[cold]
 pub fn collect_allocation(len: size_t) {
     if let Some(profiler) = Profiler::get() {
         // Safety: execute_data was provided by the engine, and the profiler doesn't mutate it.

--- a/profiling/src/exception.rs
+++ b/profiling/src/exception.rs
@@ -62,6 +62,7 @@ impl ExceptionProfilingStats {
     }
 }
 
+#[cold]
 fn collect_exception(
     #[cfg(php7)] exception: *mut zend::zval,
     #[cfg(php8)] exception: *mut zend::zend_object,

--- a/profiling/src/exception.rs
+++ b/profiling/src/exception.rs
@@ -76,8 +76,7 @@ fn collect_exception(
     let exception_name = unsafe { (*exception).class_name() };
 
     let collect_message = REQUEST_LOCALS
-        .try_with_borrow(|locals| locals.system_settings().profiling_exception_message_enabled)
-        .unwrap_or(false);
+        .borrow_or_false(|locals| locals.system_settings().profiling_exception_message_enabled);
 
     let message = if collect_message {
         Some(unsafe {
@@ -188,8 +187,7 @@ unsafe extern "C" fn exception_profiling_throw_exception_hook(
     EXCEPTION_PROFILING_EXCEPTION_COUNT.fetch_add(1, Ordering::SeqCst);
 
     let exception_enabled = REQUEST_LOCALS
-        .try_with_borrow(|locals| locals.system_settings().profiling_exception_enabled)
-        .unwrap_or(false);
+        .borrow_or_false(|locals| locals.system_settings().profiling_exception_enabled);
 
     // Up to PHP 7.1, when PHP propagated exceptions up the call stack, it would re-throw them.
     // This process involved calling this hook for each stack frame or try...catch block it
@@ -198,8 +196,7 @@ unsafe extern "C" fn exception_profiling_throw_exception_hook(
     if exception_enabled
         && !exception.is_null()
         && EXCEPTION_PROFILING_STATS
-            .try_with_borrow_mut(|exceptions| exceptions.should_collect_exception())
-            .unwrap_or(false)
+            .borrow_mut_or_false(|exceptions| exceptions.should_collect_exception())
     {
         collect_exception(exception);
     }

--- a/profiling/src/io.rs
+++ b/profiling/src/io.rs
@@ -250,28 +250,32 @@ unsafe extern "C" fn observed_poll(fds: *mut libc::pollfd, nfds: u64, timeout: c
         if (*fds).revents & 1 == 1 {
             // requested events contains reading
             if SOCKET_READ_TIME_PROFILING_STATS
-                .with_borrow_mut(|io| io.should_collect(duration_nanos))
+                .try_with_borrow_mut(|io| io.should_collect(duration_nanos))
+                .unwrap_or(false)
             {
                 collect_socket_read_time(duration_nanos);
             }
         } else if (*fds).revents & 4 == 4 {
             // requested events contains writing
             if SOCKET_WRITE_TIME_PROFILING_STATS
-                .with_borrow_mut(|io| io.should_collect(duration_nanos))
+                .try_with_borrow_mut(|io| io.should_collect(duration_nanos))
+                .unwrap_or(false)
             {
                 collect_socket_write_time(duration_nanos);
             }
         } else if (*fds).events & 1 == 1 {
             // socket became readable
             if SOCKET_READ_TIME_PROFILING_STATS
-                .with_borrow_mut(|io| io.should_collect(duration_nanos))
+                .try_with_borrow_mut(|io| io.should_collect(duration_nanos))
+                .unwrap_or(false)
             {
                 collect_socket_read_time(duration_nanos);
             }
         } else if (*fds).events & 4 == 4 {
             // socket became writeable
             if SOCKET_WRITE_TIME_PROFILING_STATS
-                .with_borrow_mut(|io| io.should_collect(duration_nanos))
+                .try_with_borrow_mut(|io| io.should_collect(duration_nanos))
+                .unwrap_or(false)
             {
                 collect_socket_write_time(duration_nanos);
             }
@@ -294,12 +298,18 @@ unsafe extern "C" fn observed_recv(
     let duration = start.elapsed();
 
     let duration_nanos = duration.as_nanos() as u64;
-    if SOCKET_READ_TIME_PROFILING_STATS.with_borrow_mut(|io| io.should_collect(duration_nanos)) {
+    if SOCKET_READ_TIME_PROFILING_STATS
+        .try_with_borrow_mut(|io| io.should_collect(duration_nanos))
+        .unwrap_or(false)
+    {
         collect_socket_read_time(duration_nanos);
     }
     if len > 0 {
         let len_u64 = len as u64;
-        if SOCKET_READ_SIZE_PROFILING_STATS.with_borrow_mut(|io| io.should_collect(len_u64)) {
+        if SOCKET_READ_SIZE_PROFILING_STATS
+            .try_with_borrow_mut(|io| io.should_collect(len_u64))
+            .unwrap_or(false)
+        {
             collect_socket_read_size(len_u64);
         }
     }
@@ -320,12 +330,18 @@ unsafe extern "C" fn observed_recvmsg(
     let duration = start.elapsed();
 
     let duration_nanos = duration.as_nanos() as u64;
-    if SOCKET_READ_TIME_PROFILING_STATS.with_borrow_mut(|io| io.should_collect(duration_nanos)) {
+    if SOCKET_READ_TIME_PROFILING_STATS
+        .try_with_borrow_mut(|io| io.should_collect(duration_nanos))
+        .unwrap_or(false)
+    {
         collect_socket_read_time(duration_nanos);
     }
     if len > 0 {
         let len_u64 = len as u64;
-        if SOCKET_READ_SIZE_PROFILING_STATS.with_borrow_mut(|io| io.should_collect(len_u64)) {
+        if SOCKET_READ_SIZE_PROFILING_STATS
+            .try_with_borrow_mut(|io| io.should_collect(len_u64))
+            .unwrap_or(false)
+        {
             collect_socket_read_size(len_u64);
         }
     }
@@ -355,12 +371,18 @@ unsafe extern "C" fn observed_recvfrom(
     let duration = start.elapsed();
 
     let duration_nanos = duration.as_nanos() as u64;
-    if SOCKET_READ_TIME_PROFILING_STATS.with_borrow_mut(|io| io.should_collect(duration_nanos)) {
+    if SOCKET_READ_TIME_PROFILING_STATS
+        .try_with_borrow_mut(|io| io.should_collect(duration_nanos))
+        .unwrap_or(false)
+    {
         collect_socket_read_time(duration_nanos);
     }
     if len > 0 {
         let len_u64 = len as u64;
-        if SOCKET_READ_SIZE_PROFILING_STATS.with_borrow_mut(|io| io.should_collect(len_u64)) {
+        if SOCKET_READ_SIZE_PROFILING_STATS
+            .try_with_borrow_mut(|io| io.should_collect(len_u64))
+            .unwrap_or(false)
+        {
             collect_socket_read_size(len_u64);
         }
     }
@@ -381,12 +403,18 @@ unsafe extern "C" fn observed_send(
     let duration = start.elapsed();
 
     let duration_nanos = duration.as_nanos() as u64;
-    if SOCKET_WRITE_TIME_PROFILING_STATS.with_borrow_mut(|io| io.should_collect(duration_nanos)) {
+    if SOCKET_WRITE_TIME_PROFILING_STATS
+        .try_with_borrow_mut(|io| io.should_collect(duration_nanos))
+        .unwrap_or(false)
+    {
         collect_socket_write_time(duration_nanos);
     }
     if len > 0 {
         let len_u64 = len as u64;
-        if SOCKET_WRITE_SIZE_PROFILING_STATS.with_borrow_mut(|io| io.should_collect(len_u64)) {
+        if SOCKET_WRITE_SIZE_PROFILING_STATS
+            .try_with_borrow_mut(|io| io.should_collect(len_u64))
+            .unwrap_or(false)
+        {
             collect_socket_write_size(len_u64);
         }
     }
@@ -406,12 +434,18 @@ unsafe extern "C" fn observed_sendmsg(
     let duration = start.elapsed();
 
     let duration_nanos = duration.as_nanos() as u64;
-    if SOCKET_WRITE_TIME_PROFILING_STATS.with_borrow_mut(|io| io.should_collect(duration_nanos)) {
+    if SOCKET_WRITE_TIME_PROFILING_STATS
+        .try_with_borrow_mut(|io| io.should_collect(duration_nanos))
+        .unwrap_or(false)
+    {
         collect_socket_write_time(duration_nanos);
     }
     if len > 0 {
         let len_u64 = len as u64;
-        if SOCKET_WRITE_SIZE_PROFILING_STATS.with_borrow_mut(|io| io.should_collect(len_u64)) {
+        if SOCKET_WRITE_SIZE_PROFILING_STATS
+            .try_with_borrow_mut(|io| io.should_collect(len_u64))
+            .unwrap_or(false)
+        {
             collect_socket_write_size(len_u64);
         }
     }
@@ -436,12 +470,18 @@ unsafe extern "C" fn observed_fwrite(
     let duration = start.elapsed();
 
     let duration_nanos = duration.as_nanos() as u64;
-    if FILE_WRITE_TIME_PROFILING_STATS.with_borrow_mut(|io| io.should_collect(duration_nanos)) {
+    if FILE_WRITE_TIME_PROFILING_STATS
+        .try_with_borrow_mut(|io| io.should_collect(duration_nanos))
+        .unwrap_or(false)
+    {
         collect_file_write_time(duration_nanos);
     }
     if len > 0 {
         let len_u64 = len as u64;
-        if FILE_WRITE_SIZE_PROFILING_STATS.with_borrow_mut(|io| io.should_collect(len_u64)) {
+        if FILE_WRITE_SIZE_PROFILING_STATS
+            .try_with_borrow_mut(|io| io.should_collect(len_u64))
+            .unwrap_or(false)
+        {
             collect_file_write_size(len_u64);
         }
     }
@@ -457,23 +497,34 @@ unsafe extern "C" fn observed_write(fd: c_int, buf: *const c_void, count: usize)
 
     let duration_nanos = duration.as_nanos() as u64;
     if fd_is_socket(fd) {
-        if SOCKET_WRITE_TIME_PROFILING_STATS.with_borrow_mut(|io| io.should_collect(duration_nanos))
+        if SOCKET_WRITE_TIME_PROFILING_STATS
+            .try_with_borrow_mut(|io| io.should_collect(duration_nanos))
+            .unwrap_or(false)
         {
             collect_socket_write_time(duration_nanos);
         }
         if len > 0 {
             let len_u64 = len as u64;
-            if SOCKET_WRITE_SIZE_PROFILING_STATS.with_borrow_mut(|io| io.should_collect(len_u64)) {
+            if SOCKET_WRITE_SIZE_PROFILING_STATS
+                .try_with_borrow_mut(|io| io.should_collect(len_u64))
+                .unwrap_or(false)
+            {
                 collect_socket_write_size(len_u64);
             }
         }
     } else {
-        if FILE_WRITE_TIME_PROFILING_STATS.with_borrow_mut(|io| io.should_collect(duration_nanos)) {
+        if FILE_WRITE_TIME_PROFILING_STATS
+            .try_with_borrow_mut(|io| io.should_collect(duration_nanos))
+            .unwrap_or(false)
+        {
             collect_file_write_time(duration_nanos);
         }
         if len > 0 {
             let len_u64 = len as u64;
-            if FILE_WRITE_SIZE_PROFILING_STATS.with_borrow_mut(|io| io.should_collect(len_u64)) {
+            if FILE_WRITE_SIZE_PROFILING_STATS
+                .try_with_borrow_mut(|io| io.should_collect(len_u64))
+                .unwrap_or(false)
+            {
                 collect_file_write_size(len_u64);
             }
         }
@@ -498,12 +549,18 @@ unsafe extern "C" fn observed_fread(
     let duration = start.elapsed();
 
     let duration_nanos = duration.as_nanos() as u64;
-    if FILE_READ_TIME_PROFILING_STATS.with_borrow_mut(|io| io.should_collect(duration_nanos)) {
+    if FILE_READ_TIME_PROFILING_STATS
+        .try_with_borrow_mut(|io| io.should_collect(duration_nanos))
+        .unwrap_or(false)
+    {
         collect_file_read_time(duration_nanos);
     }
     if len > 0 {
         let len_u64 = len as u64;
-        if FILE_READ_SIZE_PROFILING_STATS.with_borrow_mut(|io| io.should_collect(len_u64)) {
+        if FILE_READ_SIZE_PROFILING_STATS
+            .try_with_borrow_mut(|io| io.should_collect(len_u64))
+            .unwrap_or(false)
+        {
             collect_file_read_size(len_u64);
         }
     }
@@ -519,23 +576,34 @@ unsafe extern "C" fn observed_read(fd: c_int, buf: *mut c_void, count: usize) ->
 
     let duration_nanos = duration.as_nanos() as u64;
     if fd_is_socket(fd) {
-        if SOCKET_READ_TIME_PROFILING_STATS.with_borrow_mut(|io| io.should_collect(duration_nanos))
+        if SOCKET_READ_TIME_PROFILING_STATS
+            .try_with_borrow_mut(|io| io.should_collect(duration_nanos))
+            .unwrap_or(false)
         {
             collect_socket_read_time(duration_nanos);
         }
         if len > 0 {
             let len_u64 = len as u64;
-            if SOCKET_READ_SIZE_PROFILING_STATS.with_borrow_mut(|io| io.should_collect(len_u64)) {
+            if SOCKET_READ_SIZE_PROFILING_STATS
+                .try_with_borrow_mut(|io| io.should_collect(len_u64))
+                .unwrap_or(false)
+            {
                 collect_socket_read_size(len_u64);
             }
         }
     } else {
-        if FILE_READ_TIME_PROFILING_STATS.with_borrow_mut(|io| io.should_collect(duration_nanos)) {
+        if FILE_READ_TIME_PROFILING_STATS
+            .try_with_borrow_mut(|io| io.should_collect(duration_nanos))
+            .unwrap_or(false)
+        {
             collect_file_read_time(duration_nanos);
         }
         if len > 0 {
             let len_u64 = len as u64;
-            if FILE_READ_SIZE_PROFILING_STATS.with_borrow_mut(|io| io.should_collect(len_u64)) {
+            if FILE_READ_SIZE_PROFILING_STATS
+                .try_with_borrow_mut(|io| io.should_collect(len_u64))
+                .unwrap_or(false)
+            {
                 collect_file_read_size(len_u64);
             }
         }

--- a/profiling/src/io.rs
+++ b/profiling/src/io.rs
@@ -597,6 +597,7 @@ pub static SOCKET_WRITE_SIZE_PROFILING_INTERVAL: AtomicU64 = AtomicU64::new(1024
 pub static FILE_READ_SIZE_PROFILING_INTERVAL: AtomicU64 = AtomicU64::new(1024 * 100);
 pub static FILE_WRITE_SIZE_PROFILING_INTERVAL: AtomicU64 = AtomicU64::new(1024 * 100);
 
+#[cold]
 fn collect_socket_read_time(value: u64) {
     if let Some(profiler) = Profiler::get() {
         // Safety: execute_data was provided by the engine, and the profiler doesn't mutate it.
@@ -609,6 +610,7 @@ fn collect_socket_read_time(value: u64) {
     }
 }
 
+#[cold]
 fn collect_socket_write_time(value: u64) {
     if let Some(profiler) = Profiler::get() {
         // Safety: execute_data was provided by the engine, and the profiler doesn't mutate it.
@@ -621,6 +623,7 @@ fn collect_socket_write_time(value: u64) {
     }
 }
 
+#[cold]
 fn collect_file_read_time(value: u64) {
     if let Some(profiler) = Profiler::get() {
         // Safety: execute_data was provided by the engine, and the profiler doesn't mutate it.
@@ -633,6 +636,7 @@ fn collect_file_read_time(value: u64) {
     }
 }
 
+#[cold]
 fn collect_file_write_time(value: u64) {
     if let Some(profiler) = Profiler::get() {
         // Safety: execute_data was provided by the engine, and the profiler doesn't mutate it.
@@ -645,6 +649,7 @@ fn collect_file_write_time(value: u64) {
     }
 }
 
+#[cold]
 fn collect_socket_read_size(value: u64) {
     if let Some(profiler) = Profiler::get() {
         // Safety: execute_data was provided by the engine, and the profiler doesn't mutate it.
@@ -657,6 +662,7 @@ fn collect_socket_read_size(value: u64) {
     }
 }
 
+#[cold]
 fn collect_socket_write_size(value: u64) {
     if let Some(profiler) = Profiler::get() {
         // Safety: execute_data was provided by the engine, and the profiler doesn't mutate it.
@@ -669,6 +675,7 @@ fn collect_socket_write_size(value: u64) {
     }
 }
 
+#[cold]
 fn collect_file_read_size(value: u64) {
     if let Some(profiler) = Profiler::get() {
         // Safety: execute_data was provided by the engine, and the profiler doesn't mutate it.
@@ -681,6 +688,7 @@ fn collect_file_read_size(value: u64) {
     }
 }
 
+#[cold]
 fn collect_file_write_size(value: u64) {
     if let Some(profiler) = Profiler::get() {
         // Safety: execute_data was provided by the engine, and the profiler doesn't mutate it.

--- a/profiling/src/io.rs
+++ b/profiling/src/io.rs
@@ -250,32 +250,28 @@ unsafe extern "C" fn observed_poll(fds: *mut libc::pollfd, nfds: u64, timeout: c
         if (*fds).revents & 1 == 1 {
             // requested events contains reading
             if SOCKET_READ_TIME_PROFILING_STATS
-                .try_with_borrow_mut(|io| io.should_collect(duration_nanos))
-                .unwrap_or(false)
+                .borrow_mut_or_false(|io| io.should_collect(duration_nanos))
             {
                 collect_socket_read_time(duration_nanos);
             }
         } else if (*fds).revents & 4 == 4 {
             // requested events contains writing
             if SOCKET_WRITE_TIME_PROFILING_STATS
-                .try_with_borrow_mut(|io| io.should_collect(duration_nanos))
-                .unwrap_or(false)
+                .borrow_mut_or_false(|io| io.should_collect(duration_nanos))
             {
                 collect_socket_write_time(duration_nanos);
             }
         } else if (*fds).events & 1 == 1 {
             // socket became readable
             if SOCKET_READ_TIME_PROFILING_STATS
-                .try_with_borrow_mut(|io| io.should_collect(duration_nanos))
-                .unwrap_or(false)
+                .borrow_mut_or_false(|io| io.should_collect(duration_nanos))
             {
                 collect_socket_read_time(duration_nanos);
             }
         } else if (*fds).events & 4 == 4 {
             // socket became writeable
             if SOCKET_WRITE_TIME_PROFILING_STATS
-                .try_with_borrow_mut(|io| io.should_collect(duration_nanos))
-                .unwrap_or(false)
+                .borrow_mut_or_false(|io| io.should_collect(duration_nanos))
             {
                 collect_socket_write_time(duration_nanos);
             }
@@ -298,18 +294,13 @@ unsafe extern "C" fn observed_recv(
     let duration = start.elapsed();
 
     let duration_nanos = duration.as_nanos() as u64;
-    if SOCKET_READ_TIME_PROFILING_STATS
-        .try_with_borrow_mut(|io| io.should_collect(duration_nanos))
-        .unwrap_or(false)
+    if SOCKET_READ_TIME_PROFILING_STATS.borrow_mut_or_false(|io| io.should_collect(duration_nanos))
     {
         collect_socket_read_time(duration_nanos);
     }
     if len > 0 {
         let len_u64 = len as u64;
-        if SOCKET_READ_SIZE_PROFILING_STATS
-            .try_with_borrow_mut(|io| io.should_collect(len_u64))
-            .unwrap_or(false)
-        {
+        if SOCKET_READ_SIZE_PROFILING_STATS.borrow_mut_or_false(|io| io.should_collect(len_u64)) {
             collect_socket_read_size(len_u64);
         }
     }
@@ -330,18 +321,13 @@ unsafe extern "C" fn observed_recvmsg(
     let duration = start.elapsed();
 
     let duration_nanos = duration.as_nanos() as u64;
-    if SOCKET_READ_TIME_PROFILING_STATS
-        .try_with_borrow_mut(|io| io.should_collect(duration_nanos))
-        .unwrap_or(false)
+    if SOCKET_READ_TIME_PROFILING_STATS.borrow_mut_or_false(|io| io.should_collect(duration_nanos))
     {
         collect_socket_read_time(duration_nanos);
     }
     if len > 0 {
         let len_u64 = len as u64;
-        if SOCKET_READ_SIZE_PROFILING_STATS
-            .try_with_borrow_mut(|io| io.should_collect(len_u64))
-            .unwrap_or(false)
-        {
+        if SOCKET_READ_SIZE_PROFILING_STATS.borrow_mut_or_false(|io| io.should_collect(len_u64)) {
             collect_socket_read_size(len_u64);
         }
     }
@@ -371,18 +357,13 @@ unsafe extern "C" fn observed_recvfrom(
     let duration = start.elapsed();
 
     let duration_nanos = duration.as_nanos() as u64;
-    if SOCKET_READ_TIME_PROFILING_STATS
-        .try_with_borrow_mut(|io| io.should_collect(duration_nanos))
-        .unwrap_or(false)
+    if SOCKET_READ_TIME_PROFILING_STATS.borrow_mut_or_false(|io| io.should_collect(duration_nanos))
     {
         collect_socket_read_time(duration_nanos);
     }
     if len > 0 {
         let len_u64 = len as u64;
-        if SOCKET_READ_SIZE_PROFILING_STATS
-            .try_with_borrow_mut(|io| io.should_collect(len_u64))
-            .unwrap_or(false)
-        {
+        if SOCKET_READ_SIZE_PROFILING_STATS.borrow_mut_or_false(|io| io.should_collect(len_u64)) {
             collect_socket_read_size(len_u64);
         }
     }
@@ -403,18 +384,13 @@ unsafe extern "C" fn observed_send(
     let duration = start.elapsed();
 
     let duration_nanos = duration.as_nanos() as u64;
-    if SOCKET_WRITE_TIME_PROFILING_STATS
-        .try_with_borrow_mut(|io| io.should_collect(duration_nanos))
-        .unwrap_or(false)
+    if SOCKET_WRITE_TIME_PROFILING_STATS.borrow_mut_or_false(|io| io.should_collect(duration_nanos))
     {
         collect_socket_write_time(duration_nanos);
     }
     if len > 0 {
         let len_u64 = len as u64;
-        if SOCKET_WRITE_SIZE_PROFILING_STATS
-            .try_with_borrow_mut(|io| io.should_collect(len_u64))
-            .unwrap_or(false)
-        {
+        if SOCKET_WRITE_SIZE_PROFILING_STATS.borrow_mut_or_false(|io| io.should_collect(len_u64)) {
             collect_socket_write_size(len_u64);
         }
     }
@@ -434,18 +410,13 @@ unsafe extern "C" fn observed_sendmsg(
     let duration = start.elapsed();
 
     let duration_nanos = duration.as_nanos() as u64;
-    if SOCKET_WRITE_TIME_PROFILING_STATS
-        .try_with_borrow_mut(|io| io.should_collect(duration_nanos))
-        .unwrap_or(false)
+    if SOCKET_WRITE_TIME_PROFILING_STATS.borrow_mut_or_false(|io| io.should_collect(duration_nanos))
     {
         collect_socket_write_time(duration_nanos);
     }
     if len > 0 {
         let len_u64 = len as u64;
-        if SOCKET_WRITE_SIZE_PROFILING_STATS
-            .try_with_borrow_mut(|io| io.should_collect(len_u64))
-            .unwrap_or(false)
-        {
+        if SOCKET_WRITE_SIZE_PROFILING_STATS.borrow_mut_or_false(|io| io.should_collect(len_u64)) {
             collect_socket_write_size(len_u64);
         }
     }
@@ -470,18 +441,12 @@ unsafe extern "C" fn observed_fwrite(
     let duration = start.elapsed();
 
     let duration_nanos = duration.as_nanos() as u64;
-    if FILE_WRITE_TIME_PROFILING_STATS
-        .try_with_borrow_mut(|io| io.should_collect(duration_nanos))
-        .unwrap_or(false)
-    {
+    if FILE_WRITE_TIME_PROFILING_STATS.borrow_mut_or_false(|io| io.should_collect(duration_nanos)) {
         collect_file_write_time(duration_nanos);
     }
     if len > 0 {
         let len_u64 = len as u64;
-        if FILE_WRITE_SIZE_PROFILING_STATS
-            .try_with_borrow_mut(|io| io.should_collect(len_u64))
-            .unwrap_or(false)
-        {
+        if FILE_WRITE_SIZE_PROFILING_STATS.borrow_mut_or_false(|io| io.should_collect(len_u64)) {
             collect_file_write_size(len_u64);
         }
     }
@@ -498,32 +463,27 @@ unsafe extern "C" fn observed_write(fd: c_int, buf: *const c_void, count: usize)
     let duration_nanos = duration.as_nanos() as u64;
     if fd_is_socket(fd) {
         if SOCKET_WRITE_TIME_PROFILING_STATS
-            .try_with_borrow_mut(|io| io.should_collect(duration_nanos))
-            .unwrap_or(false)
+            .borrow_mut_or_false(|io| io.should_collect(duration_nanos))
         {
             collect_socket_write_time(duration_nanos);
         }
         if len > 0 {
             let len_u64 = len as u64;
             if SOCKET_WRITE_SIZE_PROFILING_STATS
-                .try_with_borrow_mut(|io| io.should_collect(len_u64))
-                .unwrap_or(false)
+                .borrow_mut_or_false(|io| io.should_collect(len_u64))
             {
                 collect_socket_write_size(len_u64);
             }
         }
     } else {
         if FILE_WRITE_TIME_PROFILING_STATS
-            .try_with_borrow_mut(|io| io.should_collect(duration_nanos))
-            .unwrap_or(false)
+            .borrow_mut_or_false(|io| io.should_collect(duration_nanos))
         {
             collect_file_write_time(duration_nanos);
         }
         if len > 0 {
             let len_u64 = len as u64;
-            if FILE_WRITE_SIZE_PROFILING_STATS
-                .try_with_borrow_mut(|io| io.should_collect(len_u64))
-                .unwrap_or(false)
+            if FILE_WRITE_SIZE_PROFILING_STATS.borrow_mut_or_false(|io| io.should_collect(len_u64))
             {
                 collect_file_write_size(len_u64);
             }
@@ -549,18 +509,12 @@ unsafe extern "C" fn observed_fread(
     let duration = start.elapsed();
 
     let duration_nanos = duration.as_nanos() as u64;
-    if FILE_READ_TIME_PROFILING_STATS
-        .try_with_borrow_mut(|io| io.should_collect(duration_nanos))
-        .unwrap_or(false)
-    {
+    if FILE_READ_TIME_PROFILING_STATS.borrow_mut_or_false(|io| io.should_collect(duration_nanos)) {
         collect_file_read_time(duration_nanos);
     }
     if len > 0 {
         let len_u64 = len as u64;
-        if FILE_READ_SIZE_PROFILING_STATS
-            .try_with_borrow_mut(|io| io.should_collect(len_u64))
-            .unwrap_or(false)
-        {
+        if FILE_READ_SIZE_PROFILING_STATS.borrow_mut_or_false(|io| io.should_collect(len_u64)) {
             collect_file_read_size(len_u64);
         }
     }
@@ -577,33 +531,26 @@ unsafe extern "C" fn observed_read(fd: c_int, buf: *mut c_void, count: usize) ->
     let duration_nanos = duration.as_nanos() as u64;
     if fd_is_socket(fd) {
         if SOCKET_READ_TIME_PROFILING_STATS
-            .try_with_borrow_mut(|io| io.should_collect(duration_nanos))
-            .unwrap_or(false)
+            .borrow_mut_or_false(|io| io.should_collect(duration_nanos))
         {
             collect_socket_read_time(duration_nanos);
         }
         if len > 0 {
             let len_u64 = len as u64;
-            if SOCKET_READ_SIZE_PROFILING_STATS
-                .try_with_borrow_mut(|io| io.should_collect(len_u64))
-                .unwrap_or(false)
+            if SOCKET_READ_SIZE_PROFILING_STATS.borrow_mut_or_false(|io| io.should_collect(len_u64))
             {
                 collect_socket_read_size(len_u64);
             }
         }
     } else {
         if FILE_READ_TIME_PROFILING_STATS
-            .try_with_borrow_mut(|io| io.should_collect(duration_nanos))
-            .unwrap_or(false)
+            .borrow_mut_or_false(|io| io.should_collect(duration_nanos))
         {
             collect_file_read_time(duration_nanos);
         }
         if len > 0 {
             let len_u64 = len as u64;
-            if FILE_READ_SIZE_PROFILING_STATS
-                .try_with_borrow_mut(|io| io.should_collect(len_u64))
-                .unwrap_or(false)
-            {
+            if FILE_READ_SIZE_PROFILING_STATS.borrow_mut_or_false(|io| io.should_collect(len_u64)) {
                 collect_file_read_size(len_u64);
             }
         }
@@ -793,9 +740,8 @@ impl IOProfilingStats {
     }
 
     fn should_collect(&mut self, value: u64) -> bool {
-        let zend_thread = REQUEST_LOCALS
-            .try_with_borrow(|locals| !locals.vm_interrupt_addr.is_null())
-            .unwrap_or(false);
+        let zend_thread =
+            REQUEST_LOCALS.borrow_or_false(|locals| !locals.vm_interrupt_addr.is_null());
         if !zend_thread {
             // `curl_exec()` for example will spawn a new thread for name resolution. GOT hooking
             // follows threads and as such we might sample from another (non PHP) thread even in a
@@ -856,9 +802,8 @@ thread_local! {
 }
 
 pub fn io_prof_first_rinit() {
-    let io_profiling = REQUEST_LOCALS
-        .try_with_borrow(|locals| locals.system_settings().profiling_io_enabled)
-        .unwrap_or(false);
+    let io_profiling =
+        REQUEST_LOCALS.borrow_or_false(|locals| locals.system_settings().profiling_io_enabled);
 
     if io_profiling {
         unsafe {

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -450,6 +450,20 @@ trait RefCellExt<T> {
     fn try_with_borrow_mut<F, R>(&'static self, f: F) -> Result<R, RefCellExtError>
     where
         F: FnOnce(&mut T) -> R;
+
+    fn borrow_or_false<F>(&'static self, f: F) -> bool
+    where
+        F: FnOnce(&T) -> bool,
+    {
+        self.try_with_borrow(f).unwrap_or(false)
+    }
+
+    fn borrow_mut_or_false<F>(&'static self, f: F) -> bool
+    where
+        F: FnOnce(&mut T) -> bool,
+    {
+        self.try_with_borrow_mut(f).unwrap_or(false)
+    }
 }
 
 impl<T> RefCellExt<T> for LocalKey<RefCell<T>> {

--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -675,14 +675,14 @@ impl Profiler {
     /// Will initialize the `PROFILER` OnceCell and makes sure that only one thread will do so.
     pub fn init(system_settings: &mut SystemSettings) {
         // SAFETY: the `get_or_init` access is a thread-safe API, and the
-        // PROFILER is not being mutated outside single-threaded phases such
-        // as minit/mshutdown.
+        // PROFILER is only being mutated in single-threaded phases such as
+        //minit/mshutdown.
         unsafe { (*ptr::addr_of!(PROFILER)).get_or_init(|| Profiler::new(system_settings)) };
     }
 
     pub fn get() -> Option<&'static Profiler> {
         // SAFETY: the `get` access is a thread-safe API, and the PROFILER is
-        // not being mutated outside single-threaded phases such as minit and
+        // only being mutated in single-threaded phases such as minit and
         // mshutdown.
         unsafe { (*ptr::addr_of!(PROFILER)).get() }
     }

--- a/profiling/src/profiling/stack_walking.rs
+++ b/profiling/src/profiling/stack_walking.rs
@@ -297,21 +297,22 @@ mod detail {
                 #[cfg(php_frameless)]
                 if !func.is_internal() {
                     if let Some(opline) = safely_get_opline(execute_data) {
-                    match opline.opcode as u32 {
-                        ZEND_FRAMELESS_ICALL_0
-                        | ZEND_FRAMELESS_ICALL_1
-                        | ZEND_FRAMELESS_ICALL_2
-                        | ZEND_FRAMELESS_ICALL_3 => {
-                            let func = unsafe {
-                                &**zend_flf_functions.offset(opline.extended_value as isize)
-                            };
-                            samples.try_push(ZendFrame {
-                                function: extract_function_name(func).unwrap(),
-                                file: None,
-                                line: 0,
-                            })?;
+                        match opline.opcode as u32 {
+                            ZEND_FRAMELESS_ICALL_0
+                            | ZEND_FRAMELESS_ICALL_1
+                            | ZEND_FRAMELESS_ICALL_2
+                            | ZEND_FRAMELESS_ICALL_3 => {
+                                let func = unsafe {
+                                    &**zend_flf_functions.offset(opline.extended_value as isize)
+                                };
+                                samples.try_push(ZendFrame {
+                                    function: extract_function_name(func).unwrap(),
+                                    file: None,
+                                    line: 0,
+                                })?;
+                            }
+                            _ => {}
                         }
-                        _ => {}
                     }
                 }
 

--- a/profiling/src/profiling/stack_walking.rs
+++ b/profiling/src/profiling/stack_walking.rs
@@ -2,9 +2,8 @@ use crate::bindings::{
     zai_str_from_zstr, zend_execute_data, zend_function, zend_op, zend_op_array,
 };
 use crate::vec_ext::VecExt;
+use crate::RefCellExtError;
 use std::borrow::Cow;
-use std::collections::TryReserveError;
-use std::str::Utf8Error;
 
 #[cfg(php_frameless)]
 use crate::bindings::zend_flf_functions;
@@ -34,10 +33,14 @@ pub struct ZendFrame {
 
 #[derive(thiserror::Error, Debug)]
 pub enum CollectStackSampleError {
-    #[error("failed to collect stack sample: `0`")]
-    Utf8Error(#[from] Utf8Error),
-    #[error("failed to collect stack sample: `{0}`")]
-    TryReserveError(#[from] TryReserveError),
+    #[error("failed to borrow request locals: already destroyed")]
+    AccessError(#[from] std::thread::AccessError),
+    #[error("failed to borrow request locals: non-mutable borrow while mutably borrowed")]
+    BorrowError(#[from] std::cell::BorrowError),
+    #[error("failed to borrow request locals: mutable borrow while mutably borrowed")]
+    BorrowMutError(#[from] std::cell::BorrowMutError),
+    #[error(transparent)]
+    TryReserveError(#[from] std::collections::TryReserveError),
 }
 
 /// Extract the "function name" component for the frame. This is a string which
@@ -148,6 +151,7 @@ mod detail {
     use super::*;
     use crate::string_set::StringSet;
     use crate::thin_str::ThinStr;
+    use crate::RefCellExt;
     use log::{debug, trace};
     use std::cell::RefCell;
     use std::ptr::NonNull;
@@ -195,9 +199,9 @@ mod detail {
         }
     }
 
-    /// Used to help track the function run_time_cache hit rate. It glosses over
-    /// the fact that there are two cache slots used, and they don't have to be in
-    /// sync. However, they usually are, so we simplify.
+    /// Used to help track the function run_time_cache hit rate. It glosses
+    /// over the fact that there are two cache slots used, and they don't have
+    /// to be in sync. However, they usually are, so we simplify.
     #[derive(Debug, Default)]
     struct FunctionRunTimeCacheStats {
         hit: usize,
@@ -235,18 +239,14 @@ mod detail {
 
     #[inline]
     pub fn rshutdown() {
-        FUNCTION_CACHE_STATS.with_borrow(|stats| {
+        // If we cannot borrow the stats, then something has gone wrong, but
+        // it's not that important.
+        _ = FUNCTION_CACHE_STATS.try_with_borrow(|stats| {
             let hit_rate = stats.hit_rate();
             debug!("Process cumulative {stats:?} hit_rate: {hit_rate}");
         });
 
-        // PANIC: panics if the string arena is already borrowed. However, it
-        // should not be borrowed at this point, so we're likely going to fail.
-        // It's probably better to fail in rshutdown.
-        // Maybe in a new PHP version, we can have the engine check rshutdown
-        // failures, and stop serving requests from that process, and go into
-        // module shutdown instead.
-        CACHED_STRINGS.with_borrow_mut(|string_set| {
+        let result = CACHED_STRINGS.try_with_borrow_mut(|string_set| {
             // A slow ramp up to 2 MiB is probably _not_ going to look like a
             // memory leak. A higher threshold may make a user suspect a leak.
             const THRESHOLD: usize = 2 * 1024 * 1024;
@@ -262,73 +262,97 @@ mod detail {
                 trace!("string cache arena is using {used_bytes} bytes which is less than the {THRESHOLD} byte threshold");
             }
         });
+
+        if let Err(err) = result {
+            // Debug level because rshutdown could be quite spammy.
+            debug!("failed to borrow request locals in rshutdown: {err}");
+        }
+    }
+
+    /// Collects the stack trace, cached strings versions.
+    ///
+    /// # Errors
+    ///
+    ///  1. Returns [`CollectStackSampleError::TryReserveError`] if the vec
+    ///     holding the frames is unable to allocate memory.
+    ///  2.
+    #[inline]
+    fn collect_stack_sample_cached(
+        top_execute_data: *mut zend_execute_data,
+        string_set: &mut StringSet,
+    ) -> Result<Vec<ZendFrame>, CollectStackSampleError> {
+        let max_depth = 512;
+        let mut samples = Vec::new();
+        let mut execute_data_ptr = top_execute_data;
+
+        samples.try_reserve(max_depth >> 3)?;
+
+        while let Some(execute_data) = unsafe { execute_data_ptr.as_ref() } {
+            // allowed because it's only used on the frameless path
+            #[allow(unused_variables)]
+            if let Some(func) = unsafe { execute_data.func.as_ref() } {
+                // It's possible that this is a fake frame put there by the
+                // engine, see accel_preload on PHP 8.4 and the local variable
+                // `fake_execute_data`. The frame is zeroed in this case, so
+                // we can check for null.
+                #[cfg(php_frameless)]
+                if !func.is_internal() {
+                    if let Some(opline) = safely_get_opline(execute_data) {
+                    match opline.opcode as u32 {
+                        ZEND_FRAMELESS_ICALL_0
+                        | ZEND_FRAMELESS_ICALL_1
+                        | ZEND_FRAMELESS_ICALL_2
+                        | ZEND_FRAMELESS_ICALL_3 => {
+                            let func = unsafe {
+                                &**zend_flf_functions.offset(opline.extended_value as isize)
+                            };
+                            samples.try_push(ZendFrame {
+                                function: extract_function_name(func).unwrap(),
+                                file: None,
+                                line: 0,
+                            })?;
+                        }
+                        _ => {}
+                    }
+                }
+
+                let maybe_frame = unsafe { collect_call_frame(execute_data, string_set) };
+                if let Some(frame) = maybe_frame {
+                    samples.try_push(frame)?;
+
+                    // -1 to reserve room for the [truncated] message. In case
+                    // the backend and/or frontend have the same limit, without
+                    // subtracting one, then the [truncated] message itself
+                    // would be truncated!
+                    if samples.len() == max_depth - 1 {
+                        samples.try_push(ZendFrame {
+                            function: COW_TRUNCATED,
+                            file: None,
+                            line: 0,
+                        })?;
+                        break;
+                    }
+                }
+            }
+
+            execute_data_ptr = execute_data.prev_execute_data;
+        }
+        Ok(samples)
     }
 
     #[inline(never)]
     pub fn collect_stack_sample(
-        top_execute_data: *mut zend_execute_data,
+        execute_data: *mut zend_execute_data,
     ) -> Result<Vec<ZendFrame>, CollectStackSampleError> {
         #[cfg(feature = "tracing")]
         let _span = tracing::trace_span!("collect_stack_sample").entered();
-
-        CACHED_STRINGS.with_borrow_mut(|string_set| {
-            let max_depth = 512;
-            let mut samples = Vec::with_capacity(max_depth >> 3);
-            let mut execute_data_ptr = top_execute_data;
-
-            while let Some(execute_data) = unsafe { execute_data_ptr.as_ref() } {
-                // allowed because it's only used on the frameless path
-                #[allow(unused_variables)]
-                if let Some(func) = unsafe { execute_data.func.as_ref() } {
-                    // It's possible that this is a fake frame put there by
-                    // the engine, see accel_preload on PHP 8.4 and the local
-                    // variable `fake_execute_data`. The frame is zeroed in
-                    // this case, so we can check for null.
-                    #[cfg(php_frameless)]
-                    if !func.is_internal() {
-                        if let Some(opline) = safely_get_opline(execute_data) {
-                            match opline.opcode as u32 {
-                                ZEND_FRAMELESS_ICALL_0
-                                | ZEND_FRAMELESS_ICALL_1
-                                | ZEND_FRAMELESS_ICALL_2
-                                | ZEND_FRAMELESS_ICALL_3 => {
-                                    let func = unsafe {
-                                        &**zend_flf_functions.offset(opline.extended_value as isize)
-                                    };
-                                    samples.try_push(ZendFrame {
-                                        function: extract_function_name(func).unwrap(),
-                                        file: None,
-                                        line: 0,
-                                    })?;
-                                }
-                                _ => {}
-                            }
-                        }
-                    }
-
-                    let maybe_frame = unsafe { collect_call_frame(execute_data, string_set) };
-                    if let Some(frame) = maybe_frame {
-                        samples.try_push(frame)?;
-
-                        /* -1 to reserve room for the [truncated] message. In case the
-                         * backend and/or frontend have the same limit, without the -1
-                         * then ironically the [truncated] message would be truncated.
-                         */
-                        if samples.len() == max_depth - 1 {
-                            samples.try_push(ZendFrame {
-                                function: COW_TRUNCATED,
-                                file: None,
-                                line: 0,
-                            })?;
-                            break;
-                        }
-                    }
-                }
-
-                execute_data_ptr = execute_data.prev_execute_data;
-            }
-            Ok(samples)
-        })
+        CACHED_STRINGS
+            .try_with_borrow_mut(|set| collect_stack_sample_cached(execute_data, set))
+            .unwrap_or_else(|err| match err {
+                RefCellExtError::AccessError(e) => Err(e.into()),
+                RefCellExtError::BorrowError(e) => Err(e.into()),
+                RefCellExtError::BorrowMutError(e) => Err(e.into()),
+            })
     }
 
     unsafe fn collect_call_frame(
@@ -351,7 +375,9 @@ mod detail {
                 let (file, line) = handle_file_cache_slot(execute_data, &mut string_cache);
 
                 let cache_slots = string_cache.cache_slots;
-                FUNCTION_CACHE_STATS.with_borrow_mut(|stats| {
+                // If we cannot borrow the stats, then something has gone
+                // wrong, but it's not that important.
+                _ = FUNCTION_CACHE_STATS.try_with_borrow_mut(|stats| {
                     if cache_slots[0] == 0 {
                         stats.missed += 1;
                     } else {
@@ -363,7 +389,9 @@ mod detail {
             }
 
             None => {
-                FUNCTION_CACHE_STATS.with_borrow_mut(|stats| stats.not_applicable += 1);
+                // If we cannot borrow the stats, then something has gone
+                // wrong, but it's not that important.
+                _ = FUNCTION_CACHE_STATS.try_with_borrow_mut(|stats| stats.not_applicable += 1);
                 let function = extract_function_name(func);
                 let (file, line) = extract_file_and_line(execute_data);
                 (function, file, line)

--- a/profiling/src/profiling/stack_walking.rs
+++ b/profiling/src/profiling/stack_walking.rs
@@ -271,10 +271,8 @@ mod detail {
     /// Collects the stack trace, cached strings versions.
     ///
     /// # Errors
-    ///
-    ///  1. Returns [`CollectStackSampleError::TryReserveError`] if the vec
-    ///     holding the frames is unable to allocate memory.
-    ///  2.
+    /// Returns [`CollectStackSampleError::TryReserveError`] if the vec holding the frames is
+    /// unable to allocate memory.
     #[inline]
     fn collect_stack_sample_cached(
         top_execute_data: *mut zend_execute_data,

--- a/profiling/src/profiling/stack_walking.rs
+++ b/profiling/src/profiling/stack_walking.rs
@@ -2,7 +2,6 @@ use crate::bindings::{
     zai_str_from_zstr, zend_execute_data, zend_function, zend_op, zend_op_array,
 };
 use crate::vec_ext::VecExt;
-use crate::RefCellExtError;
 use std::borrow::Cow;
 
 #[cfg(php_frameless)]
@@ -151,7 +150,7 @@ mod detail {
     use super::*;
     use crate::string_set::StringSet;
     use crate::thin_str::ThinStr;
-    use crate::RefCellExt;
+    use crate::{RefCellExt, RefCellExtError};
     use log::{debug, trace};
     use std::cell::RefCell;
     use std::ptr::NonNull;

--- a/profiling/src/timeline.rs
+++ b/profiling/src/timeline.rs
@@ -4,7 +4,7 @@ use crate::zend::{
     self, zai_str_from_zstr, zend_execute_data, zend_get_executed_filename_ex, zval,
     InternalFunctionHandler,
 };
-use crate::{REQUEST_LOCALS, SAPI};
+use crate::{RefCellExt, REQUEST_LOCALS, SAPI};
 use ddcommon::cstr;
 use libc::c_char;
 use log::{error, trace};
@@ -78,11 +78,9 @@ fn is_in_frankenphp_handle_request(execute_data: *mut zend_execute_data) -> bool
 }
 
 extern "C" fn frankenphp_sapi_module_activate() -> i32 {
-    let timeline_enabled = REQUEST_LOCALS.with(|cell| {
-        cell.try_borrow()
-            .map(|locals| locals.system_settings().profiling_timeline_enabled)
-            .unwrap_or(false)
-    });
+    let timeline_enabled = REQUEST_LOCALS
+        .try_with_borrow(|locals| locals.system_settings().profiling_timeline_enabled)
+        .unwrap_or(false);
 
     if timeline_enabled
         && is_in_frankenphp_handle_request(unsafe {
@@ -102,11 +100,9 @@ extern "C" fn frankenphp_sapi_module_activate() -> i32 {
 }
 
 extern "C" fn frankenphp_sapi_module_deactivate() -> i32 {
-    let timeline_enabled = REQUEST_LOCALS.with(|cell| {
-        cell.try_borrow()
-            .map(|locals| locals.system_settings().profiling_timeline_enabled)
-            .unwrap_or(false)
-    });
+    let timeline_enabled = REQUEST_LOCALS
+        .try_with_borrow(|locals| locals.system_settings().profiling_timeline_enabled)
+        .unwrap_or(false);
 
     if timeline_enabled
         && is_in_frankenphp_handle_request(unsafe {
@@ -131,11 +127,9 @@ fn sleeping_fn(
     return_value: *mut zval,
     state: State,
 ) {
-    let timeline_enabled = REQUEST_LOCALS.with(|cell| {
-        cell.try_borrow()
-            .map(|locals| locals.system_settings().profiling_timeline_enabled)
-            .unwrap_or(false)
-    });
+    let timeline_enabled = REQUEST_LOCALS
+        .try_with_borrow(|locals| locals.system_settings().profiling_timeline_enabled)
+        .unwrap_or(false);
 
     if !timeline_enabled {
         unsafe { func(execute_data, return_value) };
@@ -251,11 +245,9 @@ unsafe extern "C" fn ddog_php_prof_zend_error_observer(
         return;
     }
 
-    let timeline_enabled = REQUEST_LOCALS.with(|cell| {
-        cell.try_borrow()
-            .map(|locals| locals.system_settings().profiling_timeline_enabled)
-            .unwrap_or(false)
-    });
+    let timeline_enabled = REQUEST_LOCALS
+        .try_with_borrow(|locals| locals.system_settings().profiling_timeline_enabled)
+        .unwrap_or(false);
 
     if !timeline_enabled {
         return;
@@ -288,11 +280,9 @@ unsafe extern "C" fn ddog_php_prof_zend_error_observer(
 #[no_mangle]
 #[cfg(php_opcache_restart_hook)]
 unsafe extern "C" fn ddog_php_prof_zend_accel_schedule_restart_hook(reason: i32) {
-    let timeline_enabled = REQUEST_LOCALS.with(|cell| {
-        cell.try_borrow()
-            .map(|locals| locals.system_settings().profiling_timeline_enabled)
-            .unwrap_or(false)
-    });
+    let timeline_enabled = REQUEST_LOCALS
+        .try_with_borrow(|locals| locals.system_settings().profiling_timeline_enabled)
+        .unwrap_or(false);
 
     if timeline_enabled {
         let now = SystemTime::now().duration_since(UNIX_EPOCH).unwrap();
@@ -458,38 +448,33 @@ fn timeline_idle_stop() {
             return;
         };
 
-        REQUEST_LOCALS.with(|cell| {
-            let is_timeline_enabled = cell
-                .try_borrow()
-                .map(|locals| locals.system_settings().profiling_timeline_enabled)
-                .unwrap_or(false);
-            if !is_timeline_enabled {
-                return;
-            }
+        let is_timeline_enabled = REQUEST_LOCALS
+            .try_with_borrow(|locals| locals.system_settings().profiling_timeline_enabled)
+            .unwrap_or(false);
 
-            if let Some(profiler) = Profiler::get() {
-                profiler.collect_idle(
-                    // Safety: checked for `is_err()` above
-                    SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap()
-                        .as_nanos() as i64,
-                    idle_since.elapsed().as_nanos() as i64,
-                    State::Idle.as_str(),
-                );
-            }
-        });
+        if !is_timeline_enabled {
+            return;
+        }
+
+        if let Some(profiler) = Profiler::get() {
+            profiler.collect_idle(
+                // Safety: checked for `is_err()` above
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos() as i64,
+                idle_since.elapsed().as_nanos() as i64,
+                State::Idle.as_str(),
+            );
+        }
     });
 }
 
 fn timeline_idle_start() {
-    IDLE_SINCE.with(|cell| {
-        // try to borrow and bail out if not successful
-        let Ok(mut idle_since) = cell.try_borrow_mut() else {
-            return;
-        };
+    // If we can't borrow, not much we can do.
+    _ = IDLE_SINCE.try_with_borrow_mut(|idle_since| {
         *idle_since = Instant::now();
-    })
+    });
 }
 
 /// This function is run during the RINIT phase and reports any `IDLE_SINCE` duration as an idle
@@ -497,11 +482,9 @@ fn timeline_idle_start() {
 /// # SAFETY
 /// Must be called only in rinit and after [crate::config::first_rinit].
 pub unsafe fn timeline_rinit() {
-    let timeline_enabled = REQUEST_LOCALS.with(|cell| {
-        cell.try_borrow()
-            .map(|locals| locals.system_settings().profiling_timeline_enabled)
-            .unwrap_or(false)
-    });
+    let timeline_enabled = REQUEST_LOCALS
+        .try_with_borrow(|locals| locals.system_settings().profiling_timeline_enabled)
+        .unwrap_or(false);
 
     if !timeline_enabled {
         return;
@@ -515,38 +498,32 @@ pub unsafe fn timeline_rinit() {
             return;
         }
         cell.set(false);
-        REQUEST_LOCALS.with(|cell| {
-            let is_timeline_enabled = cell
-                .try_borrow()
-                .map(|locals| locals.system_settings().profiling_timeline_enabled)
-                .unwrap_or(false);
+        let is_timeline_enabled = REQUEST_LOCALS
+            .try_with_borrow(|locals| locals.system_settings().profiling_timeline_enabled)
+            .unwrap_or(false);
+        if !is_timeline_enabled {
+            return;
+        }
 
-            if !is_timeline_enabled {
-                return;
-            }
-
-            if let Some(profiler) = Profiler::get() {
-                profiler.collect_thread_start_end(
-                    // Safety: checked for `is_err()` above
-                    SystemTime::now()
-                        .duration_since(UNIX_EPOCH)
-                        .unwrap()
-                        .as_nanos() as i64,
-                    State::ThreadStart.as_str(),
-                );
-            }
-        });
+        if let Some(profiler) = Profiler::get() {
+            profiler.collect_thread_start_end(
+                // Safety: checked for `is_err()` above
+                SystemTime::now()
+                    .duration_since(UNIX_EPOCH)
+                    .unwrap()
+                    .as_nanos() as i64,
+                State::ThreadStart.as_str(),
+            );
+        }
     });
 }
 
 /// This function is run during the P-RSHUTDOWN phase and resets the `IDLE_SINCE` thread local to
 /// "now", indicating the start of a new idle phase
 pub fn timeline_prshutdown() {
-    let timeline_enabled = REQUEST_LOCALS.with(|cell| {
-        cell.try_borrow()
-            .map(|locals| locals.system_settings().profiling_timeline_enabled)
-            .unwrap_or(false)
-    });
+    let timeline_enabled = REQUEST_LOCALS
+        .try_with_borrow(|locals| locals.system_settings().profiling_timeline_enabled)
+        .unwrap_or(false);
 
     if !timeline_enabled {
         return;
@@ -588,27 +565,26 @@ pub(crate) fn timeline_ginit() {
 
 #[cfg(php_zts)]
 pub(crate) fn timeline_gshutdown() {
-    REQUEST_LOCALS.with(|cell| {
-        let is_timeline_enabled = cell
-            .try_borrow()
-            .map(|locals| locals.system_settings().profiling_timeline_enabled)
-            .unwrap_or(false);
+    let timeline_enabled = REQUEST_LOCALS
+        .try_with_borrow_mut(|locals| locals.system_settings().profiling_timeline_enabled)
+        .unwrap_or(false);
 
-        if !is_timeline_enabled {
-            return;
-        }
+    if !timeline_enabled {
+        return;
+    }
 
-        if let Some(profiler) = Profiler::get() {
-            profiler.collect_thread_start_end(
-                // Safety: checked for `is_err()` above
-                SystemTime::now()
-                    .duration_since(UNIX_EPOCH)
-                    .unwrap()
-                    .as_nanos() as i64,
-                State::ThreadStop.as_str(),
-            );
-        }
-    });
+    if let Some(profiler) = Profiler::get() {
+        let now = SystemTime::now()
+            .duration_since(UNIX_EPOCH)
+            .unwrap_or_default()
+            .as_nanos()
+            .min(i64::MAX as u128) as i64;
+        profiler.collect_thread_start_end(
+            // Safety: checked for `is_err()` above
+            now,
+            State::ThreadStop.as_str(),
+        );
+    }
 }
 
 /// This function gets called when a `eval()` is being called. This is done by letting the
@@ -623,11 +599,9 @@ unsafe extern "C" fn ddog_php_prof_compile_string(
     #[cfg(php_zend_compile_string_has_position)] position: zend::zend_compile_position,
 ) -> *mut zend::_zend_op_array {
     if let Some(prev) = PREV_ZEND_COMPILE_STRING {
-        let timeline_enabled = REQUEST_LOCALS.with(|cell| {
-            cell.try_borrow()
-                .map(|locals| locals.system_settings().profiling_timeline_enabled)
-                .unwrap_or(false)
-        });
+        let timeline_enabled = REQUEST_LOCALS
+            .try_with_borrow(|locals| locals.system_settings().profiling_timeline_enabled)
+            .unwrap_or(false);
 
         if !timeline_enabled {
             #[cfg(php_zend_compile_string_has_position)]
@@ -684,11 +658,9 @@ unsafe extern "C" fn ddog_php_prof_compile_file(
     r#type: i32,
 ) -> *mut zend::_zend_op_array {
     if let Some(prev) = PREV_ZEND_COMPILE_FILE {
-        let timeline_enabled = REQUEST_LOCALS.with(|cell| {
-            cell.try_borrow()
-                .map(|locals| locals.system_settings().profiling_timeline_enabled)
-                .unwrap_or(false)
-        });
+        let timeline_enabled = REQUEST_LOCALS
+            .try_with_borrow(|locals| locals.system_settings().profiling_timeline_enabled)
+            .unwrap_or(false);
 
         if !timeline_enabled {
             return prev(handle, r#type);
@@ -762,11 +734,9 @@ unsafe fn gc_reason() -> &'static str {
 #[no_mangle]
 unsafe extern "C" fn ddog_php_prof_gc_collect_cycles() -> i32 {
     if let Some(prev) = PREV_GC_COLLECT_CYCLES {
-        let timeline_enabled = REQUEST_LOCALS.with(|cell| {
-            cell.try_borrow()
-                .map(|locals| locals.system_settings().profiling_timeline_enabled)
-                .unwrap_or(false)
-        });
+        let timeline_enabled = REQUEST_LOCALS
+            .try_with_borrow(|locals| locals.system_settings().profiling_timeline_enabled)
+            .unwrap_or(false);
 
         if !timeline_enabled {
             return prev();


### PR DESCRIPTION
### Description

We found a `panic_already_borrowed` in our RelEnv with I/O profiling. The following is happening:
- the profiler takes a sample
- during this, a signal arrives (PHP timed out)
- the timeout handler want’s to write it’s usual “Fatal error: Maximum execution time ..” error
- this calls into the I/O profiling write hook which decides to take a sample :boom:

So far we've assumed that we do not sample while we sample, turns out the signal handler for timeout can bypass our assumptions and we may actually sample while we sample 😬

There is no reason to hold onto the mutable borrow for those `RefCell`'s while we collect the stack trace, so this PR aims to only hold onto the mutable borrow for those `RefCell`'s while we change the stats data and make the sampling decision. After that we release the borrow before calling into stack trace collection.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
