### PR TITLE
fix: add Cargo.lock to the .gitattributes file

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -23,3 +23,4 @@ github-actions-helpers         export-ignore
 
 .gitlab-ci.yml    export-ignore
 phpstan*.neon     export-ignore
+Cargo.lock        export-ignore


### PR DESCRIPTION
### Description

My vulnerability scanner flags `tracing-subscriber` during deployment. This MR updates .gitattributes to exclude Cargo.lock from the scan path, preventing false positives from vendor dependencies.

```
1 vulnerabilities found
0 Critical (0 fixable)
0 High (0 fixable)
1 Medium (1 fixable)
0 Low (0 fixable)
0 Negligible (0 fixable)
       PACKAGE        TYPE  VERSION  SUGGESTED FIX  CRITICAL  HIGH  MEDIUM  LOW  NEGLIGIBLE  EXPLOIT  
  tracing-subscriber  rust  0.3.19      0.3.20         0       0      1      0       0          0  
```

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
