### PR TITLE
perf(prof): pre-reserve function name buffer

### DIFF
--- a/profiling/src/profiling/stack_walking.rs
+++ b/profiling/src/profiling/stack_walking.rs
@@ -73,7 +73,7 @@ pub fn extract_function_name(func: &zend_function) -> Option<Cow<'static, str>> 
     let (has_module, has_class) = (!module_name.is_empty(), !class_name.is_empty());
     let module_len = has_module as usize * "|".len() + module_name.len();
     let class_name_len = has_class as usize * "::".len() + class_name.len();
-    buffer.reserve(module_len + class_name_len + method_name.len());
+    buffer.reserve_exact(module_len + class_name_len + method_name.len());
 
     if has_module {
         buffer.extend_from_slice(module_name);


### PR DESCRIPTION
[PROF-12543](https://datadoghq.atlassian.net/browse/PROF-12543)

### Description

When a function name isn't cached, we calculate the function name which has up to 5 "segments":

    {$module_name}|{$class_name}::{$method_name}

And with how the code was written, we were doing potentially 5 memory allocations per function name. Of course, the Vec's growth amortization prevented some of these, but not all of them.

This now pre-reserves the size of the function name buffer.

### Motivation

Here's the before/after with the whole-host profiler:

<img width="2113" height="630" alt="Screenshot 2025-10-13 at 8 16 17 PM" src="https://github.com/user-attachments/assets/f5c8b5c3-ee91-4266-a490-8711cf4f02d0" />

The "key" bit is shaving off ~8ms of the ~24ms operation, across a minute. Obviously this is a tiny gain but it is also very easy. It's a good practice to right-size your strings/buffers when you know how large they are ahead of time.

The function cache is reset at the start of each request, so at the start of each request the samples tend to have more uncached function names than ones which happen later on. Coupled with the fact that we are walking the stack on-thread, the code is reasonably hot early on when collecting a sample.

### Additional Notes

Today I was able to look at the whole-host profiler's data for the PHP profiler running on the enterprise DOE app that Florian has set up, and I noticed the memory being reallocated in the data. 

I have used ddprof before on the PHP profiler, even recently. I believed I saw this recently with ddprof, but it had a larger impact when measured by the whole host profiler. I have no idea which is more accurate, or if we are simply dealing with the fact that we're sampling something that _by design_ happens infrequently, and just got different results accordingly.

### Reviewer checklist
- [x] Test coverage seems ok.
- [x] Appropriate labels assigned.


[PROF-12543]: https://datadoghq.atlassian.net/browse/PROF-12543?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