### PR TITLE
fix(tracing): hook is_internal was backwards

### DIFF
--- a/zend_abstract_interface/hook/hook.c
+++ b/zend_abstract_interface/hook/hook.c
@@ -399,7 +399,7 @@ static void zai_hook_resolve_hooks_entry(zai_hooks_entry *hooks, zend_function *
         hooks->run_time_cache = ZEND_MAP_PTR(resolved->common.run_time_cache);
 #endif
     }
-    hooks->is_internal = ZEND_USER_CODE(resolved->type);
+    hooks->is_internal = !ZEND_USER_CODE(resolved->type);
     hooks->is_generator = (resolved->common.fn_flags & ZEND_ACC_GENERATOR) != 0;
     if (hooks->is_generator) {
 #if ZAI_JIT_BLACKLIST_ACTIVE


### PR DESCRIPTION
### Description

I'm fairly certain this is wrong but I'm not sure why it doesn't seem to affect things much. I have tried with AI's help to create reproducers that cause ASAN to fail (which is where I got started in the first place, looking at a bug report and seeing which things touch the run time cache and might get it wrong).

This field is used in a very narrow place, in `zai_hook_entries_destroy` when:

- `hooks->run_time_cache != NULL`
- `hooks->resolved == NULL`

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
