### PR TITLE
Bump llvm from 17 to 19 to match Rust's version

### DIFF
--- a/.github/workflows/prof_asan.yml
+++ b/.github/workflows/prof_asan.yml
@@ -39,12 +39,11 @@ jobs:
           rm $(php-config --ini-dir)/sqlsrv.ini #sqlsrv leaks memory and triggers asan
           cd profiling
           export CARGO_TARGET_DIR=/tmp/build-cargo
-          export CC=clang-17
           export CFLAGS='-fsanitize=address  -fno-omit-frame-pointer'
           export LDFLAGS='-fsanitize=address -shared-libasan'
-          export RUSTC_LINKER=lld-17
           triplet=$(uname -m)-unknown-linux-gnu
           RUST_NIGHTLY_VERSION="-2025-01-03"
+          rustup component add rust-src --toolchain nightly${RUST_NIGHTLY_VERSION}
           RUSTFLAGS='-Zsanitizer=address' cargo +nightly${RUST_NIGHTLY_VERSION} build -Zbuild-std --target $triplet --release
           cp -v "$CARGO_TARGET_DIR/$triplet/release/libdatadog_php_profiling.so" "$(php-config --extension-dir)/datadog-profiling.so"
 

--- a/.github/workflows/prof_correctness.yml
+++ b/.github/workflows/prof_correctness.yml
@@ -45,13 +45,15 @@ jobs:
 
       - name: Build profiler
         run: |
-          echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main" | sudo tee -a /etc/apt/sources.list
+          echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-19 main" | sudo tee -a /etc/apt/sources.list
           echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main" | sudo tee -a /etc/apt/sources.list
           curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
           curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
           sudo apt remove -y clang-*
           sudo apt-get update
-          sudo apt install -y clang-17
+          sudo apt install -y clang-19
+          export CC=clang-19
+          export RUSTC_LINKER=lld-19
           cd profiling
           version_number=$(awk -F' = ' '$1 == "channel" { gsub(/"/, "", $2); print $2 }' rust-toolchain.toml)
           curl https://sh.rustup.rs -sSf | sh -s -- --profile minimal -y --default-toolchain "$version_number"

--- a/.gitlab/build-profiler.sh
+++ b/.gitlab/build-profiler.sh
@@ -16,9 +16,12 @@ fi
 #  /usr/lib/llvm20/lib/clang/20/include/arm_vector_types.h:94:24: error: Neon vector size must be 64 or 128 bits
 #  /usr/lib/llvm20/lib/clang/20/include/arm_neon.h:6374:25: error: incompatible constant for this __builtin_neon function
 # etc.
-if [ -f /sbin/apk ] && [ $(uname -m) = "aarch64" ]; then
-    ln -sf ../lib/llvm17/bin/clang /usr/bin/clang
+if [ -f /sbin/apk ]; then
+    ln -sf ../lib/llvm19/bin/clang /usr/bin/clang
+    ln -sf ../lib/llvm19/bin/clang++ /usr/bin/clang++
 fi
+
+export CC=clang
 
 set -u
 

--- a/.gitlab/generate-appsec.php
+++ b/.gitlab/generate-appsec.php
@@ -169,7 +169,7 @@ stages:
       unzip vault.zip
       sudo cp -v vault /usr/local/bin
       cd -
-      sudo apt-get update && sudo apt-get install -y jq gcovr llvm-17 clang-17
+      sudo apt-get update && sudo apt-get install -y jq gcovr llvm-19 clang-19
 
       echo "Installing codecov"
 
@@ -203,8 +203,8 @@ stages:
         ./appsec/build/tests/helper/ddappsec_helper_test
     - |
       cd /tmp/cov-ext
-      llvm-profdata-17 merge -sparse *.profraw -o default.profdata
-      llvm-cov-17 export "$CI_PROJECT_DIR"/appsec/build/ddappsec.so \
+      llvm-profdata-19 merge -sparse *.profraw -o default.profdata
+      llvm-cov-19 export "$CI_PROJECT_DIR"/appsec/build/ddappsec.so \
         -format=lcov -instr-profile=default.profdata \
         > "$CI_PROJECT_DIR"/appsec/build/coverage-ext.lcov
       echo "Uploading extension coverage to codecov"
