### PR TITLE
fix(appsec): off by one

### DIFF
--- a/appsec/src/extension/request_abort.c
+++ b/appsec/src/extension/request_abort.c
@@ -515,8 +515,10 @@ zend_array *nonnull dd_request_abort_static_page_spec(
     }
 
     {
-        char buf[sizeof("18446744073709551615") - 1];
-        size_t len = sprintf(buf, "%zu", body_len);
+        // This magic number is the string representation of SIZE_MAX on 64 bit
+        // systems
+        char buf[sizeof("18446744073709551615")];
+        size_t len = snprintf(buf, sizeof(buf), "%zu", body_len);
         zend_string *s = zend_string_init(buf, len, 0);
         zval cont_len_zv;
         ZVAL_STR(&cont_len_zv, s);


### PR DESCRIPTION
### Description

`sizeof("1")` returns `2` because it includes the terminating `\0`, while `sprintf()` always also writes the terminating `\0`. So if we do this (decrementing the return of `sizeof("string")`:

https://github.com/DataDog/dd-trace-php/blob/0c35caf6be7af50ff84df5cb4ad518254d70963d/appsec/src/extension/request_abort.c#L518-L519

... then there is an off by one, as the `buf` is "only" 20 bytes, while `sprintf()` might actually write 21 bytes to that pointer if the number in `body_len` needs 20 digits in a string. Additionally switching to `snprintf()` makes sure we never overflow.

Granted: this number overflowing seems highly unlikely, but theoretically still possible.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
