### PR TITLE
Fix rate limiter

### DIFF
--- a/.gitlab/generate-appsec.php
+++ b/.gitlab/generate-appsec.php
@@ -169,6 +169,7 @@ stages:
       unzip vault.zip
       sudo cp -v vault /usr/local/bin
       cd -
+      sudo sed -i 's|http://deb.debian.org/debian|http://archive.debian.org/debian|g; s|http://security.debian.org/debian-security|http://archive.debian.org/debian-security|g' /etc/apt/sources.list
       sudo apt-get update && sudo apt-get install -y jq gcovr llvm-17 clang-17
 
       echo "Installing codecov"

--- a/appsec/src/extension/commands_helpers.c
+++ b/appsec/src/extension/commands_helpers.c
@@ -461,9 +461,14 @@ dd_result dd_command_proc_resp_verd_span_data(
     mpack_node_t actions = mpack_node_array_at(root, RESP_INDEX_ACTION_PARAMS);
     dd_result res = _command_process_actions(actions, ctx);
 
-    if (res == dd_should_block || res == dd_should_redirect ||
-        res == dd_should_record) {
+    if (res == dd_should_block || res == dd_should_redirect) {
+        dd_tags_set_sampling_priority();
         dd_trace_emit_asm_event();
+        _set_appsec_span_data(
+            mpack_node_array_at(root, RESP_INDEX_APPSEC_SPAN_DATA));
+    }
+
+    if (res == dd_should_record) {
         _set_appsec_span_data(
             mpack_node_array_at(root, RESP_INDEX_APPSEC_SPAN_DATA));
     }
@@ -471,7 +476,7 @@ dd_result dd_command_proc_resp_verd_span_data(
     mpack_node_t force_keep = mpack_node_array_at(root, RESP_INDEX_FORCE_KEEP);
     if (mpack_node_type(force_keep) == mpack_type_bool &&
         mpack_node_bool(force_keep)) {
-        dd_trace_emit_asm_event();
+        dd_tags_set_sampling_priority();
     }
 
     if (mpack_node_array_length(root) >= RESP_INDEX_SETTINGS + 1) {

--- a/appsec/src/extension/commands_helpers.c
+++ b/appsec/src/extension/commands_helpers.c
@@ -468,9 +468,8 @@ dd_result dd_command_proc_resp_verd_span_data(
     }
 
     mpack_node_t force_keep = mpack_node_array_at(root, RESP_INDEX_FORCE_KEEP);
-    if ((mpack_node_type(force_keep) == mpack_type_bool &&
-            mpack_node_bool(force_keep)) ||
-        res == dd_should_block || res == dd_should_redirect) {
+    if (mpack_node_type(force_keep) == mpack_type_bool &&
+        mpack_node_bool(force_keep)) {
         dd_trace_emit_asm_event();
     }
 

--- a/appsec/src/extension/commands_helpers.c
+++ b/appsec/src/extension/commands_helpers.c
@@ -461,23 +461,17 @@ dd_result dd_command_proc_resp_verd_span_data(
     mpack_node_t actions = mpack_node_array_at(root, RESP_INDEX_ACTION_PARAMS);
     dd_result res = _command_process_actions(actions, ctx);
 
-    if (res == dd_should_block || res == dd_should_redirect) {
-        dd_tags_set_sampling_priority();
-        dd_trace_emit_asm_event();
-        _set_appsec_span_data(
-            mpack_node_array_at(root, RESP_INDEX_APPSEC_SPAN_DATA));
-    }
-
-    if (res == dd_should_record) {
+    if (res == dd_should_block || res == dd_should_redirect ||
+        res == dd_should_record) {
         _set_appsec_span_data(
             mpack_node_array_at(root, RESP_INDEX_APPSEC_SPAN_DATA));
     }
 
     mpack_node_t force_keep = mpack_node_array_at(root, RESP_INDEX_FORCE_KEEP);
-    if (mpack_node_type(force_keep) == mpack_type_bool &&
-        mpack_node_bool(force_keep)) {
+    if ((mpack_node_type(force_keep) == mpack_type_bool &&
+            mpack_node_bool(force_keep)) ||
+        res == dd_should_block || res == dd_should_redirect) {
         dd_trace_emit_asm_event();
-        dd_tags_set_sampling_priority();
     }
 
     if (mpack_node_array_length(root) >= RESP_INDEX_SETTINGS + 1) {

--- a/appsec/src/extension/commands_helpers.c
+++ b/appsec/src/extension/commands_helpers.c
@@ -476,6 +476,7 @@ dd_result dd_command_proc_resp_verd_span_data(
     mpack_node_t force_keep = mpack_node_array_at(root, RESP_INDEX_FORCE_KEEP);
     if (mpack_node_type(force_keep) == mpack_type_bool &&
         mpack_node_bool(force_keep)) {
+        dd_trace_emit_asm_event();
         dd_tags_set_sampling_priority();
     }
 

--- a/appsec/src/extension/ddappsec.c
+++ b/appsec/src/extension/ddappsec.c
@@ -277,9 +277,10 @@ static PHP_RINIT_FUNCTION(ddappsec)
     }
     DDAPPSEC_G(skip_rshutdown) = false;
     dd_msgpack_helpers_rinit();
-
-    dd_req_lifecycle_rinit(false);
     dd_trace_rinit();
+
+    // Waf calls happen here. Not many rinits should go after this line.
+    dd_req_lifecycle_rinit(false);
 
     if (UNEXPECTED(get_global_DD_APPSEC_TESTING())) {
         if (get_global_DD_APPSEC_TESTING_ABORT_RINIT()) {

--- a/appsec/src/extension/ddappsec.c
+++ b/appsec/src/extension/ddappsec.c
@@ -279,6 +279,7 @@ static PHP_RINIT_FUNCTION(ddappsec)
     dd_msgpack_helpers_rinit();
 
     dd_req_lifecycle_rinit(false);
+    dd_trace_rinit();
 
     if (UNEXPECTED(get_global_DD_APPSEC_TESTING())) {
         if (get_global_DD_APPSEC_TESTING_ABORT_RINIT()) {

--- a/appsec/src/extension/ddtrace.c
+++ b/appsec/src/extension/ddtrace.c
@@ -33,6 +33,7 @@ static zend_string *_metrics_propname;
 static zend_string *_meta_struct_propname;
 static THREAD_LOCAL_ON_ZTS bool _suppress_ddtrace_rshutdown;
 static uint8_t *_ddtrace_runtime_id;
+static THREAD_LOCAL_ON_ZTS bool _asm_event_emitted;
 
 static void _setup_testing_telemetry_functions(void);
 static zend_module_entry *_find_ddtrace_module(void);
@@ -153,6 +154,8 @@ void dd_trace_startup(void)
         mod->request_shutdown_func = _ddtrace_rshutdown_testing;
     }
 }
+
+void dd_trace_rinit(void) { _asm_event_emitted = false; }
 
 static void _setup_testing_telemetry_functions(void)
 {
@@ -439,6 +442,10 @@ void dd_trace_span_add_propagated_tags(
 
 void dd_trace_emit_asm_event(void)
 {
+    if (_asm_event_emitted) {
+        return;
+    }
+
     if (UNEXPECTED(_ddtrace_emit_asm_event == NULL)) {
         return;
     }
@@ -446,6 +453,7 @@ void dd_trace_emit_asm_event(void)
     mlog(dd_log_trace, "Emitting ASM event");
 
     _ddtrace_emit_asm_event();
+    _asm_event_emitted = true;
 }
 
 static PHP_FUNCTION(datadog_appsec_testing_ddtrace_rshutdown)

--- a/appsec/src/extension/ddtrace.h
+++ b/appsec/src/extension/ddtrace.h
@@ -27,6 +27,7 @@ typedef zend_object root_span_t;
 
 void dd_trace_startup(void);
 void dd_trace_shutdown(void);
+void dd_trace_rinit(void);
 
 // Returns the tracer version
 const char *nullable dd_trace_version(void);

--- a/appsec/src/extension/tags.c
+++ b/appsec/src/extension/tags.c
@@ -960,8 +960,6 @@ static zval *nullable _root_span_get_meta(void)
     return meta;
 }
 
-static void _emit_auto_user_event(void) { dd_trace_emit_asm_event(); }
-
 static PHP_FUNCTION(datadog_appsec_track_user_signup_event_automated)
 {
     UNUSED(return_value);
@@ -1051,7 +1049,7 @@ static PHP_FUNCTION(datadog_appsec_track_user_signup_event_automated)
     _add_new_zstr_to_meta(
         meta_ht, _dd_business_logic_users_signup, _null_zstr, true, true);
 
-    _emit_auto_user_event();
+    dd_trace_emit_asm_event();
 }
 
 void dd_tags_set_user_event_triggered(void) { _user_event_triggered = true; }
@@ -1109,7 +1107,7 @@ static PHP_FUNCTION(datadog_appsec_track_user_signup_event)
     _add_new_zstr_to_meta(
         meta_ht, _dd_business_logic_users_signup, _null_zstr, true, true);
 
-    _emit_auto_user_event();
+    dd_trace_emit_asm_event();
 }
 
 static PHP_FUNCTION(datadog_appsec_track_user_login_success_event_automated)
@@ -1204,7 +1202,7 @@ static PHP_FUNCTION(datadog_appsec_track_user_login_success_event_automated)
     _add_new_zstr_to_meta(meta_ht, _dd_business_logic_users_login_success,
         _null_zstr, true, true);
 
-    _emit_auto_user_event();
+    dd_trace_emit_asm_event();
 }
 
 static PHP_FUNCTION(datadog_appsec_track_user_login_success_event)
@@ -1264,7 +1262,7 @@ static PHP_FUNCTION(datadog_appsec_track_user_login_success_event)
     _add_new_zstr_to_meta(meta_ht, _dd_business_logic_users_login_success,
         _null_zstr, true, true);
 
-    _emit_auto_user_event();
+    dd_trace_emit_asm_event();
 }
 
 static PHP_FUNCTION(datadog_appsec_track_user_login_failure_event_automated)
@@ -1366,7 +1364,7 @@ static PHP_FUNCTION(datadog_appsec_track_user_login_failure_event_automated)
     _add_new_zstr_to_meta(meta_ht, _dd_business_logic_users_login_failure,
         _null_zstr, true, true);
 
-    _emit_auto_user_event();
+    dd_trace_emit_asm_event();
 }
 
 static PHP_FUNCTION(datadog_appsec_track_user_login_failure_event)
@@ -1426,7 +1424,7 @@ static PHP_FUNCTION(datadog_appsec_track_user_login_failure_event)
     _add_new_zstr_to_meta(meta_ht, _dd_business_logic_users_login_failure,
         _null_zstr, true, true);
 
-    _emit_auto_user_event();
+    dd_trace_emit_asm_event();
 }
 
 static PHP_FUNCTION(datadog_appsec_track_authenticated_user_event_automated)
@@ -1586,7 +1584,7 @@ static PHP_FUNCTION(datadog_appsec_track_custom_event)
 
     smart_str_free(&event_str);
 
-    _emit_auto_user_event();
+    dd_trace_emit_asm_event();
 }
 
 static bool _set_appsec_enabled(zval *metrics_zv)

--- a/appsec/src/extension/tags.c
+++ b/appsec/src/extension/tags.c
@@ -145,7 +145,6 @@ static THREAD_LOCAL_ON_ZTS bool _appsec_json_frags_inited;
 static THREAD_LOCAL_ON_ZTS zend_llist _appsec_json_frags;
 static THREAD_LOCAL_ON_ZTS zend_string *nullable _event_user_id;
 static THREAD_LOCAL_ON_ZTS bool _blocked;
-static THREAD_LOCAL_ON_ZTS bool _force_keep;
 
 static void _init_relevant_headers(void);
 static zend_string *_concat_json_fragments(void);
@@ -359,7 +358,6 @@ void dd_tags_rinit(void)
     // Just in case...
     _event_user_id = NULL;
     _blocked = false;
-    _force_keep = false;
 }
 
 void dd_tags_add_appsec_json_frag(zend_string *nonnull zstr)
@@ -413,12 +411,6 @@ void dd_tags_add_tags(
     // tag _dd.runtime_family
     _set_runtime_family(span);
 
-    if (_force_keep) {
-        dd_trace_set_priority_sampling_on_span_zobj(
-            span, PRIORITY_SAMPLING_USER_KEEP, DD_MECHANISM_ASM);
-        mlog(dd_log_debug, "Updated sampling priority to asm");
-    }
-
     if (zend_llist_count(&_appsec_json_frags) == 0) {
         if (!server) {
             return;
@@ -466,8 +458,6 @@ void dd_tags_add_tags(
 }
 
 void dd_tags_add_blocked(void) { _blocked = true; }
-
-void dd_tags_set_sampling_priority(void) { _force_keep = true; }
 
 static void _zend_string_release_indirect(void *s)
 {
@@ -970,11 +960,7 @@ static zval *nullable _root_span_get_meta(void)
     return meta;
 }
 
-static void _emit_auto_user_event(void)
-{
-    dd_tags_set_sampling_priority();
-    dd_trace_emit_asm_event();
-}
+static void _emit_auto_user_event(void) { dd_trace_emit_asm_event(); }
 
 static PHP_FUNCTION(datadog_appsec_track_user_signup_event_automated)
 {

--- a/appsec/src/extension/tags.h
+++ b/appsec/src/extension/tags.h
@@ -20,7 +20,6 @@ void dd_tags_rshutdown(void);
 void dd_tags_add_tags(zend_object *nonnull span, zend_array *nullable superglob_equiv);
 void dd_tags_add_blocked(void);
 void dd_tags_set_user_event_triggered(void);
-void dd_tags_set_sampling_priority(void);
 
 // Copies (or increases refcount) of zstr
 void dd_tags_set_event_user_id(zend_string *nonnull zstr);

--- a/appsec/src/extension/tags.h
+++ b/appsec/src/extension/tags.h
@@ -20,6 +20,7 @@ void dd_tags_rshutdown(void);
 void dd_tags_add_tags(zend_object *nonnull span, zend_array *nullable superglob_equiv);
 void dd_tags_add_blocked(void);
 void dd_tags_set_user_event_triggered(void);
+void dd_tags_set_sampling_priority(void);
 
 // Copies (or increases refcount) of zstr
 void dd_tags_set_event_user_id(zend_string *nonnull zstr);

--- a/appsec/src/helper/client.cpp
+++ b/appsec/src/helper/client.cpp
@@ -416,8 +416,21 @@ bool client::send_message(const std::shared_ptr<typename T::response> &message)
                 all_verdicts << "no verdicts";
             }
         }
-        SPDLOG_DEBUG("sending response to {}, verdicts: {}",
-            message->get_type(), all_verdicts.str());
+        std::string force_keep = "not provided";
+        if constexpr (std::is_same_v<typename T::response,
+                          network::request_init::response> ||
+                      std::is_same_v<typename T::response,
+                          network::request_exec::response> ||
+                      std::is_same_v<typename T::response,
+                          network::request_shutdown::response>) {
+            if (message->force_keep) {
+                force_keep = "true";
+            } else {
+                force_keep = "false";
+            }
+        }
+        SPDLOG_DEBUG("sending response to {}, verdicts: {}, force_keep: {}",
+            message->get_type(), all_verdicts.str(), force_keep);
     }
     try {
         return broker_->send(message);

--- a/appsec/src/helper/client.hpp
+++ b/appsec/src/helper/client.hpp
@@ -98,6 +98,7 @@ protected:
     std::optional<engine::context> context_;
     std::optional<bool> client_enabled_conf;
     bool request_enabled_ = {false};
+    sidecar_settings sc_settings_;
 };
 
 } // namespace dds

--- a/appsec/src/helper/engine.cpp
+++ b/appsec/src/helper/engine.cpp
@@ -123,7 +123,7 @@ std::optional<engine::result> engine::context::publish(
         return std::nullopt;
     }
 
-    const bool force_keep = event_.keep || limiter_.allow();
+    const bool force_keep = event_.keep && limiter_.allow();
     dds::engine::result res{{}, std::move(event_.data), force_keep};
     // Currently the only action the extension can perform is block
     if (event_.actions.empty()) {

--- a/appsec/src/helper/engine_settings.hpp
+++ b/appsec/src/helper/engine_settings.hpp
@@ -90,7 +90,8 @@ template <> struct hash<dds::engine_settings> {
     std::size_t operator()(const dds::engine_settings &s) const noexcept
     {
         return dds::hash(s.rules_file, s.waf_timeout_us, s.trace_rate_limit,
-            s.obfuscator_key_regex, s.obfuscator_value_regex);
+            s.obfuscator_key_regex, s.obfuscator_value_regex,
+            s.schema_extraction.enabled, s.schema_extraction.sampling_period);
     }
 };
 } // namespace std

--- a/appsec/src/helper/main.cpp
+++ b/appsec/src/helper/main.cpp
@@ -9,6 +9,7 @@
 
 #include "config.hpp"
 #include "runner.hpp"
+#include "subscriber/waf.hpp"
 #include <csignal>
 #include <cstdlib>
 #include <spdlog/common.h>

--- a/appsec/src/helper/rate_limit.hpp
+++ b/appsec/src/helper/rate_limit.hpp
@@ -10,6 +10,7 @@
 #include <chrono>
 #include <memory>
 #include <mutex>
+#include <spdlog/spdlog.h>
 
 #include "timer.hpp"
 
@@ -21,12 +22,15 @@ public:
         : max_per_second_(max_per_second){};
     bool allow()
     {
+        SPDLOG_TRACE("rate_limiter: allow() called");
         using std::chrono::duration_cast;
         using std::chrono::microseconds;
         using std::chrono::milliseconds;
         using std::chrono::seconds;
 
         if (max_per_second_ == 0) {
+            SPDLOG_TRACE(
+                "rate_limiter: max_per_second_ is 0, allowing all requests");
             return true;
         }
 
@@ -51,11 +55,17 @@ public:
             (precounter_ * (mil - (now_ms % mil))) / mil + counter_;
 
         if (count >= max_per_second_) {
+            SPDLOG_TRACE("rate_limiter: count is greater than max_per_second_, "
+                         "returning false: {}, {}",
+                count, max_per_second_);
             return false;
         }
 
         counter_++;
 
+        SPDLOG_TRACE("rate_limiter: count is less than max_per_second_, "
+                     "returning true: {}, {}",
+            count, max_per_second_);
         return true;
     }
 

--- a/appsec/src/helper/service_manager.cpp
+++ b/appsec/src/helper/service_manager.cpp
@@ -8,10 +8,9 @@
 namespace dds {
 
 std::shared_ptr<service> service_manager::create_service(
-    const engine_settings &settings, const remote_config::settings &rc_settings,
-    sidecar_settings sc_settings)
+    const engine_settings &settings, const remote_config::settings &rc_settings)
 {
-    const cache_key key{settings, rc_settings, sc_settings};
+    const cache_key key{settings, rc_settings};
     SPDLOG_DEBUG(
         "Will try to fetch service with cache hash={}", cache_key::hash{}(key));
 
@@ -30,8 +29,7 @@ std::shared_ptr<service> service_manager::create_service(
     SPDLOG_DEBUG("Creating a service for settings={} rc_settings={}", settings,
         rc_settings);
 
-    auto service_ptr =
-        service::from_settings(settings, rc_settings, std::move(sc_settings));
+    auto service_ptr = service::from_settings(settings, rc_settings);
     cache_.emplace(key, std::move(service_ptr));
 
     last_service_ = service_ptr;
@@ -64,6 +62,7 @@ void service_manager::notify_of_rc_updates(std::string_view shmem_path)
 
 void service_manager::cleanup_cache()
 {
+    // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
     auto entries_before = cache_.size();
     for (auto it = cache_.begin(); it != cache_.end();) {
         if (it->second.expired()) {
@@ -72,6 +71,7 @@ void service_manager::cleanup_cache()
             it++;
         }
     }
+    // NOLINTNEXTLINE(clang-analyzer-deadcode.DeadStores)
     auto entries_after = cache_.size();
     SPDLOG_DEBUG("Cleaned up service cache. Entries before: {}, after: {}",
         entries_before, entries_after);

--- a/appsec/src/helper/service_manager.cpp
+++ b/appsec/src/helper/service_manager.cpp
@@ -12,6 +12,8 @@ std::shared_ptr<service> service_manager::create_service(
     sidecar_settings sc_settings)
 {
     const cache_key key{settings, rc_settings, sc_settings};
+    SPDLOG_DEBUG(
+        "Will try to fetch service with cache hash={}", cache_key::hash{}(key));
 
     const std::lock_guard guard{mutex_};
     auto hit = cache_.find(key);
@@ -62,6 +64,7 @@ void service_manager::notify_of_rc_updates(std::string_view shmem_path)
 
 void service_manager::cleanup_cache()
 {
+    auto entries_before = cache_.size();
     for (auto it = cache_.begin(); it != cache_.end();) {
         if (it->second.expired()) {
             it = cache_.erase(it);
@@ -69,6 +72,9 @@ void service_manager::cleanup_cache()
             it++;
         }
     }
+    auto entries_after = cache_.size();
+    SPDLOG_DEBUG("Cleaned up service cache. Entries before: {}, after: {}",
+        entries_before, entries_after);
 }
 
 } // namespace dds

--- a/appsec/src/helper/service_manager.hpp
+++ b/appsec/src/helper/service_manager.hpp
@@ -5,13 +5,8 @@
 // (https://www.datadoghq.com/). Copyright 2021 Datadog, Inc.
 #pragma once
 
-#include "engine.hpp"
 #include "engine_settings.hpp"
-#include "exception.hpp"
-#include "network/proto.hpp"
 #include "service.hpp"
-#include "std_logging.hpp"
-#include "subscriber/waf.hpp"
 #include "utils.hpp"
 #include <memory>
 #include <mutex>
@@ -35,8 +30,7 @@ public:
 
     virtual std::shared_ptr<service> create_service(
         const engine_settings &settings,
-        const remote_config::settings &rc_settings,
-        sidecar_settings sc_settings);
+        const remote_config::settings &rc_settings);
 
     void notify_of_rc_updates(std::string_view shmem_path);
 
@@ -44,19 +38,16 @@ protected:
     class cache_key {
     public:
         cache_key(engine_settings engine_settings,
-            remote_config::settings config_settings,
-            sidecar_settings sc_settings)
+            remote_config::settings config_settings)
             : engine_settings_{std::move(engine_settings)},
               config_settings_{std::move(config_settings)},
-              sc_settings_{std::move(sc_settings)},
-              hash_{dds::hash(engine_settings_, config_settings_, sc_settings_)}
+              hash_{dds::hash(engine_settings_, config_settings_)}
         {}
 
         bool operator==(const cache_key &other) const
         {
             return engine_settings_ == other.engine_settings_ &&
-                   config_settings_ == other.config_settings_ &&
-                   sc_settings_ == other.sc_settings_;
+                   config_settings_ == other.config_settings_;
         }
 
         struct hash {
@@ -74,7 +65,6 @@ protected:
     private:
         engine_settings engine_settings_;
         remote_config::settings config_settings_;
-        sidecar_settings sc_settings_;
         std::size_t hash_;
     };
 

--- a/appsec/src/helper/sidecar_settings.hpp
+++ b/appsec/src/helper/sidecar_settings.hpp
@@ -7,6 +7,7 @@
 
 #include "utils.hpp"
 #include <msgpack.hpp>
+#include <spdlog/fmt/bundled/base.h>
 #include <string>
 
 namespace dds {
@@ -26,6 +27,17 @@ struct sidecar_settings {
 };
 
 } // namespace dds
+
+template <> struct fmt::formatter<dds::sidecar_settings> {
+    constexpr auto parse(fmt::format_parse_context &ctx) { return ctx.begin(); }
+
+    template <typename FormatContext>
+    auto format(const dds::sidecar_settings &s, FormatContext &ctx) const
+    {
+        return fmt::format_to(ctx.out(), "{{session_id={}, runtime_id={}}}",
+            s.session_id, s.runtime_id);
+    }
+};
 
 namespace std {
 template <> struct hash<dds::sidecar_settings> {

--- a/appsec/src/helper/subscriber/waf.cpp
+++ b/appsec/src/helper/subscriber/waf.cpp
@@ -567,13 +567,15 @@ void instance::listener::call(
             DD_STDLOG(DD_STDLOG_AFTER_WAF,
                 parameter_to_json(parameter_view{*events}), duration / millis);
         }
-        SPDLOG_DEBUG("Waf response: code {} - actions {} - attributes {}",
+        SPDLOG_DEBUG(
+            "Waf response: code {} - actions {} - attributes {} - keep {}",
             fmt::underlying(code),
             actions != nullptr ? parameter_to_json(parameter_view{*actions})
                                : "",
             attributes != nullptr
                 ? parameter_to_json(parameter_view{*attributes})
-                : "");
+                : "",
+            event.keep);
     } else {
         run_waf();
     }

--- a/appsec/tests/extension/client_init_record_span_tags.phpt
+++ b/appsec/tests/extension/client_init_record_span_tags.phpt
@@ -86,9 +86,8 @@ Array
 (
     [_dd.appsec.json] => {"triggers":[{"found":"attack"},{"another":"attack"},{"yet another":"attack"}]}
     [_dd.p.appsec] => 1
-    [_dd.p.dm] => -5
+    [_dd.p.dm] => -0
     [_dd.p.tid] => %s
-    [_dd.p.ts] => 02
     [_dd.runtime_family] => php
     [appsec.event] => true
     [http.method] => GET
@@ -108,7 +107,8 @@ Array
     [metric_1] => 2
     [metric_2] => 10
     [_dd.appsec.enabled] => 1
-    [_sampling_priority_v1] => 2
+    [_dd.agent_psr] => 1
+    [_sampling_priority_v1] => 1
     [php.compilation.total_time_ms] => %f
     [php.memory.peak_usage_bytes] => %f
     [php.memory.peak_real_usage_bytes] => %f

--- a/appsec/tests/extension/inc/mock_helper.php
+++ b/appsec/tests/extension/inc/mock_helper.php
@@ -274,7 +274,7 @@ function response_request_shutdown($message, $mergeWithEmpty = true) {
                 ]
             ],
             [],
-            false,
+            false, //force_keep
             [],
             [],
             [],

--- a/appsec/tests/extension/rinit_asm_events_propagate_tags.phpt
+++ b/appsec/tests/extension/rinit_asm_events_propagate_tags.phpt
@@ -20,10 +20,10 @@ ddtrace_version_at_least('0.79.0');
 include __DIR__ . '/inc/mock_helper.php';
 
 $helper = Helper::createInitedRun([
-    response_list(response_request_init([[['record', []]], ['{"found":"attack"}','{"another":"attack"}']])),
+    response_list(response_request_init([[['block', []]], ['{"found":"attack"}','{"another":"attack"}']])),
     response_list(
      response_request_shutdown(
-          [[['record', []]], ['{"yet another":"attack"}'], false, ["rshutdown_tag" => "rshutdown_value"], ["rshutdown_metric" => 2.1]]
+          [[['block', []]], ['{"yet another":"attack"}'], false, ["rshutdown_tag" => "rshutdown_value"], ["rshutdown_metric" => 2.1]]
      )
     ),
 ], ['continuous' => true]);

--- a/appsec/tests/extension/rinit_asm_events_propagate_tags.phpt
+++ b/appsec/tests/extension/rinit_asm_events_propagate_tags.phpt
@@ -20,10 +20,14 @@ ddtrace_version_at_least('0.79.0');
 include __DIR__ . '/inc/mock_helper.php';
 
 $helper = Helper::createInitedRun([
-    response_list(response_request_init([[['block', []]], ['{"found":"attack"}','{"another":"attack"}']])),
+    response_list(response_request_init([
+            [['record', []]],
+            ['{"found":"attack"}','{"another":"attack"}'],
+            true
+    ])),
     response_list(
      response_request_shutdown(
-          [[['block', []]], ['{"yet another":"attack"}'], false, ["rshutdown_tag" => "rshutdown_value"], ["rshutdown_metric" => 2.1]]
+          [[['record', []]], ['{"yet another":"attack"}'], true, ["rshutdown_tag" => "rshutdown_value"], ["rshutdown_metric" => 2.1]]
      )
     ),
 ], ['continuous' => true]);

--- a/appsec/tests/extension/rinit_record_span_tags.phpt
+++ b/appsec/tests/extension/rinit_record_span_tags.phpt
@@ -81,9 +81,8 @@ Array
 (
     [_dd.appsec.json] => {"triggers":[{"found":"attack"},{"another":"attack"},{"yet another":"attack"}]}
     [_dd.p.appsec] => 1
-    [_dd.p.dm] => -5
+    [_dd.p.dm] => -0
     [_dd.p.tid] => %s
-    [_dd.p.ts] => 02
     [_dd.runtime_family] => php
     [appsec.event] => true
     [http.method] => GET
@@ -101,7 +100,8 @@ Array
     [%s] => %d
     [rshutdown_metric] => 2.1
     [_dd.appsec.enabled] => 1
-    [_sampling_priority_v1] => 2
+    [_dd.agent_psr] => 1
+    [_sampling_priority_v1] => 1
     [php.compilation.total_time_ms] => %f
     [php.memory.peak_usage_bytes] => %f
     [php.memory.peak_real_usage_bytes] => %f

--- a/appsec/tests/helper/client_test.cpp
+++ b/appsec/tests/helper/client_test.cpp
@@ -7,6 +7,7 @@
 #include "parameter.hpp"
 #include "service_config.hpp"
 #include "sidecar_settings.hpp"
+#include "subscriber/waf.hpp"
 #include <base64.h>
 #include <client.hpp>
 #include <compression.hpp>
@@ -39,8 +40,7 @@ class service_manager : public dds::service_manager {
 public:
     MOCK_METHOD(std::shared_ptr<dds::service>, create_service,
         (const dds::engine_settings &settings,
-            const dds::remote_config::settings &rc_settings,
-            dds::sidecar_settings sc_settings),
+            const dds::remote_config::settings &rc_settings),
         (override));
 };
 
@@ -50,8 +50,7 @@ public:
         std::shared_ptr<service_config> service_config,
         dds::sidecar_settings sc_settings)
         : dds::service{std::move(engine), std::move(service_config), {},
-              dds::service::create_shared_metrics(sc_settings), "/rc_path",
-              sc_settings}
+              dds::service::create_shared_metrics(), "/rc_path"}
     {}
 };
 
@@ -199,7 +198,7 @@ TEST(ClientTest, ClientInitRegisterRuntimeId)
         send(testing::An<const std::shared_ptr<network::base_response> &>()))
         .WillOnce(DoAll(testing::SaveArg<0>(&res), Return(true)));
 
-    EXPECT_CALL(*smanager, create_service(_, _, _))
+    EXPECT_CALL(*smanager, create_service(_, _))
         .Times(1)
         .WillOnce(Return(service));
 
@@ -234,7 +233,7 @@ TEST(ClientTest, ClientInitGeneratesRuntimeId)
         send(testing::An<const std::shared_ptr<network::base_response> &>()))
         .WillOnce(DoAll(testing::SaveArg<0>(&res), Return(true)));
 
-    EXPECT_CALL(*smanager, create_service(_, _, _))
+    EXPECT_CALL(*smanager, create_service(_, _))
         .Times(1)
         .WillOnce(Return(service));
 
@@ -2271,7 +2270,7 @@ TEST(ClientTest, ServiceIsCreatedDependingOnEnabledConfigurationValue)
                 testing::An<const std::shared_ptr<network::base_response> &>()))
             .WillRepeatedly(Return(true));
 
