### PR TITLE
Add setting to avoid obfuscating mongodb queries

### DIFF
--- a/ext/configuration.h
+++ b/ext/configuration.h
@@ -208,6 +208,7 @@ enum ddtrace_sampling_rules_format {
            .env_config_fallback = ddtrace_conf_otel_resource_attributes_version)                               \
     CONFIG(STRING, DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP, DD_TRACE_OBFUSCATION_QUERY_STRING_REGEXP_DEFAULT) \
     CONFIG(BOOL, DD_TRACE_MEMCACHED_OBFUSCATION, "true")                                                       \
+    CONFIG(BOOL, DD_TRACE_MONGODB_OBFUSCATION, "true")                                                         \
     CONFIG(BOOL, DD_TRACE_CLIENT_IP_ENABLED, "false")                                                          \
     CONFIG(CUSTOM(STRING), DD_TRACE_CLIENT_IP_HEADER, "", .parser = ddtrace_parse_client_ip_header_config)     \
     CONFIG(BOOL, DD_TRACE_FORKED_PROCESS, "true")                                                              \


### PR DESCRIPTION
The agent has a setting to avoid obfuscating these, but that's of little use if the tracer itself forcibly obfuscates.

`DD_TRACE_MONGODB_OBFUSCATION=0` will now allow this.