### PR TITLE
fix: refcounting for certain span metadata strings

### DIFF
--- a/ext/ip_extraction.c
+++ b/ext/ip_extraction.c
@@ -218,6 +218,7 @@ void ddtrace_extract_ip_from_headers(zval *server, zend_array *meta)
         return;
     }
     zval http_client_ip;
+    // `ddtrace_ip_extraction_find()` returns an owned zend_string; transfer ownership into span meta.
     ZVAL_STR(&http_client_ip, val);
     zend_hash_str_update(meta, ZEND_STRL("http.client_ip"), &http_client_ip);
 }


### PR DESCRIPTION
**EDIT:**  This is on-hold, I think I found a real issue with the streams context integration HTTP method... except due to a different bug, this doesn't execute!

Working through that in PR #3534.

<details>

<summary>Previous PR description</summary>


### Description

1. Fixes refcounting in two places that put things into the metadata of a span.
2. Adds defensive checks to `convert_zend_to_bytes_string` which is called by `ddog_add_span_meta_zstr`.

#### Background

We had crash reports coming in with this pattern:

1. `ddog_add_span_meta_zstr`
2. `ddtrace_php::bytes::convert_zend_to_bytes_string`
3. `String::from_utf8_lossy`
4. Then eventually, OOM.

The thing about the specific OOM is that `String::from_utf8_lossy` only allocates if the string is invalid UTF-8. So we have a failed allocation which is probably large with invalid UTF-8 that needs to be converted. Smells sketchy.

Additionally, one of the organizations affected by this crash was also a Datadog employee who had this in their logs:

> E_ERROR: Allowed memory size of 1073741824 bytes exhausted (tried to allocate 140437457690680 bytes)

That is over 127 TiB. So this is clearly a memory safety issue, likely a use-after-free with bad refcounts.

So I started investigating things which write to the span metadata and found these two issues.

### Reviewer checklist

I've added @Leiyks  and @cataphract as reviewers, as they wrote the respective functions I've patched. Edit: I think one of the changes was wrong, still working through it.

- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.

</details>
