### PR TITLE
fix(profiling): validate `opline` before access

### DIFF
--- a/profiling/src/allocation/allocation_ge84.rs
+++ b/profiling/src/allocation/allocation_ge84.rs
@@ -287,7 +287,7 @@ pub fn alloc_prof_rinit() {
     trace!("Memory allocation profiling enabled.")
 }
 
-#[allow(unpredictable_function_pointer_comparisons)]
+#[allow(unknown_lints, unpredictable_function_pointer_comparisons)]
 pub fn alloc_prof_rshutdown() {
     // If `is_zend_mm()` is true, the custom handlers have been reset to `None` or our observed
     // heap has been uninstalled. This is unexpected, therefore we will not touch the ZendMM

--- a/profiling/src/bindings/mod.rs
+++ b/profiling/src/bindings/mod.rs
@@ -148,8 +148,20 @@ impl _zend_function {
 
     #[inline]
     pub fn is_internal(&self) -> bool {
-        // Safety: the function's type field is always safe to access.
+        // SAFETY: the function's type field is always safe to access.
         unsafe { self.type_ == ZEND_INTERNAL_FUNCTION }
+    }
+
+    /// Returns the op_array if this is a user function or eval code.
+    #[inline]
+    pub fn op_array(&self) -> Option<&_zend_op_array> {
+        if !self.is_internal() {
+            // SAFETY: If it's not internal, then both user and eval types use
+            // the op_array field.
+            unsafe { Some(&self.op_array) }
+        } else {
+            None
+        }
     }
 }
 

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -11,13 +11,6 @@
 #include <dlfcn.h> // for dlsym
 #endif
 
-// todo: not all things are fixed upstream yet e.g. ZEND_INIT_ARRAY
-#if PHP_VERSION_ID >= 70400
-#define CFG_NEED_OPCODE_HANDLERS 1
-#else
-#define CFG_NEED_OPCODE_HANDLERS 0
-#endif
-
 const char *datadog_extension_build_id(void) { return ZEND_EXTENSION_BUILD_ID; }
 const char *datadog_module_build_id(void) { return ZEND_MODULE_BUILD_ID; }
 
@@ -107,76 +100,6 @@ bool ddog_php_prof_is_post_startup(void) {
     return _is_post_startup;
 }
 
-#if CFG_NEED_OPCODE_HANDLERS
-/* The purpose here is to set the opline, because the built-in opcode handlers
- * for some versions are missing a SAVE_OPLINE() and it causes a crash when
- * trying to access the line number. The allocation profiler is vulnerable in
- * particular because it can access the opline on any allocation.
- *
- * The handler doesn't actually need to do anything, because just by having a
- * user opcode handler the engine will save the opline before calling the user
- * handler:
- * https://heap.space/xref/PHP-7.4/Zend/zend_vm_execute.h?r=0b7dffb4#2650
- */
-static zend_result ddog_php_prof_opcode_dispatch(zend_execute_data *execute_data) {
-    (void)execute_data;
-    return ZEND_USER_OPCODE_DISPATCH;
-}
-
-// Argument `php_version_id` should be the version of PHP at runtime, not the
-// version this was compiled against.
-static void ddog_php_prof_install_opcode_handlers(uint32_t php_version_id) {
-
-    /* Only need to install user opcode handlers if there isn't one already
-     * for the given opcode, see the docs on `ddog_php_prof_opcode_dispatch`.
-     */
-    user_opcode_handler_t dispatch_handler = (user_opcode_handler_t)ddog_php_prof_opcode_dispatch;
-
-#if PHP_VERSION_ID < 80100
-    /* Issue is fixed in 8.0.26:
-     * https://github.com/php/php-src/commit/26c7c82d32dad841dd151ebc6a31b8ea6f93f94a
-     */
-    if (php_version_id < 80026 && zend_get_user_opcode_handler(ZEND_GENERATOR_CREATE) == NULL) {
-        zend_set_user_opcode_handler(ZEND_GENERATOR_CREATE, dispatch_handler);
-    }
-#endif
-
-#if PHP_VERSION_ID < 80400
-    /* Part of the issue was fixed in 8.0.12:
-     * https://github.com/php/php-src/commit/ec54ffad1e3b15fedfd07f7d29d97ec3e8d1c45a
-     * However, the fix is not complete as it's possible for the opcode to
-     * call `zend_array_dup()` before the `SAVE_OPLINE()`.
-     *
-     * This was finally fixed with https://github.com/php/php-src/pull/12758 in
-     * PHP 8.1.27, 8.2.14 and 8.3.1
-     */
-    if ((php_version_id < 80127 ||
-        (php_version_id >= 80200 && php_version_id < 80214) ||
-        php_version_id == 80300) &&
-        zend_get_user_opcode_handler(ZEND_BIND_STATIC) == NULL)
-    {
-        zend_set_user_opcode_handler(ZEND_BIND_STATIC, dispatch_handler);
-    }
-
-    /* This was fixed with https://github.com/php/php-src/pull/12768 in
-     * PHP 8.1.27, 8.2.14 and 8.3.1
-     */
-    if ((php_version_id < 80127 ||
-        (php_version_id >= 80200 && php_version_id < 80214) ||
-        php_version_id == 80300) &&
-        zend_get_user_opcode_handler(ZEND_FUNC_GET_ARGS) == NULL)
-    {
-        zend_set_user_opcode_handler(ZEND_FUNC_GET_ARGS, dispatch_handler);
-    }
-#endif
-
-    // this is not yet patched upstream
-    if (zend_get_user_opcode_handler(ZEND_INIT_ARRAY) == NULL) {
-        zend_set_user_opcode_handler(ZEND_INIT_ARRAY, dispatch_handler);
-    }
-}
-#endif
-
 #if PHP_VERSION_ID < 80000
 #define post_startup_cb_result int
 #else
@@ -196,11 +119,6 @@ static post_startup_cb_result ddog_php_prof_post_startup_cb(void) {
     }
 
     _is_post_startup = true;
-
-#if CFG_NEED_OPCODE_HANDLERS
-    uint32_t php_version_id = ddog_php_prof_php_version_id();
-    ddog_php_prof_install_opcode_handlers(php_version_id);
-#endif
 
     return SUCCESS;
 }

