### PR TITLE
fix: ext/parallel support

### DIFF
--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -601,6 +601,11 @@ static PHP_GINIT_FUNCTION(ddtrace) {
 #endif
 #if ZTS
     ddtrace_thread_ginit();
+
+    // Remember things like ext/parallel need to run stuff on each thread,
+    // and they don't call minit/rinit on those threads. See:
+    // https://github.com/DataDog/dd-trace-php/issues/3511
+    ddtrace_log_ginit();
 #endif
     ddtrace_globals->sidecar_universal_service_tags_mutex = tsrm_mutex_alloc();
     zai_hook_ginit();


### PR DESCRIPTION
### Description

Fixes #3511. Maybe, I am not an expert in this config area, but it seems plausible:

- ext/parallel makes new threads, and config levels including log levels need to be set there.
- Those ext/parallel threads do not call minit/mshutdown, but do call rinit/rshutdown.

Once I have the build artifacts, I can do more testing.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
