### PR TITLE
fix: code_origin_for_spans_enabled naming inconsistency

### DIFF
--- a/ext/configuration.c
+++ b/ext/configuration.c
@@ -170,7 +170,7 @@ static bool dd_parse_tags(zai_str value, zval *decoded_value, bool persistent) {
 INI_CHANGE_DYNAMIC_CONFIG(DD_TRACE_HEADER_TAGS, "datadog.trace.header_tags")
 INI_CHANGE_DYNAMIC_CONFIG(DD_TRACE_SAMPLE_RATE, "datadog.trace.sample_rate")
 INI_CHANGE_DYNAMIC_CONFIG(DD_TRACE_LOGS_ENABLED, "datadog.logs_injection")
-INI_CHANGE_DYNAMIC_CONFIG(DD_CODE_ORIGIN_FOR_SPANS_ENABLED, "datadog.code_origins_for_spans_enabled")
+INI_CHANGE_DYNAMIC_CONFIG(DD_CODE_ORIGIN_FOR_SPANS_ENABLED, "datadog.code_origin_for_spans_enabled")
 INI_CHANGE_DYNAMIC_CONFIG(DD_EXCEPTION_REPLAY_ENABLED, "datadog.exception_replay_enabled")
 
 #define CALIAS_EXPAND(name) {.ptr = name, .len = sizeof(name) - 1},


### PR DESCRIPTION
### Description

This fixes a typo where the name sometimes uses plural "origins" instead of singular "origin":

- `datadog.code_origins_for_spans_enabled` (incorrect - has typo, used in `ext/configuration.c`)
- `datadog.code_origin_for_spans_enabled` (correct, used in `components-rs/remote_config.rs`)

It's difficult for me to explain what happens when some paths are using plural while some are using singular. I am not familiar with how this remote config code works or is supposed to work. This  is definitely a bug, and _may_ be the reason for some "Out of memory" and "zend_mm_heap corrupted".


### Additional Notes

This is not based on the latest master, but on tag 1.14.0, so that build artifacts are simply 1.14.0 with this change.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