-        EXPECT_CALL(*smanager, create_service(_, _, _))
+        EXPECT_CALL(*smanager, create_service(_, _))
             .Times(1)
             .WillOnce(Return(service));
         client c(smanager, std::unique_ptr<mock::broker>(broker));
@@ -2287,7 +2286,7 @@ TEST(ClientTest, ServiceIsCreatedDependingOnEnabledConfigurationValue)
             send(
                 testing::An<const std::shared_ptr<network::base_response> &>()))
             .WillRepeatedly(Return(true));
-        EXPECT_CALL(*smanager, create_service(_, _, _))
+        EXPECT_CALL(*smanager, create_service(_, _))
             .Times(1)
             .WillOnce(Return(service));
         client c(smanager, std::unique_ptr<mock::broker>(broker));
@@ -2303,7 +2302,7 @@ TEST(ClientTest, ServiceIsCreatedDependingOnEnabledConfigurationValue)
             send(
                 testing::An<const std::shared_ptr<network::base_response> &>()))
             .WillRepeatedly(Return(true));
-        EXPECT_CALL(*smanager, create_service(_, _, _))
+        EXPECT_CALL(*smanager, create_service(_, _))
             .Times(1)
             .WillOnce(Return(service));
         client c(smanager, std::unique_ptr<mock::broker>(broker));

