### PR TITLE
Fix double end hook run/segault when blocking in PHP 7.x

### DIFF
--- a/tests/ext/bailout_double_hook_clear.phpt
+++ b/tests/ext/bailout_double_hook_clear.phpt
@@ -1,0 +1,43 @@
+--TEST--
+Bailout during hook END should not cause double-clear of span (internal function)
+--SKIPIF--
+<?php if (PHP_VERSION_ID >= 80000) die('skip: PHP 7 only'); ?>
+--FILE--
+<?php
+
+DDTrace\trace_function('array_sum', [
+    'prehook' => function (\DDTrace\SpanData $data, $args) {
+        echo "HOOK 1 PRE\n";
+    },
+    'posthook' => function(\DDTrace\SpanData $span, $args, $retval) {
+        static $ba = true;
+        echo "Hook 1 END\n";
+        if ($ba) {
+            echo "WILL BAILOUT!\n";
+        }
+        trigger_error("Datadog blocked the request", E_USER_ERROR);
+    }
+]);
+
+DDTrace\trace_function('array_sum', [
+    'posthook' => function(\DDTrace\SpanData $data, $args, $retval) {
+        echo "Hook 2 END\n";
+    }
+]);
+
+register_shutdown_function(function() {
+    echo "Shutdown function executed\n";
+});
+
+echo "Calling array_sum\n";
+array_sum([1, 2, 3]);
+echo "After array_sum (should not print)\n";
+
+?>
+--EXPECTF--
+Calling array_sum
+HOOK 1 PRE
+Hook 2 END
+Hook 1 END
+WILL BAILOUT!
+Shutdown function executed

--- a/zend_abstract_interface/hook/hook.c
+++ b/zend_abstract_interface/hook/hook.c
@@ -1112,6 +1112,12 @@ void zai_hook_finish(zend_execute_data *ex, zval *rv, zai_hook_memory_t *memory)
     for (zai_hook_info *hook_start = memory->dynamic, *hook_info = hook_start + memory->hook_count - 1; hook_info >= hook_start; --hook_info) {
         zai_hook_t *hook = hook_info->hook;
 
+        // if we propagate bailout during hook->end, we don't try to finish
+        // again in zai_interceptor_terminate_all_pending_observers
+        // This may even segfault due to too many calls to
+        // ddtrace_clear_execute_data_span
+        memory->hook_count--;
+
         if (hook->end) {
             hook->end(memory->invocation, ex, rv, hook->aux.data, (char *)memory->dynamic + hook_info->dynamic_offset);
         }


### PR DESCRIPTION
### Description

End hooks run twice if appsec blocks during one in PHP 7, possibly segfaulting.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
