### PR TITLE
Use php_log_err() rather than _php_error_log_ex()

### DIFF
--- a/loader/dd_library_loader.c
+++ b/loader/dd_library_loader.c
@@ -301,7 +301,7 @@ void ddloader_logv(injected_ext *config, log_level level, const char *format, va
 
     char full[512];
     snprintf(full, sizeof(full), "[dd_library_loader][%s] %s", level_str, msg);
-    _php_error_log(0, full, NULL, NULL);
+    php_log_err(full);
 }
 
 void ddloader_logf(injected_ext *config, log_level level, const char *format, ...) {


### PR DESCRIPTION
### Description

I changed the signature of `_php_error_log()` and removed `_php_error_log_ex()` on php-src@master and thinking of fully removing the exposed API as I can only find one other usage of it outside of dd-trace which is also always calling `_php_error_log()` with the same mode.

So rather than doing effectively a function indirection call `php_log_err()` directly (this is a compat macro on master, but my understanding is you support PHP 7.0 still)

<!---
Any description you feel is relevant and gives more background to this PR, if necessary.
-->

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
