### PR TITLE
fix(ci) Add `cargo test` to CI

### DIFF
--- a/.gitlab/generate-profiler.php
+++ b/.gitlab/generate-profiler.php
@@ -45,7 +45,7 @@ foreach ($profiler_minor_major_targets as $version) {
 
     - '# NTS'
     - command -v switch-php && switch-php "${PHP_MAJOR_MINOR}"
-    - cargo build --profile profiler-release --all-features
+    - cargo build --profile profiler-release
     - mkdir -p "${CI_PROJECT_DIR}/artifacts/profiler-tests"
     - (cd tests; TEST_PHP_JUNIT="${CI_PROJECT_DIR}/artifacts/profiler-tests/nts-results.xml" php run-tests.php -d "extension=/mnt/ramdisk/cargo/profiler-release/libdatadog_php_profiling.so" --show-diff -g "FAIL,XFAIL,BORK,WARN,LEAK,XLEAK,SKIP" "phpt")
 
@@ -53,7 +53,7 @@ foreach ($profiler_minor_major_targets as $version) {
 
     - '# ZTS'
     - command -v switch-php && switch-php "${PHP_MAJOR_MINOR}-zts"
-    - cargo build --profile profiler-release --all-features
+    - cargo build --profile profiler-release
     - (cd tests; TEST_PHP_JUNIT="${CI_PROJECT_DIR}/artifacts/profiler-tests/zts-results.xml" php run-tests.php -d "extension=/mnt/ramdisk/cargo/profiler-release/libdatadog_php_profiling.so" --show-diff -g "FAIL,XFAIL,BORK,WARN,LEAK,XLEAK,SKIP" "phpt")
   after_script:
     - .gitlab/upload-junit-to-datadog.sh "test.source.file:profiling"
@@ -83,3 +83,17 @@ foreach ($profiler_minor_major_targets as $version) {
     - sed -i -e "s/crate-type.*$/crate-type = [\"rlib\"]/g" Cargo.toml
     - cargo clippy --all-targets --all-features -- -D warnings -Aunknown-lints
 
+"Cargo test":
+  stage: test
+  tags: [ "arch:amd64" ]
+  image: registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:php-8.5_bookworm-5
+  variables:
+    KUBERNETES_CPU_REQUEST: 5
+    KUBERNETES_MEMORY_REQUEST: 3Gi
+    KUBERNETES_MEMORY_LIMIT: 4Gi
+    # CARGO_TARGET_DIR: /mnt/ramdisk/cargo # ramdisk??
+    libdir: /tmp/datadog-profiling
+  script:
+    - switch-php nts # not compatible with debug
+    - cd profiling
+    - cargo test --all-features

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -635,6 +635,10 @@ __attribute__((weak)) zend_write_func_t zend_write;
  * cache the result in a thread local.
  */
 bool ddog_php_prof_is_parallel_thread() {
+#if defined(CFG_TEST)
+    // In test mode, we don't have a real module_registry, so just return false
+    return false;
+#else
     // Check if parallel extension is loaded to retrieve it's dl handle
     zend_module_entry *parallel_module = zend_hash_str_find_ptr(&module_registry, ZEND_STRL("parallel"));
 
@@ -703,4 +707,5 @@ bool ddog_php_prof_is_parallel_thread() {
     // This inits the `php_parallel_scheduler_context` TLS to point to a `php_parallel_runtime_t`
     // struct right before triggering `GINIT`.
     return (*tls_ptr != NULL);
+#endif // CFG_TEST
 }


### PR DESCRIPTION
### Description

It looks like that with the migration from CircleCI to GitLab we lost the `cargo test` run in CI.

This PR:
- fixes the `ddog_php_prof_is_parallel_thread()` function to return `false` in case `cargo test --all-features` is run because it would otherwise access `module_registry` which is not there
- add running `cargo test --all-features` to CI

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
