### PR TITLE
fix(telemetry): cap dependency name length to copied bytes

### DIFF
--- a/ext/telemetry.c
+++ b/ext/telemetry.c
@@ -144,10 +144,11 @@ void ddtrace_telemetry_finalize() {
     char module_name[261] = { 'e', 'x', 't', '-' };
     ZEND_HASH_FOREACH_PTR(&module_registry, module) {
         size_t namelen = strlen(module->name);
-        memcpy(module_name + 4, module->name, MIN(256, strlen(module->name)));
+        size_t copylen = MIN(256, namelen);
+        memcpy(module_name + 4, module->name, copylen);
         const char *version = module->version ? module->version : "";
         ddog_sidecar_telemetry_addDependency_buffer(buffer,
-                                                    (ddog_CharSlice) {.len = namelen + 4, .ptr = module_name},
+                                                    (ddog_CharSlice) {.len = copylen + 4, .ptr = module_name},
                                                     (ddog_CharSlice) {.len = strlen(version), .ptr = version});
     } ZEND_HASH_FOREACH_END();
 


### PR DESCRIPTION
### Description

Example numbers for bug:
- `namelen = 500` (module name is 500 chars long)
- `copylen = min(256, 500) = 256`

Memory we actually have in the stack buffer:
- `"ext-"` + 256 bytes of name = 260 bytes total

But we were sending:
- `CharSlice.len = namelen + 4 = 504`

So Rust would try to read 504 bytes from a buffer that only contains 260 valid bytes, causing an out-of-bounds read.

I am not aware of any crashes that are happening *directly* because of this, meaning, I'm not aware of any modules which have names that long. However, this function is involved in crash reports, so that's where the additional scrutiny is coming from.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
