### PR TITLE
test: add missing CI image to mirror

### DIFF
--- a/dockerfiles/frameworks/flow.yml
+++ b/dockerfiles/frameworks/flow.yml
@@ -14,7 +14,7 @@ services:
     cap_add:
       - SYS_PTRACE
   mysql:
-    image: mysql:5.7
+    image: registry.ddbuild.io/images/mirror/mysql:5.7
     environment:
       MYSQL_ROOT_PASSWORD: ""
       MYSQL_ALLOW_EMPTY_PASSWORD: 1

--- a/dockerfiles/frameworks/laravel.yml
+++ b/dockerfiles/frameworks/laravel.yml
@@ -16,11 +16,11 @@ services:
       - SYS_PTRACE
 
   redis:
-    image: redis:5.0.5
+    image: registry.ddbuild.io/images/mirror/redis:5.0.5
     expose:
       - 6379
   memcached:
-    image: memcached
+    image: registry.ddbuild.io/images/mirror/library/memcached:latest
     expose:
       - 11211
 

--- a/dockerfiles/frameworks/mongodb-driver.yml
+++ b/dockerfiles/frameworks/mongodb-driver.yml
@@ -20,7 +20,7 @@ services:
       - SYS_PTRACE
 
   mongodb:
-    image: "circleci/mongo:4"
+    image: "registry.ddbuild.io/images/mirror/circleci/mongo:4"
     ports:
       - "27017:27017"
 

--- a/dockerfiles/frameworks/symfony.yml
+++ b/dockerfiles/frameworks/symfony.yml
@@ -17,7 +17,7 @@ services:
       - SYS_PTRACE
 
   redis:
-    image: redis:5.0.5
+    image: registry.ddbuild.io/images/mirror/redis:5.0.5
     expose:
       - 6379
   redis_cluster:
@@ -31,7 +31,7 @@ services:
       - 7004
       - 7005
   memcached:
-    image: memcached
+    image: registry.ddbuild.io/images/mirror/library/memcached:latest
     expose:
       - 11211
 

--- a/dockerfiles/frameworks/wordpress.yml
+++ b/dockerfiles/frameworks/wordpress.yml
@@ -12,7 +12,7 @@ services:
     cap_add:
       - SYS_PTRACE
   mysql:
-    image: mysql:5.7
+    image: registry.ddbuild.io/images/mirror/mysql:5.7
     environment:
       MYSQL_ROOT_PASSWORD: ""
       MYSQL_ALLOW_EMPTY_PASSWORD: 1

--- a/dockerfiles/verify_packages/Makefile
+++ b/dockerfiles/verify_packages/Makefile
@@ -63,7 +63,7 @@ verify_tar_root:
 global_test_dependencies: ../../build/packages/datadog-setup.php
 
 test_legacy_installer_no_ext_json: global_test_dependencies
-	docker run --rm -i -v $(shell pwd)/../../:/app --workdir=/app alpine:3.12 sh dockerfiles/verify_packages/verify_no_ext_json.sh
+	docker run --rm -i -v $(shell pwd)/../../:/app --workdir=/app registry.ddbuild.io/images/mirror/alpine:3.12 sh dockerfiles/verify_packages/verify_no_ext_json.sh
 
 test_installer: $(shell find installer -name 'test_*.sh' -exec basename {} \;)
 
@@ -93,30 +93,30 @@ test_upgrade_from_legacy.sh \
 test_upgrade_from_php_installer.sh \
 	: global_test_dependencies
 	@echo "################### $(@) ###################"
-	docker run --rm -i -v $(shell pwd)/../../:/app --env-file $(shell pwd)/.env -e CIRCLECI --workdir=/app php:7.4-cli sh dockerfiles/verify_packages/installer/$(@)
+	docker run --rm -i -v $(shell pwd)/../../:/app --env-file $(shell pwd)/.env -e CIRCLECI --workdir=/app registry.ddbuild.io/images/mirror/php:7.4-cli sh dockerfiles/verify_packages/installer/$(@)
 
 test_first_install_php_debug.sh \
 test_first_install_php_debugzts.sh \
 test_profiler_install_unsupported_debug.sh \
 	: global_test_dependencies
 	@echo "################### $(@) ###################"
