### PR TITLE
Fix musl appsec helper shutdown crash

### DIFF
--- a/appsec/.clang-tidy
+++ b/appsec/.clang-tidy
@@ -4,7 +4,6 @@
 Checks:          '*,-bugprone-reserved-identifier,-hicpp-signed-bitwise,-llvmlibc-restrict-system-libc-headers,-altera-unroll-loops,-hicpp-named-parameter,-cert-dcl37-c,-cert-dcl51-cpp,-read,-cppcoreguidelines-init-variables,-cppcoreguidelines-avoid-non-const-global-variables,-altera-id-dependent-backward-branch,-performance-no-int-to-ptr,-altera-struct-pack-align,-google-readability-casting,-modernize-use-trailing-return-type,-llvmlibc-implementation-in-namespace,-llvmlibc-callee-namespace,-cppcoreguidelines-pro-bounds-pointer-arithmetic,-fuchsia-default-arguments-declarations,-fuchsia-overloaded-operator,-cppcoreguidelines-pro-type-union-access,-fuchsia-default-arguments-calls,-cppcoreguidelines-non-private-member-variables-in-classes,-misc-non-private-member-variables-in-classes,-google-readability-todo,-llvm-header-guard,-readability-function-cognitive-complexity,-readability-identifier-length,-modernize-macro-to-enum,-misc-include-cleaner,-bugprone-empty-catch,-cppcoreguidelines-avoid-do-while,-hicpp-no-array-decay'
 WarningsAsErrors: '*'
 HeaderFilterRegex: ''
-AnalyzeTemporaryDtors: false
 CheckOptions:
   - key:             readability-function-cognitive-complexity.Threshold
     value:           35

--- a/appsec/src/helper/service_manager.cpp
+++ b/appsec/src/helper/service_manager.cpp
@@ -80,6 +80,7 @@ void service_manager::notify_of_rc_updates(std::string_view shmem_path)
 
 void service_manager::dump_table()
 {
+#if SPDLOG_ACTIVE_LEVEL <= SPDLOG_LEVEL_DEBUG
     // requires lock to be held
     for (auto &[key, service_ptr] : cache_) {
         if (std::shared_ptr<service> const service = service_ptr.lock()) {
@@ -89,6 +90,7 @@ void service_manager::dump_table()
             SPDLOG_DEBUG("RC path {} -> expired service", key.get_shmem_path());
         }
     }
+#endif
 }
 
 void service_manager::cleanup_cache()


### PR DESCRIPTION
### Description

musl doesn't support sending a `pthread_kill` to a detached thread that has finished (crashes). So, instead, make the appsec runner thread joinable, and attempt a non-blocking join during shutdown. C++11 thread doesn't have a non-blocking or time-limited join, so revert to using pthreads.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.