### PR TITLE
fix(ci): failing `prof_correctness` tests

### DIFF
--- a/.github/workflows/prof_correctness.yml
+++ b/.github/workflows/prof_correctness.yml
@@ -14,7 +14,7 @@ jobs:
         phpts: [nts, zts]
         include:
           - phpts: zts
-            extensions: parallel
+            extensions: parallel-krakjoe/parallel@v1.2.7
 
     steps:
       - name: Checkout
@@ -24,15 +24,16 @@ jobs:
           submodules: true
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@9e72090525849c5e82e596468b86eb55e9cc5401 # v2.32.0
+        uses: shivammathur/setup-php@0f7f1d08e3e32076e51cae65eb0b0c871405b16e # v2.34.1
         with:
           php-version: ${{ matrix.php-version }}
           extensions: ${{ matrix.extensions }}
         env:
           phpts: ${{ matrix.phpts }}
+          fail-fast: true
 
       - name: Restore build cache
-        uses: actions/cache/restore@1bd1e32a3bdc45362d1e726936510720a7c30a57 # v4.2.0
+        uses: actions/cache/restore@5a3ec84eff668545956fd18022155c47e93e2684 # v4.2.3
         with:
           path: |
             ~/.cargo/bin/


### PR DESCRIPTION
### Description

https://github.com/shivammathur/setup-php is using PECL to install extensions. Currently PECL seems to be slower than usualy and `setup-php` is not able to fetch `ext-parallel`. This PR makes the following:
- update actions
- make sure to fail if an extension can not be installed
- install `ext-parallel` from GitHub to decouple from PECL

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