@@ -212,8 +212,8 @@ stages:
       codecov -t "$CODECOV_TOKEN" -n appsec-extension -v -f appsec/build/coverage-ext.lcov
     - |
       cd /tmp/cov-helper
-      llvm-profdata-17 merge -sparse *.profraw -o default.profdata
-      llvm-cov-17 export "$CI_PROJECT_DIR"/appsec/build/tests/helper/ddappsec_helper_test \
+      llvm-profdata-19 merge -sparse *.profraw -o default.profdata
+      llvm-cov-19 export "$CI_PROJECT_DIR"/appsec/build/tests/helper/ddappsec_helper_test \
         -format=lcov -instr-profile=default.profdata \
         > "$CI_PROJECT_DIR/appsec/build/coverage-helper.lcov"
       echo "Uploading helper coverage to codecov"

--- a/.gitlab/generate-profiler.php
+++ b/.gitlab/generate-profiler.php
@@ -35,7 +35,10 @@ foreach ($profiler_minor_major_targets as $version) {
         IMAGE_SUFFIX: _centos-7
   script:
     - if [ -d '/opt/rh/devtoolset-7' ]; then set +eo pipefail; source scl_source enable devtoolset-7; set -eo pipefail; fi
-    - if [ -f /sbin/apk ] && [ $(uname -m) = "aarch64" ]; then ln -sf ../lib/llvm17/bin/clang /usr/bin/clang; fi
+    - if [ -f /sbin/apk ]; then ln -sf /usr/bin/clang-19 /usr/bin/cc; fi
+
+    - rustc -vV
+    - cc -v
 
     - cd profiling
     - export TEST_PHP_EXECUTABLE=$(which php)

--- a/dockerfiles/ci/alpine_compile_extension/base.Dockerfile
+++ b/dockerfiles/ci/alpine_compile_extension/base.Dockerfile
@@ -11,8 +11,6 @@ RUN set -eux; \
         autoconf \
         catch2 \
         coreutils \
-        g++ \
-        gcc \
         make \
         cmake \
         build-base \
@@ -32,7 +30,7 @@ RUN set -eux; \
 # Minimum: libclang. Nice-to-have: full toolchain including linker to play
 # with cross-language link-time optimization. Needs to match rustc -Vv's llvm
 # version.
-RUN apk add --no-cache llvm17-libs clang17-dev lld llvm17 rust-stdlib cargo clang git protoc unzip
+RUN apk add --no-cache llvm19-libs clang19-dev lld19 llvm19 rust-stdlib cargo clang19 git protoc unzip
 
 RUN cargo install --force --locked bindgen-cli && mv /root/.cargo/bin/bindgen /usr/local/bin/ && rm -rf /root/.cargo
 

--- a/dockerfiles/ci/bookworm/Dockerfile
+++ b/dockerfiles/ci/bookworm/Dockerfile
@@ -164,10 +164,10 @@ RUN set -eux; \
 
 # Install valgrind
 RUN set -eux; \
-    VALGRIND_VERSION="3.23.0"; \
-    VALGRIND_SHA1="ec410c75d3920d4f9249a5cfa2cac31e1bf6d586"; \
+    VALGRIND_VERSION="3.25.0"; \
+    VALGRIND_SHA256="295f60291d6b64c0d90c1ce645634bdc5361d39b0c50ecf9de6385ee77586ecc"; \
     cd /tmp && curl -OL https://sourceware.org/pub/valgrind/valgrind-${VALGRIND_VERSION}.tar.bz2; \
-    (echo "${VALGRIND_SHA1}" valgrind-${VALGRIND_VERSION}.tar.bz2 | sha1sum -c -); \
+    (echo "${VALGRIND_SHA256}" valgrind-${VALGRIND_VERSION}.tar.bz2 | sha256sum -c -); \
     mkdir valgrind && cd valgrind; \
     tar -xjf ../valgrind-${VALGRIND_VERSION}.tar.bz2 --strip 1;\
     ./configure; \

--- a/dockerfiles/ci/bookworm/Dockerfile
+++ b/dockerfiles/ci/bookworm/Dockerfile
@@ -9,10 +9,10 @@ ENV ACCEPT_EULA=Y
 # with cross-language link-time optimization. Needs to match rustc -Vv's llvm
 # version.
 ENV DEVLIBS \
-    libclang-17-dev \
-    libclang-rt-17-dev \
-    llvm-17-dev \
-    lld-17 \
+    libclang-19-dev \
+    libclang-rt-19-dev \
+    llvm-19-dev \
+    lld-19 \
     libcurl4-openssl-dev \
     libedit-dev \
     libffi-dev \
@@ -65,7 +65,7 @@ ENV PHPIZE_DEPS \
     autoconf \
     bison \
     catch2 \
-    clang-17 \
+    clang-19 \
     cmake \
     dpkg-dev \
     file \
@@ -89,12 +89,12 @@ RUN set -eux; \
     echo "deb http://deb.debian.org/debian-debug/ bookworm-debug main" | \
         tee -a /etc/apt/sources.list; \
     \
-# Use LLVM from orig vendor (also LLVM 17 is not shipped with bookworm)
+# Use LLVM from orig vendor (also LLVM 19 is not shipped with bookworm)
     apt-get update; \
     apt-get install -y curl gnupg software-properties-common; \
     curl https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc; \
-    add-apt-repository "deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-17 main"; \
-    add-apt-repository "deb-src http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-17 main"; \
+    add-apt-repository "deb http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-19 main"; \
+    add-apt-repository "deb-src http://apt.llvm.org/bookworm/ llvm-toolchain-bookworm-19 main"; \
     \
 # prevent Debian's PHP packages from being installed
 # https://github.com/docker-library/php/pull/542
@@ -128,14 +128,14 @@ RUN set -eux; \
     chown -R circleci:circleci /var/log/nginx/ /var/lib/nginx/; \
     \
 # Make clang the default compiler
-    update-alternatives --install /usr/bin/cc cc /usr/bin/clang-17 100; \
-    update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-17 100; \
-    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-17 100; \
-    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-17 100; \
-    update-alternatives --install /usr/bin/ld ld /usr/bin/ld.lld-17 100; \
-    echo "-L /usr/lib/llvm-17/lib/clang/17/lib/linux" > /usr/lib/llvm-17/bin/clang.cfg; \
+    update-alternatives --install /usr/bin/cc cc /usr/bin/clang-19 100; \
+    update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-19 100; \
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-19 100; \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-19 100; \
+    update-alternatives --install /usr/bin/ld ld /usr/bin/ld.lld-19 100; \
+    echo "-L /usr/lib/llvm-19/lib/clang/19/lib/linux" > /usr/lib/llvm-19/bin/clang.cfg; \
 # Include libasan library path
-    echo /usr/lib/llvm-17/lib/clang/17/lib/linux > /etc/ld.so.conf.d/libasan.conf && ldconfig
+    echo /usr/lib/llvm-19/lib/clang/19/lib/linux > /etc/ld.so.conf.d/libasan.conf && ldconfig
 
 # Install lcov
 RUN set -eux; \

--- a/dockerfiles/ci/buster/Dockerfile
+++ b/dockerfiles/ci/buster/Dockerfile
@@ -9,10 +9,10 @@ ENV ACCEPT_EULA=Y
 # with cross-language link-time optimization. Needs to match rustc -Vv's llvm
 # version.
 ENV DEVLIBS \
-    libclang-17-dev \
-    libclang-rt-17-dev \
-    llvm-17-dev \
-    lld-17 \
+    libclang-19-dev \
+    libclang-rt-19-dev \
+    llvm-19-dev \
+    lld-19 \
     libbrotli-dev \
     libcurl4-openssl-dev \
     libedit-dev \
@@ -46,8 +46,8 @@ ENV RUNTIME_DEPS \
     apache2 \
     apache2-dev \
     ca-certificates \
-    clang-format-17 \
-    clang-tidy-17 \
+    clang-format-19 \
+    clang-tidy-19 \
     curl \
     debian-goodies \
     git \
@@ -66,7 +66,7 @@ ENV RUNTIME_DEPS \
 ENV PHPIZE_DEPS \
     autoconf \
     bison \
-    clang-17 \
+    clang-19 \
     cmake \
     dpkg-dev \
     file \
@@ -93,11 +93,11 @@ RUN set -eux; \
     echo "deb http://deb.debian.org/debian-debug/ buster-debug main" | \
         tee -a /etc/apt/sources.list; \
     \
-# Use LLVM from orig vendor (also LLVM 17 is not shipped with buster)
+# Use LLVM from orig vendor (also LLVM 19 is not shipped with buster)
     apt-get update; \
     apt-get install -y curl gnupg; \
-    echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-17 main" >> /etc/apt/sources.list; \
-    echo "deb-src http://apt.llvm.org/buster/ llvm-toolchain-buster-17 main" >> /etc/apt/sources.list; \
+    echo "deb http://apt.llvm.org/buster/ llvm-toolchain-buster-19 main" >> /etc/apt/sources.list; \
+    echo "deb-src http://apt.llvm.org/buster/ llvm-toolchain-buster-19 main" >> /etc/apt/sources.list; \
     curl https://apt.llvm.org/llvm-snapshot.gpg.key | apt-key add -; \
     curl https://apt.llvm.org/llvm-snapshot.gpg.key | tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc; \
     \
@@ -130,14 +130,14 @@ RUN set -eux; \
     chown -R circleci:circleci /var/log/nginx/ /var/lib/nginx/; \
     \
 # Make clang the default compiler
-    update-alternatives --install /usr/bin/cc cc /usr/bin/clang-17 100; \
-    update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-17 100; \
-    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-17 100; \
-    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-17 100; \
-    update-alternatives --install /usr/bin/ld ld /usr/bin/ld.lld-17 100; \
-    echo "-L /usr/lib/llvm-17/lib/clang/17/lib/linux" > /usr/lib/llvm-17/bin/clang.cfg; \
+    update-alternatives --install /usr/bin/cc cc /usr/bin/clang-19 100; \
+    update-alternatives --install /usr/bin/c++ c++ /usr/bin/clang++-19 100; \
+    update-alternatives --install /usr/bin/clang clang /usr/bin/clang-19 100; \
+    update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-19 100; \
+    update-alternatives --install /usr/bin/ld ld /usr/bin/ld.lld-19 100; \
+    echo "-L /usr/lib/llvm-19/lib/clang/19/lib/linux" > /usr/lib/llvm-19/bin/clang.cfg; \
 # Include libasan library path
-    echo /usr/lib/llvm-17/lib/clang/17/lib/linux > /etc/ld.so.conf.d/libasan.conf && ldconfig
+    echo /usr/lib/llvm-19/lib/clang/19/lib/linux > /etc/ld.so.conf.d/libasan.conf && ldconfig
 
 ENV CMAKE_VERSION="3.24.4"
 

--- a/dockerfiles/ci/buster/Dockerfile
+++ b/dockerfiles/ci/buster/Dockerfile
@@ -195,10 +195,10 @@ RUN set -eux; \
 
 # Install valgrind
 RUN set -eux; \
-    VALGRIND_VERSION="3.23.0"; \
-    VALGRIND_SHA1="ec410c75d3920d4f9249a5cfa2cac31e1bf6d586"; \
+    VALGRIND_VERSION="3.25.0"; \
+    VALGRIND_SHA256="295f60291d6b64c0d90c1ce645634bdc5361d39b0c50ecf9de6385ee77586ecc"; \
     cd /tmp && curl -OL https://sourceware.org/pub/valgrind/valgrind-${VALGRIND_VERSION}.tar.bz2; \
-    (echo "${VALGRIND_SHA1}" valgrind-${VALGRIND_VERSION}.tar.bz2 | sha1sum -c -); \
+    (echo "${VALGRIND_SHA256}" valgrind-${VALGRIND_VERSION}.tar.bz2 | sha256sum -c -); \
     mkdir valgrind && cd valgrind; \
     tar -xjf ../valgrind-${VALGRIND_VERSION}.tar.bz2 --strip 1;\
     ./configure; \


### PR DESCRIPTION
### Description

Following #3299 this will bump llvm from 17 to 19 to match the llvm version Rust 1.84 was build with for LTO

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