--- a/appsec/tests/helper/service_manager_test.cpp
+++ b/appsec/tests/helper/service_manager_test.cpp
@@ -30,16 +30,14 @@ TEST(ServiceManagerTest, LoadRulesOK)
     dds::engine_settings engine_settings;
     engine_settings.rules_file = fn;
     engine_settings.waf_timeout_us = 42;
-    auto service = manager.create_service(
-        engine_settings, {}, sidecar_settings{"sid1", "rid1"});
+    auto service = manager.create_service(engine_settings, {});
     auto *service_rp = service.get();
     auto metrics = service->drain_legacy_metrics();
     EXPECT_EQ(manager.get_cache().size(), 1);
     EXPECT_EQ(metrics[metrics::event_rules_loaded], 5);
 
     // loading again should take from the cache
-    auto service2 = manager.create_service(
-        engine_settings, {}, sidecar_settings{"sid1", "rid1"});
+    auto service2 = manager.create_service(engine_settings, {});
     EXPECT_EQ(manager.get_cache().size(), 1);
     EXPECT_EQ(service, service2);
 
@@ -56,15 +54,13 @@ TEST(ServiceManagerTest, LoadRulesOK)
     ASSERT_FALSE(weak_ptr.expired());
 
     // loading another service should cleanup the cache
