### PR TITLE
chore: bump tracing-core from 0.1.33 to 0.1.35

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5056,9 +5056,9 @@ dependencies = [
 
 [[package]]
 name = "tracing-core"
-version = "0.1.33"
+version = "0.1.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
+checksum = "7a04e24fab5c89c6a36eb8558c9656f30d81de51dfa4d3b45f26b21d61fa0a6c"
 dependencies = [
  "once_cell",
  "valuable",


### PR DESCRIPTION
### Description

This crate is involved in an inexplicable crash. I don't think upgrading it will fix the issue, but it is good hygiene to do it anyway. This way if it keeps happening, we can open a bug report with the latest version and skip that step of triage with them.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
