### PR TITLE
fix(profiling): crash in upload for DD_EXTERNAL_ENV

### DIFF
--- a/profiling/src/config.rs
+++ b/profiling/src/config.rs
@@ -110,6 +110,10 @@ impl SystemSettings {
             }
         }
 
+        // Initialize the lazy lock holding the env var for new origin
+        // detection in a safe place.
+        _ = std::sync::LazyLock::force(&libdd_common::entity_id::DD_EXTERNAL_ENV);
+
         // Work around version-specific issues.
         #[cfg(not(php_zend_mm_set_custom_handlers_ex))]
         if allocation::allocation_le83::first_rinit_should_disable_due_to_jit() {


### PR DESCRIPTION
https://datadoghq.atlassian.net/browse/PROF-11119

### Description

The uploader calls `getenv` and crashes, a classic here in PHP. Fortunately this specific one is a low-volume crash because it's behind a lock, so if it succeeds once, that process is then safe.

Also fortunately, the lock is `pub` so we can force it to initialize on first request, which is how we fix it.

<details>
<summary>Crash Backtrace</summary>

```
#0   0x00007f10a987914d getenv 
#1   0x00007f10a50b9263 std::sys::pal::unix::os::getenv::{{closure}}::h6378d1a598548b0a (sys/pal/unix/os.rs:665:26)
#2   0x00007f10a50b8e68 std::sys::pal::common::small_c_string::run_with_cstr_stack::ha6758cc058ac984d (common/small_c_string.rs:48:18)
#3   0x00007f10a50b8e68 std::sys::pal::common::small_c_string::run_with_cstr::h7dac442e96153d9b (common/small_c_string.rs:28:18)
#4   0x00007f10a50b8e68 std::sys::pal::unix::os::getenv::h3d60d140518f3acb (sys/pal/unix/os.rs:663:5)
#5   0x00007f10a50b8e68 std::env::_var_os::h394429332d906ed4 (std/src/env.rs:262:5)
#6   0x00007f10a4f0fcbd std::env::var_os::h991487127498c269 (std/src/env.rs:258:5)
#7   0x00007f10a4f0fcbd std::env::_var::hcfe40ad695553b79 (std/src/env.rs:225:11)
#8   0x00007f10a4f0fcbd var<&str> (std/src/env.rs:221:5)
#9   0x00007f10a4f0fcbd str_not_empty (src/config.rs:26:9)
#10  0x00007f10a4f0fcbd {closure#0} (src/entity_id/mod.rs:97:40)
#11  0x00007f10a4f0fcbd call_once<libdd_common::entity_id::DD_EXTERNAL_ENV::{closure_env#0}, ()> (src/ops/function.rs:250:5)
#12  0x00007f10a4f28335 call_once<fn() -> core::option::Option<&str>, ()> (src/ops/function.rs:250:5)
#13  0x00007f10a4f28335 {closure#0}<core::option::Option<&str>, fn() -> core::option::Option<&str>> (sync/lazy_lock.rs:212:25)
#14  0x00007f10a4f28335 {closure#0}<std::sync::lazy_lock::{impl#0}::force::{closure_env#0}<core::option::Option<&str>, fn() -> core::option::Option<&str>>> (std/src/sync/once.rs:158:41)
#15  0x00007f10a4e79c44 std::sys::sync::once::futex::Once::call::h145fbd026d17cf56 (sync/once/futex.rs:176:21)
#16  0x00007f10a4f5114f call_once<std::sync::lazy_lock::{impl#0}::force::{closure_env#0}<core::option::Option<&str>, fn() -> core::option::Option<&str>>> (std/src/sync/once.rs:158:9)
#17  0x00007f10a4f5114f force<core::option::Option<&str>, fn() -> core::option::Option<&str>> (sync/lazy_lock.rs:208:9)
#18  0x00007f10a4f5114f deref<core::option::Option<&str>, fn() -> core::option::Option<&str>> (sync/lazy_lock.rs:311:9)
#19  0x00007f10a4f5114f to_request_builder (src/lib.rs:270:37)
#20  0x00007f10a4f5114f build (src/exporter/mod.rs:318:23)
#21  0x00007f10a4e8c122 upload (profiling/uploader.rs:86:23)
#22  0x00007f10a4e8c122 run (profiling/uploader.rs:134:43)
#23  0x00007f10a4e8c122 {closure#1} (src/profiling/mod.rs:703:17)
#24  0x00007f10a4e8c122 {closure#0}<datadog_php_profiling::profiling::{impl#5}::new::{closure_env#1}, ()> (profiling/thread_utils.rs:46:13)
#25  0x00007f10a4e8c122 __rust_begin_short_backtrace<datadog_php_profiling::profiling::thread_utils::spawn::{closure_env#0}<datadog_php_profiling::profiling::{impl#5}::new::{closure_env#1}, ()>, ()> (src/sys/backtrace.rs:154:18)
#26  0x00007f10a4e94460 {closure#0}<datadog_php_profiling::profiling::thread_utils::spawn::{closure_env#0}<datadog_php_profiling::profiling::{impl#5}::new::{closure_env#1}, ()>, ()> (src/thread/mod.rs:561:17)
#27  0x00007f10a4e94460 call_once<(), std::thread::{impl#0}::spawn_unchecked_::{closure#1}::{closure_env#0}<datadog_php_profiling::profiling::thread_utils::spawn::{closure_env#0}<datadog_php_profiling::profiling::{impl#5}::new::{closure_env#1}, ()>, ()>> (panic/unwind_safe.rs:272:9)
#28  0x00007f10a4e94460 do_call<core::panic::unwind_safe::AssertUnwindSafe<std::thread::{impl#0}::spawn_unchecked_::{closure#1}::{closure_env#0}<datadog_php_profiling::profiling::thread_utils::spawn::{closure_env#0}<datadog_php_profiling::profiling::{impl#5}::new::{closure_env#1}, ()>, ()>>, ()> (std/src/panicking.rs:557:40)
#29  0x00007f10a4e94460 try<(), core::panic::unwind_safe::AssertUnwindSafe<std::thread::{impl#0}::spawn_unchecked_::{closure#1}::{closure_env#0}<datadog_php_profiling::profiling::thread_utils::spawn::{closure_env#0}<datadog_php_profiling::profiling::{impl#5}::new::{closure_env#1}, ()>, ()>>> (std/src/panicking.rs:520:19)
#30  0x00007f10a4e94460 catch_unwind<core::panic::unwind_safe::AssertUnwindSafe<std::thread::{impl#0}::spawn_unchecked_::{closure#1}::{closure_env#0}<datadog_php_profiling::profiling::thread_utils::spawn::{closure_env#0}<datadog_php_profiling::profiling::{impl#5}::new::{closure_env#1}, ()>, ()>>, ()> (std/src/panic.rs:358:14)
#31  0x00007f10a4e94460 {closure#1}<datadog_php_profiling::profiling::thread_utils::spawn::{closure_env#0}<datadog_php_profiling::profiling::{impl#5}::new::{closure_env#1}, ()>, ()> (src/thread/mod.rs:559:30)
#32  0x00007f10a4e94460 call_once<std::thread::{impl#0}::spawn_unchecked_::{closure_env#1}<datadog_php_profiling::profiling::thread_utils::spawn::{closure_env#0}<datadog_php_profiling::profiling::{impl#5}::new::{closure_env#1}, ()>, ()>, ()> (src/ops/function.rs:250:5)
#33  0x00007f10a50bdefb <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::h0bbb114b77b490c1 (alloc/src/boxed.rs:1972:9)
#34  0x00007f10a50bdefb <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::h3673811012fc0688 (alloc/src/boxed.rs:1972:9)
#35  0x00007f10a50bdefb std::sys::pal::unix::thread::Thread::new::thread_start::h0feaf4a9a4b2ecde (pal/unix/thread.rs:105:17)
#36  0x00007f10a9942a40 __clone 
```
</details>

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
