### PR TITLE
Fix spurious appsec munmaps in ZTS mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -52,6 +52,7 @@ Changelog for older versions can be found in our [release page](https://github.c
 
 ### Fixed
 - Use abstract namespace on linux #3525
+- Fix spurious munmaps in ZTS mode #3590
 
 ### Internal
 - Improvements for appsec libxml2 usage #3564

--- a/appsec/src/extension/helper_process.c
+++ b/appsec/src/extension/helper_process.c
@@ -88,15 +88,17 @@ void dd_helper_startup(void)
 #endif
 }
 
-void dd_helper_shutdown(void) {}
+void dd_helper_shutdown(void)
+{
+    if (_shared_state) {
+        munmap(_shared_state, sizeof(dd_helper_shared_state));
+    }
+}
 
 void dd_helper_gshutdown(void)
 {
     pefree(_mgr.socket_path, 1);
     pefree(_mgr.lock_path, 1);
-    if (_shared_state) {
-        munmap(_shared_state, sizeof(dd_helper_shared_state));
-    }
 }
 
 void dd_helper_rshutdown(void)


### PR DESCRIPTION
Once any ZTS thread shuts down, _shared_state is munmap'ped(). It will be unmapped and any other later mapping may happen at that same place through bad luck. If another thread shuts down, it will munmap this again and accesses to the later mapping are now crashing.

Fixes #3511.