### PR TITLE
Fix language, extension_ci tests and laravel octane tests

### DIFF
--- a/.gitlab/generate-tests.php
+++ b/.gitlab/generate-tests.php
@@ -452,6 +452,7 @@ foreach ($all_minor_major_targets as $major_minor):
     REPORT_EXIT_STATUS: "1"
     TEST_PHP_JUNIT: "/tmp/artifacts/tests/php-tests.xml"
     SKIP_ONLINE_TEST: "1"
+    _DD_SIDECAR_WATCHDOG_MAX_MEMORY: "2000000000"
 <?php sidecar_logs(); ?>
   timeout: 40m
   script:

--- a/.gitlab/generate-tests.php
+++ b/.gitlab/generate-tests.php
@@ -547,6 +547,10 @@ foreach ($jobs as $type => $type_jobs):
 <?php if (preg_match("(test_web_symfony_(2|30|33|40))", $target)): ?>
     COMPOSER_VERSION: 2.2
 <?php endif; ?>
+<?php if (preg_match("(test_web_laravel_octane)", $target)): ?>
+    KUBERNETES_MEMORY_REQUEST: 6Gi
+    KUBERNETES_MEMORY_LIMIT: 6Gi
+<?php endif; ?>
 
 <?php
             endforeach;

--- a/.gitlab/generate-tests.php
+++ b/.gitlab/generate-tests.php
@@ -452,7 +452,9 @@ foreach ($all_minor_major_targets as $major_minor):
     REPORT_EXIT_STATUS: "1"
     TEST_PHP_JUNIT: "/tmp/artifacts/tests/php-tests.xml"
     SKIP_ONLINE_TEST: "1"
-    _DD_SIDECAR_WATCHDOG_MAX_MEMORY: "4000000000"
+<?php if (version_compare($major_minor, "7.2", ">=")): /* too expensive */ ?>
+    DD_INSTRUMENTATION_TELEMETRY_ENABLED: 0
+<?php endif; ?>
 <?php sidecar_logs(); ?>
   timeout: 40m
   script:

--- a/.gitlab/generate-tests.php
+++ b/.gitlab/generate-tests.php
@@ -452,7 +452,7 @@ foreach ($all_minor_major_targets as $major_minor):
     REPORT_EXIT_STATUS: "1"
     TEST_PHP_JUNIT: "/tmp/artifacts/tests/php-tests.xml"
     SKIP_ONLINE_TEST: "1"
-    _DD_SIDECAR_WATCHDOG_MAX_MEMORY: "2000000000"
+    _DD_SIDECAR_WATCHDOG_MAX_MEMORY: "4000000000"
 <?php sidecar_logs(); ?>
   timeout: 40m
   script:

--- a/.gitlab/run_php_language_tests.sh
+++ b/.gitlab/run_php_language_tests.sh
@@ -9,7 +9,7 @@ if [[ ! "${XFAIL_LIST:-none}" == "none" ]]; then
   cp "${XFAIL_LIST}" /usr/local/src/php/xfail_tests.list
   (
     cd /usr/local/src/php
-    cat xfail_tests.list | xargs -n 1 -I{} find {} -name "*.phpt" -delete || true
+    (cat xfail_tests.list; grep -lrFx zend_test.observer.enabled=0 .) | xargs -n 1 -I{} find {} -name "*.phpt" -delete || true
   )
 fi
 

--- a/dockerfiles/ci/xfail_tests/7.4.list
+++ b/dockerfiles/ci/xfail_tests/7.4.list
@@ -270,6 +270,7 @@ ext/simplexml/tests/simplexml_load_file.phpt
 ext/soap/tests/bug71610.phpt
 ext/sockets/tests/socket_create_pair.phpt
 ext/sockets/tests/socket_create_listen-nobind.phpt
+ext/sockets/tests/socket_import_stream-4.phpt
 ext/sodium/tests/utils.phpt
 ext/spl/tests/ArrayObject_clone_other_std_props.phpt
 ext/spl/tests/ArrayObject_dump_during_sort.phpt