-    auto service3 = manager.create_service(
-        engine_settings, {true}, sidecar_settings{"sid2", "rid2"});
+    auto service3 = manager.create_service(engine_settings, {true});
     ASSERT_NE(service3.get(), service_rp);
     ASSERT_TRUE(weak_ptr.expired());
     EXPECT_EQ(manager.get_cache().size(), 1);
 
     // another service identifier should result in another service
-    auto service4 = manager.create_service(
-        engine_settings, {}, sidecar_settings{"sid3", "rid3"});
+    auto service4 = manager.create_service(engine_settings, {});
     EXPECT_EQ(manager.get_cache().size(), 2);
 }
 
@@ -79,8 +75,7 @@ TEST(ServiceManagerTest, LoadRulesFileNotFound)
             dds::engine_settings engine_settings;
             engine_settings.rules_file = "/file/that/does/not/exist";
             engine_settings.waf_timeout_us = 42;
-            manager.create_service(
-                engine_settings, {}, sidecar_settings{"sid", "rid"});
+            manager.create_service(engine_settings, {});
         },
         std::runtime_error);
 }
@@ -96,8 +91,7 @@ TEST(ServiceManagerTest, BadRulesFile)
             dds::engine_settings engine_settings;
             engine_settings.rules_file = "/dev/null";
             engine_settings.waf_timeout_us = 42;
