### PR TITLE
feat(PDO): correct a bug on prepared statement regarding DBM correlation

### DIFF
--- a/src/DDTrace/Integrations/DatabaseIntegrationHelper.php
+++ b/src/DDTrace/Integrations/DatabaseIntegrationHelper.php
@@ -21,7 +21,7 @@ class DatabaseIntegrationHelper
         Tag::TARGET_HOST,
     ];
 
-    public static function injectDatabaseIntegrationData(HookData $hook, $backend, $argNum = 0)
+    public static function injectDatabaseIntegrationData(HookData $hook, $backend, $argNum = 0, $forcedMode = null)
     {
         $allowedBackends = [
             "sqlsrv" => true,
@@ -32,7 +32,7 @@ class DatabaseIntegrationHelper
             "odbc" => true,
         ];
 
-        $propagationMode = dd_trace_env_config("DD_DBM_PROPAGATION_MODE");
+        $propagationMode = $forcedMode ?? dd_trace_env_config("DD_DBM_PROPAGATION_MODE");
         if ($propagationMode != \DDTrace\DBM_PROPAGATION_DISABLED && isset($allowedBackends[$backend])) {
             $fullPropagationBackends = [
                 "mysql" => true,

--- a/src/DDTrace/Integrations/Mysqli/MysqliIntegration.php
+++ b/src/DDTrace/Integrations/Mysqli/MysqliIntegration.php
@@ -152,7 +152,8 @@ class MysqliIntegration extends Integration
             $span = $hook->span();
             self::setDefaultAttributes($span, 'mysqli_prepare', $query);
 
-            DatabaseIntegrationHelper::injectDatabaseIntegrationData($hook, 'mysql', 1);
+            // For prepared statements, downgrade to service mode
+            DatabaseIntegrationHelper::injectDatabaseIntegrationData($hook, 'mysql', 1, \DDTrace\DBM_PROPAGATION_SERVICE);
             self::handleRasp($span);
         }, static function (HookData $hook) {
             list($mysqli, $query) = $hook->args;
@@ -222,7 +223,8 @@ class MysqliIntegration extends Integration
             $span = $hook->span();
             self::setDefaultAttributes($span, 'mysqli.prepare', $query);
 
-            DatabaseIntegrationHelper::injectDatabaseIntegrationData($hook, 'mysql');
+            // For prepared statements, downgrade to service mode
+            DatabaseIntegrationHelper::injectDatabaseIntegrationData($hook, 'mysql', 0, \DDTrace\DBM_PROPAGATION_SERVICE);
             self::handleRasp($span);
         }, static function (HookData $hook) {
             list($query) = $hook->args;

--- a/src/DDTrace/Integrations/PDO/PDOIntegration.php
+++ b/src/DDTrace/Integrations/PDO/PDOIntegration.php
@@ -125,7 +125,7 @@ class PDOIntegration extends Integration
             $instance = $hook->instance;
             PDOIntegration::setCommonSpanInfo($instance, $span);
 
-            PDOIntegration::injectDBIntegration($instance, $hook);
+            PDOIntegration::injectDBIntegration($instance, $hook, \DDTrace\DBM_PROPAGATION_SERVICE);
             PDOIntegration::handleRasp($instance, $span);
         }, static function (HookData $hook) {
             ObjectKVStore::propagate($hook->instance, $hook->returned, PDOIntegration::CONNECTION_TAGS_KEY);
@@ -265,7 +265,7 @@ REGEX;
         return $tags;
     }
 
-    public static function injectDBIntegration($pdo, $hook)
+    public static function injectDBIntegration($pdo, $hook, $forcedMode = null)
     {
         $driver = $pdo->getAttribute(\PDO::ATTR_DRIVER_NAME);
         if ($driver === "odbc") {
@@ -275,7 +275,7 @@ REGEX;
                 return;
             }
         }
-        DatabaseIntegrationHelper::injectDatabaseIntegrationData($hook, $driver);
+        DatabaseIntegrationHelper::injectDatabaseIntegrationData($hook, $driver, 0, $forcedMode);
     }
 
     public static function extractConnectionMetadata(array $constructorArgs)

--- a/src/DDTrace/Integrations/SQLSRV/SQLSRVIntegration.php
+++ b/src/DDTrace/Integrations/SQLSRV/SQLSRVIntegration.php
@@ -69,7 +69,8 @@ class SQLSRVIntegration extends Integration
             $span = $hook->span();
             self::setDefaultAttributes($conn, $span, 'sqlsrv_prepare', $query);
 
-            DatabaseIntegrationHelper::injectDatabaseIntegrationData($hook, 'sqlsrv', 1);
+            // For prepared statements, downgrade to service mode
+            DatabaseIntegrationHelper::injectDatabaseIntegrationData($hook, 'sqlsrv', 1, \DDTrace\DBM_PROPAGATION_SERVICE);
         }, static function (HookData $hook) {
             list($conn, $query) = $hook->args;
             $span = $hook->span();


### PR DESCRIPTION
### Description

**Problem**                                                                                                                                                                                                                                                                               
                                                                                                                                                                                                                                                                                        
DBM correlation was broken for PDO prepared statements. The traceparent SQL comment which DBM uses to correlate database queries with APM traces contained a span_id that didn't match the span representing the actual query execution.                      
                                                                                                                                                                                                                                                                                        
**Root Cause**
                                                                                                                                                                                                                                                                          When using prepared statements (PDO::prepare() + PDOStatement::execute()):                                                                                                                                                                                                            
  - PDO::prepare() created a "PDO.prepare" span and injected traceparent with that span's ID                                                                                                                                                                                           
  - PDOStatement::execute() created a separate "PDOStatement.execute" span as a sibling                                                                                                                                                                                                
  - Mismatch: traceparent referenced the prepare span, but the actual query execution happened in the execute span

This prevented DBM from properly correlating database queries with their corresponding APM spans. 

**Solution**                                                                                                                                                                                                                                                                              
                                                                                                                                                                                                                                                                                          Following the [RFC](https://docs.google.com/document/d/1hlp3CuIRE-os2zYgc0wYOS8kPtCKqlrGL7aepbHHDaU/edit?pli=1&tab=t.0#heading=h.tzokg558cj70) we now use SERVICE mode (DBM_PROPAGATION_SERVICE) for prepared statements instead of FULL mode.                                                                                                                                                                                                                                                                       