### PR TITLE
Add forwarded header and private IP

### DIFF
--- a/ext/ip_extraction.c
+++ b/ext/ip_extraction.c
@@ -76,7 +76,7 @@ void dd_ip_extraction_startup() {
     priority_header_map[X_REAL_IP] = (header_map_node){zend_string_init_interned(ZEND_STRL("HTTP_X_REAL_IP"), 1),
                                                        zend_string_init_interned(ZEND_STRL("x-real-ip"), 1), &dd_parse_multiple_maybe_port};
     priority_header_map[FORWARDED] = (header_map_node){zend_string_init_interned(ZEND_STRL("HTTP_FORWARDED"), 1),
-                                                        zend_string_init_interned(ZEND_STRL("forwarded"), 1), &dd_parse_multiple_maybe_port};
+                                                        zend_string_init_interned(ZEND_STRL("forwarded"), 1), &dd_parse_forwarded};
     priority_header_map[TRUE_CLIENT_IP] = (header_map_node){zend_string_init_interned(ZEND_STRL("HTTP_TRUE_CLIENT_IP"), 1),
                                                             zend_string_init_interned(ZEND_STRL("true-client-ip"), 1), &dd_parse_multiple_maybe_port};
     priority_header_map[X_CLIENT_IP] = (header_map_node){zend_string_init_interned(ZEND_STRL("HTTP_X_CLIENT_IP"), 1),

--- a/ext/ip_extraction.c
+++ b/ext/ip_extraction.c
@@ -43,6 +43,7 @@ typedef struct _header_map_node {
 typedef enum _priority_header_id {
     X_FORWARDED_FOR = 0,
     X_REAL_IP,
+    FORWARDED,
     TRUE_CLIENT_IP,
     X_CLIENT_IP,
     X_FORWARDED,
@@ -74,6 +75,8 @@ void dd_ip_extraction_startup() {
                                                              zend_string_init_interned(ZEND_STRL("x-forwarded-for"), 1), &dd_parse_multiple_maybe_port};
     priority_header_map[X_REAL_IP] = (header_map_node){zend_string_init_interned(ZEND_STRL("HTTP_X_REAL_IP"), 1),
                                                        zend_string_init_interned(ZEND_STRL("x-real-ip"), 1), &dd_parse_multiple_maybe_port};
+    priority_header_map[FORWARDED] = (header_map_node){zend_string_init_interned(ZEND_STRL("HTTP_FORWARDED"), 1),
+                                                        zend_string_init_interned(ZEND_STRL("forwarded"), 1), &dd_parse_multiple_maybe_port};
     priority_header_map[TRUE_CLIENT_IP] = (header_map_node){zend_string_init_interned(ZEND_STRL("HTTP_TRUE_CLIENT_IP"), 1),
                                                             zend_string_init_interned(ZEND_STRL("true-client-ip"), 1), &dd_parse_multiple_maybe_port};
     priority_header_map[X_CLIENT_IP] = (header_map_node){zend_string_init_interned(ZEND_STRL("HTTP_X_CLIENT_IP"), 1),
@@ -445,6 +448,10 @@ static bool dd_is_private_v4(const struct in_addr *addr) {
         {
             .base.s_addr = CT_HTONL(0xA9FE0000U),  // 169.254.0.0
             .mask.s_addr = CT_HTONL(0xFFFF0000U),  // 255.255.0.0
+        },
+        {
+            .base.s_addr = CT_HTONL(0x64400000U),  // 100.64.0.0 (RFC6598, CGNAT, K8s pod IPs)
+            .mask.s_addr = CT_HTONL(0xFFC00000U),  // 255.192.0.0 (/10)
         },
     };
 

--- a/tests/ext/extract_ip_addr_precedence.phpt
+++ b/tests/ext/extract_ip_addr_precedence.phpt
@@ -30,6 +30,7 @@ function test($headers, $key_expected) {
 $headers = [
 'x_forwarded_for' => '7.7.7.1',
 'x_real_ip' => '7.7.7.2',
+'forwarded' => '7.7.7.10',
 'true_client_ip' => '7.7.7.3',
 'x_client_ip' => '7.7.7.4',
 'x_forwarded' => 'for="7.7.7.5"',
@@ -44,6 +45,8 @@ test($headers, 'x_forwarded_for');
 unset($headers['x_forwarded_for']); //Lets remove it so it it not top priority any more
 test($headers, 'x_real_ip');
 unset($headers['x_real_ip']); //Lets remove it so it it not top priority any more
+test($headers, 'forwarded');
+unset($headers['forwarded']); //Lets remove it so it it not top priority any more
 test($headers, 'true_client_ip');
 unset($headers['true_client_ip']); //Lets remove it so it it not top priority any more
 test($headers, 'x_client_ip');
@@ -65,6 +68,7 @@ unset($headers['cf_connecting_ipv6']); //Lets remove it so it it not top priorit
 --EXPECTF--
 Testing 'x_forwarded_for': Result is: 7.7.7.1
 Testing 'x_real_ip': Result is: 7.7.7.2
+Testing 'forwarded': Result is: 7.7.7.10
 Testing 'true_client_ip': Result is: 7.7.7.3
 Testing 'x_client_ip': Result is: 7.7.7.4
 Testing 'x_forwarded': Result is: 7.7.7.5

--- a/tests/ext/extract_ip_addr_precedence.phpt
+++ b/tests/ext/extract_ip_addr_precedence.phpt
@@ -30,7 +30,7 @@ function test($headers, $key_expected) {
 $headers = [
 'x_forwarded_for' => '7.7.7.1',
 'x_real_ip' => '7.7.7.2',
-'forwarded' => '7.7.7.10',
+'forwarded' => 'for="7.7.7.10"',
 'true_client_ip' => '7.7.7.3',
 'x_client_ip' => '7.7.7.4',
 'x_forwarded' => 'for="7.7.7.5"',

--- a/tests/ext/extract_ip_private_01.phpt
+++ b/tests/ext/extract_ip_private_01.phpt
@@ -1,0 +1,17 @@
+--TEST--
+Verify ips in private ranges are detected as private(Base: 100.64.0.0, Mask: 255.192.0.0)
+--ENV--
+DD_TRACE_AUTO_FLUSH_ENABLED=0
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_TRACE_CLIENT_IP_HEADER=whatever
+HTTP_WHATEVER=100.64.0.1,7.7.7.7
+DD_TRACE_CLIENT_IP_ENABLED=true
+--FILE--
+<?php
+DDTrace\start_span();
+DDTrace\close_span(0);
+$span = dd_trace_serialize_closed_spans();
+var_dump($span[0]["meta"]["http.client_ip"]);
+?>
+--EXPECTF--
+string(7) "7.7.7.7"


### PR DESCRIPTION
### Description

Add `forwarded` header as source of ip and also add a new range of private ips

[APPSEC-58242]
[APPSEC-58082]

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.


[APPSEC-58242]: https://datadoghq.atlassian.net/browse/APPSEC-58242?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

[APPSEC-58082]: https://datadoghq.atlassian.net/browse/APPSEC-58082?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