-	docker run --rm -i -v $(shell pwd)/../../:/app --env-file $(shell pwd)/.env -e CIRCLECI --workdir=/app datadog/dd-trace-ci:php-7.4_buster sh dockerfiles/verify_packages/installer/$(@)
+	docker run --rm -i -v $(shell pwd)/../../:/app --env-file $(shell pwd)/.env -e CIRCLECI --workdir=/app registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:php-7.4_buster sh dockerfiles/verify_packages/installer/$(@)
 
 test_first_install_php_zts.sh \
 	: global_test_dependencies
 	@echo "################### $(@) ###################"
-	docker run --rm -i -v $(shell pwd)/../../:/app --env-file $(shell pwd)/.env -e CIRCLECI --workdir=/app php:7.4-zts-buster sh dockerfiles/verify_packages/installer/$(@)
+	docker run --rm -i -v $(shell pwd)/../../:/app --env-file $(shell pwd)/.env -e CIRCLECI --workdir=/app registry.ddbuild.io/images/mirror/php:7.4-zts-buster sh dockerfiles/verify_packages/installer/$(@)
 
 test_install_non_binary.sh \
 test_fpm.sh \
 	: global_test_dependencies
 	@echo "################### $(@) ###################"
-	docker run --rm -i -v $(shell pwd)/../../:/app --env-file $(shell pwd)/.env -e CIRCLECI --workdir=/app php:7.4-fpm sh dockerfiles/verify_packages/installer/$(@)
+	docker run --rm -i -v $(shell pwd)/../../:/app --env-file $(shell pwd)/.env -e CIRCLECI --workdir=/app registry.ddbuild.io/images/mirror/php:7.4-fpm sh dockerfiles/verify_packages/installer/$(@)
 
 test_profiler_install_unsupported.sh \
 	: global_test_dependencies
 	@echo "################### $(@) ###################"
-	docker run --rm -i -v $(shell pwd)/../../:/app --env-file $(shell pwd)/.env -e CIRCLECI --workdir=/app php:7.0-cli sh dockerfiles/verify_packages/installer/$(@)
+	docker run --rm -i -v $(shell pwd)/../../:/app --env-file $(shell pwd)/.env -e CIRCLECI --workdir=/app registry.ddbuild.io/images/mirror/php:7.0-cli sh dockerfiles/verify_packages/installer/$(@)
 
 test_alpine_no_ext_json.sh \
 test_alpine_no_libcurl.sh \
@@ -126,17 +126,17 @@ test_alpine_install_no_ext_curl_no_curl_cli.sh \
 test_alpine_install_no_ext_curl_yes_curl_cli.sh \
 	: global_test_dependencies
 	@echo "################### $(@) ###################"
-	docker run --rm -i -v $(shell pwd)/../../:/app --env-file $(shell pwd)/.env -e CIRCLECI --workdir=/app alpine:3.13 sh dockerfiles/verify_packages/installer/$(@)
+	docker run --rm -i -v $(shell pwd)/../../:/app --env-file $(shell pwd)/.env -e CIRCLECI --workdir=/app registry.ddbuild.io/images/mirror/alpine:3.13 sh dockerfiles/verify_packages/installer/$(@)
 
 test_alpine_zts_no_zend_signals.sh \
 	: global_test_dependencies
 	@echo "################### $(@) ###################"
-	docker run --rm -i -v $(shell pwd)/../../:/app --env-file $(shell pwd)/.env -e CIRCLECI --workdir=/app dunglas/frankenphp:php8.3.12-alpine sh dockerfiles/verify_packages/installer/$(@)
+	docker run --rm -i -v $(shell pwd)/../../:/app --env-file $(shell pwd)/.env -e CIRCLECI --workdir=/app registry.ddbuild.io/images/mirror/dunglas/frankenphp:php8.3.12-alpine sh dockerfiles/verify_packages/installer/$(@)
 
 test_alpine_no_libexecinfo.sh: global_test_dependencies
 	@echo "################### $(@) ###################"
