### PR TITLE
Propagate NIGHTLY_BUILD CI var to package stage

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -93,3 +93,4 @@ package-trigger:
   variables:
     PARENT_PIPELINE_ID: $CI_PIPELINE_ID
     GIT_SUBMODULE_PATHS: libdatadog appsec/third_party/cpp-base64 appsec/third_party/libddwaf appsec/third_party/msgpack-c
+    NIGHTLY_BUILD: $NIGHTLY_BUILD


### PR DESCRIPTION
### Description

Propagate `NIGHTLY_BUILD`  CI env var to package stage in order to trigger the `promote-oci-to-staging` job.
