### PR TITLE
fix(ci): Resolve Kafka/Elasticsearch test failures and add automated supported versions tracking

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,6 @@
 # Default owners
 * @DataDog/apm-php
 
-# DD Octo STS trust policies (security-critical)
-.github/chainguard/** @DataDog/apm-php
-
 # Profiling team
 /profiling/ @DataDog/profiling-php
 

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,9 @@
 # Default owners
 * @DataDog/apm-php
 
+# DD Octo STS trust policies (security-critical)
+.github/chainguard/** @DataDog/apm-php
+
 # Profiling team
 /profiling/ @DataDog/profiling-php
 

--- a/.github/chainguard/gitlab-ci-aggregate-versions.sts.yaml
+++ b/.github/chainguard/gitlab-ci-aggregate-versions.sts.yaml
@@ -1,0 +1,13 @@
+issuer: https://gitlab.ddbuild.io
+subject_pattern: "project_path:DataDog/dd-trace-php:ref_type:branch:ref:master"
+claim_pattern:
+  project_path: "DataDog/dd-trace-php"
+  ref: "master"
+  ref_type: "branch"
+  ref_path: "refs/heads/master"
+  ref_protected: "true"
+  pipeline_source: "push"
+  ci_config_ref_uri: "gitlab.ddbuild.io/DataDog/dd-trace-php//.gitlab-ci.yml@refs/heads/master"
+permissions:
+  contents: write
+  pull_requests: write 

--- a/.github/chainguard/gitlab-ci-aggregate-versions.sts.yaml
+++ b/.github/chainguard/gitlab-ci-aggregate-versions.sts.yaml
@@ -1,15 +1,14 @@
 issuer: https://gitlab.ddbuild.io
 
-subject_pattern: "project_path:DataDog/apm-reliability/dd-trace-php:ref_type:branch:ref:alex/.*"
+subject_pattern: "project_path:DataDog/apm-reliability/dd-trace-php:ref_type:(branch|tag):ref:.*"
 
 claim_pattern:
   project_path: "DataDog/apm-reliability/dd-trace-php"
-  ref: "alex/.*"
-  ref_type: "branch"
-  ref_path: "refs/heads/alex/.*"
-  ref_protected: "true"
-  pipeline_source: "parent_pipeline"
+  ref: ".*"
+  ref_type: "(branch|tag)"
+  pipeline_source: "(push|schedule)"
 
 permissions:
+  actions: write
   contents: write
   pull_requests: write 

--- a/.github/chainguard/gitlab-ci-aggregate-versions.sts.yaml
+++ b/.github/chainguard/gitlab-ci-aggregate-versions.sts.yaml
@@ -1,13 +1,15 @@
 issuer: https://gitlab.ddbuild.io
-subject_pattern: "project_path:DataDog/dd-trace-php:ref_type:branch:ref:master"
+
+subject_pattern: "project_path:DataDog/apm-reliability/dd-trace-php:ref_type:branch:ref:alex/.*"
+
 claim_pattern:
-  project_path: "DataDog/dd-trace-php"
-  ref: "master"
+  project_path: "DataDog/apm-reliability/dd-trace-php"
+  ref: "alex/.*"
   ref_type: "branch"
-  ref_path: "refs/heads/master"
+  ref_path: "refs/heads/alex/.*"
   ref_protected: "true"
-  pipeline_source: "push"
-  ci_config_ref_uri: "gitlab.ddbuild.io/DataDog/dd-trace-php//.gitlab-ci.yml@refs/heads/master"
+  pipeline_source: "parent_pipeline"
+
 permissions:
   contents: write
   pull_requests: write 

--- a/.gitlab/generate-common.php
+++ b/.gitlab/generate-common.php
@@ -133,14 +133,18 @@ foreach ($arch_targets as $arch_target) {
     variables:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
+      ZOOKEEPER_SERVER_ID: 1
+      ZOOKEEPER_INIT_LIMIT: 5
+      ZOOKEEPER_SYNC_LIMIT: 2
+      ALLOW_ANONYMOUS_LOGIN: "yes"
 
   kafka-service:
     name: registry.ddbuild.io/images/mirror/confluentinc/cp-kafka:7.8.0
     alias: kafka-integration
     variables:
-      KAFKA_BROKER_ID: 111
-      KAFKA_CREATE_TOPICS: test-lowlevel:1:1,test-highlevel:1:1
+      KAFKA_BROKER_ID: 1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-integration:9092
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
@@ -148,6 +152,7 @@ foreach ($arch_targets as $arch_target) {
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: true
+      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
 
   redis:
     name: registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:php-redis-5.0

--- a/.gitlab/generate-common.php
+++ b/.gitlab/generate-common.php
@@ -154,6 +154,9 @@ foreach ($arch_targets as $arch_target) {
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: true
       KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
+      KAFKA_ZOOKEEPER_CONNECTION_TIMEOUT_MS: 120000
+      KAFKA_ZOOKEEPER_SESSION_TIMEOUT_MS: 120000
+      KAFKA_ZOOKEEPER_MAX_IN_FLIGHT_REQUESTS: 100
 
   redis:
     name: registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:php-redis-5.0

--- a/.gitlab/generate-common.php
+++ b/.gitlab/generate-common.php
@@ -134,7 +134,7 @@ foreach ($arch_targets as $arch_target) {
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
 
-  kafka:
+  kafka-service:
     name: registry.ddbuild.io/images/mirror/confluentinc/cp-kafka:7.8.0
     alias: kafka-integration
     variables:

--- a/.gitlab/generate-common.php
+++ b/.gitlab/generate-common.php
@@ -137,6 +137,7 @@ foreach ($arch_targets as $arch_target) {
       ZOOKEEPER_INIT_LIMIT: 5
       ZOOKEEPER_SYNC_LIMIT: 2
       ALLOW_ANONYMOUS_LOGIN: "yes"
+      ZOOKEEPER_ADMIN_ENABLE_SERVER: "false"
 
   kafka-service:
     name: registry.ddbuild.io/images/mirror/confluentinc/cp-kafka:7.8.0

--- a/.gitlab/generate-common.php
+++ b/.gitlab/generate-common.php
@@ -133,19 +133,16 @@ foreach ($arch_targets as $arch_target) {
     variables:
       ZOOKEEPER_CLIENT_PORT: 2181
       ZOOKEEPER_TICK_TIME: 2000
-      ZOOKEEPER_SERVER_ID: 1
-      ZOOKEEPER_INIT_LIMIT: 5
-      ZOOKEEPER_SYNC_LIMIT: 2
       ALLOW_ANONYMOUS_LOGIN: "yes"
       ZOOKEEPER_ADMIN_ENABLE_SERVER: "false"
 
-  kafka-service:
+  kafka:
     name: registry.ddbuild.io/images/mirror/confluentinc/cp-kafka:7.8.0
     alias: kafka-integration
     variables:
-      KAFKA_BROKER_ID: 1
+      KAFKA_BROKER_ID: 111
+      KAFKA_CREATE_TOPICS: test-lowlevel:1:1,test-highlevel:1:1
       KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
-      KAFKA_LISTENERS: PLAINTEXT://0.0.0.0:9092
       KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka-integration:9092
       KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT
       KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
@@ -153,10 +150,8 @@ foreach ($arch_targets as $arch_target) {
       KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
       KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
       KAFKA_AUTO_CREATE_TOPICS_ENABLE: true
-      KAFKA_GROUP_INITIAL_REBALANCE_DELAY_MS: 0
       KAFKA_ZOOKEEPER_CONNECTION_TIMEOUT_MS: 120000
       KAFKA_ZOOKEEPER_SESSION_TIMEOUT_MS: 120000
-      KAFKA_ZOOKEEPER_MAX_IN_FLIGHT_REQUESTS: 100
 
   redis:
     name: registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:php-redis-5.0

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -679,9 +679,6 @@ foreach ($xdebug_test_matrix as [$major_minor, $xdebug]):
   image: registry.ddbuild.io/images/dd-octo-sts-ci-base
   tags: [ "arch:amd64" ]
   when: always
-  variables:
-    KUBERNETES_CPU_REQUEST: 1
-    KUBERNETES_MEMORY_REQUEST: 2Gi
   id_tokens:
     DDOCTOSTS_ID_TOKEN:
       aud: dd-octo-sts

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -778,7 +778,7 @@ foreach ($xdebug_test_matrix as [$major_minor, $xdebug]):
           echo "A PR already exists."
         fi
       else
-        echo "Not on masterbranch, skipping PR creation"
+        echo "Not on master branch, skipping PR creation"
       fi
   after_script:
     # Revoke the GitHub token after usage

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -499,7 +499,7 @@ $services["magento"] = "elasticsearch7";
 $services["deferred_loading"] = "mysql";
 $services["deferred_loadin"] = "redis";
 $services["pdo"] = "mysql";
-$services["kafk"] = ["kafka-service", "zookeeper"];
+$services["kafk"] = ["kafka", "zookeeper"];
 
 $jobs = [];
 preg_match_all('(^TEST_(?<type>INTEGRATIONS|WEB)_(?<major>\d+)(?<minor>\d)[^\n]+(?<targets>.*?)^(?!\t))ms', file_get_contents(__DIR__ . "/../Makefile"), $matches, PREG_SET_ORDER);

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -536,7 +536,7 @@ foreach ($jobs as $type => $type_jobs):
 <?php if ($type == "web"): ?>
     - !reference [.services, mysql]
 <?php endif; ?>
-<?php 
+<?php
 foreach ($services as $part => $service) {
     if (str_contains($target, $part)) {
         foreach ((array)$service as $svc) {
@@ -678,104 +678,14 @@ foreach ($xdebug_test_matrix as [$major_minor, $xdebug]):
   id_tokens:
     DDOCTOSTS_ID_TOKEN:
       aud: dd-octo-sts
-  before_script:
-    - git config --global --add safe.directory /go/src/github.com/DataDog/apm-reliability/dd-trace-php
+  script:
+    - git config --global --add safe.directory "$CI_PROJECT_DIR"
     - git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
     - git config --global user.name "github-actions[bot]"
-  script:
-    - echo "Aggregating tested versions from all test jobs..."
-    - mkdir -p temp_versions
-    - find . -name "tested_versions_*.json" -path "*/artifacts/*" -exec sh -c 'cp "$1" "temp_versions/$(basename "$1" .json)_$(date +%s_%N).json"' _ {} \;
-    - ls -la temp_versions/
-    - |
-      jq -s 'reduce .[] as $item ({};
-        . as $acc |
-        reduce ($item | to_entries[]) as $entry ($acc;
-          .[$entry.key] = (.[$entry.key] + $entry.value | unique)
-        )
-      ) | to_entries | sort_by(.key) | from_entries' temp_versions/*.json > aggregated_tested_versions.json
-    - |
-      echo "Generating markdown table with bash/jq..."
-      echo "| Library                     | Min. Supported Version | Max. Supported Version |" > integration_versions.md
-      echo "|-----------------------------|------------------------|------------------------|" >> integration_versions.md
-      
-      # Process each library and find min/max versions
-      jq -r 'to_entries | sort_by(.key) | .[] | @base64' aggregated_tested_versions.json | while read encoded; do
-        decoded=$(echo $encoded | base64 -d)
-        library=$(echo $decoded | jq -r '.key')
-        versions=$(echo $decoded | jq -r '.value | join(" ")')
-        
-        # Find min and max versions using sort -V (version sort)
-        min_version=$(echo $versions | tr ' ' '\n' | sort -V | head -1)
-        max_version=$(echo $versions | tr ' ' '\n' | sort -V | tail -1)
-        
-        # Format library name to fit table width
-        formatted_library=$(printf "%-27s" "$library")
-        formatted_min=$(printf "%-22s" "$min_version")
-        formatted_max=$(printf "%-22s" "$max_version")
-        
-        echo "| $formatted_library | $formatted_min | $formatted_max |" >> integration_versions.md
-      done
-      
-      echo "Markdown table generated successfully"
-    - ls -la aggregated_tested_versions.json integration_versions.md
-    - cat integration_versions.md
-    - |
-      if [[ -z "$(git status --porcelain)" ]]; then
-        echo "No changes detected, exiting."
-        exit 0
-      fi
-      
-      # Only create PR if on master
-      if [[ "${CI_COMMIT_REF_NAME}" == "master" ]]; then
-        echo "Changes detected, creating/updating PR..."
-        
-        CURRENT_BRANCH=${CI_COMMIT_REF_NAME}
-        TARGET_BRANCH="update-supported-versions"
-        
-        # Get GitHub token from DD Octo STS
-        dd-octo-sts debug --scope DataDog/dd-trace-php --policy gitlab-ci-aggregate-versions
-        dd-octo-sts token --scope DataDog/dd-trace-php --policy gitlab-ci-aggregate-versions > github_token.txt
-        export GITHUB_TOKEN=$(cat github_token.txt)
-        
-        # Setup git remote with token
-        git remote remove origin || true
-        git remote add origin https://$GITHUB_TOKEN@github.com/DataDog/dd-trace-php.git
-        
-        # Check if branch exists and switch to it
-        if git ls-remote --heads origin $TARGET_BRANCH | grep $TARGET_BRANCH; then
-          echo "Branch exists, updating it..."
-          git fetch -f -u origin $TARGET_BRANCH:$TARGET_BRANCH
-          git symbolic-ref HEAD refs/heads/$TARGET_BRANCH
-          git reset
-        else
-          echo "Branch does not exist, creating it..."
-          git checkout -b $TARGET_BRANCH
-        fi
-        
-        # Add and commit changes
-        git add aggregated_tested_versions.json integration_versions.md
-        git commit -m "chore: Update supported versions" --author="github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>" || {
-          echo "No changes detected, exiting."
-          exit 0
-        }
-        git push origin $TARGET_BRANCH
-        
-        # Create or update PR
-        PR_NUMBER=$(gh pr list --repo DataDog/dd-trace-php --head $TARGET_BRANCH --json number --jq '.[0].number' || echo "")
-        if [[ -z "$PR_NUMBER" ]]; then
-          echo "Creating new PR..."
-          gh pr create --repo DataDog/dd-trace-php \
-            --base $CURRENT_BRANCH \
-            --head $TARGET_BRANCH \
-            --title "chore: update supported versions" \
-            --body "This PR updates the tested versions list automatically."
-        else
-          echo "A PR already exists."
-        fi
-      else
-        echo "Not on master branch, skipping PR creation"
-      fi
+    - dd-octo-sts debug --scope DataDog/dd-trace-php --policy gitlab-ci-aggregate-versions
+    - dd-octo-sts token --scope DataDog/dd-trace-php --policy gitlab-ci-aggregate-versions > github_token.txt
+    - export GITHUB_TOKEN=$(cat github_token.txt)
+    - ./tooling/tested_versions/create_or_update_supported_versions_pr.sh
   after_script:
     # Revoke the GitHub token after usage
     - if [[ -f github_token.txt ]]; then dd-octo-sts revoke -t $(cat github_token.txt) || true; fi
@@ -785,6 +695,7 @@ foreach ($xdebug_test_matrix as [$major_minor, $xdebug]):
       - "integration_versions.md"
     when: "always"
   rules:
+    # Run automatically on master even if previous jobs failed (flaky tests may still provide artifacts)
     - if: $CI_COMMIT_REF_NAME == "master"
       when: always
     - when: manual

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -738,10 +738,9 @@ foreach ($xdebug_test_matrix as [$major_minor, $xdebug]):
         TARGET_BRANCH="update-supported-versions"
         
         # Get GitHub token from DD Octo STS
-        # TODO: Create trust policy .github/chainguard/gitlab-ci-aggregate-versions.sts.yaml
-        # in DataDog/dd-trace-php with appropriate GitLab CI claim patterns
-        dd-octo-sts debug --scope DataDog/dd-trace-php --policy gitlab-ci-aggregate-versions
-        dd-octo-sts token --scope DataDog/dd-trace-php --policy gitlab-ci-aggregate-versions > github_token.txt
+        # Using existing policy until gitlab-ci-aggregate-versions is created
+        dd-octo-sts debug --scope DataDog/dd-trace-php --policy self.gitlab.read
+        dd-octo-sts token --scope DataDog/dd-trace-php --policy self.gitlab.read > github_token.txt
         export GITHUB_TOKEN=$(cat github_token.txt)
         
         # Setup git remote with token

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -678,6 +678,7 @@ foreach ($xdebug_test_matrix as [$major_minor, $xdebug]):
   stage: "aggregate versions"
   image: registry.ddbuild.io/images/mirror/php:8.2-cli
   tags: [ "arch:amd64" ]
+  when: always
   variables:
     KUBERNETES_CPU_REQUEST: 1
     KUBERNETES_MEMORY_REQUEST: 2Gi

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -676,7 +676,7 @@ foreach ($xdebug_test_matrix as [$major_minor, $xdebug]):
 
 "aggregate tested versions":
   stage: "aggregate versions"
-  image: registry.ddbuild.io/images/dd-octo-sts-ci-base
+  image: registry.ddbuild.io/images/dd-octo-sts-ci-base:2025.06-1
   tags: [ "arch:amd64" ]
   when: always
   id_tokens:

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -683,6 +683,7 @@ foreach ($xdebug_test_matrix as [$major_minor, $xdebug]):
     DDOCTOSTS_ID_TOKEN:
       aud: dd-octo-sts
   before_script:
+    - git config --global --add safe.directory /go/src/github.com/DataDog/apm-reliability/dd-trace-php
     - git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
     - git config --global user.name "github-actions[bot]"
   script:

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -734,12 +734,6 @@ foreach ($xdebug_test_matrix as [$major_minor, $xdebug]):
       if [[ "${CI_COMMIT_REF_NAME}" == "master" ]] || [[ "${CI_COMMIT_REF_NAME}" =~ ^alex/ ]]; then
         echo "Changes detected, creating/updating PR..."
         
-        # Install GitHub CLI
-        curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-        sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-        echo "deb [signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-        sudo apt update && sudo apt install -y gh
-        
         CURRENT_BRANCH=${CI_COMMIT_REF_NAME}
         TARGET_BRANCH="update-supported-versions"
         

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -492,15 +492,14 @@ endforeach;
 <?php
 
 // specific service maps:
-$service_mappings = [];
-$service_mappings["elasticsearch1"] = "elasticsearch2";
-$service_mappings["elasticsearch8"] = "elasticsearch7";
-$service_mappings["elasticsearch_latest"] = "elasticsearch7";
-$service_mappings["magento"] = "elasticsearch7";
-$service_mappings["deferred_loading"] = "mysql";
-$service_mappings["deferred_loadin"] = "redis";
-$service_mappings["pdo"] = "mysql";
-$service_mappings["test_integrations_kafka"] = ["kafka", "zookeeper"];
+$services["elasticsearch1"] = "elasticsearch2";
+$services["elasticsearch8"] = "elasticsearch7";
+$services["elasticsearch_latest"] = "elasticsearch7";
+$services["magento"] = "elasticsearch7";
+$services["deferred_loading"] = "mysql";
+$services["deferred_loadin"] = "redis";
+$services["pdo"] = "mysql";
+$services["kafk"] = ["kafka-service", "zookeeper"];
 
 $jobs = [];
 preg_match_all('(^TEST_(?<type>INTEGRATIONS|WEB)_(?<major>\d+)(?<minor>\d)[^\n]+(?<targets>.*?)^(?!\t))ms', file_get_contents(__DIR__ . "/../Makefile"), $matches, PREG_SET_ORDER);
@@ -538,7 +537,7 @@ foreach ($jobs as $type => $type_jobs):
     - !reference [.services, mysql]
 <?php endif; ?>
 <?php 
-foreach ($service_mappings as $part => $service) {
+foreach ($services as $part => $service) {
     if (str_contains($target, $part)) {
         if (is_array($service)) {
             foreach ($service as $svc) {

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -192,7 +192,7 @@ stages:
     HTTPBIN_PORT: 8080
   before_script:
 <?php before_script_steps() ?>
-    - for host in ${WAIT_FOR:-}; do wait-for $host --timeout=30; done
+    - for host in ${WAIT_FOR:-}; do wait-for $host --timeout=180; done
 
 .asan_test:
   extends: .base_test
@@ -482,7 +482,7 @@ endforeach;
     - if [[ "$MAKE_TARGET" != "test_composer" ]] || ! [[ "$PHP_MAJOR_MINOR" =~ 8.[01] ]]; then sudo composer self-update --$COMPOSER_VERSION --no-interaction; fi
     - COMPOSER_MEMORY_LIMIT=-1 composer update --no-interaction # disable composer memory limit completely
     - make composer_tests_update
-    - for host in ${WAIT_FOR:-}; do wait-for $host --timeout=30; done
+    - for host in ${WAIT_FOR:-}; do wait-for $host --timeout=180; done
   script:
     - DD_TRACE_AGENT_TIMEOUT=1000 make $MAKE_TARGET RUST_DEBUG_BUILD=1 PHPUNIT_OPTS="--log-junit artifacts/tests/results.xml" <?= ASSERT_NO_MEMLEAKS ?>
 <?php after_script(".", true); ?>

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -482,7 +482,14 @@ endforeach;
     - if [[ "$MAKE_TARGET" != "test_composer" ]] || ! [[ "$PHP_MAJOR_MINOR" =~ 8.[01] ]]; then sudo composer self-update --$COMPOSER_VERSION --no-interaction; fi
     - COMPOSER_MEMORY_LIMIT=-1 composer update --no-interaction # disable composer memory limit completely
     - make composer_tests_update
-    - for host in ${WAIT_FOR:-}; do wait-for $host --timeout=30; done
+    - echo "WAIT_FOR variable: ${WAIT_FOR:-}"
+    - echo "Available services and their status:"
+    - docker ps || echo "Docker not available"
+    - ss -tuln || netstat -tuln || echo "Network tools not available"
+    - echo "Testing connectivity to known service hosts:"
+    - nmap -p 9092 kafka-integration 2>/dev/null || echo "kafka-integration:9092 not reachable"
+    - nmap -p 2181 zookeeper 2>/dev/null || echo "zookeeper:2181 not reachable"
+    - for host in ${WAIT_FOR:-}; do echo "Waiting for $host"; wait-for $host --timeout=30; done
   script:
     - DD_TRACE_AGENT_TIMEOUT=1000 make $MAKE_TARGET RUST_DEBUG_BUILD=1 PHPUNIT_OPTS="--log-junit artifacts/tests/results.xml" <?= ASSERT_NO_MEMLEAKS ?>
 <?php after_script(".", true); ?>
@@ -557,7 +564,8 @@ foreach ($services as $part => $service) {
     DD_TRACE_TEST_SAPI: "<?= $sapi ?>"
 <?php endif; ?>
 <?php if (str_contains($target, "kafk")): ?>
-    WAIT_FOR: kafka-integration:9092
+    WAIT_FOR: zookeeper:2181 kafka-integration:9092
+    CI_DEBUG_SERVICES: "true"
 <?php endif; ?>
 <?php if (preg_match("(test_web_symfony_(2|30|33|40))", $target)): ?>
     COMPOSER_VERSION: 2.2

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -778,4 +778,6 @@ foreach ($xdebug_test_matrix as [$major_minor, $xdebug]):
   rules:
     - if: $CI_COMMIT_REF_NAME == "master"
       when: always
+    - if: $CI_COMMIT_REF_NAME =~ /^alex\//
+      when: always
     - when: manual

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -738,9 +738,8 @@ foreach ($xdebug_test_matrix as [$major_minor, $xdebug]):
         TARGET_BRANCH="update-supported-versions"
         
         # Get GitHub token from DD Octo STS
-        # Using existing policy until gitlab-ci-aggregate-versions is created
-        dd-octo-sts debug --scope DataDog/dd-trace-php --policy self.gitlab.read
-        dd-octo-sts token --scope DataDog/dd-trace-php --policy self.gitlab.read > github_token.txt
+        dd-octo-sts debug --scope DataDog/dd-trace-php --policy gitlab-ci-aggregate-versions
+        dd-octo-sts token --scope DataDog/dd-trace-php --policy gitlab-ci-aggregate-versions > github_token.txt
         export GITHUB_TOKEN=$(cat github_token.txt)
         
         # Setup git remote with token

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -539,12 +539,8 @@ foreach ($jobs as $type => $type_jobs):
 <?php 
 foreach ($services as $part => $service) {
     if (str_contains($target, $part)) {
-        if (is_array($service)) {
-            foreach ($service as $svc) {
-                echo "    - !reference [.services, $svc]\n";
-            }
-        } else {
-            echo "    - !reference [.services, $service]\n";
+        foreach ((array)$service as $svc) {
+            echo "    - !reference [.services, $svc]\n";
         }
     }
 }

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -681,40 +681,6 @@ foreach ($xdebug_test_matrix as [$major_minor, $xdebug]):
   id_tokens:
     DDOCTOSTS_ID_TOKEN:
       aud: dd-octo-sts
-  needs:
-<?php
-// Add all integration and web test jobs as dependencies
-foreach ($jobs as $type => $type_jobs):
-    foreach ($type_jobs as $target => $versions):
-        foreach ($versions as $major_minor):
-            $sapis = $type == "web" && version_compare($major_minor, "7.2", ">=") ? ["cli-server", "cgi-fcgi", "apache2handler"] : [""];
-            foreach ($sapis as $sapi):
-                $job_name = $target . ": [" . $major_minor . ($sapi ? ", $sapi" : "") . "]";
-?>
-    - job: "<?= $job_name ?>"
-      artifacts: true
-<?php
-            endforeach;
-        endforeach;
-    endforeach;
-endforeach;
-
-// Also add the other integration test jobs
-foreach ($all_minor_major_targets as $major_minor):
-    foreach (["test_auto_instrumentation", "test_composer", "test_integration"] as $test):
-?>
-    - job: "<?= $test ?>: [<?= $major_minor ?>]"
-      artifacts: true
-<?php
-    endforeach;
-    foreach (["cli-server", "cgi-fcgi"] as $sapi):
-?>
-    - job: "test_distributed_tracing: [<?= $major_minor ?>, <?= $sapi ?>]"
-      artifacts: true
-<?php
-    endforeach;
-endforeach;
-?>
   before_script:
     - apt update && apt install -y jq git curl
     - |

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -556,6 +556,9 @@ foreach ($services as $part => $service) {
 <?php if ($sapi): ?>
     DD_TRACE_TEST_SAPI: "<?= $sapi ?>"
 <?php endif; ?>
+<?php if (str_contains($target, "kafk")): ?>
+    WAIT_FOR: kafka-integration:9092
+<?php endif; ?>
 <?php if (preg_match("(test_web_symfony_(2|30|33|40))", $target)): ?>
     COMPOSER_VERSION: 2.2
 <?php endif; ?>

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -492,12 +492,13 @@ endforeach;
 
 // specific service maps:
 $services["elasticsearch1"] = "elasticsearch2";
+$services["elasticsearch8"] = "elasticsearch7";
 $services["elasticsearch_latest"] = "elasticsearch7";
 $services["magento"] = "elasticsearch7";
 $services["deferred_loading"] = "mysql";
 $services["deferred_loadin"] = "redis";
 $services["pdo"] = "mysql";
-$services["kafk"] = "zookeeper";
+$services["kafka"] = ["kafka", "zookeeper"];
 
 $jobs = [];
 preg_match_all('(^TEST_(?<type>INTEGRATIONS|WEB)_(?<major>\d+)(?<minor>\d)[^\n]+(?<targets>.*?)^(?!\t))ms', file_get_contents(__DIR__ . "/../Makefile"), $matches, PREG_SET_ORDER);
@@ -535,7 +536,13 @@ foreach ($jobs as $type => $type_jobs):
     - !reference [.services, mysql]
 <?php endif; ?>
 <?php foreach ($services as $part => $service): if (str_contains($target, $part)): ?>
+<?php if (is_array($service)): ?>
+<?php foreach ($service as $svc): ?>
+    - !reference [.services, <?= $svc ?>]
+<?php endforeach; ?>
+<?php else: ?>
     - !reference [.services, <?= $service ?>]
+<?php endif; ?>
 <?php endif; endforeach; ?>
   variables:
     PHP_MAJOR_MINOR: "<?= $major_minor ?>"

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -730,8 +730,8 @@ foreach ($xdebug_test_matrix as [$major_minor, $xdebug]):
         exit 0
       fi
       
-      # Only create PR if on master or alex/ branches
-      if [[ "${CI_COMMIT_REF_NAME}" == "master" ]] || [[ "${CI_COMMIT_REF_NAME}" =~ ^alex/ ]]; then
+      # Only create PR if on master
+      if [[ "${CI_COMMIT_REF_NAME}" == "master" ]]; then
         echo "Changes detected, creating/updating PR..."
         
         CURRENT_BRANCH=${CI_COMMIT_REF_NAME}
@@ -778,7 +778,7 @@ foreach ($xdebug_test_matrix as [$major_minor, $xdebug]):
           echo "A PR already exists."
         fi
       else
-        echo "Not on master or alex/ branch, skipping PR creation"
+        echo "Not on masterbranch, skipping PR creation"
       fi
   after_script:
     # Revoke the GitHub token after usage
@@ -790,7 +790,5 @@ foreach ($xdebug_test_matrix as [$major_minor, $xdebug]):
     when: "always"
   rules:
     - if: $CI_COMMIT_REF_NAME == "master"
-      when: always
-    - if: $CI_COMMIT_REF_NAME =~ /^alex\//
       when: always
     - when: manual

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -482,14 +482,7 @@ endforeach;
     - if [[ "$MAKE_TARGET" != "test_composer" ]] || ! [[ "$PHP_MAJOR_MINOR" =~ 8.[01] ]]; then sudo composer self-update --$COMPOSER_VERSION --no-interaction; fi
     - COMPOSER_MEMORY_LIMIT=-1 composer update --no-interaction # disable composer memory limit completely
     - make composer_tests_update
-    - echo "WAIT_FOR variable: ${WAIT_FOR:-}"
-    - echo "Available services and their status:"
-    - docker ps || echo "Docker not available"
-    - ss -tuln || netstat -tuln || echo "Network tools not available"
-    - echo "Testing connectivity to known service hosts:"
-    - nmap -p 9092 kafka-integration 2>/dev/null || echo "kafka-integration:9092 not reachable"
-    - nmap -p 2181 zookeeper 2>/dev/null || echo "zookeeper:2181 not reachable"
-    - for host in ${WAIT_FOR:-}; do echo "Waiting for $host"; wait-for $host --timeout=30; done
+    - for host in ${WAIT_FOR:-}; do wait-for $host --timeout=30; done
   script:
     - DD_TRACE_AGENT_TIMEOUT=1000 make $MAKE_TARGET RUST_DEBUG_BUILD=1 PHPUNIT_OPTS="--log-junit artifacts/tests/results.xml" <?= ASSERT_NO_MEMLEAKS ?>
 <?php after_script(".", true); ?>

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -676,7 +676,7 @@ foreach ($xdebug_test_matrix as [$major_minor, $xdebug]):
 
 "aggregate tested versions":
   stage: "aggregate versions"
-  image: registry.ddbuild.io/images/dd-octo-sts-ci-base:2025.01-2
+  image: registry.ddbuild.io/images/dd-octo-sts-ci-base
   tags: [ "arch:amd64" ]
   when: always
   variables:

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -487,7 +487,7 @@ endforeach;
     - DD_TRACE_AGENT_TIMEOUT=1000 make $MAKE_TARGET RUST_DEBUG_BUILD=1 PHPUNIT_OPTS="--log-junit artifacts/tests/results.xml" <?= ASSERT_NO_MEMLEAKS ?>
 <?php after_script(".", true); ?>
     - find tests -type f \( -name 'phpunit_error.log' -o -name 'nginx_*.log' -o -name 'apache_*.log' -o -name 'php_fpm_*.log' -o -name 'dd_php_error.log' \) -exec cp --parents '{}' artifacts \;
-    - make tested_versions && cp tests/tested_versions/tested_versions.json artifacts/tested_versions.json
+    - make tested_versions && cp tests/tested_versions/tested_versions.json artifacts/tested_versions_${MAKE_TARGET}_${PHP_MAJOR_MINOR}_${DD_TRACE_TEST_SAPI:-cli}.json
 
 <?php
 
@@ -689,7 +689,7 @@ foreach ($xdebug_test_matrix as [$major_minor, $xdebug]):
   script:
     - echo "Aggregating tested versions from all test jobs..."
     - mkdir -p temp_versions
-    - find . -name "tested_versions.json" -path "*/artifacts/*" -exec cp {} temp_versions/{}.$(date +%s_%N) \;
+    - find . -name "tested_versions_*.json" -path "*/artifacts/*" -exec sh -c 'cp "$1" "temp_versions/$(basename "$1" .json)_$(date +%s_%N).json"' _ {} \;
     - ls -la temp_versions/
     - |
       jq -s 'reduce .[] as $item ({};

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -676,7 +676,7 @@ foreach ($xdebug_test_matrix as [$major_minor, $xdebug]):
 
 "aggregate tested versions":
   stage: "aggregate versions"
-  image: registry.ddbuild.io/images/mirror/php:8.2-cli
+  image: registry.ddbuild.io/images/dd-octo-sts-ci-base:2025.01-2
   tags: [ "arch:amd64" ]
   when: always
   variables:
@@ -686,14 +686,7 @@ foreach ($xdebug_test_matrix as [$major_minor, $xdebug]):
     DDOCTOSTS_ID_TOKEN:
       aud: dd-octo-sts
   before_script:
-    - apt update && apt install -y jq git curl
-    - |
-      # Install dd-octo-sts binary
-      # Use crane to extract the binary from the official image
-      curl -L "https://github.com/google/go-containerregistry/releases/download/v0.19.0/go-containerregistry_Linux_x86_64.tar.gz" | tar -xz crane
-      chmod +x crane && mv crane /usr/local/bin/crane
-      crane export registry.ddbuild.io/dd-octo-sts:v1.0.0 - | tar -xf - usr/local/bin/dd-octo-sts
-      chmod +x usr/local/bin/dd-octo-sts
+    - apt update && apt install -y php8.2-cli php8.2-json
     - git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
     - git config --global user.name "github-actions[bot]"
   script:

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -735,10 +735,10 @@ foreach ($xdebug_test_matrix as [$major_minor, $xdebug]):
         echo "Changes detected, creating/updating PR..."
         
         # Install GitHub CLI
-        curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-        chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-        echo "deb [signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-        apt update && apt install -y gh
+        curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
+        sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
+        echo "deb [signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
+        sudo apt update && sudo apt install -y gh
         
         CURRENT_BRANCH=${CI_COMMIT_REF_NAME}
         TARGET_BRANCH="update-supported-versions"

--- a/tooling/tested_versions/create_or_update_supported_versions_pr.sh
+++ b/tooling/tested_versions/create_or_update_supported_versions_pr.sh
@@ -1,52 +1,91 @@
 #!/usr/bin/env bash
 set -euox pipefail
 
-if [[ -z $(git status --porcelain) ]]; then
+echo "Aggregating tested versions from all test jobs..."
+mkdir -p temp_versions
+find . -name "tested_versions_*.json" -path "*/artifacts/*" -exec sh -c 'cp "$1" "temp_versions/$(basename "$1" .json)_$(date +%s_%N).json"' _ {} \;
+ls -la temp_versions/
+
+jq -s 'reduce .[] as $item ({};
+  . as $acc |
+  reduce ($item | to_entries[]) as $entry ($acc;
+    .[$entry.key] = (.[$entry.key] + $entry.value | unique)
+  )
+) | to_entries | sort_by(.key) | from_entries' temp_versions/*.json > aggregated_tested_versions.json
+
+echo "Generating markdown table with bash/jq..."
+echo "| Library                     | Min. Supported Version | Max. Supported Version |" > integration_versions.md
+echo "|-----------------------------|------------------------|------------------------|" >> integration_versions.md
+
+# Process each library and find min/max versions
+jq -r 'to_entries | sort_by(.key) | .[] | @base64' aggregated_tested_versions.json | while read encoded; do
+  decoded=$(echo $encoded | base64 -d)
+  library=$(echo $decoded | jq -r '.key')
+  versions=$(echo $decoded | jq -r '.value | join(" ")')
+
+  # Find min and max versions using sort -V (version sort)
+  min_version=$(echo $versions | tr ' ' '\n' | sort -V | head -1)
+  max_version=$(echo $versions | tr ' ' '\n' | sort -V | tail -1)
+
+  # Format library name to fit table width
+  formatted_library=$(printf "%-27s" "$library")
+  formatted_min=$(printf "%-22s" "$min_version")
+  formatted_max=$(printf "%-22s" "$max_version")
+
+  echo "| $formatted_library | $formatted_min | $formatted_max |" >> integration_versions.md
+done
+
+echo "Markdown table generated successfully"
+ls -la aggregated_tested_versions.json integration_versions.md
+cat integration_versions.md
+
+if [[ -z "$(git status --porcelain)" ]]; then
   echo "No changes detected, exiting."
   exit 0
 fi
 
-git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
-git config --global user.name "github-actions[bot]"
+# Only create PR if on master
+if [[ "${CI_COMMIT_REF_NAME}" == "master" ]]; then
+  echo "Changes detected, creating/updating PR..."
 
-CURRENT_BRANCH=${CIRCLE_BRANCH}
-TARGET_BRANCH="update-supported-versions"
+  CURRENT_BRANCH=${CI_COMMIT_REF_NAME}
+  TARGET_BRANCH="update-supported-versions"
 
-git remote remove origin
-git remote add origin https://$GITHUB_TOKEN@github.com/DataDog/dd-trace-php.git
+  # Setup git remote with token
+  git remote remove origin || true
+  git remote add origin https://$GITHUB_TOKEN@github.com/DataDog/dd-trace-php.git
 
-if git ls-remote --heads origin $TARGET_BRANCH | grep $TARGET_BRANCH; then
-  echo "Branch exists, updating it..."
-  git fetch -f -u origin $TARGET_BRANCH:$TARGET_BRANCH
-  git symbolic-ref HEAD refs/heads/$TARGET_BRANCH
-  git reset
+  # Check if branch exists and switch to it
+  if git ls-remote --heads origin $TARGET_BRANCH | grep $TARGET_BRANCH; then
+    echo "Branch exists, updating it..."
+    git fetch -f -u origin $TARGET_BRANCH:$TARGET_BRANCH
+    git symbolic-ref HEAD refs/heads/$TARGET_BRANCH
+    git reset
+  else
+    echo "Branch does not exist, creating it..."
+    git checkout -b $TARGET_BRANCH
+  fi
+
+  # Add and commit changes
+  git add aggregated_tested_versions.json integration_versions.md
+  git commit -m "chore: Update supported versions" --author="github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>" || {
+    echo "No changes detected, exiting."
+    exit 0
+  }
+  git push origin $TARGET_BRANCH
+
+  # Create or update PR
+  PR_NUMBER=$(gh pr list --repo DataDog/dd-trace-php --head $TARGET_BRANCH --json number --jq '.[0].number' || echo "")
+  if [[ -z "$PR_NUMBER" ]]; then
+    echo "Creating new PR..."
+    gh pr create --repo DataDog/dd-trace-php \
+      --base $CURRENT_BRANCH \
+      --head $TARGET_BRANCH \
+      --title "chore: update supported versions" \
+      --body "This PR updates the tested versions list automatically."
+  else
+    echo "A PR already exists."
+  fi
 else
-  echo "Branch does not exist, creating it..."
-  git checkout -b $TARGET_BRANCH
-fi
-
-git add aggregated_tested_versions.json integration_versions.md
-git commit -m "chore: Update supported versions" --author="github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>" || {
-  echo "No changes detected, exiting."
-  exit 0
-}
-git push origin $TARGET_BRANCH
-
-# Install GitHub CLI
-curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg
-sudo chmod go+r /usr/share/keyrings/githubcli-archive-keyring.gpg
-echo "deb [signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list > /dev/null
-sudo apt update && sudo apt install -y gh
-
-# Check if PR already exists
-PR_NUMBER=$(gh pr list --repo DataDog/dd-trace-php --head $TARGET_BRANCH --json number --jq '.[0].number')
-if [[ -z $PR_NUMBER ]]; then
-  echo "Creating new PR..."
-  gh pr create --repo DataDog/dd-trace-php \
-    --base $CURRENT_BRANCH \
-    --head $TARGET_BRANCH \
-    --title "chore: update supported versions" \
-    --body "This PR updates the tested versions list automatically."
-else
-  echo "A PR already exists."
+  echo "Not on master branch, skipping PR creation"
 fi


### PR DESCRIPTION
## Description

This PR fixes failing GitLab CI integration tests and restores automated tracking of supported library versions that was lost during the CircleCI → GitLab migration.

## Issues

### Issue 1: Kafka Integration Tests Failing
**Error**: `RdKafka\Exception: Connect to ipv4#127.0.0.1:9092 failed: Connection refused`

**Root Cause Analysis**:
1. **Missing Kafka Service**: Service mapping was `$services["kafk"] = "zookeeper"` - this only added Zookeeper service, but tests connect to `kafka-integration:9092`
2. **Startup Timing**: Zookeeper takes time to start in CI, but Kafka was timing out waiting for Zookeeper
3. **Port Conflicts**: Default Zookeeper admin server conflicted with other services

**Solutions Applied**:
- **Array Service Handling**: Modified service mapping logic to handle arrays: `$services["kafk"] = ["kafka", "zookeeper"]` 
- **Extended Timeouts**: Added `KAFKA_ZOOKEEPER_CONNECTION_TIMEOUT_MS: 120000` and `KAFKA_ZOOKEEPER_SESSION_TIMEOUT_MS: 120000` (2 minutes) to wait for slow Zookeeper startup
- **Port Conflict Fix**: Added `ZOOKEEPER_ADMIN_ENABLE_SERVER: "false"` to disable admin server that was conflicting with other services
- **Global Timeout Extension**: Increased all `wait-for` timeouts from 30s to 180s

### Issue 2: Elasticsearch V8 Tests Failing  
**Error**: `Could not resolve host: elasticsearch7-integration`

**Root Cause**: Missing service mapping for `elasticsearch8` tests - they needed to use the `elasticsearch7` service but no mapping existed.

**Solution**: Added `$services["elasticsearch8"] = "elasticsearch7"`

### Issue 3: Lost Artifact Management System
**Root Cause**: During CircleCI → GitLab migration, the automated supported versions tracking system was lost. This system:
- Collected `tested_versions.json` from all integration tests
- Aggregated them into a single compatibility matrix
- Generated markdown documentation
- Created PRs with version updates

**Additional Problem**: All tests were creating artifacts with identical name `tested_versions.json`, causing overwrites

**Solutions Applied**:
- **Unique Artifact Naming**: Changed to `tested_versions_${MAKE_TARGET}_${PHP_MAJOR_MINOR}_${DD_TRACE_TEST_SAPI:-cli}.json`
- **Restored Aggregation Job**: Added "aggregate tested versions" job that:
  - Collects all unique version artifacts
  - Aggregates them with `jq` into single JSON
  - Generates markdown table with min/max supported versions per library
  - Creates/updates GitHub PR automatically

#### ⚠️ Prerequisites
The trust policy `.github/chainguard/gitlab-ci-aggregate-versions.sts.yaml` must be merged to `master` branch before the aggregation job can create GitHub PRs. I will have to test if it's working properly after this is merged. I don't have any other choice.

I'll remove the related now-unused scripts in another PR, when I'm sure the PR creation works (I want to have them easily under my eye in the meanwhile).


<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

## Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