--- a/dockerfiles/ci/xfail_tests/7.4.list
+++ b/dockerfiles/ci/xfail_tests/7.4.list
@@ -371,6 +371,7 @@ ext/standard/tests/class_object/get_object_vars_variation_002.phpt
 ext/standard/tests/class_object/get_object_vars_variation_004.phpt
 ext/standard/tests/file/disk_free_space_basic.phpt
 ext/standard/tests/file/lstat_stat_variation10.phpt
+ext/standard/tests/file/lstat_stat_variation15.phpt
 ext/standard/tests/general_functions/bug73973.phpt
 ext/standard/tests/general_functions/get_included_files.phpt
 ext/standard/tests/general_functions/gettype_settype_basic.phpt

--- a/dockerfiles/ci/xfail_tests/8.0.list
+++ b/dockerfiles/ci/xfail_tests/8.0.list
@@ -323,6 +323,7 @@ ext/sockets/tests/socket_addrinfo_bind.phpt
 ext/sockets/tests/socket_addrinfo_connect.phpt
 ext/sockets/tests/socket_create_pair.phpt
 ext/sockets/tests/socket_create_listen-nobind.phpt
+ext/sockets/tests/socket_import_stream-4.phpt
 ext/sockets/tests/socket_set_nonblock.phpt
 ext/sodium/tests/utils.phpt
 ext/spl/tests/ArrayObject_clone_other_std_props.phpt

--- a/dockerfiles/ci/xfail_tests/8.0.list
+++ b/dockerfiles/ci/xfail_tests/8.0.list
@@ -432,6 +432,7 @@ ext/standard/tests/class_object/get_object_vars_variation_002.phpt
 ext/standard/tests/class_object/get_object_vars_variation_004.phpt
 ext/standard/tests/file/disk_free_space_basic.phpt
 ext/standard/tests/file/lstat_stat_variation10.phpt
+ext/standard/tests/file/lstat_stat_variation15.phpt
 ext/standard/tests/filters/bug54350.phpt
 ext/standard/tests/general_functions/bug73973.phpt
 ext/standard/tests/general_functions/floatval.phpt

--- a/dockerfiles/ci/xfail_tests/8.1.list
+++ b/dockerfiles/ci/xfail_tests/8.1.list
@@ -137,6 +137,7 @@ ext/sockets/tests/mcast_ipv6_recv.phpt
 ext/sockets/tests/mcast_ipv6_recv_limited.phpt
 ext/sockets/tests/mcast_ipv6_send.phpt
 ext/sockets/tests/socket_create_listen-nobind.phpt
+ext/sockets/tests/socket_import_stream-4.phpt
 ext/spl/tests/SplFixedArray_setSize_param_float.phpt
 ext/spl/tests/bug40091.phpt
 ext/spl/tests/bug44144.phpt

--- a/dockerfiles/ci/xfail_tests/8.1.list
+++ b/dockerfiles/ci/xfail_tests/8.1.list
@@ -191,6 +191,8 @@ ext/tokenizer/tests/PhpToken_getAll.phpt
 ext/zend_test/tests/
 ext/zip/tests/bug38943.phpt
 sapi/cli/tests/bug80092.phpt
+sapi/cli/tests/gh8827-001.phpt
+sapi/cli/tests/gh8827-003.phpt
 sapi/cli/tests/upload_2G.phpt
 sapi/fpm/tests/log-bm-in-shutdown-fn.phpt
 sapi/fpm/tests/log-bm-limit-1024-msg-80.phpt

--- a/dockerfiles/ci/xfail_tests/8.2.list
+++ b/dockerfiles/ci/xfail_tests/8.2.list
@@ -124,6 +124,7 @@ ext/soap/tests/bug77088.phpt
 ext/sockets/tests/mcast_ipv6_recv.phpt
 ext/sockets/tests/mcast_ipv6_send.phpt
 ext/sockets/tests/mcast_ipv6_recv_limited.phpt
+ext/sockets/tests/socket_import_stream-4.phpt
 ext/sockets/tests/socket_create_listen-nobind.phpt
 ext/spl/tests/bug40091.phpt
 ext/spl/tests/bug44144.phpt

