### PR TITLE
Fix incorrectly hardcoded _GET

### DIFF
--- a/appsec/src/extension/php_helpers.c
+++ b/appsec/src/extension/php_helpers.c
@@ -64,7 +64,7 @@ const zend_array *nonnull dd_get_superglob_or_equiv(
     if (equiv) {
         ret = zend_hash_str_find(equiv, name, name_len);
     } else {
-        ret = dd_php_get_autoglobal(track, ZEND_STRL("_GET"));
+        ret = dd_php_get_autoglobal(track, name, name_len);
     }
 
     if (!ret || Z_TYPE_P(ret) != IS_ARRAY) {


### PR DESCRIPTION
Could be related to segfault seen in the wild during _pack_filenames.

### Description

<!---
Any description you feel is relevant and gives more background to this PR, if necessary.
-->

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
