### PR TITLE
fix: update git remote URL format to use x-access-token for authentication

### DIFF
--- a/tooling/tested_versions/create_or_update_supported_versions_pr.sh
+++ b/tooling/tested_versions/create_or_update_supported_versions_pr.sh
@@ -53,7 +53,7 @@ if [[ "${CI_COMMIT_REF_NAME}" == "master" ]]; then
 
   # Setup git remote with token
   git remote remove origin || true
-  git remote add origin https://$GITHUB_TOKEN@github.com/DataDog/dd-trace-php.git
+  git remote add origin https://x-access-token:$GITHUB_TOKEN@github.com/DataDog/dd-trace-php.git
 
   # Check if branch exists and switch to it
   if git ls-remote --heads origin $TARGET_BRANCH | grep $TARGET_BRANCH; then


### PR DESCRIPTION
### Description

Picked up from https://github.com/DataDog/dd-trace-php/pull/3368

**Reason**: Proper GitHub token authentication format to resolve fatal: could not read Password errors during git push
<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
