### PR TITLE
Increase PDOBench & TraceFlushBench stability

### DIFF
--- a/tests/Benchmarks/API/TraceFlushBench.php
+++ b/tests/Benchmarks/API/TraceFlushBench.php
@@ -10,7 +10,7 @@ class TraceFlushBench
 {
     /**
      * @Revs(1)
-     * @Iterations(10)
+     * @Iterations(20)
      * @OutputTimeUnit("microseconds")
      * @RetryThreshold(10.0)
      * @BeforeMethods("setUp")
@@ -24,7 +24,8 @@ class TraceFlushBench
     {
         \dd_trace_serialize_closed_spans();
         Utils::putEnvAndReloadConfig([
-            'DD_TRACE_GENERATE_ROOT_SPAN=0'
+            'DD_TRACE_GENERATE_ROOT_SPAN=0',
+            'DD_TRACE_AUTO_FLUSH_ENABLED=0'
         ]);
 
         for ($i = 0; $i < 100; $i++) {

--- a/tests/Benchmarks/Integrations/PDOBench.php
+++ b/tests/Benchmarks/Integrations/PDOBench.php
@@ -7,8 +7,8 @@ namespace Benchmarks\Integrations;
 use DDTrace\Tests\Common\Utils;
 
 /**
- * @BeforeClassMethods({"setUp"})
- * @AfterClassMethods({"tearDown"})
+ * @BeforeClassMethods({"setUpDatabase"})
+ * @AfterClassMethods({"tearDownDatabase"})
  */
 class PDOBench
 {
@@ -17,15 +17,16 @@ class PDOBench
     const MYSQL_PASSWORD = 'test';
     const MYSQL_HOST = 'mysql-integration';
 
-    public $pdo;
+    public static $sharedPdo;
+    public static $sharedStmt;
 
     /**
-     * @BeforeMethods({"disablePDOIntegration"})
-     * @Revs(100)
-     * @Iterations(15)
+     * @BeforeMethods({"initSharedPdoAndStmt","disablePDOIntegration"})
+     * @Revs(1000)
+     * @Iterations(20)
      * @OutputTimeUnit("microseconds")
-     * @RetryThreshold(10.0)
-     * @Warmup(1)
+     * @RetryThreshold(5.0)
+     * @Warmup(2)
      */
     public function benchPDOBaseline()
     {
@@ -33,12 +34,12 @@ class PDOBench
     }
 
     /**
-     * @BeforeMethods({"enablePDOIntegration"})
-     * @Revs(100)
-     * @Iterations(15)
+     * @BeforeMethods({"initSharedPdoAndStmt", "enablePDOIntegration"})
+     * @Revs(1000)
+     * @Iterations(20)
      * @OutputTimeUnit("microseconds")
-     * @RetryThreshold(10.0)
-     * @Warmup(1)
+     * @RetryThreshold(5.0)
+     * @Warmup(2)
      */
     public function benchPDOOverhead()
     {
@@ -46,34 +47,77 @@ class PDOBench
     }
 
     /**
-     * @BeforeMethods({"enablePDOIntegrationWithDBM"})
-     * @Revs(100)
-     * @Iterations(15)
+     * @BeforeMethods({"initSharedPdoAndStmt", "enablePDOIntegrationWithDBM"})
+     * @Revs(1000)
+     * @Iterations(20)
      * @OutputTimeUnit("microseconds")
-     * @RetryThreshold(10.0)
-     * @Warmup(1)
+     * @RetryThreshold(5.0)
+     * @Warmup(2)
      */
     public function benchPDOOverheadWithDBM()
     {
         $this->PDOScenario();
     }
 
-    public static function setUp()
+    public static function setUpDatabase()
     {
-        self::setUpDatabase();
+        try {
+            $pdo = self::pdoInstance();
+            // Drop table if it exists (cleanup from previous failed runs)
+            $pdo->exec("DROP TABLE IF EXISTS tests");
+
+            // Create table
+            $pdo->exec("
+                CREATE TABLE tests (
+                    id integer not null primary key AUTO_INCREMENT,
+                    name varchar(100)
+                ) ENGINE=MEMORY
+            ");
+
+            // Insert test data
+            $pdo->exec("INSERT INTO tests (id, name) VALUES (1, 'Tom')");
+        } catch (\Exception $e) {
+            throw new \RuntimeException("Database setup failed: " . $e->getMessage(), 0, $e);
+        }
     }
 
-    public static function tearDown()
+    public static function tearDownDatabase()
     {
-        self::clearDatabase();
+        try {
+            $pdo = self::pdoInstance();
+            $pdo->exec("DROP TABLE IF EXISTS tests");
+        } catch (\Exception $e) {
+            // Ignore cleanup errors
+        }
+    }
+
+    public function initSharedPdoAndStmt()
+    {
+        if (!self::$sharedPdo) {
+            self::$sharedPdo = self::pdoInstance();
+            if (!self::$sharedPdo) {
+                throw new \RuntimeException("Failed to create PDO instance");
+            }
+        }
+
+        if (!self::$sharedStmt) {
+            self::$sharedStmt = self::$sharedPdo->prepare("SELECT * FROM tests WHERE id = ?");
+            if (!self::$sharedStmt) {
+                throw new \RuntimeException("Failed to prepare statement");
+            }
+
+            // Warm up the statement with a few executions
+            for ($i = 0; $i < 10; $i++) {
+                self::$sharedStmt->execute([1]);
+                self::$sharedStmt->fetch();
+            }
+        }
     }
 
     public function PDOScenario()
     {
-        $this->pdo->beginTransaction();
-        $stmt = $this->pdo->prepare("SELECT * FROM tests WHERE id = ?");
-        $stmt->execute([1]);
-        $this->pdo->commit();
+        self::$sharedStmt->execute([1]);
+        self::$sharedStmt->fetch();
     }
 
     public function disablePDOIntegration()
@@ -82,7 +126,6 @@ class PDOBench
         Utils::putEnvAndReloadConfig([
             'DD_TRACE_ENABLED=0'
         ]);
-        $this->pdo = $this->pdoInstance();
     }
 
     public function enablePDOIntegration()
@@ -91,7 +134,6 @@ class PDOBench
         Utils::putEnvAndReloadConfig([
             'DD_TRACE_ENABLED=1'
         ]);
-        $this->pdo = $this->pdoInstance();
     }
 
     public function enablePDOIntegrationWithDBM()
@@ -101,9 +143,7 @@ class PDOBench
             'DD_TRACE_ENABLED=1',
             'DD_DBM_PROPAGATION_MODE=full'
         ]);
