### PR TITLE
feat(profiling): internal metrics for overhead improvements

### DIFF
--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -64,7 +64,8 @@ static mut PROFILER: OnceLock<Profiler> = OnceLock::new();
 
 pub static STACK_WALK_COUNT: AtomicU64 = AtomicU64::new(0);
 pub static STACK_WALK_CPU_TIME_NS: AtomicU64 = AtomicU64::new(0);
-pub static BACKGROUND_THREAD_CPU_TIME_NS: AtomicU64 = AtomicU64::new(0);
+pub static DDPROF_TIME_CPU_TIME_NS: AtomicU64 = AtomicU64::new(0);
+pub static DDPROF_UPLOAD_CPU_TIME_NS: AtomicU64 = AtomicU64::new(0);
 
 fn cpu_time_delta_ns(now: ThreadTime, prev: ThreadTime) -> u64 {
     match now.as_duration().checked_sub(prev.as_duration()) {
@@ -73,14 +74,14 @@ fn cpu_time_delta_ns(now: ThreadTime, prev: ThreadTime) -> u64 {
     }
 }
 
-pub(crate) fn update_background_cpu_time(last: &mut Option<ThreadTime>) {
+pub(crate) fn update_cpu_time_counter(last: &mut Option<ThreadTime>, counter: &AtomicU64) {
     let Some(prev) = last.take() else {
         *last = ThreadTime::try_now().ok();
         return;
     };
     if let Ok(now) = ThreadTime::try_now() {
         let elapsed_ns = cpu_time_delta_ns(now, prev);
-        BACKGROUND_THREAD_CPU_TIME_NS.fetch_add(elapsed_ns, Ordering::Relaxed);
+        counter.fetch_add(elapsed_ns, Ordering::Relaxed);
         *last = Some(now);
     } else {
         *last = Some(prev);
@@ -621,7 +622,7 @@ impl TimeCollector {
                                 Self::handle_resource_message(message, &mut profiles),
                             ProfilerMessage::Cancel => {
                                 // flush what we have before exiting
-                                update_background_cpu_time(&mut last_cpu);
+                                update_cpu_time_counter(&mut last_cpu, &DDPROF_TIME_CPU_TIME_NS);
                                 last_wall_export = self.handle_timeout(&mut profiles, &last_wall_export);
                                 running = false;
                             },
@@ -659,7 +660,7 @@ impl TimeCollector {
 
                 recv(upload_tick) -> message => {
                     if message.is_ok() {
-                        update_background_cpu_time(&mut last_cpu);
+                        update_cpu_time_counter(&mut last_cpu, &DDPROF_TIME_CPU_TIME_NS);
                         last_wall_export = self.handle_timeout(&mut profiles, &last_wall_export);
                     }
                 },


### PR DESCRIPTION
> [!IMPORTANT]
> This PR is not against `master`, but against `levi/stack_walk_metric` in https://github.com/DataDog/dd-trace-php/pull/3616

### Description

A few improvements to the CPU time tracking for background threads:

- Moved `update_background_cpu_time()` to just before `exporter.build()` so that profile serialization time is included in the metric for the current exported profile. Note: metadata generation, exporter building, and HTTP request time will still be attributed to the next profile period (left a comment in the code about that as well)
- Added tracking for `ddprof_time` thread
- Split the single `background_threads_cpu_time_ns` counter into two metrics, `ddprof_time_cpu_time_ns` for the `ddprof_time` thread and `ddprof_upload_cpu_time_ns` for the `ddprof_upload` thread

I did those changes in three separate commits (in the order above).

```json
{
  "ddprof_upload_cpu_time_ns": 894625,
  "libdatadog_version": "1.0.0",
  "stack_walk_cpu_time_ns": 0,
  "stack_walk_count": 0,
  "ddprof_time_cpu_time_ns": 8158083
}
```

vs.

```json
{
  "libdatadog_version": "1.0.0",
  "stack_walk_cpu_time_ns": 0,
  "stack_walk_count": 0,
  "background_threads_cpu_time_ns": 28375
}
```

.. on the first profile received.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
