### PR TITLE
Investigate if joining meaningfully reduces CPU

### DIFF
--- a/profiling/src/profiling/thread_utils.rs
+++ b/profiling/src/profiling/thread_utils.rs
@@ -50,6 +50,7 @@ where
     }
 }
 
+#[allow(unused)]
 #[derive(thiserror::Error, Debug)]
 #[error("timeout of {timeout_ms} ms reached when joining thread {thread}")]
 pub struct TimeoutError {
@@ -61,6 +62,7 @@ pub struct TimeoutError {
 /// Otherwise, it will leak the handle and return an error.
 /// # Panics
 /// If the thread being joined has panic'd, this will resume the panic.
+#[allow(unused)]
 pub fn join_timeout(handle: JoinHandle<()>, timeout: Duration) -> Result<(), TimeoutError> {
     // After notifying the other threads, it's likely they'll need some time
     // to respond adequately. Joining on the JoinHandle is supposed to be the


### PR DESCRIPTION
### Description

The whole-host profiler on one of our benchmarks regularly shows an unusually large amount of CPU spent in shutdown:

<img width="697" height="315" alt="Flame chart showing time spent in shutdown." src="https://github.com/user-attachments/assets/b27b6014-5a16-4437-a864-44dfaa2aaeb3" />

As you can see, most of it is spent in `sched_yield`. It's not surprising that this burns CPU (it's roughly what we're asking it to do, spin-loop and wait for the other thread to finish), but what _is_ surprising is that this chunk accounts for roughly 1/3 of all time spent in the profiler in the benchmark.

Perhaps this basically says that our CPU overhead is _very_ low, and that on shutdown we have to wait a few hundred milliseconds for another thread to complete. Waiting for that thread is dominating our time spent.

But I wanted to see what the profiles would look like if I ran this with a traditional thread join. We busy-wait because of an obscure bug we never were able to reproduce.

### Results

```
2025-10-15T16:42:46Z: archetype=enterprise, language=php, framework=symfony, workers=12, loops_cpu=0.01, off_cpu=0.1, profiling=true, rps=100, duration=180, full_host=true
resolved_library_version                         cpu      
-----------------------------------------------  -------  
1.13.0                                           219.866  
1.13.0                                           218.763  
1.13.0                                           219.307  
1.13.0                                           219.288  
1.13.0                                           219.595  
1.13.0                                           219.141  
1.13.0                                           219.684  
1.14.0+24924cb5dfb98309fc785738e0ff587cbd28ce35  217.137  
1.14.0+24924cb5dfb98309fc785738e0ff587cbd28ce35  217.987  
1.14.0+24924cb5dfb98309fc785738e0ff587cbd28ce35  217.364  
1.14.0+24924cb5dfb98309fc785738e0ff587cbd28ce35  217.708  
1.14.0+24924cb5dfb98309fc785738e0ff587cbd28ce35  217.473  
1.14.0+24924cb5dfb98309fc785738e0ff587cbd28ce35  217.513  
1.14.0+24924cb5dfb98309fc785738e0ff587cbd28ce35  217.669  
```

The version with the commit hash behind it is the branch that uses `join` instead. As you can see, it does reduce the CPU a bit. I looked at the profiles from the whole-host profiler and `shutdown` wasn't present at all.

So yes, confirmed that it lowers the CPU. It's not particularly meaningful to use less CPU during shutdown, though.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
