### PR TITLE
Fix language tests failures

### DIFF
--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -492,7 +492,7 @@ foreach ($all_minor_major_targets as $major_minor):
     DD_TRACE_GIT_METADATA_ENABLED: "0"
     REPORT_EXIT_STATUS: "1"
     TEST_PHP_JUNIT: "${CI_PROJECT_DIR}/artifacts/tests/php-tests.xml"
-    SKIP_ONLINE_TEST: "1"
+    SKIP_ONLINE_TESTS: "1"
 <?php if (version_compare($major_minor, "7.2", ">=")): /* too expensive */ ?>
     DD_INSTRUMENTATION_TELEMETRY_ENABLED: 0
 <?php endif; ?>

--- a/dockerfiles/ci/xfail_tests/7.1.list
+++ b/dockerfiles/ci/xfail_tests/7.1.list
@@ -257,7 +257,6 @@ ext/simplexml/tests/bug72971_2.phpt
 ext/simplexml/tests/simplexml_load_file.phpt
 ext/soap/tests/bug71610.phpt
 ext/soap/tests/bugs/bug28751.phpt
-ext/soap/tests/bugs/bug76348.phpt
 ext/sockets/tests/socket_connect_params.phpt
 ext/sockets/tests/socket_create_listen-nobind.phpt
 ext/sockets/tests/socket_create_pair.phpt

--- a/dockerfiles/ci/xfail_tests/7.2.list
+++ b/dockerfiles/ci/xfail_tests/7.2.list
@@ -235,7 +235,6 @@ ext/simplexml/tests/bug72971.phpt
 ext/simplexml/tests/bug72971_2.phpt
 ext/simplexml/tests/simplexml_load_file.phpt
 ext/soap/tests/bug71610.phpt
-ext/soap/tests/bugs/bug76348.phpt
 ext/sockets/tests/socket_connect_params.phpt
 ext/sockets/tests/socket_create_listen-nobind.phpt
 ext/sockets/tests/socket_create_pair.phpt

--- a/dockerfiles/ci/xfail_tests/8.1.list
+++ b/dockerfiles/ci/xfail_tests/8.1.list
@@ -134,6 +134,7 @@ ext/readline/tests/libedit_callback_handler_remove_001.phpt
 ext/simplexml/tests/bug51615.phpt
 ext/soap/tests/bug71610.phpt
 ext/soap/tests/bug77088.phpt
+ext/soap/tests/soap_qname_crash.phpt
 ext/sockets/tests/mcast_ipv6_recv.phpt
 ext/sockets/tests/mcast_ipv6_recv_limited.phpt
 ext/sockets/tests/mcast_ipv6_send.phpt

--- a/dockerfiles/ci/xfail_tests/8.2.list
+++ b/dockerfiles/ci/xfail_tests/8.2.list
@@ -123,6 +123,7 @@ ext/readline/tests/libedit_callback_handler_install_001.phpt
 ext/readline/tests/libedit_callback_handler_remove_001.phpt
 ext/simplexml/tests/bug51615.phpt
 ext/soap/tests/bug77088.phpt
+ext/soap/tests/soap_qname_crash.phpt
 ext/sockets/tests/mcast_ipv6_recv.phpt
 ext/sockets/tests/mcast_ipv6_send.phpt
 ext/sockets/tests/mcast_ipv6_recv_limited.phpt

--- a/dockerfiles/ci/xfail_tests/8.3.list
+++ b/dockerfiles/ci/xfail_tests/8.3.list
@@ -121,6 +121,7 @@ ext/readline/tests/libedit_callback_handler_install_001.phpt
 ext/readline/tests/libedit_callback_handler_remove_001.phpt
 ext/simplexml/tests/bug51615.phpt
 ext/soap/tests/bug77088.phpt
+ext/soap/tests/soap_qname_crash.phpt
 ext/sockets/tests/socket_create_listen-nobind.phpt
 ext/sockets/tests/socket_import_stream-4.phpt
 ext/spl/tests/bug40091.phpt

--- a/dockerfiles/ci/xfail_tests/8.4.list
+++ b/dockerfiles/ci/xfail_tests/8.4.list
@@ -125,6 +125,7 @@ ext/readline/tests/libedit_callback_handler_install_001.phpt
 ext/readline/tests/libedit_callback_handler_remove_001.phpt
 ext/simplexml/tests/bug51615.phpt
 ext/soap/tests/bugs/bug77088.phpt
+ext/soap/tests/soap_qname_crash.phpt
 ext/sockets/tests/socket_create_listen-nobind.phpt
 ext/sockets/tests/socket_import_stream-4.phpt
 ext/spl/tests/bug40091.phpt

--- a/dockerfiles/ci/xfail_tests/README.md
+++ b/dockerfiles/ci/xfail_tests/README.md
@@ -225,7 +225,7 @@ These tests use object ids, and %00; changing the EXPECT to EXPECTF will cause t
 
 ## `ext/soap/tests/soap_qname_crash.phpt`
 
-Disabled on versions: `8.5+`.
+Disabled on versions: `8.1+`.
 
 This test checks PHP's handling of excessively large QName prefix in SoapVar (a stress test for edge cases). With ddtrace loaded, the additional memory overhead causes the test to be killed before it can complete, due to hitting memory limits during the stress test.
 


### PR DESCRIPTION
### Description

This PR fix the language tests recent failures by:
- properly skipping online tests
- Disabling the `soap_qname_crash.phpt` test on all versions
