### PR TITLE
fix(prof): reset interrupt count when removing interrupt

### DIFF
--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -577,7 +577,6 @@ extern "C" fn rinit(_type: c_int, _module_number: c_int) -> ZendResult {
     let result = REQUEST_LOCALS.try_with_borrow_mut(|locals| {
         // SAFETY: we are in rinit on a PHP thread.
         locals.vm_interrupt_addr = unsafe { zend::datadog_php_profiling_vm_interrupt_addr() };
-        locals.interrupt_count.store(0, Ordering::SeqCst);
 
         // SAFETY: We are after first rinit and before mshutdown.
         unsafe {


### PR DESCRIPTION
### Description

Move resetting the `REQUEST_LOCALS.interrupt_count` to `0` from `rinit` to `rshutdown` or better: to the interrupt manager when we remove an interrupt. This fixes a tiny race condition:
- Our interrupt manager triggers an interrupt
  https://github.com/DataDog/dd-trace-php/blob/3456dec3802cbe0c16229b118561269b48f55c8d/profiling/src/profiling/interrupts.rs#L56-L62
- while the PHP engine finished processing the request and enters `RSHUTDOWN`
- the raised interrupt, as well as our incremented counter leak into the next request
- PHP does not handle a new request, but instead shuts down
- `MSHUTDOWN` gets called and PHP cleans up internal classes' static properties which could trigger a userland constructor (bug in PHP 8.0, fixed in >8.1) and we collect a sample and crash in the first `execute_ex` because of the leaked interrupt

So far we mitigated sampling bias (just collecting at the first opportunity in the new request because of the leaked interrupt) by initialising the `interrupt_count` with `0` in `RINIT`:
https://github.com/DataDog/dd-trace-php/blob/3456dec3802cbe0c16229b118561269b48f55c8d/profiling/src/lib.rs#L580

Moving this to `RSHUTDOWN` makes sure it does not leak to whatever comes after `RSHUTDOWN`, also does not introduce any sampling bias and seems a cleaner approach.

I can't think of any situation right now that could result in `REQUEST_LOCALS.interrupt_count` being not `0` in `RINIT`.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
