### PR TITLE
fix(CI: Yii Integration): add yii-bower asset to composer

### DIFF
--- a/tests/Frameworks/Yii/Latest/composer.json
+++ b/tests/Frameworks/Yii/Latest/composer.json
@@ -22,7 +22,8 @@
         "php": ">=5.4.0",
         "yiisoft/yii2": "2.0.53",
         "yiisoft/yii2-bootstrap": "~2.0.0",
-        "yiisoft/yii2-swiftmailer": "~2.0.0 || ~2.1.0"
+        "yiisoft/yii2-swiftmailer": "~2.0.0 || ~2.1.0",
+        "yidas/yii2-bower-asset": "2.0.13"
     },
     "require-dev": {
         "yiisoft/yii2-debug": "~2.1.0",

--- a/tests/Frameworks/Yii/Version_2_0_49/composer.json
+++ b/tests/Frameworks/Yii/Version_2_0_49/composer.json
@@ -22,7 +22,8 @@
         "php": ">=5.4.0",
         "yiisoft/yii2": "2.0.49",
         "yiisoft/yii2-bootstrap": "~2.0.0",
-        "yiisoft/yii2-swiftmailer": "~2.0.0 || ~2.1.0"
+        "yiisoft/yii2-swiftmailer": "~2.0.0 || ~2.1.0",
+        "yidas/yii2-bower-asset": "2.0.13"
     },
     "require-dev": {
         "yiisoft/yii2-debug": "~2.1.0",


### PR DESCRIPTION
### Description

Yii Integration tests have been recently failing due to a missing deficiency which this PR is now adding.

```
Problem 1
    - Root composer.json requires yiisoft/yii2 2.0.53 -> satisfiable by yiisoft/yii2[2.0.53].
    - yiisoft/yii2 2.0.53 requires bower-asset/punycode ^1.4 -> could not be found in any version, but the following packages provide it:
      - yidas/yii2-bower-asset Bower Assets for Yii 2 app provided via Composer repository
      - craftcms/cms Craft CMS
      - yidas/yii2-composer-bower-skip A Composer package that allows you to install or update Yii2 without Bower-Asset
      - demokn/yii2-composer-asset
      - kriss/yii2-calendar-schedule Yii2 Calendar Schedule
      - craftcms/yii2-dynamodb Yii2 implementation of a cache, session, and queue driver for DynamoDB
      - lsat/yii2-bower-asset Bower Assets for Yii 2 app provided via Composer repository
      - jamband/yii2-schemadump Generate the schema from an existing database
      - davidhirtz/yii2-skeleton Extended framework and admin panel based on Yii 2.0 framework
      - craftcms/yii2-adapter Craft CMS Yii2 adapter
      - blackhive/yii2-app-advanced Yii 2 Advanced Project Template
      - cliff363825/yii2-bower-asset Yii2 bower asset
      - jamband/yii2-ensure-unique-behavior This extension insert unique identifier automatically for the Yii 2 framework
      - kriss/yii2-advanced Yii2 advanced project template, Frontend for API and Backend with AdminLTE
      - kriss/yii2-amap Yii2 Amap
      ... and 14 more.
      Consider requiring one of these to satisfy the bower-asset/punycode requirement.
  Problem 2
    - Root composer.json requires yiisoft/yii2-gii ~2.1.0 -> satisfiable by yiisoft/yii2-gii[2.1.0, ..., 2.1.4].
    - yiisoft/yii2 2.0.53 requires bower-asset/punycode ^1.4 -> could not be found in any version, but the following packages provide it:
      - yidas/yii2-bower-asset Bower Assets for Yii 2 app provided via Composer repository
      - craftcms/cms Craft CMS
      - yidas/yii2-composer-bower-skip A Composer package that allows you to install or update Yii2 without Bower-Asset
      - demokn/yii2-composer-asset
      - kriss/yii2-calendar-schedule Yii2 Calendar Schedule
      - craftcms/yii2-dynamodb Yii2 implementation of a cache, session, and queue driver for DynamoDB
      - lsat/yii2-bower-asset Bower Assets for Yii 2 app provided via Composer repository
      - jamband/yii2-schemadump Generate the schema from an existing database
      - davidhirtz/yii2-skeleton Extended framework and admin panel based on Yii 2.0 framework
      - craftcms/yii2-adapter Craft CMS Yii2 adapter
      - blackhive/yii2-app-advanced Yii 2 Advanced Project Template
      - cliff363825/yii2-bower-asset Yii2 bower asset
      - jamband/yii2-ensure-unique-behavior This extension insert unique identifier automatically for the Yii 2 framework
      - kriss/yii2-advanced Yii2 advanced project template, Frontend for API and Backend with AdminLTE
      - kriss/yii2-amap Yii2 Amap
      ... and 14 more.
      Consider requiring one of these to satisfy the bower-asset/punycode requirement.
    - yiisoft/yii2-gii[2.1.0, ..., 2.1.4] require yiisoft/yii2 ~2.0.14 -> satisfiable by yiisoft/yii2[2.0.53].
Potential causes:
 - A typo in the package name
 - The package is not available in a stable-enough version according to your minimum-stability setting
   see <https://getcomposer.org/doc/04-schema.md#minimum-stability> for more details.
 - It's a private package and you forgot to add a custom repository to find it
Read <https://getcomposer.org/doc/articles/troubleshooting.md> for further common problems.
```