### PR TITLE
Audit ignore PKSA-wws7-mr54-jsny which we are not affected by

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -38,6 +38,9 @@
             "g1a/composer-test-scenarios": true,
             "php-http/discovery": true,
             "cakephp/plugin-installer": true
+        },
+        "audit": {
+            "block-insecure": false
         }
     },
     "autoload": {

--- a/tests/Benchmarks/composer.json
+++ b/tests/Benchmarks/composer.json
@@ -13,5 +13,10 @@
     },
     "autoload": {
         "files": [ "ignore_annotations.php" ]
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }

--- a/tests/Frameworks/CakePHP/Version_3_10/composer.json
+++ b/tests/Frameworks/CakePHP/Version_3_10/composer.json
@@ -53,6 +53,9 @@
         "sort-packages": true,
         "allow-plugins": {
             "cakephp/plugin-installer": true
+        },
+        "audit": {
+            "block-insecure": false
         }
     }
 }

--- a/tests/Frameworks/CakePHP/Version_4_5/composer.json
+++ b/tests/Frameworks/CakePHP/Version_4_5/composer.json
@@ -53,6 +53,9 @@
         "allow-plugins": {
             "cakephp/plugin-installer": true,
             "dealerdirect/phpcodesniffer-composer-installer": true
+        },
+        "audit": {
+            "block-insecure": false
         }
     }
 }

--- a/tests/Frameworks/Drupal/Version_10_1/composer.json
+++ b/tests/Frameworks/Drupal/Version_10_1/composer.json
@@ -61,6 +61,9 @@
             "drupal/core-vendor-hardening": true,
             "phpstan/extension-installer": true,
             "dealerdirect/phpcodesniffer-composer-installer": true
+        },
+        "audit": {
+            "block-insecure": false
         }
     },
     "extra": {

--- a/tests/composer.json
+++ b/tests/composer.json
@@ -25,6 +25,9 @@
             "g1a/composer-test-scenarios": true,
             "php-http/discovery": true,
             "cakephp/plugin-installer": true
+        },
+        "audit": {
+            "block-insecure": false
         }
     }
 }


### PR DESCRIPTION
### Description

CI in `master` stopped working since `composer` enforces [PKSA-wws7-mr54-jsny](https://packagist.org/security-advisories/PKSA-wws7-mr54-jsny) which we are not affected by, as we are using `symfony/process` only in `require-dev` on Linux machines and not on Windows.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
