### PR TITLE
perf: const-ify some logging thread-local variables

### DIFF
--- a/components-rs/log.rs
+++ b/components-rs/log.rs
@@ -38,8 +38,10 @@ pub static mut ddog_log_callback: Option<extern "C" fn(CharSlice)> = None;
 
 // Avoid RefCell for performance
 std::thread_local! {
-    static LOGGED_MSGS: RefCell<BTreeSet<String>> = RefCell::default();
-    static TRACING_GUARDS: RefCell<Option<tracing_core::dispatcher::DefaultGuard>> = RefCell::default();
+    static LOGGED_MSGS: RefCell<BTreeSet<String>> = const { RefCell::new(BTreeSet::new()) };
+    static TRACING_GUARDS: RefCell<Option<tracing_core::dispatcher::DefaultGuard>> = const { RefCell::new(None) };
+
+    // todo: MSRV 1.85+ make this const with HashMap::with_hasher
     static COUNTERS: RefCell<HashMap<Level, u32>> = RefCell::default();
 }
 


### PR DESCRIPTION
### Description

Perf is not the real story here, but it's technically true. The rest is speculative:

`TRACING_GUARDS` is involved in some inexplicable crash reports. Making it const will simplify the runtime, because it no longer needs to lazily initialize the thread-local storage for it; see [thread_local's docs](https://doc.rust-lang.org/std/macro.thread_local.html#syntax).  I am hoping that somehow that this helps, but there's no downside to trying.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
