### PR TITLE
Drop asan from s3 as it overrwites the normal linux .tar.gz (same name)

### DIFF
--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -1321,8 +1321,9 @@ endforeach;
       artifacts: true
     - job: "datadog-setup.php"
       artifacts: true
-    - job: "package extension asan"
-      artifacts: true
+# Maybe use a different base name for these
+#    - job: "package extension asan"
+#      artifacts: true
     - job: "package extension windows"
       artifacts: true
 <?php


### PR DESCRIPTION
### Description

<!---
Any description you feel is relevant and gives more background to this PR, if necessary.
-->

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
