### PR TITLE
Disable legacy Gitlab exec in order to fix jobs failing with green status

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -37,9 +37,6 @@ variables:
     UPSTREAM_BRANCH: $CI_COMMIT_REF_NAME
     UPSTREAM_COMMIT_SHA: $CI_COMMIT_SHA
 
-    KUBERNETES_SERVICE_ACCOUNT_OVERWRITE: dd-trace-php
-    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
-
 benchmarks-profiler:
   extends: .microbenchmarks
   rules:
@@ -148,7 +145,6 @@ check-big-regressions:
       - platform/artifacts/
     expire_in: 3 months
   variables:
-    FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY: "true"
     K6_OPTIONS_WARMUP_RATE: 70
     K6_OPTIONS_WARMUP_DURATION: 1m
     K6_OPTIONS_WARMUP_GRACEFUL_STOP: 10s


### PR DESCRIPTION
### Description

Disables FF_USE_LEGACY_KUBERNETES_EXECUTION_STRATEGY that we used before to ensure build containers have QoS guaranteed. As of now, it doesn't seem to be necessary anymore, but leads to problems like https://gitlab.com/gitlab-org/gitlab-runner/-/issues/4119.

Example failing jobs:
* https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-php/-/jobs/1026475701

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
