### PR TITLE
feat(prof): move allocation profiler stack collection to safe point

### DIFF
--- a/.github/workflows/prof_correctness.yml
+++ b/.github/workflows/prof_correctness.yml
@@ -75,7 +75,7 @@ jobs:
           export DD_PROFILING_EXCEPTION_MESSAGE_ENABLED=1
           php -v
           php -d extension=target/release/libdatadog_php_profiling.so --ri datadog-profiling
-          for test_case in "allocations" "time" "strange_frames" "timeline" "exceptions"; do
+          for test_case in "allocations" "time" "strange_frames" "timeline" "exceptions" "multi_allocations"; do
               mkdir -p profiling/tests/correctness/"$test_case"/
               export DD_PROFILING_OUTPUT_PPROF=$PWD/profiling/tests/correctness/"$test_case"/test.pprof
               php -d extension=$PWD/target/release/libdatadog_php_profiling.so profiling/tests/correctness/"$test_case".php
@@ -102,6 +102,11 @@ jobs:
           export DD_PROFILING_OUTPUT_PPROF=$PWD/profiling/tests/correctness/allocations_1byte/test.pprof
           export DD_PROFILING_ALLOCATION_SAMPLING_DISTANCE=1
           php -d extension=$PWD/target/release/libdatadog_php_profiling.so profiling/tests/correctness/allocations.php
+          unset DD_PROFILING_ALLOCATION_SAMPLING_DISTANCE
+          mkdir -p profiling/tests/correctness/multi_allocations/
+          export DD_PROFILING_OUTPUT_PPROF=$PWD/profiling/tests/correctness/multi_allocations/test.pprof
+          export DD_PROFILING_ALLOCATION_SAMPLING_DISTANCE=1
+          php -d extension=$PWD/target/release/libdatadog_php_profiling.so profiling/tests/correctness/multi_allocations.php
           unset DD_PROFILING_ALLOCATION_SAMPLING_DISTANCE
 
       - name: Run ZTS tests
@@ -130,6 +135,12 @@ jobs:
         with:
           expected_json: profiling/tests/correctness/allocations.json
           pprof_path: profiling/tests/correctness/allocations_1byte/
+
+      - name: Check profiler correctness for multi allocations with 1 byte sampling distance
+        uses: Datadog/prof-correctness/analyze@main
+        with:
+          expected_json: profiling/tests/correctness/multi_allocations.json
+          pprof_path: profiling/tests/correctness/multi_allocations/
 
       - name: Check profiler correctness for time
         uses: Datadog/prof-correctness/analyze@main

--- a/profiling/src/capi.rs
+++ b/profiling/src/capi.rs
@@ -44,7 +44,9 @@ extern "C" fn ddog_php_prof_trigger_time_sample() {
             if locals.system_settings().profiling_enabled {
                 // Safety: only vm interrupts are stored there, or possibly null (edges only).
                 if let Some(vm_interrupt) = unsafe { locals.vm_interrupt_addr.as_ref() } {
-                    locals.interrupt_count.fetch_add(1, Ordering::SeqCst);
+                    locals
+                        .wall_cpu_time_interrupt_count
+                        .fetch_add(1, Ordering::SeqCst);
                     vm_interrupt.store(true, Ordering::SeqCst);
                 }
             }

--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -749,6 +749,10 @@ impl Profiler {
         // likely to be other threads serving requests.
     }
 
+    pub fn trigger_interrupt(&self) {
+        self.interrupt_manager.trigger_interrupts();
+    }
+
     /// Call before a fork, on the thread of the parent process that will fork.
     pub fn fork_prepare(&self) -> anyhow::Result<()> {
         // Send the message to the uploader first, as it has a longer worst

--- a/profiling/tests/correctness/multi_allocations.json
+++ b/profiling/tests/correctness/multi_allocations.json
@@ -1,0 +1,36 @@
+{
+  "scale_by_duration": true,
+  "test_name": "php_multi_allocations",
+  "stacks": [
+    {
+      "profile-type": "alloc-size",
+      "stack-content": [
+        {
+          "regular_expression": "<?php;main;a;standard\\|array_intersect$",
+          "percent": 56,
+          "error_margin": 5
+        },
+        {
+          "regular_expression": "<?php;main;b;standard\\|array_intersect$",
+          "percent": 43,
+          "error_margin": 5
+        }
+      ]
+    },
+    {
+      "profile-type": "alloc-samples",
+      "stack-content": [
+        {
+          "regular_expression": "<?php;main;a;standard\\|array_intersect$",
+          "percent": 50,
+          "error_margin": 5
+        },
+        {
+          "regular_expression": "<?php;main;b;standard\\|array_intersect$",
+          "percent": 50,
+          "error_margin": 5
+        }
+      ]
+    }
+  ]
+}

--- a/profiling/tests/correctness/multi_allocations.php
+++ b/profiling/tests/correctness/multi_allocations.php
@@ -1,0 +1,34 @@
+<?php
+
+function a()
+{
+    $a = ['a', 'b', 'c', 'd'];
+    $b = ['a', 'b', 'c', 'd'];
+    array_intersect($a, $b);
+}
+
+function b()
+{
+    $a = ['a', 'b'];
+    $b = ['a', 'b'];
+    array_intersect($a, $b);
+}
+
+function main()
+{
+    $duration = $_ENV["EXECUTION_TIME"] ?? 10;
+    $end = microtime(true) + $duration;
+    while (microtime(true) < $end) {
+        $start = microtime(true);
+        a();
+        b();
+        $elapsed = microtime(true) - $start;
+        // sleep for the remainder to 100 ms
+        // so we end up doing 10 iterations per second
+        $sleep = (0.1 - $elapsed);
+        if ($sleep > 0.0) {
+            usleep((int) ($sleep * 1_000_000));
+        }
+    }
+}
+main();


### PR DESCRIPTION
### Description

The allocation profiler currently collects a stack trace immediately when the sampling threshold (4MB) is reached. This can occur anywhere in the PHP VM, including outside safe points. While usually safe, there are rare cases where `opline` has been `free()`'d and not restored, leading to use-after-free issues during stack collection 💥

These are engine-level bugs, which we've addressed retroactively via upstream fixes and/or profiler-side workarounds. This PR takes a proactive approach by deferring stack trace collection until the next safe point, by storing allocation samples in TLS and raising the engine interrupt flag. At the next interrupt - where we already handle wall/CPU time sampling - we check for a pending allocation sample and collect the trace then.

Out of Scope / Follow-Up Work
1. Stack trace collection for I/O samples should also be deferred to safe points.
2. When multiple profiler events (e.g., wall time, CPU time, allocation) are pending, we should ideally collect only one stack trace to reduce overhead. This will require additional refactoring.
3. Investigate whether we can attach wall/CPU timing metrics to allocation samples when collected, potentially increasing resolution without introducing sampling bias.

Point 2 seems like a clear improvement, but due to its architectural implications, it's deferred for now. Importantly, this PR already avoids redundant stack walks in one case: when a single PHP function call performs multiple allocations and hits the sampling threshold multiple times, we previously performed multiple redundant stack walks. With this change, those are consolidated into a single stack trace collected at the next safe point.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
