### PR TITLE
update mysql image to support 8.4 lts

### DIFF
--- a/dockerfiles/services/mysql/Dockerfile
+++ b/dockerfiles/services/mysql/Dockerfile
@@ -1,3 +1,3 @@
-FROM mysql:5.6
+FROM mysql:8.4
 
 COPY init.sql /docker-entrypoint-initdb.d/init.sql


### PR DESCRIPTION
### Description

<!---
Any description you feel is relevant and gives more background to this PR, if necessary.
-->

moves `mysql` image to a non-eol verison

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
