### PR TITLE
ci: fix chainguard claim pattern

### DIFF
--- a/.github/chainguard/gitlab-ci-aggregate-versions.sts.yaml
+++ b/.github/chainguard/gitlab-ci-aggregate-versions.sts.yaml
@@ -2,12 +2,6 @@ issuer: https://gitlab.ddbuild.io
 
 subject_pattern: "project_path:DataDog/apm-reliability/dd-trace-php:ref_type:(branch|tag):ref:.*"
 
-claim_pattern:
-  project_path: "DataDog/apm-reliability/dd-trace-php"
-  ref: ".*"
-  ref_type: "(branch|tag)"
-  pipeline_source: "(push|schedule)"
-
 permissions:
   actions: write
   contents: write


### PR DESCRIPTION
### Description

Following the pattern from `vaccine`, we don't need the `claim_pattern` at all

https://github.com/DataDog/vaccine/blob/master/.github/chainguard/dd-trace-rb.dispatch.sts.yaml

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