--- a/dockerfiles/ci/xfail_tests/8.2.list
+++ b/dockerfiles/ci/xfail_tests/8.2.list
@@ -147,6 +147,7 @@ ext/standard/tests/file/bug52820.phpt
 ext/standard/tests/file/disk_free_space_basic.phpt
 ext/standard/tests/file/file_get_contents_file_put_contents_5gb.phpt
 ext/standard/tests/file/lstat_stat_variation10.phpt
+ext/standard/tests/file/lstat_stat_variation15.phpt
 ext/standard/tests/filters/bug54350.phpt
 ext/standard/tests/general_functions/bug73973.phpt
 ext/standard/tests/general_functions/floatval.phpt
@@ -176,6 +177,8 @@ ext/standard/tests/strings/implode1.phpt
 ext/standard/tests/strings/sprintf_variation54.phpt
 ext/zend_test/tests/
 sapi/cli/tests/bug80092.phpt
+sapi/cli/tests/gh8827-001.phpt
+sapi/cli/tests/gh8827-003.phpt
 sapi/cli/tests/upload_2G.phpt
 sapi/fpm/tests/log-bm-in-shutdown-fn.phpt
 sapi/fpm/tests/log-bm-limit-1024-msg-80.phpt

--- a/dockerfiles/ci/xfail_tests/8.3.list
+++ b/dockerfiles/ci/xfail_tests/8.3.list
@@ -120,6 +120,7 @@ ext/readline/tests/libedit_callback_handler_remove_001.phpt
 ext/simplexml/tests/bug51615.phpt
 ext/soap/tests/bug77088.phpt
 ext/sockets/tests/socket_create_listen-nobind.phpt
+ext/sockets/tests/socket_import_stream-4.phpt
 ext/spl/tests/bug40091.phpt
 ext/spl/tests/bug44144.phpt
 ext/spl/tests/bug48493.phpt

--- a/dockerfiles/ci/xfail_tests/8.3.list
+++ b/dockerfiles/ci/xfail_tests/8.3.list
@@ -142,6 +142,7 @@ ext/standard/tests/file/bug52820.phpt
 ext/standard/tests/file/disk_free_space_basic.phpt
 ext/standard/tests/file/file_get_contents_file_put_contents_5gb.phpt
 ext/standard/tests/file/lstat_stat_variation10.phpt
+ext/standard/tests/file/lstat_stat_variation15.phpt
 ext/standard/tests/filters/bug54350.phpt
 ext/standard/tests/general_functions/bug73973.phpt
 ext/standard/tests/general_functions/floatval.phpt
@@ -171,6 +172,8 @@ ext/standard/tests/strings/sprintf_variation54.phpt
 ext/standard/tests/strings/gh15613.phpt
 ext/zend_test/tests/
 sapi/cli/tests/bug80092.phpt
+sapi/cli/tests/gh8827-001.phpt
+sapi/cli/tests/gh8827-003.phpt
 sapi/cli/tests/upload_2G.phpt
 sapi/fpm/tests/log-bm-in-shutdown-fn.phpt
 sapi/fpm/tests/log-bm-limit-1024-msg-80.phpt

--- a/dockerfiles/ci/xfail_tests/8.4.list
+++ b/dockerfiles/ci/xfail_tests/8.4.list
@@ -123,6 +123,7 @@ ext/readline/tests/libedit_callback_handler_remove_001.phpt
 ext/simplexml/tests/bug51615.phpt
 ext/soap/tests/bugs/bug77088.phpt
 ext/sockets/tests/socket_create_listen-nobind.phpt
+ext/sockets/tests/socket_import_stream-4.phpt
 ext/spl/tests/bug40091.phpt
 ext/spl/tests/bug44144.phpt
 ext/spl/tests/bug48493.phpt

--- a/dockerfiles/ci/xfail_tests/8.4.list
+++ b/dockerfiles/ci/xfail_tests/8.4.list
@@ -145,6 +145,7 @@ ext/standard/tests/file/bug52820.phpt
 ext/standard/tests/file/disk_free_space_basic.phpt
 ext/standard/tests/file/file_get_contents_file_put_contents_5gb.phpt
 ext/standard/tests/file/lstat_stat_variation10.phpt