-            manager.create_service(
-                engine_settings, {}, sidecar_settings{"sid", "rid"});
+            manager.create_service(engine_settings, {});
         },
         dds::parsing_error);
 }
@@ -111,12 +105,9 @@ TEST(ServiceManagerTest, UniqueServices)
     auto fn = create_sample_rules_ok();
     dds::engine_settings engine_settings;
     engine_settings.rules_file = fn;
-
-    auto service1 = manager.create_service(
-        engine_settings, {}, sidecar_settings{"sid", "rid"});
-    auto service2 = manager.create_service(
-        engine_settings, {}, sidecar_settings{"sid", "rid"});
-
-    EXPECT_EQ(service1.get(), service2.get());
+    engine_settings.waf_timeout_us = 42;
+    auto service1 = manager.create_service(engine_settings, {});
+    auto service2 = manager.create_service(engine_settings, {});
+    EXPECT_EQ(service1, service2);
 }
 } // namespace dds

--- a/appsec/tests/integration/src/docker/fpm-common/www.conf
+++ b/appsec/tests/integration/src/docker/fpm-common/www.conf
@@ -7,7 +7,7 @@ listen = 127.0.0.1:9000
 listen.allowed_clients = 127.0.0.1
 
 pm = static
-pm.max_children = 1
+pm.max_children = 5
 pm.max_requests = 50
 pm.status_path = /status
 ping.path = /ping

