### PR TITLE
fix(telemetry): integration telemetry log messages are now constant

### DIFF
--- a/ext/autoload_php_files.c
+++ b/ext/autoload_php_files.c
@@ -103,7 +103,7 @@ int dd_execute_php_file(const char *filename, zval *result, bool try) {
             if (PG(last_error_message)) {
                 log("Error raised in autoloaded file %s: %s in %s on line %d", filename, LAST_ERROR_STRING, LAST_ERROR_FILE, PG(last_error_lineno));
                 if (get_global_DD_INSTRUMENTATION_TELEMETRY_ENABLED() && get_DD_TELEMETRY_LOG_COLLECTION_ENABLED() && VCWD_ACCESS(filename, R_OK) == 0) {
-                    INTEGRATION_ERROR_TELEMETRY(ERROR, "Error raised in autoloaded file %s: %s in %s on line %d", filename, LAST_ERROR_STRING, LAST_ERROR_FILE, PG(last_error_lineno));
+                    INTEGRATION_ERROR_TELEMETRY(ERROR, "Error raised in autoloaded file %s: $ERROR_MSG in %s on line %d", filename, LAST_ERROR_STRING, LAST_ERROR_FILE, PG(last_error_lineno));
                 }
             }
             zend_object *ex = EG(exception);

--- a/ext/hook/uhook.c
+++ b/ext/hook/uhook.c
@@ -175,8 +175,8 @@ void dd_uhook_report_sandbox_error(zend_execute_data *execute_data, zend_object 
             log("%s thrown in ddtrace's closure defined at %s:%d for %s%s%s(): %s in %s on line %d",
                              type, deffile, defline, scope, colon, name, msg, regular_exception ? ZSTR_VAL(exfile) : "Unknown", exline);
             if (get_global_DD_INSTRUMENTATION_TELEMETRY_ENABLED() && get_DD_TELEMETRY_LOG_COLLECTION_ENABLED()) {
-                INTEGRATION_ERROR_TELEMETRY(ERROR, "%s thrown in ddtrace's closure defined at <redacted>%s:%d for %s%s%s(): %s in <redacted>%s on line %d",
-                             type, ddtrace_telemetry_redact_file(deffile), defline, scope, colon, name, msg, regular_exception ? ddtrace_telemetry_redact_file(ZSTR_VAL(exfile)) : "Unknown", exline);
+                INTEGRATION_ERROR_TELEMETRY(ERROR, "%s thrown in ddtrace's closure defined at <redacted>%s:%d for %s%s%s(): $ERROR_MSG in <redacted>%s on line %d",
+                             type, ddtrace_telemetry_redact_file(deffile), defline, scope, colon, name, regular_exception ? ddtrace_telemetry_redact_file(ZSTR_VAL(exfile)) : "Unknown", exline);
             }
             if (exfile) {
                 zend_string_release(exfile);
@@ -185,8 +185,8 @@ void dd_uhook_report_sandbox_error(zend_execute_data *execute_data, zend_object 
             log("Error raised in ddtrace's closure defined at %s:%d for %s%s%s(): %s in %s on line %d",
                              deffile, defline, scope, colon, name, LAST_ERROR_STRING, LAST_ERROR_FILE, PG(last_error_lineno));
             if (get_global_DD_INSTRUMENTATION_TELEMETRY_ENABLED() && get_DD_TELEMETRY_LOG_COLLECTION_ENABLED()) {
-                INTEGRATION_ERROR_TELEMETRY(ERROR, "Error raised in ddtrace's closure defined at <redacted>%s:%d for %s%s%s(): %s in <redacted>%s on line %d",
-                             ddtrace_telemetry_redact_file(deffile), defline, scope, colon, name, LAST_ERROR_STRING, ddtrace_telemetry_redact_file(LAST_ERROR_FILE), PG(last_error_lineno));
+                INTEGRATION_ERROR_TELEMETRY(ERROR, "Error raised in ddtrace's closure defined at <redacted>%s:%d for %s%s%s(): $ERROR_MSG in <redacted>%s on line %d",
+                             ddtrace_telemetry_redact_file(deffile), defline, scope, colon, name, ddtrace_telemetry_redact_file(LAST_ERROR_FILE), PG(last_error_lineno));
             }
         }
     })

--- a/ext/integrations/integrations.c
+++ b/ext/integrations/integrations.c
@@ -158,15 +158,15 @@ static void dd_invoke_integration_loader_and_unhook_posthook(zend_ulong invocati
                     log("%s thrown in ddtrace's integration autoloader for %s: %s",
                         type, ZSTR_VAL(aux->classname), msg);
                     if (get_global_DD_INSTRUMENTATION_TELEMETRY_ENABLED() && get_DD_TELEMETRY_LOG_COLLECTION_ENABLED()) {
-                        INTEGRATION_ERROR_TELEMETRY(ERROR, "%s thrown in ddtrace's integration autoloader for %s: %s",
-                            type, ZSTR_VAL(aux->classname), msg);
+                        INTEGRATION_ERROR_TELEMETRY(ERROR, "%s thrown in ddtrace's integration autoloader for %s: $ERROR_MSG",
+                            type, ZSTR_VAL(aux->classname));
                     }
                 } else if (PG(last_error_message)) {
                     log("Error raised in ddtrace's integration autoloader for %s: %s in %s on line %d",
                         ZSTR_VAL(aux->classname), LAST_ERROR_STRING, LAST_ERROR_FILE, PG(last_error_lineno));
                     if (get_global_DD_INSTRUMENTATION_TELEMETRY_ENABLED() && get_DD_TELEMETRY_LOG_COLLECTION_ENABLED()) {
-                        INTEGRATION_ERROR_TELEMETRY(ERROR, "Error raised in ddtrace's integration autoloader for %s: %s in <redacted>%s on line %d",
-                            ZSTR_VAL(aux->classname), LAST_ERROR_STRING, ddtrace_telemetry_redact_file(LAST_ERROR_FILE), PG(last_error_lineno));
+                        INTEGRATION_ERROR_TELEMETRY(ERROR, "Error raised in ddtrace's integration autoloader for %s: $ERROR_MSG in <redacted>%s on line %d",
+                            ZSTR_VAL(aux->classname), ddtrace_telemetry_redact_file(LAST_ERROR_FILE), PG(last_error_lineno));
                     }
                 }
             })