--- a/profiling/src/profiling/stack_walking.rs
+++ b/profiling/src/profiling/stack_walking.rs
@@ -109,11 +109,10 @@ fn safely_get_opline(execute_data: &zend_execute_data) -> Option<&crate::binding
         return None;
     }
 
-    // Safety: `opcodes_start` is null checked and both point/pointed to the same allocated object.
-    let opline_offset = unsafe { execute_data.opline.offset_from(opcodes_start) };
-
-    // Check if `opline` is within the allocated opcodes array `op_array`
-    if opline_offset >= 0 && (opline_offset as u32) < op_array.last {
+    // Check if `opline` is within the allocated opcodes array `op_array`. `op_array.last` is the
+    // index of the last opcode, so valid range is [opcodes_start, opcodes_start + last]
+    let opcodes_end = unsafe { opcodes_start.add(op_array.last as usize) };
+    if execute_data.opline >= opcodes_start && execute_data.opline < opcodes_end {
         // Safety: we did our best we could to validate that this pointer is not NULL and not
         // dangling and actually pointing to the right kind of data. Otherwise this is the crash
         // site you are looking for.

--- a/profiling/src/profiling/stack_walking.rs
+++ b/profiling/src/profiling/stack_walking.rs
@@ -116,11 +116,9 @@ unsafe fn safely_get_opline(execute_data: &zend_execute_data) -> Option<&crate::
     // Check if `opline` is within the allocated opcodes array `op_array`. `op_array.last` is the
     // index of the last opcode, so valid range is [opcodes_start, opcodes_start + last]
     let opcodes_end = unsafe { opcodes_start.add(op_array.last as usize) };
-    if { execute_data.opline as usize } >= { opcodes_start as usize } && {
-        execute_data.opline as usize
-    } < {
-        opcodes_end as usize
-    } {
+    if (execute_data.opline as usize) >= (opcodes_start as usize)
+        && (execute_data.opline as usize) < (opcodes_end as usize)
+    {
         // Safety: we did our best we could to validate that this pointer is not NULL and not
         // dangling and actually pointing to the right kind of data. Otherwise this is the crash
         // site you are looking for.

--- a/profiling/src/profiling/stack_walking.rs
+++ b/profiling/src/profiling/stack_walking.rs
@@ -116,7 +116,11 @@ unsafe fn safely_get_opline(execute_data: &zend_execute_data) -> Option<&crate::
     // Check if `opline` is within the allocated opcodes array `op_array`. `op_array.last` is the
     // index of the last opcode, so valid range is [opcodes_start, opcodes_start + last]
     let opcodes_end = unsafe { opcodes_start.add(op_array.last as usize) };
-    if execute_data.opline >= opcodes_start && execute_data.opline < opcodes_end {
+    if { execute_data.opline as usize } >= { opcodes_start as usize } && {
+        execute_data.opline as usize
+    } < {
+        opcodes_end as usize
+    } {
         // Safety: we did our best we could to validate that this pointer is not NULL and not
         // dangling and actually pointing to the right kind of data. Otherwise this is the crash
         // site you are looking for.

--- a/profiling/tests/phpt/allocation_generator_01.phpt
+++ b/profiling/tests/phpt/allocation_generator_01.phpt
@@ -13,17 +13,19 @@ restores the opline in a opcode handler!
 --SKIPIF--
 <?php
 if (!extension_loaded('datadog-profiling'))
-    echo "skip: test requires datadog-profiling", PHP_EOL;
+    die("skip: test requires datadog-profiling");
+if (PHP_VERSION_ID <= 80010)
+    die("skip: PHP is buggy");
 ?>
+--ENV--
+DD_PROFILING_ALLOCATION_SAMPLING_DISTANCE=1
 --INI--
 memory_limit=16m
 --FILE--
 <?php
-
 function a() {
     yield from a();
 }
-
 foreach(a() as $v);
 ?>
 --EXPECTF--


### PR DESCRIPTION
### Description

When collecting the stack trace outside of a vm interrupt, the `execute_data.opline` might be a dangling pointer. So far we had some mitigations in place for known cases, but there are some cases where this may still happen. Granted this is extremely rare, but annoying.

The root cause is that the `execute_data.opline` pointer has a different lifetime than the `execute_data.func.op_array` it points into.

This PR:
- adds an out-of-bounds check for accessing the `opline`
- removes all our mitigations
- runs the `allocation_generator_01.phpt` test only if PHP > 8.0.10 is used, as otherwise it crashes in PHP

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