+ext/standard/tests/file/lstat_stat_variation15.phpt
 ext/standard/tests/filters/bug54350.phpt
 ext/standard/tests/general_functions/bug73973.phpt
 ext/standard/tests/general_functions/floatval.phpt
@@ -174,6 +175,8 @@ ext/standard/tests/strings/gh15613.phpt
 ext/standard/tests/strings/sprintf_variation54.phpt
 ext/zend_test/tests/
 sapi/cli/tests/bug80092.phpt
+sapi/cli/tests/gh8827-001.phpt
+sapi/cli/tests/gh8827-003.phpt
 sapi/cli/tests/upload_2G.phpt
 sapi/fpm/tests/log-bm-in-shutdown-fn.phpt
 sapi/fpm/tests/log-bm-limit-1024-msg-80.phpt

--- a/tests/Integrations/Guzzle/Latest/response_body_stream_closed.phpt
+++ b/tests/Integrations/Guzzle/Latest/response_body_stream_closed.phpt
@@ -17,8 +17,11 @@ require __DIR__ . '/vendor/autoload.php';
     }
 );
 
+$port = getenv('HTTPBIN_PORT') ?: '80';
+$url = 'http://' . getenv('HTTPBIN_HOSTNAME') . ':' . $port .'/json';
+
 $client  = new \GuzzleHttp\Client();
-$request = new \GuzzleHttp\Psr7\Request('GET', 'https://httpbin.org/json');
+$request = new \GuzzleHttp\Psr7\Request('GET', $url);
 for ($i = 1; $i <= 3; $i++) {
     echo 'Request ' . $i . PHP_EOL;
     $response = $client->sendRequest($request);

--- a/tests/Integrations/Guzzle/V5/response_body_stream_closed.phpt
+++ b/tests/Integrations/Guzzle/V5/response_body_stream_closed.phpt
@@ -17,8 +17,11 @@ require __DIR__ . '/vendor/autoload.php';
     }
 );
 
+$port = getenv('HTTPBIN_PORT') ?: '80';
+$url = 'http://' . getenv('HTTPBIN_HOSTNAME') . ':' . $port .'/json';
+
 $client  = new \GuzzleHttp\Client();
-$request = new \GuzzleHttp\Message\Request('GET', 'https://httpbin.org/json');
+$request = new \GuzzleHttp\Message\Request('GET', $url);
 for ($i = 1; $i <= 3; $i++) {
     echo 'Request ' . $i . PHP_EOL;
     $response = $client->send($request);

--- a/tests/Integrations/Guzzle/V6/response_body_stream_closed.phpt
+++ b/tests/Integrations/Guzzle/V6/response_body_stream_closed.phpt
@@ -17,8 +17,11 @@ require __DIR__ . '/vendor/autoload.php';
     }
 );
 
+$port = getenv('HTTPBIN_PORT') ?: '80';
+$url = 'http://' . getenv('HTTPBIN_HOSTNAME') . ':' . $port .'/json';
+
 $client  = new \GuzzleHttp\Client();
-$request = new \GuzzleHttp\Psr7\Request('GET', 'https://httpbin.org/json');
+$request = new \GuzzleHttp\Psr7\Request('GET', $url);
 for ($i = 1; $i <= 3; $i++) {
     echo 'Request ' . $i . PHP_EOL;
     $response = $client->send($request);

--- a/tests/ext/startup_logging_skipif_unix.inc
+++ b/tests/ext/startup_logging_skipif_unix.inc
@@ -1,5 +1,4 @@
 <?php
 
-include_once 'startup_logging.inc';
-if (!dd_get_php_cgi()) die('skip: php-cgi SAPI required');
+include_once 'startup_logging_skipif.inc';
 if (strncasecmp(PHP_OS, "WIN", 3) == 0) die('skip: There is no background sender on Windows');


### PR DESCRIPTION
Note:
Telemetry is very slow currently (try having 10k telemetry clients launched in 60 seconds with debug logging active. ...) Disabling telemetry for parallel language tests.