-	docker run --rm -i -v $(shell pwd)/../../:/app --env-file $(shell pwd)/.env -e CIRCLECI --workdir=/app php:7.4-cli-alpine sh dockerfiles/verify_packages/installer/$(@)
+	docker run --rm -i -v $(shell pwd)/../../:/app --env-file $(shell pwd)/.env -e CIRCLECI --workdir=/app registry.ddbuild.io/images/mirror/php:7.4-cli-alpine sh dockerfiles/verify_packages/installer/$(@)
 
 test_install_on_plesk.sh: global_test_dependencies
 	@echo "################### $(@) ###################"
-	docker run --rm -i -v $(shell pwd)/../../:/app --env-file $(shell pwd)/.env -e CIRCLECI --workdir=/app plesk/plesk:18.0 sh dockerfiles/verify_packages/installer/$(@)
+	docker run --rm -i -v $(shell pwd)/../../:/app --env-file $(shell pwd)/.env -e CIRCLECI --workdir=/app registry.ddbuild.io/images/mirror/plesk/plesk:18.0 sh dockerfiles/verify_packages/installer/$(@)

--- a/tests/randomized/docker-compose.yml
+++ b/tests/randomized/docker-compose.yml
@@ -9,7 +9,7 @@ services:
           - linux/amd64
       args:
         PHP_MAJOR_MINOR: "7.0"
-    image: 'datadog/dd-trace-ci:php-randomizedtests-centos7-7.0-2'
+    image: 'registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:php-randomizedtests-centos7-7.0-2'
 
   centos-7.1:
     build:
@@ -18,7 +18,7 @@ services:
       x-bake: *bake
       args:
         PHP_MAJOR_MINOR: "7.1"
-    image: 'datadog/dd-trace-ci:php-randomizedtests-centos7-7.1-2'
+    image: 'registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:php-randomizedtests-centos7-7.1-2'
 
   centos-7.2:
     build:
@@ -27,7 +27,7 @@ services:
       x-bake: *bake
       args:
         PHP_MAJOR_MINOR: "7.2"
-    image: 'datadog/dd-trace-ci:php-randomizedtests-centos7-7.2-2'
+    image: 'registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:php-randomizedtests-centos7-7.2-2'
 
   centos-7.3:
     build:
@@ -36,7 +36,7 @@ services:
       x-bake: *bake
       args:
         PHP_MAJOR_MINOR: "7.3"
-    image: 'datadog/dd-trace-ci:php-randomizedtests-centos7-7.3-2'
+    image: 'registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:php-randomizedtests-centos7-7.3-2'
 
   centos-7.4:
     build:
@@ -45,7 +45,7 @@ services:
       x-bake: *bake
       args:
         PHP_MAJOR_MINOR: "7.4"
-    image: 'datadog/dd-trace-ci:php-randomizedtests-centos7-7.4-2'
+    image: 'registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:php-randomizedtests-centos7-7.4-2'
 
   buster-7.4:
     build:
@@ -54,7 +54,7 @@ services:
       x-bake: *bake
       args:
         PHP_MAJOR_MINOR: "7.4"
-    image: 'datadog/dd-trace-ci:php-randomizedtests-buster-7.4-2'
+    image: 'registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:php-randomizedtests-buster-7.4-2'
 
   centos-8.0:
     build:
@@ -63,7 +63,7 @@ services:
       x-bake: *bake
       args:
         PHP_MAJOR_MINOR: "8.0"
-    image: 'datadog/dd-trace-ci:php-randomizedtests-centos7-8.0-2'
+    image: 'registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:php-randomizedtests-centos7-8.0-2'
 
   buster-8.0:
     build:
@@ -72,7 +72,7 @@ services:
       x-bake: *bake
       args:
         PHP_MAJOR_MINOR: "8.0"
-    image: 'datadog/dd-trace-ci:php-randomizedtests-buster-8.0-2'
+    image: 'registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:php-randomizedtests-buster-8.0-2'
 
   centos-8.1:
     build:
@@ -81,7 +81,7 @@ services:
       x-bake: *bake
       args:
         PHP_MAJOR_MINOR: "8.1"
-    image: 'datadog/dd-trace-ci:php-randomizedtests-centos7-8.1-2'
+    image: 'registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:php-randomizedtests-centos7-8.1-2'
 
   buster-8.1:
     build:
@@ -90,7 +90,7 @@ services:
       x-bake: *bake
       args:
         PHP_MAJOR_MINOR: "8.1"
-    image: 'datadog/dd-trace-ci:php-randomizedtests-buster-8.1-2'
+    image: 'registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:php-randomizedtests-buster-8.1-2'
 
   centos-8.2:
     build:
@@ -99,7 +99,7 @@ services:
       x-bake: *bake
       args:
         PHP_MAJOR_MINOR: "8.2"
-    image: 'datadog/dd-trace-ci:php-randomizedtests-centos7-8.2-2'
+    image: 'registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:php-randomizedtests-centos7-8.2-2'
 
   buster-8.2:
     build:
@@ -108,7 +108,7 @@ services:
       x-bake: *bake
       args:
         PHP_MAJOR_MINOR: "8.2"
-    image: 'datadog/dd-trace-ci:php-randomizedtests-buster-8.2-2'
+    image: 'registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:php-randomizedtests-buster-8.2-2'
 
   centos-8.3:
     build:
@@ -117,7 +117,7 @@ services:
       x-bake: *bake
       args:
         PHP_MAJOR_MINOR: "8.3"
-    image: 'datadog/dd-trace-ci:php-randomizedtests-centos7-8.3-2'
+    image: 'registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:php-randomizedtests-centos7-8.3-2'
 
   buster-8.3:
     build:
@@ -126,4 +126,4 @@ services:
       x-bake: *bake
       args:
         PHP_MAJOR_MINOR: "8.3"
-    image: 'datadog/dd-trace-ci:php-randomizedtests-buster-8.3-2'
+    image: 'registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:php-randomizedtests-buster-8.3-2'

--- a/tests/randomized/docker/buster.Dockerfile
+++ b/tests/randomized/docker/buster.Dockerfile
@@ -1,6 +1,6 @@
 ARG PHP_MAJOR_MINOR
 
-FROM datadog/dd-trace-ci:php-${PHP_MAJOR_MINOR}_buster
+FROM registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:php-${PHP_MAJOR_MINOR}_buster
 
 USER root
 

--- a/tests/randomized/docker/centos.Dockerfile
+++ b/tests/randomized/docker/centos.Dockerfile
@@ -1,6 +1,6 @@
 ARG PHP_MAJOR_MINOR
 
-FROM datadog/dd-trace-ci:php-${PHP_MAJOR_MINOR}_centos-7
+FROM registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:php-${PHP_MAJOR_MINOR}_centos-7
 
 # Getting the latest nginx
 RUN echo $'[nginx]\nname=nginx repo\nbaseurl=https://nginx.org/packages/mainline/centos/7/$basearch/\ngpgcheck=0\nenabled=1' >> /etc/yum.repos.d/nginx.repo

--- a/tests/randomized/lib/docker-compose.yml
+++ b/tests/randomized/lib/docker-compose.yml
@@ -7,25 +7,25 @@ services:
 
   redis:
     container_name: redis
-    image: redis:latest
+    image: registry.ddbuild.io/images/mirror/redis:latest
 
   httpbin:
     container_name: httpbin
-    image: kong/httpbin:0.2.2
+    image: registry.ddbuild.io/images/mirror/kong/httpbin:0.2.2
 
   memcached:
     container_name: memcached
-    image: "memcached:1.5-alpine"
+    image: "registry.ddbuild.io/images/mirror/library/memcached:1.5-alpine"
 
   elasticsearch:
     container_name: elasticsearch
-    image: "elasticsearch:7.17.4"
+    image: "registry.ddbuild.io/images/mirror/elasticsearch:7.17.4"
     environment:
       - discovery.type=single-node
 
   mysql:
     container_name: mysql
-    image: mysql/mysql-server:8.0
+    image: registry.ddbuild.io/images/mirror/mysql/mysql-server:8.0
     command: --default-authentication-plugin=mysql_native_password
     environment:
       - MYSQL_ROOT_PASSWORD=test


### PR DESCRIPTION
### Description

This PR modify our CI to use our private registry instead of dockerhub to pull the public images we are using.
The goal is to stop having image pull rate limits errors when we are running too many pipeline.