--- a/tests/ext/telemetry/integration_runtime_error.phpt
+++ b/tests/ext/telemetry/integration_runtime_error.phpt
@@ -68,7 +68,7 @@ array(2) {
   [0]=>
   array(7) {
     ["message"]=>
-    string(165) "Error raised in ddtrace's closure defined at <redacted>%cintegration_runtime_error.php:12 for foo(): Testnotice in <redacted>%cintegration_runtime_error.php on line 13"
+    string(165) "Error raised in ddtrace's closure defined at <redacted>%cintegration_runtime_error.php:12 for foo(): $ERROR_MSG in <redacted>%cintegration_runtime_error.php on line 13"
     ["level"]=>
     string(5) "ERROR"
     ["count"]=>
@@ -85,7 +85,7 @@ array(2) {
   [1]=>
   array(7) {
     ["message"]=>
-    string(161) "Exception thrown in ddtrace's closure defined at <redacted>%cintegration_runtime_error.php:7 for foo(): test in <redacted>%cintegration_runtime_error.php on line %d"
+    string(167) "Exception thrown in ddtrace's closure defined at <redacted>%cintegration_runtime_error.php:7 for foo(): $ERROR_MSG in <redacted>%cintegration_runtime_error.php on line 9"
     ["level"]=>
     string(5) "ERROR"
     ["count"]=>


### PR DESCRIPTION
### Description
Ensure that integration error telemetry log messages are constant.
-> Replace error message by a constant $ERROR_MSG.

This is to prevent potential risk of PII leak and is a currently a requirement (having a constant message).

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
