### PR TITLE
fix(prof): early init default connector to fix env var race

### DIFF
--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -318,6 +318,14 @@ extern "C" fn minit(_type: c_int, module_number: c_int) -> ZendResult {
 
     config::minit(module_number);
 
+    // Force early initialization of the HTTPS connector while we're still
+    // single-threaded. This ensures rustls-native-certs reads SSL_CERT_FILE
+    // and SSL_CERT_DIR environment variables safely before any threads are
+    // spawned, avoiding potential getenv/setenv race conditions.
+    {
+        let _connector = ddcommon::connector::Connector::default();
+    }
+
     // Use a hybrid extension hack to load as a module but have the
     // zend_extension hooks available:
     // https://www.phpinternalsbook.com/php7/extensions_design/zend_extensions.html#hybrid-extensions


### PR DESCRIPTION
### Description

This pr make sure we initialize `ddcommon::connector::Connector::default();` in `MINIT` already, so that [`rustls_native_certs::load_native_certs()`](https://docs.rs/rustls-native-certs/latest/rustls_native_certs/fn.load_native_certs.html) calls `env::var()` for `SSL_CERT_FILE` and `SSL_CERT_DIR` while still single threaded. This fixes a very rare crash we have seen when the uploading thread is doing it's first upload while the main thread (or any other thread) manipulates the environment variables for this process.

### Reviewer checklist
- [x] Test coverage seems ok.
- [x] Appropriate labels assigned.

PROF-12605