### PR TITLE
fix: Protect sidecar globals access with mutex

### DIFF
--- a/appsec/src/extension/commands/client_init.c
+++ b/appsec/src/extension/commands/client_init.c
@@ -121,6 +121,13 @@ static dd_result _pack_command(
 
     mpack_finish_map(w); // telemetry settings
 
+    if (tel_rc_info.service_name) {
+        zend_string_release(tel_rc_info.service_name);
+    }
+    if (tel_rc_info.env_name) {
+        zend_string_release(tel_rc_info.env_name);
+    }
+
     // Sidecar settings
     mpack_start_map(w, 2);
     {

--- a/appsec/src/extension/request_lifecycle.c
+++ b/appsec/src/extension/request_lifecycle.c
@@ -158,11 +158,23 @@ static bool _rem_cfg_path_changed(bool ignore_empty /* called from rinit */)
         cur_path = "";
     }
     if (strcmp(cur_path, _last_rem_cfg_path) == 0) {
+        if (tel_rc_info.service_name) {
+            zend_string_release(tel_rc_info.service_name);
+        }
+        if (tel_rc_info.env_name) {
+            zend_string_release(tel_rc_info.env_name);
+        }
         return false;
     }
 
     if (strlen(cur_path) > MAX_LENGTH_OF_REM_CFG_PATH) {
         mlog(dd_log_warning, "Remote config path too long: %s", cur_path);
+        if (tel_rc_info.service_name) {
+            zend_string_release(tel_rc_info.service_name);
+        }
+        if (tel_rc_info.env_name) {
+            zend_string_release(tel_rc_info.env_name);
+        }
         return false;
     }
 
@@ -173,6 +185,13 @@ static bool _rem_cfg_path_changed(bool ignore_empty /* called from rinit */)
         cur_path[0] ? cur_path : "(none)",
         ZSTR_PRINTF(tel_rc_info.service_name),
         ZSTR_PRINTF(tel_rc_info.env_name));
+
+    if (tel_rc_info.service_name) {
+        zend_string_release(tel_rc_info.service_name);
+    }
+    if (tel_rc_info.env_name) {
+        zend_string_release(tel_rc_info.env_name);
+    }
 
     // NOLINTNEXTLINE(clang-analyzer-security.insecureAPI.strcpy)
     strcpy(_last_rem_cfg_path, cur_path);
@@ -217,9 +236,16 @@ static zend_array *nullable _do_request_begin(
     if (_rem_cfg_path_changed(true) ||
         (!DDAPPSEC_G(active) &&
             DDAPPSEC_G(enabled) == APPSEC_ENABLED_VIA_REMCFG)) {
+        struct telemetry_rc_info tel_rc_info = dd_trace_get_telemetry_rc_info();
         res = dd_config_sync(
             conn, &(struct config_sync_data){.rem_cfg_path = _last_rem_cfg_path,
-                      .telemetry_settings = dd_trace_get_telemetry_rc_info()});
+                      .telemetry_settings = tel_rc_info});
+        if (tel_rc_info.service_name) {
+            zend_string_release(tel_rc_info.service_name);
+        }
+        if (tel_rc_info.env_name) {
+            zend_string_release(tel_rc_info.env_name);
+        }
         if (res == dd_success && DDAPPSEC_G(active)) {
             res = dd_request_init(conn, &req_info);
         }
@@ -291,9 +317,16 @@ void dd_req_lifecycle_rshutdown(bool ignore_verdict, bool force)
             mlog_g(dd_log_debug,
                 "No connection to the helper for rshutdown config sync");
         } else {
+            struct telemetry_rc_info tel_rc_info = dd_trace_get_telemetry_rc_info();
             dd_result res = dd_config_sync(conn,
                 &(struct config_sync_data){.rem_cfg_path = _last_rem_cfg_path,
-                    .telemetry_settings = dd_trace_get_telemetry_rc_info()});
+                    .telemetry_settings = tel_rc_info});
+            if (tel_rc_info.service_name) {
+                zend_string_release(tel_rc_info.service_name);
+            }
+            if (tel_rc_info.env_name) {
+                zend_string_release(tel_rc_info.env_name);
+            }
             if (res == dd_network) {
                 mlog_g(dd_log_info, "request_init/config_sync failed with "
                                     "dd_network; closing "

--- a/ext/sidecar.h
+++ b/ext/sidecar.h
@@ -16,7 +16,7 @@ struct telemetry_rc_info {
     const char *rc_path;
     zend_string *service_name;
     zend_string *env_name;
-    // caller does not own the data
+    // caller owns the service_name and env_name (must release)
 };
 DDTRACE_PUBLIC struct telemetry_rc_info ddtrace_get_telemetry_rc_info(void);
 


### PR DESCRIPTION
### Description

The `last_service_name` and `last_env_name` globals could result in a use-after-free when the calling site to `ddtrace_get_telemetry_rc_info()` does not finish usage before those get cycled in `ddtrace_sidecar_submit_root_span_data_direct()`:
https://github.com/DataDog/dd-trace-php/blob/1dff083b79a234a66a76637069c1c2a9b63d2525/ext/sidecar.c#L508-L517

Thanks @yuandesu for reaching out regarding this race condition.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
