### PR TITLE
Fix top Code Origin frame for ExecIntegration and KafkaIntegration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Changelog for older versions can be found in our [release page](https://github.c
 - Fix names of global git tags for debugger #3377
 - Fix SQLSRVIntegration resource handling #3379
 - Set DD_APPSEC_RASP_ENABLED default to true as on the tracer #3374
+- Fix top Code Origin frame for ExecIntegration and KafkaIntegration #3392
 
 ### Internal
 - Update baggage telemetry typo #3382

--- a/src/DDTrace/Integrations/Exec/ExecIntegration.php
+++ b/src/DDTrace/Integrations/Exec/ExecIntegration.php
@@ -278,6 +278,7 @@ class ExecIntegration extends Integration
         $span->meta = $tags;
         $span->type = Type::SYSTEM;
         $span->resource = $resource;
+        \DDTrace\collect_code_origins(2); // manually collect origin, otherwise the top frame will be this integration
         switch_stack();
 
         return $span;

--- a/src/DDTrace/Integrations/Kafka/KafkaIntegration.php
+++ b/src/DDTrace/Integrations/Kafka/KafkaIntegration.php
@@ -143,6 +143,7 @@ class KafkaIntegration extends Integration
 
                     $hook->data['span'] = $span;
                     $integration->setupKafkaConsumeSpan($hook, $this);
+                    \DDTrace\collect_code_origins(1);
                     \DDTrace\close_span();
                 }
             );


### PR DESCRIPTION
Otherwise the top frame is within our integration, which will be shown as "missing file".