### PR TITLE
fix(profiling): crash in ddtrace_get_profiling_context

### DIFF
--- a/ext/profiling.c
+++ b/ext/profiling.c
@@ -8,7 +8,11 @@ ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
 
 DDTRACE_PUBLIC struct ddtrace_profiling_context ddtrace_get_profiling_context(void) {
     struct ddtrace_profiling_context context = {0, 0};
-    if (DDTRACE_G(active_stack) && DDTRACE_G(active_stack)->root_span && get_DD_TRACE_ENABLED()) {
+    // NOTE: `active_stack->active` may legitimately be NULL during span close (e.g. when closing the last span on a
+    // stack, `ddtrace_close_top_span_without_stack_swap()` updates it before running additional logic that may still
+    // allocate, such as JSON encoding during sampling decisions). Allocation profiling can call into this function
+    // from within those allocations, so treat "no active span" as "no profiling context" instead of dereferencing.
+    if (DDTRACE_G(active_stack) && DDTRACE_G(active_stack)->root_span && DDTRACE_G(active_stack)->active && get_DD_TRACE_ENABLED()) {
         context.local_root_span_id = DDTRACE_G(active_stack)->root_span->span_id;
         context.span_id = SPANDATA(DDTRACE_G(active_stack)->active)->span_id;
     }


### PR DESCRIPTION
### Description

This crash shows that if a span is closed and an allocation takes place, then it's possible for the allocation profiler to dereference a null pointer. GENERALLY, this pointer is not null, it's just a sort of weird edge:

```
#0   0x00007f9765f9a37c ddtrace_get_profiling_context (ext/profiling.c:12)
#1   0x00007f97654a5a68 common_labels (src/profiling/mod.rs:1446:32)
#2   0x00007f9765466e1e collect_allocations (src/profiling/mod.rs:953:30)
#3   0x00007f9765466e1e collect_allocation (allocation/mod.rs:77:13)
#4   0x00007f97654a827f alloc_prof_malloc (allocation/allocation_le83.rs:361:9)
#5   0x0000564703741654 smart_str_erealloc 
#6   0x000056470354c5fb php_json_encode_ex 
#7   0x00007f9765f9969e ddtrace_decide_on_closed_span_sampling (priority_sampling/priority_sampling.c:187)
#8   0x00007f9765fa78d9 ddtrace_close_top_span_without_stack_swap (ext/span.c:965)
#9   0x00007f9765fa7ebb ddtrace_close_span (ext/span.c:912)
#10  0x00007f9765fa849b ddtrace_clear_execute_data_span (ext/span.c:562)
#11  0x00007f9765fb137a dd_uhook_end (hook/uhook_legacy.c:246)
#12  0x00007f9765f55515 zai_hook_finish (hook/hook.c:1116)
#13  0x00007f9765f46e5e zai_hook_safe_finish (php8/interceptor.c:56)
#14  0x00007f9765f46f83 zai_interceptor_observer_end_handler (php8/interceptor.c:176)
#15  0x0000564703742be4 zend_observer_fcall_end 
#16  0x000056470370c89c execute_ex 
#17  0x0000564703716885 zend_execute 
#18  0x00005647036a0f10 zend_execute_scripts 
#19  0x00005647036347fa php_execute_script 
#20  0x00007f9772514e40 __libc_start_main 
#21  0x00005647034c2b65 _start 
```

You can use this code with a `datadog.profiling.allocation_sample_distance=1` to verify this, but I struggled to make a test and reproduce this without patching code:

```dff
diff --git a/ext/span.c b/ext/span.c
index 000000000..111111111 100644
--- a/ext/span.c
+++ b/ext/span.c
@@ -825,10 +825,25 @@ static void dd_close_entry_span_of_stack(ddtrace_span_stack *stack) {
     if (!stack->root_span || stack->root_span->stack == stack) {
         // Ensure the root span is cleared before allocations may happen in priority sampling deciding
         ddtrace_root_span_data *root_span = stack->root_span;
         if (stack->root_span) {
+            // Reproducer assist: if allocation profiling calls back into ddtrace while the trace root
+            // is closing, `stack->active` can already be NULL, while `stack->root_span` is still set.
+            // Force a small burst of allocations in that window so the crash (NULL deref in
+            // ddtrace_get_profiling_context on affected versions) becomes much easier to hit.
+            //
+            // Only enabled when ddtrace debug is on, to avoid impacting normal runs.
+            if (UNEXPECTED(get_DD_TRACE_DEBUG())) {
+                for (int i = 0; i < 10000; i++) {
+                    zend_string *tmp = zend_string_init(ZEND_STRL("profctx-repro"), 0);
+                    zend_string_release(tmp);
+                }
+            }
+
             // Root span stacks are automatic and tied to the lifetime of that root
             stack->root_span = NULL;
 
             // Enforce a sampling decision here
             ddtrace_fetch_priority_sampling_from_span(root_span);
         }
```

This crash was detected roughly 786 in the past week.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
