### PR TITLE
test(profiling): fix linking by removing recently added test

### DIFF
--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -390,7 +390,7 @@ uintptr_t *ddog_test_php_prof_function_run_time_cache(zend_function const *func)
 }
 #endif
 
-#if CFG_STACK_WALKING_TESTS || defined(CFG_TEST)
+#if CFG_STACK_WALKING_TESTS
 static int (*og_snprintf)(char *, size_t, const char *, ...);
 
 // "weak" let's us polyfill, needed by zend_string_init(..., persistent: 1).
@@ -463,33 +463,7 @@ void ddog_php_test_free_fake_zend_execute_data(zend_execute_data *execute_data) 
 
     free(execute_data);
 }
-
-zend_function *ddog_php_test_create_fake_zend_function_with_name_len(size_t len) {
-    zend_op_array *op_array = calloc(1, sizeof(zend_function));
-    if (!op_array) return NULL;
-
-    op_array->type = ZEND_USER_FUNCTION;
-
-    if (len > 0) {
-        op_array->function_name = zend_string_alloc(len, true);
-        if (!op_array->function_name) {
-            free(op_array);
-            return NULL;
-        }
-        memset(ZSTR_VAL(op_array->function_name), 'x', len);
-        ZSTR_VAL(op_array->function_name)[len] = '\0';
-    }
-
-    return (zend_function *)op_array;
-}
-
-void ddog_php_test_free_fake_zend_function(zend_function *func) {
-    if (!func) return;
-
-    free(func->common.function_name);
-    free(func);
-}
-#endif // CFG_STACK_WALKING_TESTS || CFG_TEST
+#endif
 
 void *opcache_handle = NULL;
 

--- a/profiling/src/profiling/stack_walking.rs
+++ b/profiling/src/profiling/stack_walking.rs
@@ -528,20 +528,14 @@ mod detail {
 
 pub use detail::*;
 
-#[cfg(test)]
+// todo: this should be feature = "stack_walking_tests" but it seemed to
+//       cause a failure in CI to migrate it.
+#[cfg(all(test, stack_walking_tests))]
 mod tests {
     use super::*;
     use crate::bindings as zend;
 
-    extern "C" {
-        fn ddog_php_test_create_fake_zend_function_with_name_len(
-            len: libc::size_t,
-        ) -> *mut zend::zend_function;
-        fn ddog_php_test_free_fake_zend_function(func: *mut zend::zend_function);
-    }
-
     #[test]
-    #[cfg(stack_walking_tests)]
     fn test_collect_stack_sample() {
         unsafe {
             let fake_execute_data = zend::ddog_php_test_create_fake_zend_execute_data(3);
@@ -564,59 +558,6 @@ mod tests {
 
             // Free the allocated memory
             zend::ddog_php_test_free_fake_zend_execute_data(fake_execute_data);
-        }
-    }
-
-    #[test]
-    fn test_extract_function_name_short_string() {
-        unsafe {
-            let func = ddog_php_test_create_fake_zend_function_with_name_len(10);
-            assert!(!func.is_null());
-
-            let name = extract_function_name(&*func).expect("should extract name");
-            assert_eq!(name, "xxxxxxxxxx");
-
-            ddog_php_test_free_fake_zend_function(func);
-        }
-    }
-
-    #[test]
-    fn test_extract_function_name_at_limit_minus_one() {
-        unsafe {
-            let func = ddog_php_test_create_fake_zend_function_with_name_len(STR_LEN_LIMIT - 1);
-            assert!(!func.is_null());
-
-            let name = extract_function_name(&*func).expect("should extract name");
-            assert_eq!(name.len(), STR_LEN_LIMIT - 1);
-            assert_ne!(name, COW_LARGE_STRING);
-
-            ddog_php_test_free_fake_zend_function(func);
-        }
-    }
-
-    #[test]
-    fn test_extract_function_name_at_limit() {
-        unsafe {
-            let func = ddog_php_test_create_fake_zend_function_with_name_len(STR_LEN_LIMIT);
-            assert!(!func.is_null());
-
-            let name = extract_function_name(&*func).expect("should return large string marker");
-            assert_eq!(name, COW_LARGE_STRING);
-
-            ddog_php_test_free_fake_zend_function(func);
-        }
-    }
-
-    #[test]
-    fn test_extract_function_name_over_limit() {
-        unsafe {
-            let func = ddog_php_test_create_fake_zend_function_with_name_len(STR_LEN_LIMIT + 1000);
-            assert!(!func.is_null());
-
-            let name = extract_function_name(&*func).expect("should return large string marker");
-            assert_eq!(name, COW_LARGE_STRING);
-
-            ddog_php_test_free_fake_zend_function(func);
         }
     }
 }


### PR DESCRIPTION
### Description

This reverts commit fa1f099ed4ef2d11daea4f787b4e1614a9c34fbf. The issue is that `ddog_php_test_create_fake_zend_function_with_name_len` creates a dependency on `_emalloc` by using `zend_string_alloc` and then we fail to link in some cases.

This went unnoticed due to merge order.

If we want to fix it "properly" then we need to link in the embed SAPI or similar to our tests, which seems like quite a bit of work for right now.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
