### PR TITLE
Clear client_ip on request_init

### DIFF
--- a/appsec/src/extension/request_lifecycle.c
+++ b/appsec/src/extension/request_lifecycle.c
@@ -118,6 +118,13 @@ void dd_req_lifecycle_rinit(bool force)
     if (!_cur_req_span) {
         mlog(dd_log_debug, "No root span available on request init");
     }
+
+    if (_client_ip) {
+        mlog(dd_log_warning, "Client IP not cleared on prev request. Value %p",
+            (void *)_client_ip);
+        _client_ip = NULL;
+    }
+
     _do_request_begin_php();
 }
 


### PR DESCRIPTION
### Description

Telemetry showed a crash when serializing the client ip. The data looks corrupted:

```
  - RSI = 0x7ff82c5ff0f8 (source pointer - 2nd parameter to memcpy)
  - RDX = 0x3078 = 12408 (size parameter - 3rd parameter to memcpy)
  - CR2 = 0x7ff82c6000f8 (fault address; read)
```

1.13.1:

```
0x7ff82a411e95 _iovec_writer_flush (/go/src/github.com/DataDog/apm-reliability/dd-trace-php/appsec/src/extension/msgpack_helpers.c:485)
0x7ff82a408250 _request_pack (/go/src/github.com/DataDog/apm-reliability/dd-trace-php/appsec/src/extension/commands/request_init.c:132)
0x7ff82a408f7c _dd_command_exec (/go/src/github.com/DataDog/apm-reliability/dd-trace-php/appsec/src/extension/commands_helpers.c:69)
0x7ff82a4167e2 _do_request_begin (/go/src/github.com/DataDog/apm-reliability/dd-trace-php/appsec/src/extension/request_lifecycle.c:221)
0x7ff82a416af4 _do_request_begin_php (/go/src/github.com/DataDog/apm-reliability/dd-trace-php/appsec/src/extension/request_lifecycle.c:130)
0x7ff82a416af4 dd_req_lifecycle_rinit (/go/src/github.com/DataDog/apm-reliability/dd-trace-php/appsec/src/extension/request_lifecycle.c:121)
0x7ff82a40cfc3 zm_activate_ddappsec (/go/src/github.com/DataDog/apm-reliability/dd-trace-php/appsec/src/extension/ddappsec.c:284)
0x7ff82fc7b570 zend_activate_modules
0x7ff82fc0f483 php_request_startup
```

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
