### PR TITLE
Set DD_APPSEC_RASP_ENABLED default to true as on the tracer

### DIFF
--- a/appsec/src/extension/configuration.h
+++ b/appsec/src/extension/configuration.h
@@ -46,7 +46,7 @@ extern bool runtime_config_first_init;
     SYSCFG(BOOL, DD_APPSEC_HELPER_LAUNCH, "true")                                                                                     \
     CONFIG(STRING, DD_APPSEC_HELPER_PATH, DD_BASE("bin/libddappsec-helper.so"))                                                       \
     SYSCFG(BOOL, DD_APPSEC_STACK_TRACE_ENABLED, "true")                                                                               \
-    SYSCFG(BOOL, DD_APPSEC_RASP_ENABLED , "false")                                                                                    \
+    SYSCFG(BOOL, DD_APPSEC_RASP_ENABLED , "true")                                                                                     \
     SYSCFG(INT, DD_APPSEC_MAX_STACK_TRACE_DEPTH, "32")                                                                                \
     SYSCFG(INT, DD_APPSEC_MAX_STACK_TRACES, "2")                                                                                      \
     CONFIG(STRING, DD_APPSEC_HELPER_RUNTIME_PATH, "/tmp", .ini_change = dd_on_runtime_path_update)                                    \


### PR DESCRIPTION
### Description

Align the default value of `DD_APPSEC_RASP_ENABLED` on appsec with the tracer

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
