### PR TITLE
Do not skip error handling for timeouts happening during hook execution

### DIFF
--- a/ext/serializer.c
+++ b/ext/serializer.c
@@ -2091,7 +2091,7 @@ void ddtrace_error_cb(DDTRACE_ERROR_CB_PARAMETERS) {
     // We just save the error for later handling by sandbox error reporting functionality.
     // On fatal error we explicitly bail out.
     bool is_fatal_error = orig_type & (E_ERROR | E_CORE_ERROR | E_COMPILE_ERROR | E_USER_ERROR);
-    if (zai_sandbox_active) {
+    if (zai_sandbox_active && !zai_sandbox_timed_out()) {
         // Do not track silenced errors like via @ operator
         if (!is_fatal_error && (orig_type & EG(error_reporting)) == 0) {
             return;


### PR DESCRIPTION
Otherwise timeouts are skipped in trace and PHP error logs, when they happen to happen during a hook.