### PR TITLE
Fix installer AppSec tests for duplicate INI entry registration   

### DIFF
--- a/dockerfiles/verify_packages/installer/utils.sh
+++ b/dockerfiles/verify_packages/installer/utils.sh
@@ -116,7 +116,7 @@ assert_appsec_installed() {
 
 assert_appsec_enabled() {
     output="$(php --ri ddappsec)"
-    if [ -z "${output##*datadog.appsec.enabled => On*}" ]; then
+    if [ -z "${output##*Current state => Enabled*}" ]; then
         echo "---\nOk: ddappsec is enabled\n---\n${output}\n---\n"
     else
         echo "---\nError: Wrong ddappsec should be enabled\n---\n${output}\n---\n"
@@ -126,7 +126,7 @@ assert_appsec_enabled() {
 
 assert_appsec_disabled() {
     output="$(php --ri ddappsec)"
-    if [ -n "${output##*datadog.appsec.enabled => On*}" ]; then
+    if [ -n "${output##*Current state => Enabled*}" ]; then
         echo "---\nOk: ddappsec is not enabled\n---\n${output}\n---\n"
     else
         echo "---\nError: Wrong ddappsec should not be enabled\n---\n${output}\n---\n"


### PR DESCRIPTION
### Description

Fixes installer test failures caused by duplicate INI entry registration in 1.16.0.                                                                                                                                                                                                   
                                                                                                                                                                                                                                                                                        
### Problem                                                                                                                                                                                                                                                                           
In 1.16.0, commit f1ee6fbfb added `DD_APPSEC_ENABLED` to `ext/configuration.h`. This created a duplicate registration since the same INI entry was already defined in `appsec/src/extension/configuration.h`.                  
                                                                                                                                                                                                                                                                                        
When both extensions register the same INI entry, only the first one (ddtrace) succeeds. The AppSec extension's `php --ri ddappsec` output no longer displays `datadog.appsec.enabled` because it's now owned by the ddtrace extension.                                               
                                                                                                                                                                                                                                                                                        
### Solution                                                                                                                                                                                                                                                                          
Updated `assert_appsec_enabled()` and `assert_appsec_disabled()` to check for `"Current state => Enabled"` instead of `datadog.appsec.enabled => On`. This status line is always displayed by AppSec's phpinfo function regardless of INI ownership