--- a/appsec/tests/integration/src/test/bin/enable_extensions.sh
+++ b/appsec/tests/integration/src/test/bin/enable_extensions.sh
@@ -24,7 +24,7 @@ if [[ -f /appsec/ddappsec.so && -d /project ]]; then
     echo datadog.appsec.helper_path=/appsec/libddappsec-helper.so
     echo datadog.appsec.helper_log_file=/tmp/logs/helper.log
     echo datadog.appsec.helper_log_level=info
-#    echo datadog.appsec.helper_log_level=trace
+    echo datadog.appsec.helper_log_level=trace
     echo datadog.appsec.rules=/etc/recommended.json
     echo datadog.appsec.log_file=/tmp/logs/appsec.log
     echo datadog.appsec.log_level=debug

--- a/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/CommonTests.groovy
+++ b/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/CommonTests.groovy
@@ -225,7 +225,6 @@ trait CommonTests {
         assert span.meta."_dd.appsec.event_rules.version" != ''
     }
 
-
     @Test
     void 'trace with an attack'() {
         HttpRequest req = container.buildReq('/hello.php')


### PR DESCRIPTION
## Description
Fixes two bugs in the AppSec helper/extension pipeline.

The first is in ASM event propagation: when the WAF returns a `keep` decision and the rate limiter allows it, the helper sets `force_keep` in the response. The extension needs to act on that signal immediately to set trace priority and propagate headers to downstream services. Instead, the event was being emitted at shutdown — too late for header propagation.

The second is an engine hashing bug causing each FPM worker to create its own AppSec service instance instead of reusing the shared one, resulting in N parallel WAF instances where there should be one.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
