### PR TITLE
chore(profiling): update libdatadog to v24.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1100,7 +1100,7 @@ dependencies = [
  "glibc_version",
  "io-lifetimes",
  "libc 0.2.177",
- "libdd-common",
+ "libdd-common 1.0.0",
  "libdd-tinybytes",
  "memfd",
  "nix",
@@ -1137,7 +1137,7 @@ dependencies = [
  "constcat",
  "http-body-util",
  "hyper",
- "libdd-common",
+ "libdd-common 1.0.0",
  "libdd-data-pipeline",
  "percent-encoding",
  "regex",
@@ -1156,7 +1156,7 @@ version = "0.0.1"
 dependencies = [
  "build_common",
  "datadog-live-debugger",
- "libdd-common",
+ "libdd-common 1.0.0",
  "libdd-common-ffi",
  "log",
  "percent-encoding",
@@ -1182,13 +1182,13 @@ dependencies = [
  "criterion-perf-events",
  "crossbeam-channel",
  "datadog-php-profiling",
- "datadog-profiling",
- "ddcommon",
  "env_logger 0.11.6",
  "lazy_static",
  "libc 0.2.177",
- "libdd-alloc",
+ "libdd-alloc 1.0.0 (git+https://github.com/DataDog/libdatadog?tag=v24.0.1)",
+ "libdd-common 1.0.0 (git+https://github.com/DataDog/libdatadog?rev=v24.0.1)",
  "libdd-library-config-ffi",
+ "libdd-profiling",
  "log",
  "once_cell",
  "perfcnt",
@@ -1201,36 +1201,6 @@ dependencies = [
  "tracing",
  "tracing-subscriber",
  "uuid",
-]
-
-[[package]]
-name = "datadog-profiling"
-version = "23.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=aa2396efbb14b196e91de88a73bb4e1a7d06f74b#aa2396efbb14b196e91de88a73bb4e1a7d06f74b"
-dependencies = [
- "anyhow",
- "bitmaps",
- "byteorder",
- "bytes",
- "chrono",
- "ddcommon",
- "futures",
- "http",
- "http-body-util",
- "hyper",
- "hyper-multipart-rfc7578",
- "indexmap 2.12.0",
- "libdd-alloc",
- "libdd-profiling-protobuf",
- "mime",
- "prost",
- "rustc-hash",
- "serde",
- "serde_json",
- "target-triple",
- "tokio",
- "tokio-util",
- "zstd",
 ]
 
 [[package]]
@@ -1247,7 +1217,7 @@ dependencies = [
  "http-body-util",
  "hyper",
  "hyper-util",
- "libdd-common",
+ "libdd-common 1.0.0",
  "libdd-trace-protobuf",
  "manual_future",
  "serde",
@@ -1282,7 +1252,7 @@ dependencies = [
  "httpmock",
  "hyper",
  "libc 0.2.177",
- "libdd-common",
+ "libdd-common 1.0.0",
  "libdd-common-ffi",
  "libdd-crashtracker",
  "libdd-crashtracker-ffi",
@@ -1327,7 +1297,7 @@ dependencies = [
  "datadog-sidecar",
  "http",
  "libc 0.2.177",
- "libdd-common",
+ "libdd-common 1.0.0",
  "libdd-common-ffi",
  "libdd-crashtracker-ffi",
  "libdd-dogstatsd-client",
@@ -1350,39 +1320,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ddcommon"
-version = "23.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=aa2396efbb14b196e91de88a73bb4e1a7d06f74b#aa2396efbb14b196e91de88a73bb4e1a7d06f74b"
-dependencies = [
- "anyhow",
- "cc",
- "const_format",
- "futures",
- "futures-core",
- "futures-util",
- "hex",
- "http",
- "http-body",
- "http-body-util",
- "hyper",
- "hyper-rustls",
- "hyper-util",
- "libc 0.2.177",
- "nix",
- "pin-project",
- "regex",
- "rustls",
- "rustls-native-certs",
- "serde",
- "static_assertions",
- "thiserror 1.0.69",
- "tokio",
- "tokio-rustls",
- "tower-service",
- "windows-sys 0.52.0",
-]
-
-[[package]]
 name = "ddtrace-php"
 version = "0.0.1"
 dependencies = [
@@ -1402,7 +1339,7 @@ dependencies = [
  "itertools 0.11.0",
  "lazy_static",
  "libc 0.2.177",
- "libdd-common",
+ "libdd-common 1.0.0",
  "libdd-common-ffi",
  "libdd-crashtracker-ffi",
  "libdd-library-config-ffi",
@@ -2504,7 +2441,17 @@ checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 [[package]]
 name = "libdd-alloc"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=aa2396efbb14b196e91de88a73bb4e1a7d06f74b#aa2396efbb14b196e91de88a73bb4e1a7d06f74b"
+source = "git+https://github.com/DataDog/libdatadog?tag=v24.0.1#26059cd130019c16e75232b06c298be4299697e9"
+dependencies = [
+ "allocator-api2",
+ "libc 0.2.177",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "libdd-alloc"
+version = "1.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v24.0.1#26059cd130019c16e75232b06c298be4299697e9"
 dependencies = [
  "allocator-api2",
  "libc 0.2.177",
@@ -2547,6 +2494,39 @@ dependencies = [
 ]
 
 [[package]]
+name = "libdd-common"
+version = "1.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v24.0.1#26059cd130019c16e75232b06c298be4299697e9"
+dependencies = [
+ "anyhow",
+ "cc",
+ "const_format",
+ "futures",
+ "futures-core",
+ "futures-util",
+ "hex",
+ "http",
+ "http-body",
+ "http-body-util",
+ "hyper",
+ "hyper-rustls",
+ "hyper-util",
+ "libc 0.2.177",
+ "nix",
+ "pin-project",
+ "regex",
+ "rustls",
+ "rustls-native-certs",
+ "serde",
+ "static_assertions",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "libdd-common-ffi"
 version = "0.0.1"
 dependencies = [
@@ -2556,7 +2536,7 @@ dependencies = [
  "chrono",
  "crossbeam-queue",
  "hyper",
- "libdd-common",
+ "libdd-common 1.0.0",
  "serde",
 ]
 
@@ -2573,7 +2553,7 @@ dependencies = [
  "goblin",
  "http",
  "libc 0.2.177",
- "libdd-common",
+ "libdd-common 1.0.0",
  "libdd-telemetry",
  "nix",
  "num-derive",
@@ -2602,7 +2582,7 @@ dependencies = [
  "build_common",
  "function_name",
  "libc 0.2.177",
- "libdd-common",
+ "libdd-common 1.0.0",
  "libdd-common-ffi",
  "libdd-crashtracker",
  "serde",
@@ -2628,7 +2608,7 @@ dependencies = [
  "httpmock",
  "hyper",
  "hyper-util",
- "libdd-common",
+ "libdd-common 1.0.0",
  "libdd-ddsketch",
  "libdd-dogstatsd-client",
  "libdd-log",
@@ -2666,7 +2646,7 @@ dependencies = [
  "anyhow",
  "cadence",
  "http",
- "libdd-common",
+ "libdd-common 1.0.0",
  "serde",
  "tokio",
  "tracing",
@@ -2693,7 +2673,7 @@ dependencies = [
  "anyhow",
  "build_common",
  "constcat",
- "libdd-common",
+ "libdd-common 1.0.0",
  "libdd-common-ffi",
  "libdd-library-config",
  "tempfile",
@@ -2711,9 +2691,40 @@ dependencies = [
 ]
 
 [[package]]
+name = "libdd-profiling"
+version = "1.0.0"
+source = "git+https://github.com/DataDog/libdatadog?rev=v24.0.1#26059cd130019c16e75232b06c298be4299697e9"
+dependencies = [
+ "anyhow",
+ "bitmaps",
+ "byteorder",
+ "bytes",
+ "chrono",
+ "futures",
+ "http",
+ "http-body-util",
+ "hyper",
+ "hyper-multipart-rfc7578",
+ "indexmap 2.12.0",
+ "libdd-alloc 1.0.0 (git+https://github.com/DataDog/libdatadog?rev=v24.0.1)",
+ "libdd-common 1.0.0 (git+https://github.com/DataDog/libdatadog?rev=v24.0.1)",
+ "libdd-profiling-protobuf",
+ "lz4_flex",
+ "mime",
+ "prost",
+ "rustc-hash",
+ "serde",
+ "serde_json",
+ "target-triple",
+ "tokio",
+ "tokio-util",
+ "zstd",
+]
+
+[[package]]
 name = "libdd-profiling-protobuf"
 version = "1.0.0"
-source = "git+https://github.com/DataDog/libdatadog?rev=aa2396efbb14b196e91de88a73bb4e1a7d06f74b#aa2396efbb14b196e91de88a73bb4e1a7d06f74b"
+source = "git+https://github.com/DataDog/libdatadog?rev=v24.0.1#26059cd130019c16e75232b06c298be4299697e9"
 dependencies = [
  "prost",
 ]
@@ -2731,7 +2742,7 @@ dependencies = [
  "hyper",
  "hyper-util",
  "libc 0.2.177",
- "libdd-common",
+ "libdd-common 1.0.0",
  "libdd-ddsketch",
  "serde",
  "serde_json",
@@ -2751,7 +2762,7 @@ dependencies = [
  "build_common",
  "function_name",
  "libc 0.2.177",
- "libdd-common",
+ "libdd-common 1.0.0",
  "libdd-common-ffi",
  "libdd-telemetry",
  "paste",
@@ -2824,7 +2835,7 @@ dependencies = [
  "httpmock",
  "hyper",
  "indexmap 2.12.0",
- "libdd-common",
+ "libdd-common 1.0.0",
  "libdd-tinybytes",
  "libdd-trace-normalization",
  "libdd-trace-protobuf",
@@ -2886,6 +2897,15 @@ name = "log"
 version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
+
+[[package]]
+name = "lz4_flex"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1a8cbbb2831780bc3b9c15a41f5b49222ef756b6730a95f3decfdd15903eb5a3"
+dependencies = [
+ "twox-hash",
+]
 
 [[package]]
 name = "manual_future"

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -22,12 +22,9 @@ cfg-if = { version = "1.0" }
 cpu-time = { version = "1.0" }
 chrono = { version = "0.4" }
 crossbeam-channel = { version = "0.5", default-features = false, features = ["std"] }
-
-# Use a libdatadog version after v23 to get a fix for cc_utils. Unfortunately,
-# it's also only halfway through the crate renaming migration.
-libdd-alloc = {  git = "https://github.com/DataDog/libdatadog", rev = "aa2396efbb14b196e91de88a73bb4e1a7d06f74b" }
-datadog-profiling = {  git = "https://github.com/DataDog/libdatadog", rev = "aa2396efbb14b196e91de88a73bb4e1a7d06f74b" }
-ddcommon = {  git = "https://github.com/DataDog/libdatadog", rev = "aa2396efbb14b196e91de88a73bb4e1a7d06f74b" }
+libdd-alloc = {  git = "https://github.com/DataDog/libdatadog", tag = "v24.0.1" }
+libdd-profiling = {  git = "https://github.com/DataDog/libdatadog", rev = "v24.0.1" }
+libdd-common = {  git = "https://github.com/DataDog/libdatadog", rev = "v24.0.1" }
 libdd-library-config-ffi = { path = "../libdatadog/libdd-library-config-ffi" }
 env_logger = { version = "0.11", default-features = false }
 lazy_static = { version = "1.4" }

--- a/profiling/build.rs
+++ b/profiling/build.rs
@@ -431,7 +431,9 @@ fn cfg_zts() {
     // Create a temporary C file to probe ZTS
     let out_dir = env::var("OUT_DIR").unwrap();
     let probe_path = Path::new(&out_dir).join("zts_probe.c");
-    fs::write(&probe_path, r#"
+    fs::write(
+        &probe_path,
+        r#"
 #include "main/php_config.h"
 #include <stdio.h>
 int main() {
@@ -442,7 +444,9 @@ int main() {
 #endif
     return 0;
 }
-"#).expect("Failed to write ZTS probe file");
+"#,
+    )
+    .expect("Failed to write ZTS probe file");
 
     // Get the C compiler from cc crate
     let compiler = cc::Build::new().get_compiler();

--- a/profiling/src/config.rs
+++ b/profiling/src/config.rs
@@ -12,9 +12,9 @@ use core::fmt::{Display, Formatter};
 use core::mem::{swap, transmute, MaybeUninit};
 use core::ptr;
 use core::str::FromStr;
-pub use datadog_profiling::exporter::Uri;
-use ddcommon::tag::{parse_tags, Tag};
 use libc::{c_char, c_int};
+use libdd_common::tag::{parse_tags, Tag};
+pub use libdd_profiling::exporter::Uri;
 use log::{warn, LevelFilter};
 use std::borrow::Cow;
 use std::ffi::CString;
@@ -190,24 +190,24 @@ impl Default for AgentEndpoint {
     }
 }
 
-impl TryFrom<AgentEndpoint> for ddcommon::Endpoint {
+impl TryFrom<AgentEndpoint> for libdd_common::Endpoint {
     type Error = anyhow::Error;
 
     fn try_from(value: AgentEndpoint) -> Result<Self, Self::Error> {
         match value {
-            AgentEndpoint::Uri(uri) => datadog_profiling::exporter::config::agent(uri),
-            AgentEndpoint::Socket(path) => datadog_profiling::exporter::config::agent_uds(&path),
+            AgentEndpoint::Uri(uri) => libdd_profiling::exporter::config::agent(uri),
+            AgentEndpoint::Socket(path) => libdd_profiling::exporter::config::agent_uds(&path),
         }
     }
 }
 
-impl TryFrom<&AgentEndpoint> for ddcommon::Endpoint {
+impl TryFrom<&AgentEndpoint> for libdd_common::Endpoint {
     type Error = anyhow::Error;
 
     fn try_from(value: &AgentEndpoint) -> Result<Self, Self::Error> {
         match value {
-            AgentEndpoint::Uri(uri) => datadog_profiling::exporter::config::agent(uri.clone()),
-            AgentEndpoint::Socket(path) => datadog_profiling::exporter::config::agent_uds(path),
+            AgentEndpoint::Uri(uri) => libdd_profiling::exporter::config::agent(uri.clone()),
+            AgentEndpoint::Socket(path) => libdd_profiling::exporter::config::agent_uds(path),
         }
     }
 }

--- a/profiling/src/io/got.rs
+++ b/profiling/src/io/got.rs
@@ -181,7 +181,11 @@ unsafe fn override_got_entry(
 
 /// Callback function that should be passed to `libc::dl_iterate_phdr()` and gets called for every
 /// shared object.
-pub unsafe extern "C" fn callback(info: *mut dl_phdr_info, _size: usize, data: *mut c_void) -> c_int {
+pub unsafe extern "C" fn callback(
+    info: *mut dl_phdr_info,
+    _size: usize,
+    data: *mut c_void,
+) -> c_int {
     let overwrites = &mut *(data as *mut Vec<GotSymbolOverwrite>);
 
     // detect myself ...

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -31,8 +31,8 @@ use bindings::{
 use clocks::*;
 use core::ffi::{c_char, c_int, c_void, CStr};
 use core::ptr;
-use ddcommon::{cstr, tag, tag::Tag};
 use lazy_static::lazy_static;
+use libdd_common::{cstr, tag, tag::Tag};
 use log::{debug, error, info, trace, warn};
 use once_cell::sync::{Lazy, OnceCell};
 use profiling::{LocalRootSpanResourceMessage, Profiler, VmInterrupt};
@@ -318,7 +318,7 @@ extern "C" fn minit(_type: c_int, module_number: c_int) -> ZendResult {
     // and SSL_CERT_DIR environment variables safely before any threads are
     // spawned, avoiding potential getenv/setenv race conditions.
     {
-        let _connector = ddcommon::connector::Connector::default();
+        let _connector = libdd_common::connector::Connector::default();
     }
 
     // Use a hybrid extension hack to load as a module but have the

--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -24,11 +24,11 @@ use chrono::Utc;
 use core::mem::forget;
 use core::{ptr, str};
 use crossbeam_channel::{Receiver, Sender, TrySendError};
-use datadog_profiling::api::{
+use libdd_profiling::api::{
     Function, Label as ApiLabel, Location, Period, Sample, UpscalingInfo, ValueType as ApiValueType,
 };
-use datadog_profiling::exporter::Tag;
-use datadog_profiling::internal::Profile as InternalProfile;
+use libdd_profiling::exporter::Tag;
+use libdd_profiling::internal::Profile as InternalProfile;
 use log::{debug, info, trace, warn};
 use once_cell::sync::OnceCell;
 use std::borrow::Cow;
@@ -1528,7 +1528,7 @@ pub struct JoinError {
 mod tests {
     use super::*;
     use crate::{allocation::DEFAULT_ALLOCATION_SAMPLING_INTERVAL, config::AgentEndpoint};
-    use datadog_profiling::exporter::Uri;
+    use libdd_profiling::exporter::Uri;
     use log::LevelFilter;
 
     fn get_frames() -> Vec<ZendFrame> {

--- a/profiling/src/profiling/uploader.rs
+++ b/profiling/src/profiling/uploader.rs
@@ -5,7 +5,7 @@ use crate::profiling::{UploadMessage, UploadRequest};
 use crate::{PROFILER_NAME_STR, PROFILER_VERSION_STR};
 use chrono::{DateTime, Utc};
 use crossbeam_channel::{select, Receiver};
-use ddcommon::Endpoint;
+use libdd_common::Endpoint;
 use log::{debug, info, warn};
 use serde_json::json;
 use std::borrow::Cow;
@@ -67,7 +67,7 @@ impl Uploader {
         let endpoint = Endpoint::try_from(agent_endpoint)?;
 
         let tags = Some(Arc::unwrap_or_clone(index.tags));
-        let mut exporter = datadog_profiling::exporter::ProfileExporter::new(
+        let mut exporter = libdd_profiling::exporter::ProfileExporter::new(
             profiling_library_name,
             profiling_library_version,
             "php",

--- a/profiling/src/thin_str.rs
+++ b/profiling/src/thin_str.rs
@@ -191,7 +191,7 @@ static EMPTY_INLINE_STRING: StaticInlineString<0> = StaticInlineString::<0> {
 mod tests {
     use super::*;
     use libdd_alloc::Global;
-    use datadog_profiling::collections::string_table::wordpress_test_data;
+    use libdd_profiling::collections::string_table::wordpress_test_data;
 
     // Not really, please manually de-allocate strings when done with them.
     impl ArenaAllocator for Global {}

--- a/profiling/src/timeline.rs
+++ b/profiling/src/timeline.rs
@@ -5,8 +5,8 @@ use crate::zend::{
     InternalFunctionHandler,
 };
 use crate::{RefCellExt, REQUEST_LOCALS, SAPI};
-use ddcommon::cstr;
 use libc::c_char;
+use libdd_common::cstr;
 use log::{error, trace};
 #[cfg(php_zts)]
 use std::cell::Cell;


### PR DESCRIPTION
### Description

This updates from a specific commit after v23 to v24.0.1. This puts us on a release again and is also a stepping stone for adopting new improvements which are coming down libdd_profiling.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
