### PR TITLE
fix(prof): revert to more stable hooking for allocation profiling

### DIFF
--- a/profiling/build.rs
+++ b/profiling/build.rs
@@ -410,7 +410,10 @@ fn cfg_php_feature_flags(vernum: u64) {
     if vernum >= 80400 {
         println!("cargo:rustc-cfg=php_frameless");
         println!("cargo:rustc-cfg=php_opcache_restart_hook");
-        println!("cargo:rustc-cfg=php_zend_mm_set_custom_handlers_ex");
+        // Commenting the following line temporary disables the new hooking mechanism for
+        // allocation profiling until we solved the intefereing with
+        // `memory_get_usage()`/`memory_get_peak_usage()`
+        // println!("cargo:rustc-cfg=php_zend_mm_set_custom_handlers_ex");
     }
 }
 

--- a/profiling/src/allocation/allocation_le83.rs
+++ b/profiling/src/allocation/allocation_le83.rs
@@ -114,11 +114,13 @@ macro_rules! tls_zend_mm_state_set {
 }
 
 const NEEDS_RUN_TIME_CHECK_FOR_ENABLED_JIT: bool =
-    zend::PHP_VERSION_ID >= 80000 && zend::PHP_VERSION_ID < 80300;
+    zend::PHP_VERSION_ID >= 80000 && zend::PHP_VERSION_ID < 80300 || zend::PHP_VERSION_ID >= 80400;
 
 fn alloc_prof_needs_disabled_for_jit(version: u32) -> bool {
     // see https://github.com/php/php-src/pull/11380
-    (80000..80121).contains(&version) || (80200..80208).contains(&version)
+    (80000..80121).contains(&version)
+        || (80200..80208).contains(&version)
+        || (80400..80406).contains(&version)
 }
 
 lazy_static! {
@@ -134,7 +136,11 @@ pub fn first_rinit_should_disable_due_to_jit() -> bool {
         && alloc_prof_needs_disabled_for_jit(crate::RUNTIME_PHP_VERSION_ID.load(Relaxed))
         && *JIT_ENABLED
     {
-        error!("Memory allocation profiling will be disabled as long as JIT is active. To enable allocation profiling disable JIT or upgrade PHP to at least version 8.1.21 or 8.2.8. See https://github.com/DataDog/dd-trace-php/pull/2088");
+        if zend::PHP_VERSION_ID >= 80400 {
+            error!("Memory allocation profiling will be disabled as long as JIT is active. To enable allocation profiling disable JIT or upgrade PHP to at least version 8.4.7. See https://github.com/DataDog/dd-trace-php/pull/3199");
+        } else {
+            error!("Memory allocation profiling will be disabled as long as JIT is active. To enable allocation profiling disable JIT or upgrade PHP to at least version 8.1.21 or 8.2.8. See https://github.com/DataDog/dd-trace-php/pull/2088");
+        }
         true
     } else {
         false

--- a/profiling/tests/phpt/memory_get_peak_usage_01.phpt
+++ b/profiling/tests/phpt/memory_get_peak_usage_01.phpt
@@ -1,0 +1,27 @@
+--TEST--
+[profiling] test allocation profiling not interfering with `memory_get_peak_usage()`
+--DESCRIPTION--
+https://github.com/DataDog/dd-trace-php/issues/3360
+--SKIPIF--
+<?php
+if (getenv('USE_ZEND_ALLOC') === '0')
+    die("skip requires ZendMM");
+if (!extension_loaded('datadog-profiling'))
+    echo "skip: test requires Datadog Continuous Profiler\n";
+?>
+--ENV--
+DD_PROFILING_ENABLED=yes
+DD_PROFILING_EXPERIMENTAL_CPU_TIME_ENABLED=no
+DD_PROFILING_ALLOCATION_ENABLED=yes
+DD_PROFILING_LOG_LEVEL=off
+--FILE--
+<?php
+$x = str_repeat("a", 1024*1024);
+var_dump(memory_get_peak_usage(false) > 0);
+var_dump(memory_get_peak_usage(true) > 0);
+echo 'Done.';
+?>
+--EXPECT--
+bool(true)
+bool(true)
+Done.


### PR DESCRIPTION
### Description

With #2969 we have added a new way to hook into the ZendMM for allocation profiling. Creating a new `zend_mm_heap` structure makes hooking way easier, but as the actual allocations still happen in the originally installed heap, and calls for stats on ZendMM are not hook-able, calls to `memory_get_peak_usage(false)` / `memory_get_usage(false)` and such will return `int(0)`.

This PR disables the `php_zend_mm_set_custom_handlers_ex` feature flag that enables the new hooking mechanism in PHP >= 8.4.0 and as such reverts back to the mechanism used for PHP <= 8.3 to make allocation profiling not interfere with those user land functions.

We'll create a follow-up PR to cleanup and use the new hooking mechanism without interfering in this way.

Fixes #3360 

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