-        $this->pdo = $this->pdoInstance();
     }
-
 
     private static function mysqlDns(): string
     {
@@ -112,44 +152,18 @@ class PDOBench
 
     private static function pdoInstance($opts = null): \PDO
     {
-        // The default error mode is PDO::ERRMODE_SILENT on PHP < 8
-        if (!isset($opts[\PDO::ATTR_ERRMODE])) {
-            $opts[\PDO::ATTR_ERRMODE] = \PDO::ERRMODE_SILENT;
+        $defaultOpts = [
+            \PDO::ATTR_DEFAULT_FETCH_MODE => \PDO::FETCH_ASSOC, // Fetch associative array
+            \PDO::ATTR_EMULATE_PREPARES => false, // Use real prepared statements
+            \PDO::MYSQL_ATTR_USE_BUFFERED_QUERY => true, // Consistent buffering
+        ];
+
+        if ($opts) {
+            $opts = array_merge($defaultOpts, $opts);
+        } else {
+            $opts = $defaultOpts;
         }
+
         return new \PDO(self::mysqlDns(), self::MYSQL_USER, self::MYSQL_PASSWORD, $opts);
-    }
-
-    private static function setUpDatabase()
-    {
-        $pdo = self::pdoInstance();
-        $pdo->beginTransaction();
-        $pdo->exec("
-                CREATE TABLE tests (
-                    id integer not null primary key AUTO_INCREMENT,
-                    name varchar(100)
-                )
-            ");
-        if (PHP_VERSION_ID >= 80000 && !$pdo->inTransaction()) {
-            // CREATE TABLE causes an implicit commit on PHP 8
-            // @see https://dev.mysql.com/doc/refman/8.0/en/implicit-commit.html
-            $pdo->beginTransaction();
-        }
-        $pdo->exec("INSERT INTO tests (id, name) VALUES (1, 'Tom')");
-
-        $pdo->commit();
-        $pdo = null;
-    }
-
-    private static function clearDatabase()
-    {
-        $pdo = self::pdoInstance();
-        $pdo->beginTransaction();
-        $pdo->exec("DROP TABLE tests");
-        if (PHP_VERSION_ID < 80000) {
-            // DROP TABLE causes an implicit commit on PHP 8
-            // @see https://dev.mysql.com/doc/refman/8.0/en/implicit-commit.html
-            $pdo->commit();
-        }
-        $pdo = null;
     }
 }


### PR DESCRIPTION
### Description

- Increased iterations from 10 to 20 in TraceFlushBench.
- Added 'DD_TRACE_AUTO_FLUSH_ENABLED=0' to environment variables in TraceFlushBench.
- Refactored PDOBench to use shared PDO and statement instances
- Updated benchmark iterations and revisions in PDOBench from 15 to 20 and from 100 to 1000 respectively.
- 
<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
