### PR TITLE
feat(ffe): Add Feature Flagging and Experimentation support

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -13,9 +13,9 @@ dependencies = [
 
 [[package]]
 name = "adler2"
-version = "2.0.1"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "320119579fcad9c21884f5c4861d16174d0e06250625266f50fe6898340abefa"
+checksum = "512761e0bb2578dd7380c6baaa0f4ce03e84f95e960231d1dec8bf4d7d6e2627"
 
 [[package]]
 name = "ahash"
@@ -24,17 +24,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a15f179cd60c4584b8a8c596927aadc462e27f2ca70c04e0071964a73ba7a75"
 dependencies = [
  "cfg-if",
- "getrandom 0.3.4",
+ "getrandom 0.3.2",
  "once_cell",
  "version_check 0.9.5",
- "zerocopy",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
 name = "aho-corasick"
-version = "1.1.4"
+version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ddd31a130427c27518df266943a5308ed92d4b226cc639f5a8f1002816174301"
+checksum = "8e60d3430d3a69478ad0993f19238d2df97c507009a52b3c10addcd7f6bcb916"
 dependencies = [
  "memchr",
 ]
@@ -46,12 +46,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "683d7910e743518b0e34f1186f92494becacb047c7b6bf616c96772180fef923"
 
 [[package]]
+name = "android-tzdata"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e999941b234f3131b00bc13c22d06e8c5ff726d1b6318ac7eb276997bbb4fef0"
+
+[[package]]
 name = "android_system_properties"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "819e7219dbd41043ac279b19830f2efc897156490d7fd6ea916720117ee66311"
 dependencies = [
- "libc 0.2.181",
+ "libc 0.2.177",
 ]
 
 [[package]]
@@ -62,9 +68,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.21"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43d5b281e737544384e969a5ccad3f1cdd24b48086a0fc1b2a5262a26b8f4f4a"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -77,44 +83,44 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.13"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5192cca8006f1fd4f7237516f40fa183bb07f8fbdfedaa0036de5ea9b0b45e78"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.7"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e7644824f0aa2c7b9384579234ef10eb7efb6a0deb83f9630a49594dd9c15c2"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.5"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.60.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.11"
+version = "3.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
+checksum = "ca3534e77181a9cc07539ad51f2141fe32f6c3ffd4df76db8ad92346b003ae4e"
 dependencies = [
  "anstyle",
- "once_cell_polyfill",
- "windows-sys 0.60.2",
+ "once_cell",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.101"
+version = "1.0.98"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f0e0fee31ef5ed1ba1316088939cea399010ed7731dba877ed44aeb407a75ea"
+checksum = "e16d2d3311acee920a9eb8d33b8cbc1787ce4a264e85f964c2404b969bdcd487"
 
 [[package]]
 name = "arbitrary"
@@ -127,12 +133,9 @@ dependencies = [
 
 [[package]]
 name = "arc-swap"
-version = "1.8.1"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ded5f9a03ac8f24d1b8a25101ee812cd32cdc8c50a4c50237de2c4915850e73"
-dependencies = [
- "rustversion",
-]
+checksum = "69f7f8c3906b62b754cd5326047894316021dcfe5a194c8ea52bdd94934a3457"
 
 [[package]]
 name = "arrayref"
@@ -176,9 +179,9 @@ checksum = "55ca83137a482d61d916ceb1eba52a684f98004f18e0cafea230fe5579c178a3"
 
 [[package]]
 name = "async-lock"
-version = "3.4.2"
+version = "3.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
+checksum = "ff6e472cdea888a4bd64f342f09b3f50e1886d32afe8df3d663c01140b811b18"
 dependencies = [
  "event-listener",
  "event-listener-strategy",
@@ -197,13 +200,13 @@ dependencies = [
 
 [[package]]
 name = "async-trait"
-version = "0.1.89"
+version = "0.1.85"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
+checksum = "3f934833b4b7233644e5848f235df3f57ed8c80f1528a26c3dfa13d2147fa056"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -218,22 +221,22 @@ version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0dde43e75fd43e8a1bf86103336bc699aa8d17ad1be60c76c0bdfd4828e19b78"
 dependencies = [
- "autocfg 1.5.0",
+ "autocfg 1.4.0",
 ]
 
 [[package]]
 name = "autocfg"
-version = "1.5.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
+checksum = "ace50bade8e6234aa140d9a2f552bbee1db4d353f69b8217bc503490fc1a9f26"
 
 [[package]]
 name = "aws-lc-fips-sys"
-version = "0.13.11"
+version = "0.13.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df6ea8e07e2df15b9f09f2ac5ee2977369b06d116f0c4eb5fa4ad443b73c7f53"
+checksum = "e99d74bb793a19f542ae870a6edafbc5ecf0bc0ba01d4636b7f7e0aba9ee9bd3"
 dependencies = [
- "bindgen 0.72.1",
+ "bindgen",
  "cc",
  "cmake",
  "dunce",
@@ -280,7 +283,7 @@ dependencies = [
  "matchit",
  "memchr",
  "mime 0.3.17",
- "percent-encoding 2.3.2",
+ "percent-encoding 2.3.1",
  "pin-project-lite",
  "serde_core",
  "sync_wrapper",
@@ -315,7 +318,7 @@ checksum = "8d82cb332cdfaed17ae235a638438ac4d4839913cc2af585c3c6746e8f8bee1a"
 dependencies = [
  "addr2line",
  "cfg-if",
- "libc 0.2.181",
+ "libc 0.2.177",
  "miniz_oxide",
  "object 0.36.7",
  "rustc-demangle",
@@ -359,48 +362,28 @@ version = "0.69.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "271383c67ccabffb7381723dea0672a673f292304fcb45c01cc648c7a8d58088"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.8.0",
  "cexpr",
  "clang-sys",
  "itertools 0.12.1",
  "lazy_static",
  "lazycell",
- "log 0.4.29",
+ "log 0.4.25",
  "prettyplease",
  "proc-macro2",
  "quote",
  "regex",
  "rustc-hash 1.1.0",
  "shlex",
- "syn 2.0.114",
+ "syn 2.0.96",
  "which",
 ]
 
 [[package]]
-name = "bindgen"
-version = "0.72.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "993776b509cfb49c750f11b8f07a46fa23e0a1386ffc01fb1e7d343efc387895"
-dependencies = [
- "bitflags 2.10.0",
- "cexpr",
- "clang-sys",
- "itertools 0.13.0",
- "log 0.4.29",
- "prettyplease",
- "proc-macro2",
- "quote",
- "regex",
- "rustc-hash 2.1.1",
- "shlex",
- "syn 2.0.114",
-]
-
-[[package]]
 name = "bit_field"
-version = "0.10.3"
+version = "0.10.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e4b40c7323adcfc0a41c4b88143ed58346ff65a288fc144329c5c45e05d70c6"
+checksum = "dc827186963e592360843fb5ba4b973e145841266c1357f7180c43526f2e5b61"
 
 [[package]]
 name = "bitflags"
@@ -410,9 +393,9 @@ checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
 name = "bitflags"
-version = "2.10.0"
+version = "2.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "812e12b5285cc515a9c72a5c1d3b6d46a19dac5acfef5265968c166106e31dd3"
+checksum = "8f68f53c83ab957f72c32642f3868eec03eb974d1fb82e453128456482613d36"
 
 [[package]]
 name = "bitmaps"
@@ -426,9 +409,9 @@ version = "0.2.0-rc.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95824d1dd4f20b4a4dfa63b72954e81914a718357231468180b30314e85057fa"
 dependencies = [
- "cpp_demangle 0.4.5",
- "gimli 0.32.3",
- "libc 0.2.181",
+ "cpp_demangle",
+ "gimli 0.32.0",
+ "libc 0.2.177",
  "memmap2",
  "miniz_oxide",
  "rustc-demangle",
@@ -454,9 +437,9 @@ dependencies = [
 
 [[package]]
 name = "bolero"
-version = "0.13.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ff44d278fc0062c95327087ed96b3d256906d1d8f579e534a3de8d6b386913a"
+checksum = "eeae9bae5224be9a368c3b4f8cc83451473d55bcc1aa522cf56a48828dcf7f6e"
 dependencies = [
  "bolero-afl",
  "bolero-engine",
@@ -465,7 +448,7 @@ dependencies = [
  "bolero-kani",
  "bolero-libfuzzer",
  "cfg-if",
- "rand 0.9.2",
+ "rand 0.9.0",
 ]
 
 [[package]]
@@ -480,41 +463,42 @@ dependencies = [
 
 [[package]]
 name = "bolero-engine"
-version = "0.13.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dca199170a7c92c669c1019f9219a316b66bcdcfa4b36cac5a460a4c1a851aba"
+checksum = "6b2496696794ca673fd085c7237d2b64b825bfe0dedbd5e947ca633532d8132b"
 dependencies = [
  "anyhow",
+ "backtrace",
  "bolero-generator",
  "lazy_static",
  "pretty-hex",
- "rand 0.9.2",
+ "rand 0.9.0",
  "rand_xoshiro",
 ]
 
 [[package]]
 name = "bolero-generator"
-version = "0.13.5"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "98a5782f2650f80d533f58ec339c6dce4cc5428f9c2755894f98156f52af81f2"
+checksum = "06b0c9bd47ec1d25ce698a2b4a0c3d8e527d0046919a04c800035e30bf4ea6d1"
 dependencies = [
  "bolero-generator-derive",
  "either",
- "getrandom 0.3.4",
- "rand_core 0.9.5",
+ "getrandom 0.3.2",
+ "rand_core 0.9.3",
  "rand_xoshiro",
 ]
 
 [[package]]
 name = "bolero-generator-derive"
-version = "0.13.4"
+version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9a21a3b022507b9edd2050caf370d945e398c1a7c8455531220fa3968c45d29e"
+checksum = "385f38498675c06532bed10cd40a4313691a8fb7d9b698fcf096739d422e1764"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 1.0.109",
 ]
 
 [[package]]
@@ -559,16 +543,16 @@ dependencies = [
 name = "build_common"
 version = "0.0.1"
 dependencies = [
- "cbindgen 0.29.2",
+ "cbindgen 0.29.0",
  "serde",
  "serde_json",
 ]
 
 [[package]]
 name = "bumpalo"
-version = "3.19.1"
+version = "3.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5dd9dc738b7a8311c7ade152424974d8115f2cdad61e8dab8dac9f2362298510"
+checksum = "79296716171880943b8470b5f8d03aa55eb2e645a4874bdbb28adb49162e012c"
 
 [[package]]
 name = "byteorder"
@@ -578,29 +562,29 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.11.1"
+version = "1.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e748733b7cbc798e1434b6ac524f0c1ff2ab456fe201501e6497c8417a4fc33"
+checksum = "325918d6fe32f23b19878fe4b34794ae41fc19ddbe53b10571a4874d44ffd39b"
 dependencies = [
  "serde",
 ]
 
 [[package]]
 name = "cadence"
-version = "1.7.0"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7aff0c323415907f37007d645d7499c378df47efb3e33ffc1f397fa4e549b2e"
+checksum = "62fd689c825a93386a2ac05a46f88342c6df9ec3e79416f665650614e92e7475"
 dependencies = [
  "crossbeam-channel",
 ]
 
 [[package]]
 name = "camino"
-version = "1.2.2"
+version = "1.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629a66d692cb9ff1a1c664e41771b3dcaf961985a9774c0eb0bd1b51cf60a48"
+checksum = "8b96ec4966b5813e2c0507c1f86115c8c5abaadc3980879c3424042a02fd1ad3"
 dependencies = [
- "serde_core",
+ "serde",
 ]
 
 [[package]]
@@ -640,34 +624,34 @@ checksum = "3fce8dd7fcfcbf3a0a87d8f515194b49d6135acab73e18bd380d1d93bb1a15eb"
 dependencies = [
  "clap",
  "heck 0.4.1",
- "indexmap 2.13.0",
- "log 0.4.29",
+ "indexmap 2.12.1",
+ "log 0.4.25",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.114",
+ "syn 2.0.96",
  "tempfile",
- "toml 0.8.23",
+ "toml",
 ]
 
 [[package]]
 name = "cbindgen"
-version = "0.29.2"
+version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "befbfd072a8e81c02f8c507aefce431fe5e7d051f83d48a23ffc9b9fe5a11799"
+checksum = "975982cdb7ad6a142be15bdf84aea7ec6a9e5d4d797c004d43185b24cfe4e684"
 dependencies = [
  "clap",
  "heck 0.5.0",
- "indexmap 2.13.0",
- "log 0.4.29",
+ "indexmap 2.12.1",
+ "log 0.4.25",
  "proc-macro2",
  "quote",
  "serde",
  "serde_json",
- "syn 2.0.114",
+ "syn 2.0.96",
  "tempfile",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
 ]
 
 [[package]]
@@ -678,7 +662,7 @@ checksum = "47b26a0954ae34af09b50f0de26458fa95369a0d478d8236d3f93082b219bd29"
 dependencies = [
  "find-msvc-tools",
  "jobserver",
- "libc 0.2.181",
+ "libc 0.2.177",
  "shlex",
 ]
 
@@ -707,9 +691,9 @@ dependencies = [
 
 [[package]]
 name = "cfg-if"
-version = "1.0.4"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
+checksum = "9555578bc9e57714c812a1f84e4fc5b4d21fcb063490c624de019f7464c91268"
 
 [[package]]
 name = "cfg_aliases"
@@ -719,16 +703,17 @@ checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
-version = "0.4.43"
+version = "0.4.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fac4744fb15ae8337dc853fee7fb3f4e48c0fbaa23d0afe49c447b4fab126118"
+checksum = "c469d952047f47f91b68d1cba3f10d63c11d73e4636f24f08daf0278abf01c4d"
 dependencies = [
+ "android-tzdata",
  "iana-time-zone",
  "js-sys",
  "num-traits",
  "serde",
  "wasm-bindgen",
- "windows-link 0.2.1",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -771,15 +756,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b023947811758c97c59bf9d1c188fd619ad4718dcaa767947df1cadb14f39f4"
 dependencies = [
  "glob",
- "libc 0.2.181",
+ "libc 0.2.177",
  "libloading",
 ]
 
 [[package]]
 name = "clap"
-version = "4.5.58"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63be97961acde393029492ce0be7a1af7e323e6bae9511ebfac33751be5e6806"
+checksum = "769b0145982b4b48713e01ec42d61614425f27b7058bda7180a3a41f30104796"
 dependencies = [
  "clap_builder",
  "clap_derive",
@@ -787,9 +772,9 @@ dependencies = [
 
 [[package]]
 name = "clap_builder"
-version = "4.5.58"
+version = "4.5.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f13174bda5dfd69d7e947827e5af4b0f2f94a4a3ee92912fba07a66150f21e2"
+checksum = "1b26884eb4b57140e4d2d93652abfa49498b938b3c9179f9fc487b0acc3edad7"
 dependencies = [
  "anstream",
  "anstyle",
@@ -799,21 +784,21 @@ dependencies = [
 
 [[package]]
 name = "clap_derive"
-version = "4.5.55"
+version = "4.5.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a92793da1a46a5f2a02a6f4c46c6496b28c43638adea8306fcb0caa1634f24e5"
+checksum = "54b755194d6389280185988721fffba69495eed5ee9feeee9a599b53db80318c"
 dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "clap_lex"
-version = "1.0.0"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3a822ea5bc7590f9d40f1ba12c0dc3c2760f3482c6984db1573ad11031420831"
+checksum = "f46ad14479a25103f283c0f10005961cf086d8dc42205bb44c46ac563475dca6"
 
 [[package]]
 name = "cloudabi"
@@ -846,9 +831,9 @@ dependencies = [
 
 [[package]]
 name = "colorchoice"
-version = "1.0.4"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b05b61dc5112cbb17e4b6cd61790d9845d13888356391624cbe7e41efeac1e75"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "combine"
@@ -917,9 +902,9 @@ checksum = "3618cccc083bb987a415d85c02ca6c9994ea5b44731ec28b9ecf09658655fba9"
 
 [[package]]
 name = "const_format"
-version = "0.2.35"
+version = "0.2.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7faa7469a93a566e9ccc1c73fe783b4a65c274c5ace346038dca9c39fe0030ad"
+checksum = "126f97965c8ad46d6d9163268ff28432e8f6a1196a55578867832e3049df63dd"
 dependencies = [
  "const_format_proc_macros",
 ]
@@ -943,12 +928,12 @@ checksum = "7d5cd0c57ef83705837b1cb872c973eff82b070846d3e23668322b2c0f8246d0"
 
 [[package]]
 name = "core-foundation"
-version = "0.10.1"
+version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2a6cd9ae233e7f62ba4e9353e81a88df7fc8a5987b8d445b4d90c879bd156f6"
+checksum = "b55271e5c8c478ad3f38ad24ef34923091e0548492a266d19b3c0b4d82574c63"
 dependencies = [
  "core-foundation-sys",
- "libc 0.2.181",
+ "libc 0.2.177",
 ]
 
 [[package]]
@@ -959,18 +944,9 @@ checksum = "773648b94d0e5d620f64f280777445740e61fe701025087ec8b57f45c791888b"
 
 [[package]]
 name = "cpp_demangle"
-version = "0.4.5"
+version = "0.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2bb79cb74d735044c972aae58ed0aaa9a837e85b01106a54c39e42e97f62253"
-dependencies = [
- "cfg-if",
-]
-
-[[package]]
-name = "cpp_demangle"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0667304c32ea56cb4cd6d2d7c0cfe9a2f8041229db8c033af7f8d69492429def"
+checksum = "96e58d342ad113c2b878f16d5d034c03be492ae460cdbc02b7f0f2284d310c7d"
 dependencies = [
  "cfg-if",
 ]
@@ -981,24 +957,24 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e9e393a7668fe1fad3075085b86c781883000b4ede868f43627b34a87c8b7ded"
 dependencies = [
- "libc 0.2.181",
+ "libc 0.2.177",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.17"
+version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ed5838eebb26a2bb2e58f6d5b5316989ae9d08bab10e0e6d103e656d1b0280"
+checksum = "16b80225097f2e5ae4e7179dd2266824648f3e2f49d9134d584b76389d31c4c3"
 dependencies = [
- "libc 0.2.181",
+ "libc 0.2.177",
 ]
 
 [[package]]
 name = "crc32fast"
-version = "1.5.0"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9481c1c90cbf2ac953f07c8d4a58aa3945c425b7185c9154d67a65e4230da511"
+checksum = "a97769d94ddab943e4510d138150169a2758b5ef3eb191a9ee688de3e23ef7b3"
 dependencies = [
  "cfg-if",
 ]
@@ -1094,15 +1070,15 @@ checksum = "d0a5c400df2834b80a4c3327b3aad3a4c4cd4de0629063962b03235697506a28"
 
 [[package]]
 name = "crunchy"
-version = "0.2.4"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
+checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
 name = "crypto-common"
-version = "0.1.7"
+version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78c8292055d1c1df0cce5d180393dc8cce0abec0a7102adb6c7b1eef6016d60a"
+checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
@@ -1110,21 +1086,21 @@ dependencies = [
 
 [[package]]
 name = "csv"
-version = "1.4.0"
+version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52cd9d68cf7efc6ddfaaee42e7288d3a99d613d4b50f76ce9827ae0c6e14f938"
+checksum = "acdc4883a9c96732e4733212c01447ebd805833b7275a73ca3ee080fd77afdaf"
 dependencies = [
  "csv-core",
  "itoa",
  "ryu",
- "serde_core",
+ "serde",
 ]
 
 [[package]]
 name = "csv-core"
-version = "0.1.13"
+version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "704a3c26996a80471189265814dbc2c257598b96b8a7feae2d31ace646bb9782"
+checksum = "5efa2b3d7902f4b634a20cae3c9c4e6209dc4779feb6863329607560143efa70"
 dependencies = [
  "memchr",
 ]
@@ -1158,11 +1134,11 @@ checksum = "b0f4697d190a142477b16aef7da8a99bfdc41e7e8b1687583c0d23a79c7afc1e"
 dependencies = [
  "cc",
  "codespan-reporting",
- "indexmap 2.13.0",
+ "indexmap 2.12.1",
  "proc-macro2",
  "quote",
  "scratch",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1173,10 +1149,10 @@ checksum = "d0956799fa8678d4c50eed028f2de1c0552ae183c76e976cf7ca8c4e36a7c328"
 dependencies = [
  "clap",
  "codespan-reporting",
- "indexmap 2.13.0",
+ "indexmap 2.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1191,17 +1167,17 @@ version = "1.0.194"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e6acc6b5822b9526adfb4fc377b67128fdd60aac757cc4a741a6278603f763cf"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "darling"
-version = "0.21.3"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9cdf337090841a411e2a7f3deb9187445851f91b309c0c0a29e05f74a00a48c0"
+checksum = "6f63b86c8a8826a49b8c21f08a2d07338eec8d900540f8630dc76284be802989"
 dependencies = [
  "darling_core",
  "darling_macro",
@@ -1209,27 +1185,27 @@ dependencies = [
 
 [[package]]
 name = "darling_core"
-version = "0.21.3"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1247195ecd7e3c85f83c8d2a366e4210d588e802133e1e355180a9870b517ea4"
+checksum = "95133861a8032aaea082871032f5815eb9e98cef03fa916ab4500513994df9e5"
 dependencies = [
  "fnv",
  "ident_case",
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "darling_macro"
-version = "0.21.3"
+version = "0.20.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d38308df82d1080de0afee5d069fa14b0326a88c14f15c5ccda35b4a6c414c81"
+checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1241,7 +1217,7 @@ dependencies = [
  "derive_more",
  "env_logger 0.10.2",
  "faststr",
- "log 0.4.29",
+ "log 0.4.25",
  "md5",
  "pyo3",
  "regex",
@@ -1249,8 +1225,8 @@ dependencies = [
  "serde-bool",
  "serde_json",
  "serde_with",
- "thiserror 2.0.18",
- "url 2.5.8",
+ "thiserror 2.0.12",
+ "url 2.5.4",
 ]
 
 [[package]]
@@ -1264,7 +1240,7 @@ dependencies = [
  "futures",
  "glibc_version",
  "io-lifetimes",
- "libc 0.2.181",
+ "libc 0.2.177",
  "libdd-common 1.1.0",
  "libdd-tinybytes",
  "memfd",
@@ -1291,7 +1267,7 @@ name = "datadog-ipc-macros"
 version = "0.0.1"
 dependencies = [
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1301,12 +1277,12 @@ dependencies = [
  "anyhow",
  "constcat",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.6.0",
  "libdd-common 1.1.0",
  "libdd-data-pipeline",
- "percent-encoding 2.3.2",
+ "percent-encoding 2.3.1",
  "regex",
- "regex-automata",
+ "regex-automata 0.4.9",
  "serde",
  "serde_json",
  "smallvec",
@@ -1323,8 +1299,8 @@ dependencies = [
  "datadog-live-debugger",
  "libdd-common 1.1.0",
  "libdd-common-ffi",
- "log 0.4.29",
- "percent-encoding 2.3.2",
+ "log 0.4.25",
+ "percent-encoding 2.3.1",
  "serde_json",
  "tokio",
  "tokio-util",
@@ -1338,7 +1314,7 @@ dependencies = [
  "ahash",
  "allocator-api2",
  "anyhow",
- "bindgen 0.69.5",
+ "bindgen",
  "cc",
  "cfg-if",
  "chrono",
@@ -1347,21 +1323,21 @@ dependencies = [
  "criterion-perf-events",
  "crossbeam-channel",
  "datadog-php-profiling",
- "env_logger 0.11.9",
+ "env_logger 0.11.6",
  "http",
  "lazy_static",
- "libc 0.2.181",
+ "libc 0.2.177",
  "libdd-alloc",
  "libdd-common 1.1.0 (git+https://github.com/DataDog/libdatadog?tag=v26.0.0)",
  "libdd-library-config-ffi",
  "libdd-profiling",
- "log 0.4.29",
+ "log 0.4.25",
  "perfcnt",
  "rand 0.8.5",
  "rand_distr",
  "rustc-hash 1.1.0",
  "serde_json",
- "thiserror 2.0.18",
+ "thiserror 2.0.12",
  "tracing",
  "tracing-subscriber",
  "uuid",
@@ -1380,7 +1356,7 @@ dependencies = [
  "futures-util",
  "http",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.6.0",
  "hyper-util",
  "libdd-common 1.1.0",
  "libdd-trace-protobuf",
@@ -1390,7 +1366,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2",
- "time 0.3.47",
+ "time 0.3.37",
  "tokio",
  "tokio-util",
  "tracing",
@@ -1416,8 +1392,8 @@ dependencies = [
  "http",
  "http-body-util",
  "httpmock",
- "hyper 1.8.1",
- "libc 0.2.181",
+ "hyper 1.6.0",
+ "libc 0.2.177",
  "libdd-common 1.1.0",
  "libdd-common-ffi",
  "libdd-crashtracker",
@@ -1462,7 +1438,7 @@ dependencies = [
  "datadog-remote-config",
  "datadog-sidecar",
  "http",
- "libc 0.2.181",
+ "libc 0.2.177",
  "libdd-common 1.1.0",
  "libdd-common-ffi",
  "libdd-crashtracker-ffi",
@@ -1483,7 +1459,7 @@ name = "datadog-sidecar-macros"
 version = "0.0.1"
 dependencies = [
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1494,6 +1470,7 @@ dependencies = [
  "bincode",
  "cbindgen 0.27.0",
  "const-str",
+ "datadog-ffe",
  "datadog-ipc",
  "datadog-live-debugger",
  "datadog-live-debugger-ffi",
@@ -1501,11 +1478,11 @@ dependencies = [
  "datadog-sidecar",
  "datadog-sidecar-ffi",
  "env_logger 0.10.2",
- "hashbrown 0.15.5",
+ "hashbrown 0.15.2",
  "http",
  "itertools 0.11.0",
  "lazy_static",
- "libc 0.2.181",
+ "libc 0.2.177",
  "libdd-common 1.1.0",
  "libdd-common-ffi",
  "libdd-crashtracker-ffi",
@@ -1514,10 +1491,10 @@ dependencies = [
  "libdd-telemetry-ffi",
  "libdd-tinybytes",
  "libdd-trace-utils",
- "log 0.4.29",
+ "log 0.4.25",
  "paste",
  "regex",
- "regex-automata",
+ "regex-automata 0.4.9",
  "serde",
  "serde_json",
  "serde_with",
@@ -1542,12 +1519,12 @@ dependencies = [
 
 [[package]]
 name = "deranged"
-version = "0.5.6"
+version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cc3dc5ad92c2e2d1c193bbbbdf2ea477cb81331de4f3103f267ca18368b988c4"
+checksum = "b42b6fa04a440b495c8b04d0e71b707c585f83cb9cb28cf8cd0d976c315e31b4"
 dependencies = [
  "powerfmt",
- "serde_core",
+ "serde",
 ]
 
 [[package]]
@@ -1558,7 +1535,7 @@ checksum = "1e567bd82dcff979e4b03460c307b3cdc9e96fde3d73bed1496d2bc75d9dd62a"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1579,7 +1556,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1604,7 +1581,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "89a09f22a6c6069a18470eb92d2298acf25463f14256d24778e1230d789a2aec"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.8.0",
  "objc2",
 ]
 
@@ -1616,7 +1593,7 @@ checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1637,9 +1614,9 @@ dependencies = [
 
 [[package]]
 name = "dyn-clone"
-version = "1.0.20"
+version = "1.0.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
+checksum = "0d6ef0072f8a535281e4876be788938b528e9a1d43900b82c2569af7da799125"
 
 [[package]]
 name = "educe"
@@ -1655,9 +1632,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.15.0"
+version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
 
 [[package]]
 name = "enum-ordinalize"
@@ -1669,16 +1646,16 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "env_filter"
-version = "1.0.0"
+version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a1c3cc8e57274ec99de65301228b537f1e4eedc1b8e0f9411c6caac8ae7308f"
+checksum = "186e05a59d4c50738528153b83b0b0194d3a29507dfec16eccd4b342903397d0"
 dependencies = [
- "log 0.4.29",
+ "log 0.4.25",
 ]
 
 [[package]]
@@ -1689,26 +1666,26 @@ checksum = "4cd405aab171cb85d6735e5c8d9db038c17d3ca007a4d2c25f337935c3d90580"
 dependencies = [
  "humantime",
  "is-terminal",
- "log 0.4.29",
+ "log 0.4.25",
  "regex",
  "termcolor",
 ]
 
 [[package]]
 name = "env_logger"
-version = "0.11.9"
+version = "0.11.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2daee4ea451f429a58296525ddf28b45a3b64f1acf6587e2067437bb11e218d"
+checksum = "dcaee3d8e3cfc3fd92428d477bc97fc29ec8716d180c0d74c643bb26166660e0"
 dependencies = [
  "env_filter",
- "log 0.4.29",
+ "log 0.4.25",
 ]
 
 [[package]]
 name = "equivalent"
-version = "1.0.2"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "877a4ace8713b0bcf2a4e7eec82529c029f1d0619886d18145fea96c3ffe5c0f"
+checksum = "5443807d6dff69373d433ab9ef5378ad8df50ca6298caf15de6e52e24aaf54d5"
 
 [[package]]
 name = "erased-serde"
@@ -1723,19 +1700,19 @@ dependencies = [
 
 [[package]]
 name = "errno"
-version = "0.3.14"
+version = "0.3.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
+checksum = "33d852cb9b869c2a9b3df2f71a3074817f01e1844f839a144f5fcef059a4eb5d"
 dependencies = [
- "libc 0.2.181",
- "windows-sys 0.52.0",
+ "libc 0.2.177",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "event-listener"
-version = "5.4.1"
+version = "5.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
+checksum = "3492acde4c3fc54c845eaab3eed8bd00c7a7d881f78bfc801e43a93dec1331ae"
 dependencies = [
  "concurrent-queue",
  "parking",
@@ -1744,9 +1721,9 @@ dependencies = [
 
 [[package]]
 name = "event-listener-strategy"
-version = "0.5.4"
+version = "0.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
+checksum = "3c3e4e0dd3673c1139bf041f3008816d9cf2946bbfac2945c09e523b8d7b05b2"
 dependencies = [
  "event-listener",
  "pin-project-lite",
@@ -1789,9 +1766,9 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 
 [[package]]
 name = "flate2"
-version = "1.1.9"
+version = "1.0.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "843fba2746e448b37e26a819579957415c8cef339bf08564fe8b7ddbd959573c"
+checksum = "c936bfdafb507ebbf50b8074c54fa31c5be9a1e7e5f467dd659697041407d07c"
 dependencies = [
  "crc32fast",
  "miniz_oxide",
@@ -1826,11 +1803,11 @@ checksum = "77ce24cb58228fbb8aa041425bb1050850ac19177686ea6e0f41a70416f56fdb"
 
 [[package]]
 name = "form_urlencoded"
-version = "1.2.2"
+version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
+checksum = "e13624c2627564efccf4934284bdd98cbaa14e79b0b5a141218e507b3a823456"
 dependencies = [
- "percent-encoding 2.3.2",
+ "percent-encoding 2.3.1",
 ]
 
 [[package]]
@@ -1916,7 +1893,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -1983,28 +1960,28 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.2.17"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+checksum = "c4567c8db10ae91089c99af84c68c38da3ec2f087c3f82960bcdbf3656b6f4d7"
 dependencies = [
  "cfg-if",
  "js-sys",
- "libc 0.2.181",
- "wasi 0.11.1+wasi-snapshot-preview1",
+ "libc 0.2.177",
+ "wasi 0.11.0+wasi-snapshot-preview1",
  "wasm-bindgen",
 ]
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
+checksum = "73fea8450eea4bac3940448fb7ae50d91f034f941199fcd9d909a5a07aa455f0"
 dependencies = [
  "cfg-if",
  "js-sys",
- "libc 0.2.181",
+ "libc 0.2.177",
  "r-efi",
- "wasip2",
+ "wasi 0.14.2+wasi-0.2.4",
  "wasm-bindgen",
 ]
 
@@ -2016,12 +1993,12 @@ checksum = "07e28edb80900c19c28f1072f2e8aeca7fa06b23cd4169cefe1af5aa3260783f"
 
 [[package]]
 name = "gimli"
-version = "0.32.3"
+version = "0.32.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e629b9b98ef3dd8afe6ca2bd0f89306cec16d43d907889945bc5d6687f2f13c7"
+checksum = "93563d740bc9ef04104f9ed6f86f1e3275c2cdafb95664e26584b9ca807a8ffe"
 dependencies = [
  "fallible-iterator",
- "indexmap 2.13.0",
+ "indexmap 2.12.1",
  "stable_deref_trait",
 ]
 
@@ -2036,9 +2013,9 @@ dependencies = [
 
 [[package]]
 name = "glob"
-version = "0.3.3"
+version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0cc23270f6e1808e30a928bdc84dea0b9b4136a8bc82338574f23baf47bbd280"
+checksum = "a8d1add55171497b4705a648c6b583acafb01d58050a51727785f0b2c8e0a2b2"
 
 [[package]]
 name = "goblin"
@@ -2046,7 +2023,7 @@ version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daa0a64d21a7eb230583b4c5f4e23b7e4e57974f96620f42a7e75e08ae66d745"
 dependencies = [
- "log 0.4.29",
+ "log 0.4.25",
  "plain",
  "scroll",
 ]
@@ -2059,9 +2036,9 @@ checksum = "32619942b8be646939eaf3db0602b39f5229b74575b67efc897811ded1db4e57"
 
 [[package]]
 name = "h2"
-version = "0.4.13"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f44da3a8150a6703ed5d34e164b875fd14c2cdab9af1252a9a1020bde2bdc54"
+checksum = "5017294ff4bb30944501348f6f8e42e6ad28f42c8bbef7a74029aff064a4e3c2"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -2069,7 +2046,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "http",
- "indexmap 2.13.0",
+ "indexmap 2.12.1",
  "slab",
  "tokio",
  "tokio-util",
@@ -2078,13 +2055,12 @@ dependencies = [
 
 [[package]]
 name = "half"
-version = "2.7.1"
+version = "2.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ea2d84b969582b4b1864a92dc5d27cd2b77b622a8d79306834f1be5ba20d84b"
+checksum = "6dd08c532ae367adf81c312a4580bc67f1d0fe8bc9c460520283f4c0ff277888"
 dependencies = [
  "cfg-if",
  "crunchy",
- "zerocopy",
 ]
 
 [[package]]
@@ -2115,9 +2091,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.5"
+version = "0.15.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
+checksum = "bf151400ff0baff5465007dd2f3e717f3fe502074ca563069ce3a6629d07b289"
 dependencies = [
  "allocator-api2",
  "equivalent",
@@ -2145,11 +2121,11 @@ dependencies = [
 
 [[package]]
 name = "headers"
-version = "0.4.1"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b3314d5adb5d94bcdf56771f2e50dbbc80bb4bdf88967526706205ac9eff24eb"
+checksum = "322106e6bd0cba2d5ead589ddb8150a13d7c4217cf80d7c4f682ca994ccc6aa9"
 dependencies = [
- "base64 0.22.1",
+ "base64 0.21.7",
  "bytes",
  "headers-core",
  "http",
@@ -2187,9 +2163,9 @@ checksum = "d231dfb89cfffdbc30e7fc41579ed6066ad03abda9e567ccafae602b97ec5024"
 
 [[package]]
 name = "hermit-abi"
-version = "0.5.2"
+version = "0.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
+checksum = "fbf6a919d6cf397374f7dfeeea91d974c7c0a7221d0d0f4f20d859d329e53fcc"
 
 [[package]]
 name = "hex"
@@ -2228,12 +2204,12 @@ dependencies = [
 
 [[package]]
 name = "http-body-util"
-version = "0.1.3"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
+checksum = "793429d76616a256bcb62c2a2ec2bed781c8307e797e2598c50010f2bee2544f"
 dependencies = [
  "bytes",
- "futures-core",
+ "futures-util",
  "http",
  "http-body",
  "pin-project-lite",
@@ -2241,9 +2217,9 @@ dependencies = [
 
 [[package]]
 name = "httparse"
-version = "1.10.1"
+version = "1.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6dbf3de79e51f3d586ab4cb9d5c3e2c14aa28ed23d180cf89b4df0454a69cc87"
+checksum = "7d71d3574edd2771538b901e6549113b4006ece66150fb69c0fb6d9a2adae946"
 
 [[package]]
 name = "httpdate"
@@ -2253,9 +2229,9 @@ checksum = "df3b46402a9d5adb4c86a0cf463f42e19994e3ee891101b1841f30a545cb49a9"
 
 [[package]]
 name = "httpmock"
-version = "0.8.3"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf4888a4d02d8e1f92ffb6b4965cf5ff56dda36ef41975f41c6fa0f6bde78c4e"
+checksum = "1cccf7d3f1b6ee94515933ed2d24615bc8aa2a68c3858e318422f10f538888f2"
 dependencies = [
  "assert-json-diff",
  "async-object-pool",
@@ -2269,7 +2245,7 @@ dependencies = [
  "headers",
  "http",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.6.0",
  "hyper-util",
  "path-tree",
  "regex",
@@ -2279,17 +2255,17 @@ dependencies = [
  "similar",
  "stringmetrics",
  "tabwriter",
- "thiserror 2.0.18",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
- "url 2.5.8",
+ "url 2.5.4",
 ]
 
 [[package]]
 name = "humantime"
-version = "2.3.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
+checksum = "9a3a5bfb195931eeb336b2a7b4d761daec841b97f947d34394601737a7bba5e4"
 
 [[package]]
 name = "hyper"
@@ -2312,14 +2288,13 @@ dependencies = [
 
 [[package]]
 name = "hyper"
-version = "1.8.1"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2ab2d4f250c3d7b1c9fcdff1cece94ea4e2dfbec68614f7b87cb205f24ca9d11"
+checksum = "cc2b571658e38e0c01b1fdca3bbbe93c00d3d71693ff2770043f8c29bc7d6f80"
 dependencies = [
- "atomic-waker",
  "bytes",
  "futures-channel",
- "futures-core",
+ "futures-util",
  "h2",
  "http",
  "http-body",
@@ -2327,7 +2302,6 @@ dependencies = [
  "httpdate",
  "itoa",
  "pin-project-lite",
- "pin-utils",
  "smallvec",
  "tokio",
  "want",
@@ -2335,12 +2309,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-rustls"
-version = "0.27.7"
+version = "0.27.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
+checksum = "2d191583f3da1305256f22463b9bb0471acad48a4e534a5218b9963e9c1f59b2"
 dependencies = [
+ "futures-util",
  "http",
- "hyper 1.8.1",
+ "hyper 1.6.0",
  "hyper-util",
  "rustls",
  "rustls-native-certs",
@@ -2357,7 +2332,7 @@ version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b90d566bffbce6a75bd8b09a05aa8c2cb1fabb6cb348f8840c9e4c90a0d83b0"
 dependencies = [
- "hyper 1.8.1",
+ "hyper 1.6.0",
  "hyper-util",
  "pin-project-lite",
  "tokio",
@@ -2366,22 +2341,23 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.20"
+version = "0.1.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "96547c2556ec9d12fb1578c4eaf448b04993e7fb79cbaad930a656880a6bdfa0"
+checksum = "7f66d5bd4c6f02bf0542fad85d626775bab9258cf795a4256dcaf3161114d1df"
 dependencies = [
  "base64 0.22.1",
  "bytes",
  "futures-channel",
+ "futures-core",
  "futures-util",
  "http",
  "http-body",
- "hyper 1.8.1",
+ "hyper 1.6.0",
  "ipnet",
- "libc 0.2.181",
- "percent-encoding 2.3.2",
+ "libc 0.2.177",
+ "percent-encoding 2.3.1",
  "pin-project-lite",
- "socket2",
+ "socket2 0.5.10",
  "tokio",
  "tower-service",
  "tracing",
@@ -2389,17 +2365,16 @@ dependencies = [
 
 [[package]]
 name = "iana-time-zone"
-version = "0.1.65"
+version = "0.1.61"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e31bc9ad994ba00e440a8aa5c9ef0ec67d5cb5e5cb0cc7f8b744a35b389cc470"
+checksum = "235e081f3925a06703c2d0117ea8b91f042756fd6e7a6e5d901e8ca1a996b220"
 dependencies = [
  "android_system_properties",
  "core-foundation-sys",
  "iana-time-zone-haiku",
  "js-sys",
- "log 0.4.29",
  "wasm-bindgen",
- "windows-core 0.62.2",
+ "windows-core 0.52.0",
 ]
 
 [[package]]
@@ -2413,22 +2388,21 @@ dependencies = [
 
 [[package]]
 name = "icu_collections"
-version = "2.1.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c6b649701667bbe825c3b7e6388cb521c23d88644678e83c0c4d0a621a34b43"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
 dependencies = [
  "displaydoc",
- "potential_utf",
  "yoke",
  "zerofrom",
  "zerovec",
 ]
 
 [[package]]
-name = "icu_locale_core"
-version = "2.1.1"
+name = "icu_locid"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "edba7861004dd3714265b4db54a3c390e880ab658fec5f7db895fae2046b5bb6"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
 dependencies = [
  "displaydoc",
  "litemap",
@@ -2438,58 +2412,96 @@ dependencies = [
 ]
 
 [[package]]
-name = "icu_normalizer"
-version = "2.1.1"
+name = "icu_locid_transform"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f6c8828b67bf8908d82127b2054ea1b4427ff0230ee9141c54251934ab1b599"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
 dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
  "icu_collections",
  "icu_normalizer_data",
  "icu_properties",
  "icu_provider",
  "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_normalizer_data"
-version = "2.1.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7aedcccd01fc5fe81e6b489c15b247b8b0690feb23304303a9e560f37efc560a"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
 
 [[package]]
 name = "icu_properties"
-version = "2.1.2"
+version = "1.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "020bfc02fe870ec3a66d93e677ccca0562506e5872c650f893269e08615d74ec"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
 dependencies = [
+ "displaydoc",
  "icu_collections",
- "icu_locale_core",
+ "icu_locid_transform",
  "icu_properties_data",
  "icu_provider",
- "zerotrie",
+ "tinystr",
  "zerovec",
 ]
 
 [[package]]
 name = "icu_properties_data"
-version = "2.1.2"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "616c294cf8d725c6afcd8f55abc17c56464ef6211f9ed59cccffe534129c77af"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
 
 [[package]]
 name = "icu_provider"
-version = "2.1.1"
+version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85962cf0ce02e1e0a629cc34e7ca3e373ce20dda4c4d7294bbd0bf1fdb59e614"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
 dependencies = [
  "displaydoc",
- "icu_locale_core",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
  "writeable",
  "yoke",
  "zerofrom",
- "zerotrie",
  "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -2511,9 +2523,9 @@ dependencies = [
 
 [[package]]
 name = "idna"
-version = "1.1.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b0875f23caa03898994f6ddc501886a45c7d3d62d04d2d90788d47be1b1e4de"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
  "idna_adapter",
  "smallvec",
@@ -2522,9 +2534,9 @@ dependencies = [
 
 [[package]]
 name = "idna_adapter"
-version = "1.2.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3acae9609540aa318d1bc588455225fb2085b9ed0c4f6bd0d9d5bcd86f1a0344"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
 dependencies = [
  "icu_normalizer",
  "icu_properties",
@@ -2536,16 +2548,16 @@ version = "1.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bd070e393353796e801d209ad339e89596eb4c8d430d18ede6a1cced8fafbd99"
 dependencies = [
- "autocfg 1.5.0",
+ "autocfg 1.4.0",
  "hashbrown 0.12.3",
  "serde",
 ]
 
 [[package]]
 name = "indexmap"
-version = "2.13.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7714e70437a7dc3ac8eb7e6f8df75fd8eb422675fc7678aff7364301092b1017"
+checksum = "0ad4bb2b565bca0645f4d68c5c9af97fba094e9791da685bf83cb5f3ce74acf2"
 dependencies = [
  "equivalent",
  "hashbrown 0.16.1",
@@ -2575,7 +2587,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eae7b9aee968036d54dce06cebaefd919e4472e753296daccd6d344e3e2df0c2"
 dependencies = [
  "hermit-abi 0.3.9",
- "libc 0.2.181",
+ "libc 0.2.177",
  "windows-sys 0.48.0",
 ]
 
@@ -2613,20 +2625,20 @@ dependencies = [
 
 [[package]]
 name = "is-terminal"
-version = "0.4.17"
+version = "0.4.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
+checksum = "261f68e344040fbd0edea105bef17c66edf46f984ddb1115b775ce31be948f4b"
 dependencies = [
- "hermit-abi 0.5.2",
- "libc 0.2.181",
+ "hermit-abi 0.4.0",
+ "libc 0.2.177",
  "windows-sys 0.52.0",
 ]
 
 [[package]]
 name = "is_terminal_polyfill"
-version = "1.70.2"
+version = "1.70.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6cb138bb79a146c1bd460005623e142ef0181e3d0219cb493e02f7d08a35695"
+checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
@@ -2656,28 +2668,10 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
-version = "1.0.17"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92ecc6618181def0457392ccd0ee51198e065e016d1d527a7ac1b6dc7c1f09d2"
+checksum = "d75a2a4b1b190afb6f5425f10f6a8f959d2ea0b9c2b1d79553551850539e4674"
 
 [[package]]
 name = "jni"
@@ -2689,7 +2683,7 @@ dependencies = [
  "cfg-if",
  "combine",
  "jni-sys",
- "log 0.4.29",
+ "log 0.4.25",
  "thiserror 1.0.69",
  "walkdir",
  "windows-sys 0.45.0",
@@ -2703,19 +2697,18 @@ checksum = "8eaf4bc02d17cbdd7ff4c7438cafcdf7fb9a4613313ad11b4f8fefe7d3fa0130"
 
 [[package]]
 name = "jobserver"
-version = "0.1.34"
+version = "0.1.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
+checksum = "48d1dbcbbeb6a7fec7e059840aa538bd62aaccf972c7346c4d9d2059312853d0"
 dependencies = [
- "getrandom 0.3.4",
- "libc 0.2.181",
+ "libc 0.2.177",
 ]
 
 [[package]]
 name = "js-sys"
-version = "0.3.85"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8c942ebf8e95485ca0d52d97da7c5a2c387d0e7f0ba4c35e93bfcaee045955b3"
+checksum = "1cfaf33c695fc6e08064efbc1f72ec937429614f25eef83af942d0e227c3a28f"
 dependencies = [
  "once_cell",
  "wasm-bindgen",
@@ -2739,9 +2732,9 @@ checksum = "a91d884b6667cd606bb5a69aa0c99ba811a115fc68915e7056ec08a46e93199a"
 
 [[package]]
 name = "lazy_static"
-version = "1.5.0"
+version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+checksum = "e2abad23fbc42b3700f2f279844dc832adb2b2eb069b2df918f455c4e18cc646"
 
 [[package]]
 name = "lazycell"
@@ -2757,9 +2750,9 @@ checksum = "e32a70cf75e5846d53a673923498228bbec6a8624708a9ea5645f075d6276122"
 
 [[package]]
 name = "libc"
-version = "0.2.181"
+version = "0.2.177"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "459427e2af2b9c839b132acb702a1c654d95e10f8c326bfc2ad11310e458b1c5"
+checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
 
 [[package]]
 name = "libdd-alloc"
@@ -2767,7 +2760,7 @@ version = "1.0.0"
 source = "git+https://github.com/DataDog/libdatadog?tag=v26.0.0#9aa79d219d0fa74ce667c4013005008f69052786"
 dependencies = [
  "allocator-api2",
- "libc 0.2.181",
+ "libc 0.2.177",
  "windows-sys 0.52.0",
 ]
 
@@ -2786,11 +2779,11 @@ dependencies = [
  "http-body",
  "http-body-util",
  "httparse",
- "hyper 1.8.1",
+ "hyper 1.6.0",
  "hyper-rustls",
  "hyper-util",
- "indexmap 2.13.0",
- "libc 0.2.181",
+ "indexmap 2.12.1",
+ "libc 0.2.177",
  "maplit",
  "mime 0.3.17",
  "multipart",
@@ -2826,10 +2819,10 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.6.0",
  "hyper-rustls",
  "hyper-util",
- "libc 0.2.181",
+ "libc 0.2.177",
  "nix 0.29.0",
  "pin-project",
  "regex",
@@ -2855,7 +2848,7 @@ dependencies = [
  "chrono",
  "crossbeam-queue",
  "function_name",
- "hyper 1.8.1",
+ "hyper 1.6.0",
  "libdd-common 1.1.0",
  "serde",
 ]
@@ -2874,7 +2867,7 @@ dependencies = [
  "cxx-build",
  "goblin",
  "http",
- "libc 0.2.181",
+ "libc 0.2.177",
  "libdd-common 1.1.0",
  "libdd-telemetry",
  "nix 0.29.0",
@@ -2884,7 +2877,7 @@ dependencies = [
  "page_size",
  "portable-atomic",
  "rand 0.8.5",
- "schemars 0.8.22",
+ "schemars",
  "serde",
  "serde_json",
  "symbolic-common",
@@ -2903,7 +2896,7 @@ dependencies = [
  "anyhow",
  "build_common",
  "function_name",
- "libc 0.2.181",
+ "libc 0.2.177",
  "libdd-common 1.1.0",
  "libdd-common-ffi",
  "libdd-crashtracker",
@@ -2928,7 +2921,7 @@ dependencies = [
  "http",
  "http-body-util",
  "httpmock",
- "hyper 1.8.1",
+ "hyper 1.6.0",
  "hyper-util",
  "libdd-common 1.1.0",
  "libdd-ddsketch",
@@ -3029,7 +3022,7 @@ dependencies = [
  "http",
  "http-body-util",
  "httparse",
- "indexmap 2.13.0",
+ "indexmap 2.12.1",
  "libdd-alloc",
  "libdd-common 1.1.0 (git+https://github.com/DataDog/libdatadog?tag=v26.0.0)",
  "libdd-profiling-protobuf",
@@ -3041,8 +3034,8 @@ dependencies = [
  "rustc-hash 1.1.0",
  "serde",
  "serde_json",
- "target-triple 0.1.4",
- "thiserror 2.0.18",
+ "target-triple",
+ "thiserror 2.0.12",
  "tokio",
  "tokio-util",
  "zstd",
@@ -3063,12 +3056,12 @@ dependencies = [
  "anyhow",
  "base64 0.22.1",
  "futures",
- "hashbrown 0.15.5",
+ "hashbrown 0.15.2",
  "http",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.6.0",
  "hyper-util",
- "libc 0.2.181",
+ "libc 0.2.177",
  "libdd-common 1.1.0",
  "libdd-ddsketch",
  "serde",
@@ -3088,7 +3081,7 @@ version = "0.0.1"
 dependencies = [
  "build_common",
  "function_name",
- "libc 0.2.181",
+ "libc 0.2.177",
  "libdd-common 1.1.0",
  "libdd-common-ffi",
  "libdd-telemetry",
@@ -3140,7 +3133,7 @@ name = "libdd-trace-stats"
 version = "1.0.0"
 dependencies = [
  "criterion",
- "hashbrown 0.15.5",
+ "hashbrown 0.15.2",
  "libdd-ddsketch",
  "libdd-trace-protobuf",
  "libdd-trace-utils",
@@ -3162,8 +3155,8 @@ dependencies = [
  "http",
  "http-body-util",
  "httpmock",
- "hyper 1.8.1",
- "indexmap 2.13.0",
+ "hyper 1.6.0",
+ "indexmap 2.12.1",
  "libdd-common 1.1.0",
  "libdd-tinybytes",
  "libdd-trace-normalization",
@@ -3185,19 +3178,19 @@ dependencies = [
 
 [[package]]
 name = "libloading"
-version = "0.8.9"
+version = "0.8.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7c4b02199fee7c5d21a5ae7d8cfa79a6ef5bb2fc834d6e9058e89c825efdc55"
+checksum = "fc2f4eb4bc735547cfed7c0a4922cbd04a4655978c09b54f1f7b228750664c34"
 dependencies = [
  "cfg-if",
- "windows-link 0.2.1",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "libm"
-version = "0.2.16"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "link-cplusplus"
@@ -3222,16 +3215,17 @@ checksum = "df1d3c3b53da64cf5760482273a98e575c651a67eec7f77df96b5b642de8f039"
 
 [[package]]
 name = "litemap"
-version = "0.8.1"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6373607a59f0be73a39b6fe456b8192fcc3585f602af20751600e974dd455e77"
+checksum = "4ee93343901ab17bd981295f2cf0026d4ad018c7c31ba84549a4ddbb47a45104"
 
 [[package]]
 name = "lock_api"
-version = "0.4.14"
+version = "0.4.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "224399e74b87b5f3557511d98dff8b14089b3dadafcab6bb93eab67d3aace965"
+checksum = "07af8b9cdd281b7915f413fa73f29ebd5d55d0d3f0155584dade1ff18cea1b17"
 dependencies = [
+ "autocfg 1.4.0",
  "scopeguard",
 ]
 
@@ -3241,16 +3235,16 @@ version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e19e8d5c34a3e0e2223db8e060f9e8264aeeb5c5fc64a4ee9965c062211c024b"
 dependencies = [
- "log 0.4.29",
+ "log 0.4.25",
 ]
 
 [[package]]
 name = "log"
-version = "0.4.29"
+version = "0.4.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e5032e24019045c762d3c0f28f5b6b8bbf38563a65908389bf7978758920897"
+checksum = "04cbf5b083de1c7e0222a7a51dbfdba1cbe1c6ab0b15e29fff3f6c077fd9cd9f"
 dependencies = [
- "serde_core",
+ "serde",
  "value-bag",
 ]
 
@@ -3262,11 +3256,11 @@ checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "manual_future"
-version = "0.1.4"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0c72f11f1d8e0c453cbd8042dfb83c2b50384f78a5a5d41019627c5f2062ece"
+checksum = "943968aefb9b0fdf36cccc03f6cd9d6698b23574ab49eccc185ae6c5cb6ad43e"
 dependencies = [
- "futures-util",
+ "futures",
 ]
 
 [[package]]
@@ -3277,11 +3271,11 @@ checksum = "3e2e65a1a2e43cfcb47a895c4c8b10d1f4a61097f9f254f183aee60cad9c651d"
 
 [[package]]
 name = "matchers"
-version = "0.2.0"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1525a2a28c7f4fa0fc98bb91ae755d1e2d1505079e05539e35bc876b5d65ae9"
+checksum = "8263075bb86c5a1b1427b5ae862e8889656f126e9f77c484496e8b47cf5c5558"
 dependencies = [
- "regex-automata",
+ "regex-automata 0.1.10",
 ]
 
 [[package]]
@@ -3304,26 +3298,26 @@ checksum = "490cc448043f947bae3cbee9c203358d62dbee0db12107a74be5c30ccfd09771"
 
 [[package]]
 name = "memchr"
-version = "2.8.0"
+version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
+checksum = "78ca9ab1a0babb1e7d5695e3530886289c18cf2f87ec19a575a0abdce112e3a3"
 
 [[package]]
 name = "memfd"
-version = "0.6.5"
+version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ad38eb12aea514a0466ea40a80fd8cc83637065948eb4a426e4aa46261175227"
+checksum = "b2cffa4ad52c6f791f4f8b15f0c05f9824b2ced1160e88cc393d64fff9a8ac64"
 dependencies = [
- "rustix 1.1.3",
+ "rustix 0.38.43",
 ]
 
 [[package]]
 name = "memmap2"
-version = "0.9.9"
+version = "0.9.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "744133e4a0e0a658e1374cf3bf8e415c4052a15a111acd372764c55b4177d490"
+checksum = "fd3f7eed9d3848f8b98834af67102b720745c4ec028fcd0aa0239277e7de374f"
 dependencies = [
- "libc 0.2.181",
+ "libc 0.2.177",
 ]
 
 [[package]]
@@ -3332,7 +3326,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "488016bfae457b036d996092f6cb448677611ce4449e970ceaf42695203f218a"
 dependencies = [
- "autocfg 1.5.0",
+ "autocfg 1.4.0",
 ]
 
 [[package]]
@@ -3341,7 +3335,7 @@ version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c73f5c649995a115e1a0220b35e4df0a1294500477f97a91d0660fb5abeb574a"
 dependencies = [
- "libc 0.2.181",
+ "libc 0.2.177",
  "windows-sys 0.52.0",
 ]
 
@@ -3352,7 +3346,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26b2a7c5ccfb370edd57fda423f3a551516ee127e10bc22a6215e8c63b20a38"
 dependencies = [
  "cc",
- "libc 0.2.181",
+ "libc 0.2.177",
  "windows-sys 0.42.0",
 ]
 
@@ -3390,7 +3384,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
 dependencies = [
  "mime 0.3.17",
- "unicase 2.9.0",
+ "unicase 2.8.1",
 ]
 
 [[package]]
@@ -3401,9 +3395,9 @@ checksum = "68354c5c6bd36d73ff3feceb05efa59b6acb7626617f4962be322a825e61f79a"
 
 [[package]]
 name = "miniz_oxide"
-version = "0.8.9"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1fa76a2c86f704bdb222d66965fb3d63269ce38518b83cb0575fca855ebb6316"
+checksum = "b8402cab7aefae129c6977bb0ff1b8fd9a04eb5b51efc50a70bea51cda0c7924"
 dependencies = [
  "adler2",
  "simd-adler32",
@@ -3411,13 +3405,13 @@ dependencies = [
 
 [[package]]
 name = "mio"
-version = "1.1.1"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a69bcab0ad47271a0234d9422b131806bf3968021e5dc9328caf2d4cd58557fc"
+checksum = "2886843bf800fba2e3377cff24abf6379b4c4d5c6681eaf9ea5b0d15090450bd"
 dependencies = [
- "libc 0.2.181",
- "wasi 0.11.1+wasi-snapshot-preview1",
- "windows-sys 0.61.2",
+ "libc 0.2.177",
+ "wasi 0.11.0+wasi-snapshot-preview1",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3438,19 +3432,18 @@ checksum = "41f5c9112cb662acd3b204077e0de5bc66305fa8df65c8019d5adb10e9ab6e58"
 
 [[package]]
 name = "msvc-demangler"
-version = "0.11.0"
+version = "0.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fbeff6bd154a309b2ada5639b2661ca6ae4599b34e8487dc276d2cd637da2d76"
+checksum = "c4c25a3bb7d880e8eceab4822f3141ad0700d20f025991c1f03bd3d00219a5fc"
 dependencies = [
- "bitflags 2.10.0",
- "itoa",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
 name = "multimap"
-version = "0.10.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d87ecb2933e8aeadb3e3a02b828fed80a7528047e68b4f424523a0981a3a084"
+checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
 
 [[package]]
 name = "multipart"
@@ -3462,7 +3455,7 @@ dependencies = [
  "httparse",
  "hyper 0.10.16",
  "iron",
- "log 0.4.29",
+ "log 0.4.25",
  "mime 0.3.17",
  "mime_guess 2.0.5",
  "nickel",
@@ -3511,10 +3504,10 @@ version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "71e2746dc3a24dd78b3cfcb7be93368c6de9963d30f43a6a73998a9cf4b17b46"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.8.0",
  "cfg-if",
  "cfg_aliases",
- "libc 0.2.181",
+ "libc 0.2.177",
  "memoffset",
 ]
 
@@ -3524,10 +3517,10 @@ version = "0.30.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "74523f3a35e05aba87a1d978330aef40f67b0304ac79c1c00b294c9830543db6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.8.0",
  "cfg-if",
  "cfg_aliases",
- "libc 0.2.181",
+ "libc 0.2.177",
 ]
 
 [[package]]
@@ -3552,11 +3545,12 @@ dependencies = [
 
 [[package]]
 name = "nu-ansi-term"
-version = "0.50.3"
+version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7957b9740744892f114936ab4a57b3f487491bbeafaf8083688b16841a4240e5"
+checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
- "windows-sys 0.59.0",
+ "overload",
+ "winapi 0.3.9",
 ]
 
 [[package]]
@@ -3571,9 +3565,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.2.0"
+version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf97ec579c3c42f953ef76dbf8d55ac91fb219dde70e49aa4a6b7d74e9919050"
+checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
 
 [[package]]
 name = "num-derive"
@@ -3583,7 +3577,7 @@ checksum = "ed3955f1a9c7c0c15e092f9c887db08b1fc683305fdf6eb6684f22555355e202"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -3601,18 +3595,18 @@ version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
- "autocfg 1.5.0",
+ "autocfg 1.4.0",
  "libm",
 ]
 
 [[package]]
 name = "num_cpus"
-version = "1.17.0"
+version = "1.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91df4bbde75afed763b708b7eee1e8e7651e02d97f6d5dd763e89367e957b23b"
+checksum = "4161fcb6d602d4d2081af7c3a45852d875a03dd337a6bfdd6e06407b61342a43"
 dependencies = [
- "hermit-abi 0.5.2",
- "libc 0.2.181",
+ "hermit-abi 0.3.9",
+ "libc 0.2.177",
 ]
 
 [[package]]
@@ -3630,7 +3624,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73ad74d880bb43877038da939b7427bba67e9dd42004a18b809ba7d87cee241c"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.8.0",
  "objc2",
  "objc2-foundation",
 ]
@@ -3651,7 +3645,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a180dd8642fa45cdb7dd721cd4c11b1cadd4929ce112ebd8b9f5803cc79d536"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.8.0",
  "dispatch2",
  "objc2",
 ]
@@ -3662,7 +3656,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e022c9d066895efa1345f8e33e584b9f958da2fd4cd116792e15e07e4720a807"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.8.0",
  "dispatch2",
  "objc2",
  "objc2-core-foundation",
@@ -3695,7 +3689,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0cde0dfb48d25d2b4862161a4d5fcc0e3c24367869ad306b0c9ec0073bfed92d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.8.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-core-graphics",
@@ -3713,9 +3707,9 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3e0adef53c21f888deb4fa59fc59f7eb17404926ee8a6f59f5df0fd7f9f3272"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.8.0",
  "block2",
- "libc 0.2.181",
+ "libc 0.2.177",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3726,7 +3720,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "180788110936d59bab6bd83b6060ffdfffb3b922ba1396b312ae795e1de9d81d"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.8.0",
  "objc2",
  "objc2-core-foundation",
 ]
@@ -3737,7 +3731,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "96c1358452b371bf9f104e21ec536d37a650eb10f7ee379fff67d2e08d537f1f"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.8.0",
  "objc2",
  "objc2-core-foundation",
  "objc2-foundation",
@@ -3749,7 +3743,7 @@ version = "0.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d87d638e33c06f577498cbcc50491496a3ed4246998a7fbba7ccb98b1e7eab22"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.8.0",
  "block2",
  "objc2",
  "objc2-cloud-kit",
@@ -3801,22 +3795,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
-name = "once_cell_polyfill"
-version = "1.70.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
-
-[[package]]
 name = "oorandom"
-version = "11.1.5"
+version = "11.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6790f58c7ff633d8771f42965289203411a5e5c68388703c06e14f24770b41e"
+checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
 
 [[package]]
 name = "openssl-probe"
-version = "0.2.1"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7c87def4c32ab89d880effc9e097653c8da5d6ef28e6b539d313baaacfbafcbe"
+checksum = "ff011a302c396a5197692431fc1948019154afc178baf7d8e37367442a4601cf"
 
 [[package]]
 name = "opentelemetry"
@@ -3831,7 +3819,7 @@ dependencies = [
  "futures-util",
  "js-sys",
  "lazy_static",
- "percent-encoding 2.3.2",
+ "percent-encoding 2.3.1",
  "pin-project",
  "rand 0.8.5",
  "thiserror 1.0.69",
@@ -3879,7 +3867,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e4022a17595a00d6a369236fdae483f0de7f0a339960a53118b818238e132224"
 dependencies = [
  "android_system_properties",
- "log 0.4.29",
+ "log 0.4.25",
  "nix 0.30.1",
  "objc2",
  "objc2-foundation",
@@ -3889,12 +3877,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "overload"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b15813163c1d831bf4a13c3610c05c0d03b39feb07f7e09fa234dac9b15aaf39"
+
+[[package]]
 name = "page_size"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30d5b2194ed13191c1999ae0704b7839fb18384fa22e49b57eeaa97d79ce40da"
 dependencies = [
- "libc 0.2.181",
+ "libc 0.2.177",
  "winapi 0.3.9",
 ]
 
@@ -3906,9 +3900,9 @@ checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
-version = "0.12.5"
+version = "0.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93857453250e3077bd71ff98b6a65ea6621a19bb0f559a85248955ac12c45a1a"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
 dependencies = [
  "lock_api",
  "parking_lot_core",
@@ -3916,15 +3910,15 @@ dependencies = [
 
 [[package]]
 name = "parking_lot_core"
-version = "0.9.12"
+version = "0.9.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2621685985a2ebf1c516881c026032ac7deafcda1a2c9b7850dc81e3dfcb64c1"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
 dependencies = [
  "cfg-if",
- "libc 0.2.181",
+ "libc 0.2.177",
  "redox_syscall",
  "smallvec",
- "windows-link 0.2.1",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -3950,9 +3944,9 @@ checksum = "31010dd2e1ac33d5b46a5b413495239882813e0369f8ed8a5e266f173602f831"
 
 [[package]]
 name = "percent-encoding"
-version = "2.3.2"
+version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
+checksum = "e3148f5046208a5d56bcfc03053e3ca6334e51da8dfb19b6cdc8b306fae3283e"
 
 [[package]]
 name = "perfcnt"
@@ -3961,7 +3955,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4ba1fd955270ca6f8bd8624ec0c4ee1a251dd3cc0cc18e1e2665ca8f5acb1501"
 dependencies = [
  "bitflags 1.3.2",
- "libc 0.2.181",
+ "libc 0.2.177",
  "mmap",
  "nom 4.2.3",
  "x86",
@@ -3974,8 +3968,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
- "hashbrown 0.15.5",
- "indexmap 2.13.0",
+ "hashbrown 0.15.2",
+ "indexmap 2.12.1",
 ]
 
 [[package]]
@@ -4066,22 +4060,22 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.10"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "677f1add503faace112b9f1373e43e9e054bfdd22ff1a63c1bc485eaec6a6a8a"
+checksum = "1e2ec53ad785f4d35dac0adea7f7dc6f1bb277ad84a680c7afefeae05d1f5916"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.10"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e918e4ff8c4549eb882f14b3a4bc8c8bc93de829416eacf579f1207a8fbf861"
+checksum = "d56a66c0c55993aa927429d0f8a0abfd74f084e4d9c192cffed01e418d83eefb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4147,20 +4141,11 @@ dependencies = [
 
 [[package]]
 name = "portable-atomic"
-version = "1.13.1"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c33a9471896f1c69cecef8d20cbe2f7accd12527ce60845ff44c153bb2a21b49"
+checksum = "280dc24453071f1b63954171985a0b0d30058d287960968b9b2aca264c8d4ee6"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "potential_utf"
-version = "0.1.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b73949432f5e2a09657003c25bca5e19a0e9c84f8058ca374f49e0ebe605af77"
-dependencies = [
- "zerovec",
 ]
 
 [[package]]
@@ -4171,11 +4156,11 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "ppv-lite86"
-version = "0.2.21"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
+checksum = "77957b295656769bb8ad2b6a6b09d897d94f05c41b069aede1fcdaa675eaea04"
 dependencies = [
- "zerocopy",
+ "zerocopy 0.7.35",
 ]
 
 [[package]]
@@ -4184,8 +4169,8 @@ version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "059a34f111a9dee2ce1ac2826a68b24601c4298cfeb1a587c3cb493d5ab46f52"
 dependencies = [
- "libc 0.1.12",
- "nix 0.30.1",
+ "libc 0.2.177",
+ "nix 0.29.0",
 ]
 
 [[package]]
@@ -4206,23 +4191,23 @@ dependencies = [
 
 [[package]]
 name = "prettyplease"
-version = "0.2.37"
+version = "0.2.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
+checksum = "6924ced06e1f7dfe3fa48d57b9f74f55d8915f5036121bef647ef4b204895fac"
 dependencies = [
  "proc-macro2",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "priority-queue"
-version = "2.7.0"
+version = "2.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "93980406f12d9f8140ed5abe7155acb10bb1e69ea55c88960b9c2f117445ef96"
+checksum = "714c75db297bc88a63783ffc6ab9f830698a6705aa0201416931759ef4c8183d"
 dependencies = [
+ "autocfg 1.4.0",
  "equivalent",
- "indexmap 2.13.0",
- "serde",
+ "indexmap 2.12.1",
 ]
 
 [[package]]
@@ -4260,25 +4245,26 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.106"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd00f0bb2e90d81d1044c2b32617f68fcb9fa3bb7640c23e9c748e53fb30934"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "proptest"
-version = "1.10.0"
+version = "1.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "37566cb3fdacef14c0737f9546df7cfeadbfbc9fef10991038bf5015d0c80532"
+checksum = "14cae93065090804185d3b75f0bf93b8eeda30c7a9b4a33d3bdb3988d6229e50"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.8.0",
+ "lazy_static",
  "num-traits",
- "rand 0.9.2",
- "rand_chacha 0.9.0",
- "rand_xorshift 0.4.0",
- "regex-syntax",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
+ "rand_xorshift 0.3.0",
+ "regex-syntax 0.8.5",
  "unarray",
 ]
 
@@ -4298,16 +4284,16 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "343d3bd7056eda839b03204e68deff7d1b13aba7af2b2fd16890697274262ee7"
 dependencies = [
- "heck 0.4.1",
- "itertools 0.14.0",
- "log 0.4.29",
+ "heck 0.5.0",
+ "itertools 0.12.1",
+ "log 0.4.25",
  "multimap",
  "petgraph",
  "prettyplease",
  "prost",
  "prost-types",
  "regex",
- "syn 2.0.114",
+ "syn 2.0.96",
  "tempfile",
 ]
 
@@ -4318,10 +4304,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27c6023962132f4b30eb4c172c91ce92d933da334c59c23cddee82358ddafb0b"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.12.1",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4335,13 +4321,12 @@ dependencies = [
 
 [[package]]
 name = "protoc-bin-vendored"
-version = "3.2.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d1c381df33c98266b5f08186583660090a4ffa0889e76c7e9a5e175f645a67fa"
+checksum = "dd89a830d0eab2502c81a9b8226d446a52998bb78e5e33cb2637c0cdd6068d99"
 dependencies = [
  "protoc-bin-vendored-linux-aarch_64",
  "protoc-bin-vendored-linux-ppcle_64",
- "protoc-bin-vendored-linux-s390_64",
  "protoc-bin-vendored-linux-x86_32",
  "protoc-bin-vendored-linux-x86_64",
  "protoc-bin-vendored-macos-aarch_64",
@@ -4351,51 +4336,45 @@ dependencies = [
 
 [[package]]
 name = "protoc-bin-vendored-linux-aarch_64"
-version = "3.2.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c350df4d49b5b9e3ca79f7e646fde2377b199e13cfa87320308397e1f37e1a4c"
+checksum = "f563627339f1653ea1453dfbcb4398a7369b768925eb14499457aeaa45afe22c"
 
 [[package]]
 name = "protoc-bin-vendored-linux-ppcle_64"
-version = "3.2.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a55a63e6c7244f19b5c6393f025017eb5d793fd5467823a099740a7a4222440c"
-
-[[package]]
-name = "protoc-bin-vendored-linux-s390_64"
-version = "3.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1dba5565db4288e935d5330a07c264a4ee8e4a5b4a4e6f4e83fad824cc32f3b0"
+checksum = "5025c949a02cd3b60c02501dd0f348c16e8fff464f2a7f27db8a9732c608b746"
 
 [[package]]
 name = "protoc-bin-vendored-linux-x86_32"
-version = "3.2.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8854774b24ee28b7868cd71dccaae8e02a2365e67a4a87a6cd11ee6cdbdf9cf5"
+checksum = "9c9500ce67d132c2f3b572504088712db715755eb9adf69d55641caa2cb68a07"
 
 [[package]]
 name = "protoc-bin-vendored-linux-x86_64"
-version = "3.2.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b38b07546580df720fa464ce124c4b03630a6fb83e05c336fea2a241df7e5d78"
+checksum = "5462592380cefdc9f1f14635bcce70ba9c91c1c2464c7feb2ce564726614cc41"
 
 [[package]]
 name = "protoc-bin-vendored-macos-aarch_64"
-version = "3.2.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89278a9926ce312e51f1d999fee8825d324d603213344a9a706daa009f1d8092"
+checksum = "c637745681b68b4435484543667a37606c95ddacf15e917710801a0877506030"
 
 [[package]]
 name = "protoc-bin-vendored-macos-x86_64"
-version = "3.2.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "81745feda7ccfb9471d7a4de888f0652e806d5795b61480605d4943176299756"
+checksum = "38943f3c90319d522f94a6dfd4a134ba5e36148b9506d2d9723a82ebc57c8b55"
 
 [[package]]
 name = "protoc-bin-vendored-win32"
-version = "3.2.0"
+version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "95067976aca6421a523e491fce939a3e65249bac4b977adee0ee9771568e8aa3"
+checksum = "7dc55d7dec32ecaf61e0bd90b3d2392d721a28b95cfd23c3e176eccefbeab2f2"
 
 [[package]]
 name = "pyo3"
@@ -4404,7 +4383,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ab53c047fcd1a1d2a8820fe84f05d6be69e9526be40cb03b73f86b6b03e6d87d"
 dependencies = [
  "indoc",
- "libc 0.2.181",
+ "libc 0.2.177",
  "memoffset",
  "once_cell",
  "portable-atomic",
@@ -4429,7 +4408,7 @@ version = "0.27.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c85c9cbfaddf651b1221594209aed57e9e5cff63c4d11d1feead529b872a089"
 dependencies = [
- "libc 0.2.181",
+ "libc 0.2.177",
  "pyo3-build-config",
 ]
 
@@ -4442,7 +4421,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-macros-backend",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4455,7 +4434,7 @@ dependencies = [
  "proc-macro2",
  "pyo3-build-config",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -4477,8 +4456,8 @@ dependencies = [
  "quinn-udp",
  "rustc-hash 2.1.1",
  "rustls",
- "socket2",
- "thiserror 2.0.18",
+ "socket2 0.6.2",
+ "thiserror 2.0.12",
  "tokio",
  "tracing",
  "web-time",
@@ -4492,15 +4471,15 @@ checksum = "f1906b49b0c3bc04b5fe5d86a77925ae6524a19b816ae38ce1e426255f1d8a31"
 dependencies = [
  "aws-lc-rs",
  "bytes",
- "getrandom 0.3.4",
+ "getrandom 0.3.2",
  "lru-slab",
- "rand 0.9.2",
+ "rand 0.9.0",
  "ring",
  "rustc-hash 2.1.1",
  "rustls",
  "rustls-pki-types",
  "slab",
- "thiserror 2.0.18",
+ "thiserror 2.0.12",
  "tinyvec",
  "tracing",
  "web-time",
@@ -4513,27 +4492,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
 dependencies = [
  "cfg_aliases",
- "libc 0.2.181",
+ "libc 0.2.177",
  "once_cell",
- "socket2",
+ "socket2 0.6.2",
  "tracing",
  "windows-sys 0.60.2",
 ]
 
 [[package]]
 name = "quote"
-version = "1.0.44"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "21b2ebcf727b7760c461f091f9f0f539b77b8e87f2fd88131e7f1b433b3cece4"
+checksum = "0e4dccaaaf89514f546c693ddc140f729f958c247918a13380cccc6078391acc"
 dependencies = [
  "proc-macro2",
 ]
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
+version = "5.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
+checksum = "74765f6d916ee2faa39bc8e68e4f3ed8949b48cccdac59983d287a7cb71ce9c5"
 
 [[package]]
 name = "rand"
@@ -4542,7 +4521,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "552840b97013b1a26992c11eac34bdd778e464601a4c2054b5f0bff7c6761293"
 dependencies = [
  "fuchsia-cprng",
- "libc 0.2.181",
+ "libc 0.2.177",
  "rand_core 0.3.1",
  "rdrand",
  "winapi 0.3.9",
@@ -4555,7 +4534,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6d71dacdc3c88c1fde3885a3be3fbab9f35724e6ce99467f7d9c5026132184ca"
 dependencies = [
  "autocfg 0.1.8",
- "libc 0.2.181",
+ "libc 0.2.177",
  "rand_chacha 0.1.1",
  "rand_core 0.4.2",
  "rand_hc",
@@ -4573,19 +4552,20 @@ version = "0.8.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "34af8d1a0e25924bc5b7c43c079c942339d8f0a8b57c39049bef581b46327404"
 dependencies = [
- "libc 0.2.181",
+ "libc 0.2.177",
  "rand_chacha 0.3.1",
  "rand_core 0.6.4",
 ]
 
 [[package]]
 name = "rand"
-version = "0.9.2"
+version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6db2770f06117d490610c7488547d543617b21bfa07796d7a12f6f1bd53850d1"
+checksum = "3779b94aeb87e8bd4e834cee3650289ee9e0d5677f976ecdb6d219e5f4f6cd94"
 dependencies = [
  "rand_chacha 0.9.0",
- "rand_core 0.9.5",
+ "rand_core 0.9.3",
+ "zerocopy 0.8.24",
 ]
 
 [[package]]
@@ -4615,7 +4595,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
 dependencies = [
  "ppv-lite86",
- "rand_core 0.9.5",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -4639,16 +4619,16 @@ version = "0.6.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec0be4795e2f6a28069bec0b5ff3e2ac9bafc99e6a9a7dc3547996c5c816922c"
 dependencies = [
- "getrandom 0.2.17",
+ "getrandom 0.2.15",
 ]
 
 [[package]]
 name = "rand_core"
-version = "0.9.5"
+version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
+checksum = "99d9a13982dcf210057a8a78572b2217b667c3beacbf3a0d8b454f6f82837d38"
 dependencies = [
- "getrandom 0.3.4",
+ "getrandom 0.3.2",
 ]
 
 [[package]]
@@ -4685,7 +4665,7 @@ version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1166d5c91dc97b88d1decc3285bb0a99ed84b05cfd0bc2341bdf2d43fc41e39b"
 dependencies = [
- "libc 0.2.181",
+ "libc 0.2.177",
  "rand_core 0.4.2",
  "winapi 0.3.9",
 ]
@@ -4698,7 +4678,7 @@ checksum = "7b75f676a1e053fc562eafbb47838d67c84801e38fc1ba459e8f180deabd5071"
 dependencies = [
  "cloudabi",
  "fuchsia-cprng",
- "libc 0.2.181",
+ "libc 0.2.177",
  "rand_core 0.4.2",
  "rdrand",
  "winapi 0.3.9",
@@ -4725,11 +4705,11 @@ dependencies = [
 
 [[package]]
 name = "rand_xorshift"
-version = "0.4.0"
+version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "513962919efc330f829edb2535844d1b912b0fbe2ca165d613e4e8788bb05a5a"
+checksum = "d25bf25ec5ae4a3f1b92f929810509a2f53d7dca2f50b794ff57e3face536c8f"
 dependencies = [
- "rand_core 0.9.5",
+ "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4738,7 +4718,7 @@ version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f703f4665700daf5512dcca5f43afa6af89f09db47fb56be587f80636bda2d41"
 dependencies = [
- "rand_core 0.9.5",
+ "rand_core 0.9.3",
 ]
 
 [[package]]
@@ -4752,9 +4732,9 @@ dependencies = [
 
 [[package]]
 name = "rayon"
-version = "1.11.0"
+version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368f01d005bf8fd9b1206fb6fa653e6c4a81ceb1466406b81792d87c5677a58f"
+checksum = "b418a60154510ca1a002a752ca9714984e21e4241e804d32555251faf8b78ffa"
 dependencies = [
  "either",
  "rayon-core",
@@ -4762,9 +4742,9 @@ dependencies = [
 
 [[package]]
 name = "rayon-core"
-version = "1.13.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22e18b0f0062d30d4230b2e85ff77fdfe4326feb054b9783a3460d8435c8ab91"
+checksum = "1465873a3dfdaa8ae7cb14b4383657caab0b3e8a0aa9ae8e04b044854c8dfce2"
 dependencies = [
  "crossbeam-deque",
  "crossbeam-utils",
@@ -4781,61 +4761,76 @@ dependencies = [
 
 [[package]]
 name = "redox_syscall"
-version = "0.5.18"
+version = "0.5.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ed2bf2547551a7053d6fdfafda3f938979645c44812fbfcda098faae3f1a362d"
+checksum = "03a862b389f93e68874fbf580b9de08dd02facb9a788ebadaf4a3fd33cf58834"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.8.0",
 ]
 
 [[package]]
 name = "ref-cast"
-version = "1.0.25"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+checksum = "ccf0a6f84d5f1d581da8b41b47ec8600871962f2a528115b542b362d4b744931"
 dependencies = [
  "ref-cast-impl",
 ]
 
 [[package]]
 name = "ref-cast-impl"
-version = "1.0.25"
+version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+checksum = "bcc303e793d3734489387d205e9b186fac9c6cfacedd98cbb2e8a5943595f3e6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "regex"
-version = "1.12.3"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e10754a14b9137dd7b1e3e5b0493cc9171fdd105e0ab477f51b72e7f3ac0e276"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata",
- "regex-syntax",
+ "regex-automata 0.4.9",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
 name = "regex-automata"
-version = "0.4.14"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e1dd4122fc1595e8162618945476892eefca7b88c52820e74af6262213cae8f"
+checksum = "6c230d73fb8d8c1b9c0b3135c5142a8acee3a0558fb8db5cf1cb65f8d7862132"
+dependencies = [
+ "regex-syntax 0.6.29",
+]
+
+[[package]]
+name = "regex-automata"
+version = "0.4.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-syntax",
+ "regex-syntax 0.8.5",
 ]
 
 [[package]]
 name = "regex-syntax"
-version = "0.8.9"
+version = "0.6.29"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a96887878f22d7bad8a3b6dc5b7440e0ada9a245242924394987b21cf2210a4c"
+checksum = "f162c6dd7b008981e4d40210aca20b4bd0f9b60ca9271061b07f78537722f2e1"
+
+[[package]]
+name = "regex-syntax"
+version = "0.8.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2b15c43186be67a4fd63bee50d0303afffcef381492ebe2c5d87f324e1b8815c"
 
 [[package]]
 name = "remove_dir_all"
@@ -4859,13 +4854,13 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.6.0",
  "hyper-rustls",
  "hyper-util",
  "js-sys",
- "log 0.4.29",
+ "log 0.4.25",
  "mime_guess 2.0.5",
- "percent-encoding 2.3.2",
+ "percent-encoding 2.3.1",
  "pin-project-lite",
  "quinn",
  "rustls",
@@ -4877,7 +4872,7 @@ dependencies = [
  "tower",
  "tower-http",
  "tower-service",
- "url 2.5.8",
+ "url 2.5.4",
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
@@ -4891,8 +4886,8 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.17",
- "libc 0.2.181",
+ "getrandom 0.2.15",
+ "libc 0.2.177",
  "untrusted",
  "windows-sys 0.52.0",
 ]
@@ -4903,7 +4898,7 @@ version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8a29d87a652dc4d43c586328706bb5cdff211f3f39a530f240b53f7221dab8e"
 dependencies = [
- "libc 0.2.181",
+ "libc 0.2.177",
 ]
 
 [[package]]
@@ -4930,18 +4925,19 @@ dependencies = [
 
 [[package]]
 name = "rmpv"
-version = "1.3.1"
+version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7a4e1d4b9b938a26d2996af33229f0ca0956c652c1375067f0b45291c1df8417"
+checksum = "58450723cd9ee93273ce44a20b6ec4efe17f8ed2e3631474387bfdecf18bb2a9"
 dependencies = [
+ "num-traits",
  "rmp",
 ]
 
 [[package]]
 name = "rustc-demangle"
-version = "0.1.27"
+version = "0.1.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b50b8869d9fc858ce7266cce0194bd74df58b9d0e3f6df3a9fc8eb470d95c09d"
+checksum = "56f7d92ca342cea22a06f2121d944b4fd82af56988c270852495420f961d4ace"
 
 [[package]]
 name = "rustc-hash"
@@ -4966,13 +4962,13 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.44"
+version = "0.38.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fdb5bc1ae2baa591800df16c9ca78619bf65c0488b41b96ccec5d11220d8c154"
+checksum = "a78891ee6bf2340288408954ac787aa063d8e8817e9f53abb37c695c6d834ef6"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.8.0",
  "errno",
- "libc 0.2.181",
+ "libc 0.2.177",
  "linux-raw-sys 0.4.15",
  "windows-sys 0.59.0",
 ]
@@ -4983,11 +4979,11 @@ version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "146c9e247ccc180c1f61615433868c99f3de3ae256a30a43b49f67c2d9171f34"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.8.0",
  "errno",
- "libc 0.2.181",
+ "libc 0.2.177",
  "linux-raw-sys 0.11.0",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5007,9 +5003,9 @@ dependencies = [
 
 [[package]]
 name = "rustls-native-certs"
-version = "0.8.3"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "612460d5f7bea540c490b2b6395d8e34a953e52b491accd6c86c8164c5932a63"
+checksum = "7fcff2dd52b58a8d98a70243663a0d234c4e2b79235637849d15913394a247d3"
 dependencies = [
  "openssl-probe",
  "rustls-pki-types",
@@ -5036,7 +5032,7 @@ dependencies = [
  "core-foundation",
  "core-foundation-sys",
  "jni",
- "log 0.4.29",
+ "log 0.4.25",
  "once_cell",
  "rustls",
  "rustls-native-certs",
@@ -5045,7 +5041,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5068,9 +5064,9 @@ dependencies = [
 
 [[package]]
 name = "rustversion"
-version = "1.0.22"
+version = "1.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b39cdef0fa800fc44525c84ccb54a029961a8215f9619753635a9c0d2538d46d"
+checksum = "f7c45b9784283f1b2e7fb61b42047c2fd678ef0960d4f6f1eba131594cc369d4"
 
 [[package]]
 name = "ruzstd"
@@ -5085,9 +5081,9 @@ dependencies = [
 
 [[package]]
 name = "ryu"
-version = "1.0.23"
+version = "1.0.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9774ba4a74de5f7b1c1451ed6cd5285a32eddb5cccb8cc655a4e50009e06477f"
+checksum = "f3cb5ba0dc43242ce17de99c180e96db90b235b8a9fdc9543c96d2209116bd9f"
 
 [[package]]
 name = "safemem"
@@ -5106,18 +5102,18 @@ dependencies = [
 
 [[package]]
 name = "schannel"
-version = "0.1.28"
+version = "0.1.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "891d81b926048e76efe18581bf793546b4c0eaf8448d72be8de2bbee5fd166e1"
+checksum = "1f29ebaa345f945cec9fbbc532eb307f0fdad8161f281b6369539c8d84876b3d"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "schemars"
-version = "0.8.22"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
+checksum = "09c024468a378b7e36765cd36702b7a90cc3cba11654f6685c8f233408e89e92"
 dependencies = [
  "dyn-clone",
  "schemars_derive",
@@ -5126,39 +5122,15 @@ dependencies = [
 ]
 
 [[package]]
-name = "schemars"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4cd191f9397d57d581cddd31014772520aa448f65ef991055d7f61582c65165f"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
-]
-
-[[package]]
-name = "schemars"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
-dependencies = [
- "dyn-clone",
- "ref-cast",
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "schemars_derive"
-version = "0.8.22"
+version = "0.8.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+checksum = "b1eee588578aff73f856ab961cd2f79e36bc45d7ded33a7562adba4667aecc0e"
 dependencies = [
  "proc-macro2",
  "quote",
  "serde_derive_internals",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5184,13 +5156,13 @@ dependencies = [
 
 [[package]]
 name = "scroll_derive"
-version = "0.12.1"
+version = "0.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1783eabc414609e28a5ba76aee5ddd52199f7107a0b24c2e9746a1ecc34a683d"
+checksum = "7f81c2fde025af7e69b1d1420531c8a8811ca898919db177141a85313b1cb932"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5199,10 +5171,10 @@ version = "3.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b3297343eaf830f66ede390ea39da1d462b6b0c1b000f420d0a83f898bbbe6ef"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.8.0",
  "core-foundation",
  "core-foundation-sys",
- "libc 0.2.181",
+ "libc 0.2.177",
  "security-framework-sys",
 ]
 
@@ -5213,26 +5185,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cc1f0cbffaac4852523ce30d8bd3c5cdc873501d96ff467ca09b6767bb8cd5c0"
 dependencies = [
  "core-foundation-sys",
- "libc 0.2.181",
+ "libc 0.2.177",
 ]
 
 [[package]]
 name = "semver"
-version = "1.0.27"
+version = "1.0.25"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d767eb0aabc880b29956c35734170f26ed551a859dbd361d140cdbeca61ab1e2"
+checksum = "f79dfe2d285b0488816f30e700a7438c5a73d816b5b7d3ac72fbc48b0d185e03"
 dependencies = [
  "serde",
- "serde_core",
 ]
 
 [[package]]
 name = "sendfd"
-version = "0.4.4"
+version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b183bfd5b1bc64ab0c1ef3ee06b008a9ef1b68a7d3a99ba566fbfe7a7c6d745b"
+checksum = "604b71b8fc267e13bb3023a2c901126c8f349393666a6d98ac1ae5729b701798"
 dependencies = [
- "libc 0.2.181",
+ "libc 0.2.177",
  "tokio",
 ]
 
@@ -5257,12 +5228,11 @@ dependencies = [
 
 [[package]]
 name = "serde_bytes"
-version = "0.11.19"
+version = "0.11.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a5d440709e79d88e51ac01c4b72fc6cb7314017bb7da9eeff678aa94c10e3ea8"
+checksum = "387cc504cb06bb40a96c8e04e951fe01854cf6bc921053c954e4a606d9675c6a"
 dependencies = [
  "serde",
- "serde_core",
 ]
 
 [[package]]
@@ -5282,7 +5252,7 @@ checksum = "d540f220d3187173da220f885ab66608367b6574e925011a9353e4badda91d79"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5293,7 +5263,7 @@ checksum = "18d26a20a969b9e3fdf2fc2d9f21eda6c40e2de84c9408bb5d3b05d499aae711"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5307,15 +5277,14 @@ dependencies = [
 
 [[package]]
 name = "serde_json"
-version = "1.0.149"
+version = "1.0.137"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83fc039473c5595ace860d8c4fafa220ff474b3fc6bfdb4293327f1a37e94d86"
+checksum = "930cfb6e6abf99298aaad7d29abbef7a9999a9a8806a40088f55f0dcec03146b"
 dependencies = [
  "itoa",
  "memchr",
+ "ryu",
  "serde",
- "serde_core",
- "zmij",
 ]
 
 [[package]]
@@ -5330,51 +5299,41 @@ dependencies = [
 
 [[package]]
 name = "serde_spanned"
-version = "0.6.9"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+checksum = "87607cb1398ed59d48732e575a4c28a7a8ebf2454b964fe3f224f2afc07909e1"
 dependencies = [
  "serde",
 ]
 
 [[package]]
-name = "serde_spanned"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f8bbf91e5a4d6315eee45e704372590b30e260ee83af6639d64557f51b067776"
-dependencies = [
- "serde_core",
-]
-
-[[package]]
 name = "serde_with"
-version = "3.16.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4fa237f2807440d238e0364a218270b98f767a00d3dada77b1c53ae88940e2e7"
+checksum = "d6b6f7f2fcb69f747921f79f3926bd1e203fce4fef62c268dd3abfb6d86029aa"
 dependencies = [
  "base64 0.22.1",
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.13.0",
- "schemars 0.9.0",
- "schemars 1.2.1",
- "serde_core",
+ "indexmap 2.12.1",
+ "serde",
+ "serde_derive",
  "serde_json",
  "serde_with_macros",
- "time 0.3.47",
+ "time 0.3.37",
 ]
 
 [[package]]
 name = "serde_with_macros"
-version = "3.16.1"
+version = "3.12.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52a8e3ca0ca629121f70ab50f95249e5a6f925cc0f6ffe8256c45b728875706c"
+checksum = "8d00caa5193a3c8362ac2b73be6b9e768aa5a4b2f721d8f4b339600c3cb51f8e"
 dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5383,7 +5342,7 @@ version = "0.9.34+deprecated"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a8b1a1a2ebf674015cc02edccce75287f1a0130d394307b36743c2f5d504b47"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.12.1",
  "itoa",
  "ryu",
  "serde",
@@ -5403,9 +5362,9 @@ dependencies = [
 
 [[package]]
 name = "sha2"
-version = "0.10.9"
+version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a7507d819769d01a365ab707794a4084392c824f54a7a6a7862f8c3d0892b283"
+checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
@@ -5436,19 +5395,18 @@ dependencies = [
 
 [[package]]
 name = "signal-hook-registry"
-version = "1.4.8"
+version = "1.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4db69cba1110affc0e9f7bcd48bbf87b3f4fc7c61fc9155afd4c469eb3d6c1b"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
- "errno",
- "libc 0.2.181",
+ "libc 0.2.177",
 ]
 
 [[package]]
 name = "simd-adler32"
-version = "0.3.8"
+version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e320a6c5ad31d271ad523dcf3ad13e2767ad8b1cb8f047f75a8aeaf8da139da2"
+checksum = "d66dc143e6b11c1eddc06d5c423cfc97062865baf299914ab64caa38182078fe"
 
 [[package]]
 name = "simd-json"
@@ -5456,7 +5414,7 @@ version = "0.14.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aa2bcf6c6e164e81bc7a5d49fc6988b3d515d9e8c07457d7b74ffb9324b9cd40"
 dependencies = [
- "getrandom 0.2.17",
+ "getrandom 0.2.15",
  "halfbrown",
  "ref-cast",
  "serde",
@@ -5491,9 +5449,12 @@ checksum = "38b58827f4464d87d377d175e90bf58eb00fd8716ff0a62f80356b5e61555d0d"
 
 [[package]]
 name = "slab"
-version = "0.4.12"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c790de23124f9ab44544d7ac05d60440adc586479ce501c1d6d7da3cd8c9cf5"
+checksum = "8f92a496fb766b417c996b9c5e57daf2f7ad3b0bebe1ccfca4856390e3d3bb67"
+dependencies = [
+ "autocfg 1.4.0",
+]
 
 [[package]]
 name = "smallvec"
@@ -5503,11 +5464,21 @@ checksum = "67b1b7a3b5fe4f1376887184045fcf45c69e92af734b7aaddc05fb777b6fbd03"
 
 [[package]]
 name = "socket2"
+version = "0.5.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e22376abed350d73dd1cd119b57ffccad95b4e585a7cda43e286245ce23c0678"
+dependencies = [
+ "libc 0.2.177",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "socket2"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86f4aa3ad99f2088c990dfa82d367e19cb29268ed67c574d10d0a4bfe71f07e0"
 dependencies = [
- "libc 0.2.181",
+ "libc 0.2.177",
  "windows-sys 0.60.2",
 ]
 
@@ -5520,7 +5491,7 @@ dependencies = [
  "fastrand",
  "io-lifetimes",
  "kernel32-sys",
- "libc 0.2.181",
+ "libc 0.2.177",
  "memfd",
  "nix 0.29.0",
  "rlimit",
@@ -5531,9 +5502,9 @@ dependencies = [
 
 [[package]]
 name = "stable_deref_trait"
-version = "1.2.1"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ce2be8dc25455e1f91df71bfa12ad37d7af1092ae736f3a6cd0e37bc7810596"
+checksum = "a8f112729512f8e442d81f95a8a7ddf2b7c6b8a1a6f509a95864142b30cab2d3"
 
 [[package]]
 name = "static_assertions"
@@ -5639,9 +5610,9 @@ dependencies = [
 
 [[package]]
 name = "symbolic-common"
-version = "12.17.2"
+version = "12.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "751a2823d606b5d0a7616499e4130a516ebd01a44f39811be2b9600936509c23"
+checksum = "13a4dfe4bbeef59c1f32fc7524ae7c95b9e1de5e79a43ce1604e181081d71b0c"
 dependencies = [
  "debugid",
  "memmap2",
@@ -5651,11 +5622,11 @@ dependencies = [
 
 [[package]]
 name = "symbolic-demangle"
-version = "12.17.2"
+version = "12.13.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b237cfbe320601dd24b4ac817a5b68bb28f5508e33f08d42be0682cadc8ac9"
+checksum = "98cf6a95abff97de4d7ff3473f33cacd38f1ddccad5c1feab435d6760300e3b6"
 dependencies = [
- "cpp_demangle 0.5.1",
+ "cpp_demangle",
  "msvc-demangler",
  "rustc-demangle",
  "symbolic-common",
@@ -5674,9 +5645,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.114"
+version = "2.0.96"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4d107df263a3013ef9b1879b0df87d706ff80f65a86ea879bd9c31f9b307c2a"
+checksum = "d5d0adab1ae378d7f53bdebc67a39f1f151407ef230f0ce2883572f5d8985c80"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5694,13 +5665,13 @@ dependencies = [
 
 [[package]]
 name = "synstructure"
-version = "0.13.2"
+version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "728a70f3dbaf5bab7f0c4b1ac8d7ae5ea60a4b5549c8a5914361c99147a709d2"
+checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
@@ -5710,7 +5681,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
 dependencies = [
  "cc",
- "libc 0.2.181",
+ "libc 0.2.177",
 ]
 
 [[package]]
@@ -5733,12 +5704,6 @@ name = "target-triple"
 version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ac9aa371f599d22256307c24a9d748c041e548cbf599f35d890f9d365361790"
-
-[[package]]
-name = "target-triple"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "591ef38edfb78ca4771ee32cf494cb8771944bee237a9b91fc9c1424ac4b777b"
 
 [[package]]
 name = "tarpc"
@@ -5797,15 +5762,15 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.25.0"
+version = "3.24.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0136791f7c95b1f6dd99f9cc786b91bb81c3800b639b3478e561ddb7be95e5f1"
+checksum = "655da9c7eb6305c55742045d5a8d2037996d61d8de95806335c7c86ce0f82e9c"
 dependencies = [
  "fastrand",
- "getrandom 0.3.4",
+ "getrandom 0.3.2",
  "once_cell",
  "rustix 1.1.3",
- "windows-sys 0.52.0",
+ "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5850,11 +5815,11 @@ dependencies = [
 
 [[package]]
 name = "thiserror"
-version = "2.0.18"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4288b5bcbc7920c07a1149a35cf9590a2aa808e0bc1eafaade0b80947865fbc4"
+checksum = "567b8a2dae586314f7be2a752ec7474332959c6460e02bde30d702a66d488708"
 dependencies = [
- "thiserror-impl 2.0.18",
+ "thiserror-impl 2.0.12",
 ]
 
 [[package]]
@@ -5865,27 +5830,28 @@ checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "2.0.18"
+version = "2.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebc4ee7f67670e9b64d05fa4253e753e016c6c95ff35b89b7941d6b856dec1d5"
+checksum = "7f7cf42b4507d8ea322120659672cf1b9dbb93f8f2d4ecfd6e51350ff5b17a1d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "thread_local"
-version = "1.1.9"
+version = "1.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f60246a4944f24f6e018aa17cdeffb7818b76356965d03b07d6a9886e8962185"
+checksum = "8b9ef9bad013ada3808854ceac7b46812a6465ba368859a37e2100283d2d719c"
 dependencies = [
  "cfg-if",
+ "once_cell",
 ]
 
 [[package]]
@@ -5905,7 +5871,7 @@ checksum = "b82ca8f46f95b3ce96081fe3dd89160fdea970c254bb72925255d1b62aae692e"
 dependencies = [
  "byteorder",
  "integer-encoding",
- "log 0.4.29",
+ "log 0.4.25",
  "ordered-float",
  "threadpool",
 ]
@@ -5916,37 +5882,37 @@ version = "0.1.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b797afad3f312d1c66a56d11d0316f916356d11bd158fbc6ca6389ff6bf805a"
 dependencies = [
- "libc 0.2.181",
+ "libc 0.2.177",
  "wasi 0.10.0+wasi-snapshot-preview1",
  "winapi 0.3.9",
 ]
 
 [[package]]
 name = "time"
-version = "0.3.47"
+version = "0.3.37"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
+checksum = "35e7868883861bd0e56d9ac6efcaaca0d6d5d82a2a7ec8209ff492c07cf37b21"
 dependencies = [
  "deranged",
  "itoa",
  "num-conv",
  "powerfmt",
- "serde_core",
+ "serde",
  "time-core",
  "time-macros",
 ]
 
 [[package]]
 name = "time-core"
-version = "0.1.8"
+version = "0.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
+checksum = "ef927ca75afb808a4d64dd374f00a2adf8d0fcff8e7b184af886c3c87ec4a3f3"
 
 [[package]]
 name = "time-macros"
-version = "0.2.27"
+version = "0.2.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
+checksum = "2834e6017e3e5e4b9834939793b282bc03b37a3336245fa820e35e233e2a85de"
 dependencies = [
  "num-conv",
  "time-core",
@@ -5961,15 +5927,15 @@ dependencies = [
  "ascii",
  "chrono",
  "chunked_transfer",
- "log 0.4.29",
+ "log 0.4.25",
  "url 1.7.2",
 ]
 
 [[package]]
 name = "tinystr"
-version = "0.8.2"
+version = "0.7.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42d3e9c45c09de15d06dd8acf5f4e0e399e85927b7f00711024eb7ae10fa4869"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
 dependencies = [
  "displaydoc",
  "zerovec",
@@ -6008,12 +5974,12 @@ checksum = "72a2903cd7736441aac9df9d7688bd0ce48edccaadf181c3b90be801e81d3d86"
 dependencies = [
  "backtrace",
  "bytes",
- "libc 0.2.181",
+ "libc 0.2.177",
  "mio",
  "parking_lot",
  "pin-project-lite",
  "signal-hook-registry",
- "socket2",
+ "socket2 0.6.2",
  "tokio-macros",
  "tracing",
  "windows-sys 0.61.2",
@@ -6027,14 +5993,14 @@ checksum = "af407857209536a95c8e56f8231ef2c2e2aff839b22e07a1ffcbc617e9db9fa5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "tokio-rustls"
-version = "0.26.4"
+version = "0.26.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1729aa945f29d91ba541258c8df89027d5792d85a8841fb65e8bf0f4ede4ef61"
+checksum = "5f6d0975eaace0cf0fcadee4e4aaa5da15b5c079146f2cffb67c113be122bf37"
 dependencies = [
  "rustls",
  "tokio",
@@ -6058,9 +6024,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.18"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "32da49809aab5c3bc678af03902d4ccddea2a87d028d86392a4b1560c6906c70"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
  "pin-project-lite",
@@ -6069,14 +6035,15 @@ dependencies = [
 
 [[package]]
 name = "tokio-util"
-version = "0.7.18"
+version = "0.7.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ae9cec805b01e8fc3fd2fe289f89149a9b66dd16786abd8b19cfa7b48cb0098"
+checksum = "d7fcaa8d55a2bdd6b83ace262b016eca0d79ee02818c5c1bcdf0305114081078"
 dependencies = [
  "bytes",
  "futures-core",
  "futures-sink",
  "futures-util",
+ "hashbrown 0.14.5",
  "pin-project-lite",
  "slab",
  "tokio",
@@ -6084,47 +6051,23 @@ dependencies = [
 
 [[package]]
 name = "toml"
-version = "0.8.23"
+version = "0.8.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+checksum = "a1ed1f98e3fdc28d6d910e6737ae6ab1a93bf1985935a1193e68f93eeb68d24e"
 dependencies = [
  "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_edit 0.22.27",
-]
-
-[[package]]
-name = "toml"
-version = "0.9.12+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "cf92845e79fc2e2def6a5d828f0801e29a2f8acc037becc5ab08595c7d5e9863"
-dependencies = [
- "indexmap 2.13.0",
- "serde_core",
- "serde_spanned 1.0.4",
- "toml_datetime 0.7.5+spec-1.1.0",
- "toml_parser",
- "toml_writer",
- "winnow 0.7.14",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit 0.22.22",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.11"
+version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+checksum = "0dd7358ecb8fc2f8d014bf86f6f638ce72ba252a2c3a2572f2a795f1d23efb41"
 dependencies = [
  "serde",
-]
-
-[[package]]
-name = "toml_datetime"
-version = "0.7.5+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92e1cfed4a3038bc5a127e35a2d360f145e1f4b971b551a2ba5fd7aedf7e1347"
-dependencies = [
- "serde_core",
 ]
 
 [[package]]
@@ -6133,51 +6076,29 @@ version = "0.20.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70f427fce4d84c72b5b732388bf4a9f4531b53f74e2887e3ecb2481f68f66d81"
 dependencies = [
- "indexmap 2.13.0",
- "toml_datetime 0.6.11",
+ "indexmap 2.12.1",
+ "toml_datetime",
  "winnow 0.5.40",
 ]
 
 [[package]]
 name = "toml_edit"
-version = "0.22.27"
+version = "0.22.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+checksum = "4ae48d6208a266e853d946088ed816055e556cc6028c5e8e2b84d9fa5dd7c7f5"
 dependencies = [
- "indexmap 2.13.0",
+ "indexmap 2.12.1",
  "serde",
- "serde_spanned 0.6.9",
- "toml_datetime 0.6.11",
- "toml_write",
- "winnow 0.7.14",
+ "serde_spanned",
+ "toml_datetime",
+ "winnow 0.6.24",
 ]
-
-[[package]]
-name = "toml_parser"
-version = "1.0.7+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "247eaa3197818b831697600aadf81514e577e0cba5eab10f7e064e78ae154df1"
-dependencies = [
- "winnow 0.7.14",
-]
-
-[[package]]
-name = "toml_write"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
-
-[[package]]
-name = "toml_writer"
-version = "1.0.6+spec-1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ab16f14aed21ee8bfd8ec22513f7287cd4a91aa92e44edfe2c17ddd004e92607"
 
 [[package]]
 name = "tonic"
-version = "0.14.3"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a286e33f82f8a1ee2df63f4fa35c0becf4a85a0cb03091a15fd7bf0b402dc94a"
+checksum = "eb7613188ce9f7df5bfe185db26c5814347d110db17920415cf2fbcad85e7203"
 dependencies = [
  "async-trait",
  "axum",
@@ -6187,12 +6108,12 @@ dependencies = [
  "http",
  "http-body",
  "http-body-util",
- "hyper 1.8.1",
+ "hyper 1.6.0",
  "hyper-timeout",
  "hyper-util",
- "percent-encoding 2.3.2",
+ "percent-encoding 2.3.1",
  "pin-project",
- "socket2",
+ "socket2 0.6.2",
  "sync_wrapper",
  "tokio",
  "tokio-stream",
@@ -6204,9 +6125,9 @@ dependencies = [
 
 [[package]]
 name = "tonic-prost"
-version = "0.14.3"
+version = "0.14.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6c55a2d6a14174563de34409c9f92ff981d006f56da9c6ecd40d9d4a31500b0"
+checksum = "66bd50ad6ce1252d87ef024b3d64fe4c3cf54a86fb9ef4c631fdd0ded7aeaa67"
 dependencies = [
  "bytes",
  "prost",
@@ -6215,13 +6136,13 @@ dependencies = [
 
 [[package]]
 name = "tower"
-version = "0.5.3"
+version = "0.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ebe5ef63511595f1344e2d5cfa636d973292adc0eec1f0ad45fae9f0851ab1d4"
+checksum = "d039ad9159c98b70ecfd540b2573b97f7f52c3e8d9f8ad57a24b916a536975f9"
 dependencies = [
  "futures-core",
  "futures-util",
- "indexmap 2.13.0",
+ "indexmap 2.12.1",
  "pin-project-lite",
  "slab",
  "sync_wrapper",
@@ -6238,7 +6159,7 @@ version = "0.6.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d4e6559d53cc268e5031cd8429d05415bc4cb4aefc4aa5d6cc35fbf5b924a1f8"
 dependencies = [
- "bitflags 2.10.0",
+ "bitflags 2.8.0",
  "bytes",
  "futures-util",
  "http",
@@ -6264,11 +6185,11 @@ checksum = "8df9b6e13f2d32c91b9bd719c00d1958837bc7dec474d94952798cc8e69eeec3"
 
 [[package]]
 name = "tracing"
-version = "0.1.44"
+version = "0.1.41"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
+checksum = "784e0ac535deb450455cbfa28a6f0df145ea1bb7ae51b821cf5e7927fdcfbdd0"
 dependencies = [
- "log 0.4.29",
+ "log 0.4.25",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -6276,32 +6197,32 @@ dependencies = [
 
 [[package]]
 name = "tracing-appender"
-version = "0.2.4"
+version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "786d480bce6247ab75f005b14ae1624ad978d3029d9113f0a22fa1ac773faeaf"
+checksum = "3566e8ce28cc0a3fe42519fc80e6b4c943cc4c8cef275620eb8dac2d3d4e06cf"
 dependencies = [
  "crossbeam-channel",
- "thiserror 2.0.18",
- "time 0.3.47",
+ "thiserror 1.0.69",
+ "time 0.3.37",
  "tracing-subscriber",
 ]
 
 [[package]]
 name = "tracing-attributes"
-version = "0.1.31"
+version = "0.1.28"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
+checksum = "395ae124c09f9e6918a2310af6038fba074bcf474ac352496d5910dd59a2226d"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "tracing-core"
-version = "0.1.36"
+version = "0.1.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db97caf9d906fbde555dd62fa95ddba9eecfd14cb388e4f491a66d74cd5fb79a"
+checksum = "e672c95779cf947c5311f83787af4fa8fffd12fb27e4993211a84bdfd9610f9c"
 dependencies = [
  "once_cell",
  "valuable",
@@ -6313,7 +6234,7 @@ version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ee855f1f400bd0e5c02d150ae5de3840039a3f54b025156404e34c23c03f47c3"
 dependencies = [
- "log 0.4.29",
+ "log 0.4.25",
  "once_cell",
  "tracing-core",
 ]
@@ -6343,14 +6264,14 @@ dependencies = [
 
 [[package]]
 name = "tracing-subscriber"
-version = "0.3.22"
+version = "0.3.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2f30143827ddab0d256fd843b7a66d164e9f271cfa0dde49142c5ca0ca291f1e"
+checksum = "e8189decb5ac0fa7bc8b96b7cb9b2701d60d48805aca84a238004d665fcc4008"
 dependencies = [
  "matchers",
  "nu-ansi-term",
  "once_cell",
- "regex-automata",
+ "regex",
  "serde",
  "serde_json",
  "sharded-slab",
@@ -6376,17 +6297,17 @@ checksum = "e421abadd41a4225275504ea4d6566923418b7f05506fbc9c0fe86ba7396114b"
 
 [[package]]
 name = "trybuild"
-version = "1.0.115"
+version = "1.0.102"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f614c21bd3a61bad9501d75cbb7686f00386c806d7f456778432c25cf86948a"
+checksum = "9f14b5c02a137632f68194ec657ecb92304138948e8957c932127eb1b58c23be"
 dependencies = [
  "glob",
  "serde",
  "serde_derive",
  "serde_json",
- "target-triple 1.0.0",
+ "target-triple",
  "termcolor",
- "toml 0.9.12+spec-1.1.0",
+ "toml",
 ]
 
 [[package]]
@@ -6431,9 +6352,9 @@ dependencies = [
 
 [[package]]
 name = "typenum"
-version = "1.19.0"
+version = "1.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
+checksum = "42ff0bf0c66b8238c6f3b578df37d0b7848e55df8577b3f74f92a69acceeb825"
 
 [[package]]
 name = "unarray"
@@ -6452,9 +6373,9 @@ dependencies = [
 
 [[package]]
 name = "unicase"
-version = "2.9.0"
+version = "2.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbc4bc3a9f746d862c45cb89d705aa10f187bb96c76001afab07a0d35ce60142"
+checksum = "75b844d17643ee918803943289730bec8aac480150456169e647ed0b576ba539"
 
 [[package]]
 name = "unicode-bidi"
@@ -6464,9 +6385,9 @@ checksum = "5c1cb5db39152898a79168971543b1cb5020dff7fe43c8dc468b0885f5e29df5"
 
 [[package]]
 name = "unicode-ident"
-version = "1.0.23"
+version = "1.0.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "537dd038a89878be9b64dd4bd1b260315c1bb94f4d784956b81e27a088d9a09e"
+checksum = "adb9e6ca4f869e1180728b7950e35922a7fc6397f7b641499e8f3ef06e50dc83"
 
 [[package]]
 name = "unicode-normalization"
@@ -6479,9 +6400,9 @@ dependencies = [
 
 [[package]]
 name = "unicode-width"
-version = "0.2.2"
+version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4ac048d71ede7ee76d585517add45da530660ef4390e49b098733c6e897f254"
+checksum = "4a1a07cc7db3810833284e8d372ccdc6da29741639ecc70c9ec107df0fa6154c"
 
 [[package]]
 name = "unicode-xid"
@@ -6529,14 +6450,13 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.8"
+version = "2.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ff67a8a4397373c3ef660812acab3268222035010ab8680ec4215f38ba3d0eed"
+checksum = "32f8b686cadd1473f4bd0117a5d28d36b1ade384ea9b5069a1c40aefed7fda60"
 dependencies = [
  "form_urlencoded",
- "idna 1.1.0",
- "percent-encoding 2.3.2",
- "serde",
+ "idna 1.0.3",
+ "percent-encoding 2.3.1",
 ]
 
 [[package]]
@@ -6544,6 +6464,12 @@ name = "urlencoding"
 version = "2.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "daf8dba3b7eb870caf1ddeed7bc9d2a049f3cfdfae7cb521b087cc33ae4c49da"
+
+[[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
 
 [[package]]
 name = "utf8_iter"
@@ -6559,14 +6485,12 @@ checksum = "06abde3611657adf66d383f00b093d7faecc7fa57071cce2578660c9f1010821"
 
 [[package]]
 name = "uuid"
-version = "1.20.0"
+version = "1.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee48d38b119b0cd71fe4141b30f5ba9c7c5d9f4e7a3a8b4a674e4b6ef789976f"
+checksum = "b3758f5e68192bb96cc8f9b7e2c2cfdabb435499a28499a42f8f984092adad4b"
 dependencies = [
- "getrandom 0.3.4",
- "js-sys",
- "serde_core",
- "wasm-bindgen",
+ "getrandom 0.2.15",
+ "serde",
 ]
 
 [[package]]
@@ -6662,40 +6586,52 @@ checksum = "1a143597ca7c7793eff794def352d41792a93c481eb1042423ff7ff72ba2c31f"
 
 [[package]]
 name = "wasi"
-version = "0.11.1+wasi-snapshot-preview1"
+version = "0.11.0+wasi-snapshot-preview1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
+checksum = "9c8d87e72b64a3b4db28d11ce29237c246188f4f51057d65a7eab63b7987e423"
 
 [[package]]
-name = "wasip2"
-version = "1.0.2+wasi-0.2.9"
+name = "wasi"
+version = "0.14.2+wasi-0.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9517f9239f02c069db75e65f174b3da828fe5f5b945c4dd26bd25d89c03ebcf5"
+checksum = "9683f9a5a998d873c0d21fcbe3c083009670149a8fab228644b8bd36b2c48cb3"
 dependencies = [
- "wit-bindgen",
+ "wit-bindgen-rt",
 ]
 
 [[package]]
 name = "wasm-bindgen"
-version = "0.2.108"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64024a30ec1e37399cf85a7ffefebdb72205ca1c972291c51512360d90bd8566"
+checksum = "1edc8929d7499fc4e8f0be2262a241556cfc54a0bea223790e71446f2aab1ef5"
 dependencies = [
  "cfg-if",
  "once_cell",
  "rustversion",
  "wasm-bindgen-macro",
+]
+
+[[package]]
+name = "wasm-bindgen-backend"
+version = "0.2.100"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2f0a0651a5c2bc21487bde11ee802ccaf4c51935d0d3d42a6101f98161700bc6"
+dependencies = [
+ "bumpalo",
+ "log 0.4.25",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-futures"
-version = "0.4.58"
+version = "0.4.50"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "70a6e77fd0ae8029c9ea0063f87c46fde723e7d887703d74ad2616d792e51e6f"
+checksum = "555d470ec0bc3bb57890405e5d4322cc9ea83cebb085523ced7be4144dac1e61"
 dependencies = [
  "cfg-if",
- "futures-util",
  "js-sys",
  "once_cell",
  "wasm-bindgen",
@@ -6704,9 +6640,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro"
-version = "0.2.108"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "008b239d9c740232e71bd39e8ef6429d27097518b6b30bdf9086833bd5b6d608"
+checksum = "7fe63fc6d09ed3792bd0897b314f53de8e16568c2b3f7982f468c0bf9bd0b407"
 dependencies = [
  "quote",
  "wasm-bindgen-macro-support",
@@ -6714,31 +6650,31 @@ dependencies = [
 
 [[package]]
 name = "wasm-bindgen-macro-support"
-version = "0.2.108"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5256bae2d58f54820e6490f9839c49780dff84c65aeab9e772f15d5f0e913a55"
+checksum = "8ae87ea40c9f689fc23f209965b6fb8a99ad69aeeb0231408be24920604395de"
 dependencies = [
- "bumpalo",
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
+ "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
 
 [[package]]
 name = "wasm-bindgen-shared"
-version = "0.2.108"
+version = "0.2.100"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f01b580c9ac74c8d8f0c0e4afb04eeef2acf145458e52c03845ee9cd23e3d12"
+checksum = "1a05d73b933a847d6cccdda8f838a22ff101ad9bf93e33684f39c1f5f0eece3d"
 dependencies = [
  "unicode-ident",
 ]
 
 [[package]]
 name = "web-sys"
-version = "0.3.85"
+version = "0.3.77"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "312e32e551d92129218ea9a2452120f4aabc03529ef03e4d0d82fb2780608598"
+checksum = "33b6dd2ef9186f1f2072e409e99cd22a975331a6b3591b12c764e0e55c60d5d2"
 dependencies = [
  "js-sys",
  "wasm-bindgen",
@@ -6765,9 +6701,9 @@ dependencies = [
 
 [[package]]
 name = "webpki-roots"
-version = "1.0.6"
+version = "0.26.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22cfaf3c063993ff62e73cb4311efde4db1efb31ab78a3e5c457939ad5cc0bed"
+checksum = "5d642ff16b7e79272ae451b7322067cdc17cadf68c23264be9d94a32319efe7e"
 dependencies = [
  "rustls-pki-types",
 ]
@@ -6781,7 +6717,7 @@ dependencies = [
  "either",
  "home",
  "once_cell",
- "rustix 0.38.44",
+ "rustix 0.38.43",
 ]
 
 [[package]]
@@ -6814,11 +6750,11 @@ checksum = "ac3b87c63620426dd9b991e5ce0329eff545bccbbb34f3be09ff6fb6ab51b7b6"
 
 [[package]]
 name = "winapi-util"
-version = "0.1.11"
+version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
+checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.48.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -6867,28 +6803,24 @@ dependencies = [
 
 [[package]]
 name = "windows-core"
-version = "0.59.0"
+version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce"
+checksum = "33ab640c8d7e35bf8ba19b884ba838ceb4fba93a4e8c65a9059d08afcfc683d9"
 dependencies = [
- "windows-implement 0.59.0",
- "windows-interface",
- "windows-result 0.3.4",
- "windows-strings 0.3.1",
- "windows-targets 0.53.5",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
 name = "windows-core"
-version = "0.62.2"
+version = "0.59.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b8e83a14d34d0623b51dce9581199302a221863196a1dde71a7663a4c2be9deb"
+checksum = "810ce18ed2112484b0d4e15d022e5f598113e220c53e373fb31e67e21670c1ce"
 dependencies = [
- "windows-implement 0.60.2",
+ "windows-implement",
  "windows-interface",
- "windows-link 0.2.1",
- "windows-result 0.4.1",
- "windows-strings 0.5.1",
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.53.5",
 ]
 
 [[package]]
@@ -6899,36 +6831,25 @@ checksum = "83577b051e2f49a058c308f17f273b570a6a758386fc291b5f6a934dd84e48c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
-]
-
-[[package]]
-name = "windows-implement"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053e2e040ab57b9dc951b72c264860db7eb3b0200ba345b4e4c3b14f67855ddf"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "windows-interface"
-version = "0.59.3"
+version = "0.59.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f316c4a2570ba26bbec722032c4099d8c8bc095efccdc15688708623367e358"
+checksum = "bd9211b69f8dcdfa817bfd14bf1c97c9188afa36f4750130fcdf3f400eca9fa8"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "windows-link"
-version = "0.1.3"
+version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e6ad25900d524eaabdbbb96d20b4311e1e7ae1699af4fb28c17ae66c80d798a"
+checksum = "76840935b766e1b0a05c0066835fb9ec80071d4c09a16f6bd5f7e655e3c14c38"
 
 [[package]]
 name = "windows-link"
@@ -6942,16 +6863,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56f42bd332cc6c8eac5af113fc0c1fd6a8fd2aa08a0119358686e5160d0586c6"
 dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-result"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7781fa89eaf60850ac3d2da7af8e5242a5ea78d1a11c49bf2910bb5a73853eb5"
-dependencies = [
- "windows-link 0.2.1",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -6960,16 +6872,7 @@ version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "87fa48cc5d406560701792be122a10132491cff9d0aeb23583cc2dcafc847319"
 dependencies = [
- "windows-link 0.1.3",
-]
-
-[[package]]
-name = "windows-strings"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7837d08f69c77cf6b07689544538e017c1bfcf57e34b4c0ff58e6c2cd3b37091"
-dependencies = [
- "windows-link 0.2.1",
+ "windows-link 0.1.1",
 ]
 
 [[package]]
@@ -7094,14 +6997,14 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
 dependencies = [
  "windows-link 0.2.1",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm 0.53.0",
+ "windows_aarch64_msvc 0.53.0",
+ "windows_i686_gnu 0.53.0",
+ "windows_i686_gnullvm 0.53.0",
+ "windows_i686_msvc 0.53.0",
+ "windows_x86_64_gnu 0.53.0",
+ "windows_x86_64_gnullvm 0.53.0",
+ "windows_x86_64_msvc 0.53.0",
 ]
 
 [[package]]
@@ -7124,9 +7027,9 @@ checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
 name = "windows_aarch64_gnullvm"
-version = "0.53.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
+checksum = "86b8d5f90ddd19cb4a147a5fa63ca848db3df085e25fee3cc10b39b6eebae764"
 
 [[package]]
 name = "windows_aarch64_msvc"
@@ -7148,9 +7051,9 @@ checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
 
 [[package]]
 name = "windows_aarch64_msvc"
-version = "0.53.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
+checksum = "c7651a1f62a11b8cbd5e0d42526e55f2c99886c77e007179efff86c2b137e66c"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -7172,9 +7075,9 @@ checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
 name = "windows_i686_gnu"
-version = "0.53.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
+checksum = "c1dc67659d35f387f5f6c479dc4e28f1d4bb90ddd1a5d3da2e5d97b42d6272c3"
 
 [[package]]
 name = "windows_i686_gnullvm"
@@ -7184,9 +7087,9 @@ checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
 
 [[package]]
 name = "windows_i686_gnullvm"
-version = "0.53.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
+checksum = "9ce6ccbdedbf6d6354471319e781c0dfef054c81fbc7cf83f338a4296c0cae11"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -7208,9 +7111,9 @@ checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
 name = "windows_i686_msvc"
-version = "0.53.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
+checksum = "581fee95406bb13382d2f65cd4a908ca7b1e4c2f1917f143ba16efe98a589b5d"
 
 [[package]]
 name = "windows_x86_64_gnu"
@@ -7232,9 +7135,9 @@ checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
 
 [[package]]
 name = "windows_x86_64_gnu"
-version = "0.53.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
+checksum = "2e55b5ac9ea33f2fc1716d1742db15574fd6fc8dadc51caab1c16a3d3b4190ba"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -7256,9 +7159,9 @@ checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
-version = "0.53.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
+checksum = "0a6e035dd0599267ce1ee132e51c27dd29437f63325753051e71dd9e42406c57"
 
 [[package]]
 name = "windows_x86_64_msvc"
@@ -7280,9 +7183,9 @@ checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
 name = "windows_x86_64_msvc"
-version = "0.53.1"
+version = "0.53.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
+checksum = "271414315aff87387382ec3d271b52d7ae78726f5d44ac98b4f4030c91880486"
 
 [[package]]
 name = "winnow"
@@ -7295,9 +7198,9 @@ dependencies = [
 
 [[package]]
 name = "winnow"
-version = "0.7.14"
+version = "0.6.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a5364e9d77fcdeeaa6062ced926ee3381faa2ee02d3eb83a5c27a8825540829"
+checksum = "c8d71a593cc5c42ad7876e2c1fda56f314f3754c084128833e64f1345ff8a03a"
 dependencies = [
  "memchr",
 ]
@@ -7312,16 +7215,25 @@ dependencies = [
 ]
 
 [[package]]
-name = "wit-bindgen"
-version = "0.51.0"
+name = "wit-bindgen-rt"
+version = "0.39.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d7249219f66ced02969388cf2bb044a09756a083d0fab1e566056b04d9fbcaa5"
+checksum = "6f42320e61fe2cfd34354ecb597f86f413484a798ba44a8ca1165c58d42da6c1"
+dependencies = [
+ "bitflags 2.8.0",
+]
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
 
 [[package]]
 name = "writeable"
-version = "0.6.2"
+version = "0.5.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9edde0db4769d2dc68579893f2306b26c6ecfbe0ef499b013d731b7b9247e0b9"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "x86"
@@ -7346,10 +7258,11 @@ checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
 name = "yoke"
-version = "0.8.1"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72d6e5c6afb84d73944e5cedb052c4680d5657337201555f9f2a16b7406d4954"
+checksum = "120e6aef9aa629e3d4f52dc8cc43a015c7724194c97dfaf45180d2daf2b77f40"
 dependencies = [
+ "serde",
  "stable_deref_trait",
  "yoke-derive",
  "zerofrom",
@@ -7357,79 +7270,89 @@ dependencies = [
 
 [[package]]
 name = "yoke-derive"
-version = "0.8.1"
+version = "0.7.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b659052874eb698efe5b9e8cf382204678a0086ebf46982b79d6ca3182927e5d"
+checksum = "2380878cad4ac9aac1e2435f3eb4020e8374b5f13c296cb75b4620ff8e229154"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
  "synstructure",
 ]
 
 [[package]]
 name = "zerocopy"
-version = "0.8.39"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db6d35d663eadb6c932438e763b262fe1a70987f9ae936e60158176d710cae4a"
+checksum = "1b9b4fd18abc82b8136838da5d50bae7bdea537c574d8dc1a34ed098d6c166f0"
 dependencies = [
- "zerocopy-derive",
+ "byteorder",
+ "zerocopy-derive 0.7.35",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2586fea28e186957ef732a5f8b3be2da217d65c5969d4b1e17f973ebbe876879"
+dependencies = [
+ "zerocopy-derive 0.8.24",
 ]
 
 [[package]]
 name = "zerocopy-derive"
-version = "0.8.39"
+version = "0.7.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4122cd3169e94605190e77839c9a40d40ed048d305bfdc146e7df40ab0f3e517"
+checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.8.24"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a996a8f63c5c4448cd959ac1bab0aaa3306ccfd060472f85943ee0750f0169be"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.96",
 ]
 
 [[package]]
 name = "zerofrom"
-version = "0.1.6"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "50cc42e0333e05660c3587f3bf9d0478688e15d870fab3346451ce7f8c9fbea5"
+checksum = "cff3ee08c995dee1859d998dea82f7374f2826091dd9cd47def953cae446cd2e"
 dependencies = [
  "zerofrom-derive",
 ]
 
 [[package]]
 name = "zerofrom-derive"
-version = "0.1.6"
+version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d71e5d6e06ab090c67b5e44993ec16b72dcbaabc526db883a360057678b48502"
+checksum = "595eed982f7d355beb85837f651fa22e90b3c044842dc7f2c2842c086f295808"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
  "synstructure",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.8.2"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b97154e67e32c85465826e8bcc1c59429aaaf107c1e4a9e53c8d8ccd5eff88d0"
-
-[[package]]
-name = "zerotrie"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a59c17a5562d507e4b54960e8569ebee33bee890c70aa3fe7b97e85a9fd7851"
-dependencies = [
- "displaydoc",
- "yoke",
- "zerofrom",
-]
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
 
 [[package]]
 name = "zerovec"
-version = "0.11.5"
+version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6c28719294829477f525be0186d13efa9a3c602f7ec202ca9e353d310fb9a002"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
 dependencies = [
  "yoke",
  "zerofrom",
@@ -7438,20 +7361,14 @@ dependencies = [
 
 [[package]]
 name = "zerovec-derive"
-version = "0.11.2"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eadce39539ca5cb3985590102671f2567e659fca9666581ad3411d59207951f3"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.114",
+ "syn 2.0.96",
 ]
-
-[[package]]
-name = "zmij"
-version = "1.0.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4de98dfa5d5b7fef4ee834d0073d560c9ca7b6c46a71d058c48db7960f8cfaf7"
 
 [[package]]
 name = "zstd"
@@ -7473,9 +7390,9 @@ dependencies = [
 
 [[package]]
 name = "zstd-sys"
-version = "2.0.16+zstd.1.5.7"
+version = "2.0.15+zstd.1.5.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "91e19ebc2adc8f83e43039e79776e3fda8ca919132d68a1fed6a5faca2683748"
+checksum = "eb81183ddd97d0c74cedf1d50d85c8d08c1b8b68ee863bdee9e706eedba1a237"
 dependencies = [
  "cc",
  "pkg-config",

--- a/components-rs/Cargo.toml
+++ b/components-rs/Cargo.toml
@@ -15,7 +15,7 @@ libdd-telemetry-ffi = { path = "../libdatadog/libdd-telemetry-ffi", default-feat
 datadog-live-debugger = { path = "../libdatadog/datadog-live-debugger" }
 datadog-live-debugger-ffi = { path = "../libdatadog/datadog-live-debugger-ffi", default-features = false }
 datadog-ipc = { path = "../libdatadog/datadog-ipc" }
-datadog-remote-config = { path = "../libdatadog/datadog-remote-config" }
+datadog-remote-config = { path = "../libdatadog/datadog-remote-config", features = ["ffe"] }
 datadog-sidecar = { path = "../libdatadog/datadog-sidecar" }
 datadog-sidecar-ffi = { path = "../libdatadog/datadog-sidecar-ffi" }
 libdd-tinybytes = { path = "../libdatadog/libdd-tinybytes" }
@@ -23,6 +23,7 @@ libdd-trace-utils = { path = "../libdatadog/libdd-trace-utils" }
 libdd-crashtracker-ffi = { path = "../libdatadog/libdd-crashtracker-ffi", default-features = false, features = ["collector"] }
 libdd-library-config-ffi = { path = "../libdatadog/libdd-library-config-ffi", default-features = false }
 spawn_worker = { path = "../libdatadog/spawn_worker" }
+datadog-ffe = { path = "../libdatadog/datadog-ffe" }
 anyhow = { version = "1.0" }
 const-str = "0.5.6"
 itertools = "0.11.0"

--- a/components-rs/ddtrace.h
+++ b/components-rs/ddtrace.h
@@ -61,13 +61,45 @@ uint32_t ddog_get_logs_count(ddog_CharSlice level);
 
 void ddog_init_remote_config(bool live_debugging_enabled,
                              bool appsec_activation,
-                             bool appsec_config);
+                             bool appsec_config,
+                             bool ffe_enabled);
 
 struct ddog_RemoteConfigState *ddog_init_remote_config_state(const struct ddog_Endpoint *endpoint);
 
 const char *ddog_remote_config_get_path(const struct ddog_RemoteConfigState *remote_config);
 
 bool ddog_process_remote_configs(struct ddog_RemoteConfigState *remote_config);
+
+bool ddog_ffe_load_config(const char *json);
+
+bool ddog_ffe_has_config(void);
+
+bool ddog_ffe_config_changed(void);
+
+struct FfeResult;
+
+struct FfeAttribute {
+    const char *key;
+    int32_t value_type;       /* 0=string, 1=number, 2=bool */
+    const char *string_value;
+    double number_value;
+    bool bool_value;
+};
+
+struct FfeResult *ddog_ffe_evaluate(
+    const char *flag_key,
+    int32_t expected_type,
+    const char *targeting_key,
+    const struct FfeAttribute *attributes,
+    size_t attributes_count);
+
+const char *ddog_ffe_result_value(const struct FfeResult *r);
+const char *ddog_ffe_result_variant(const struct FfeResult *r);
+const char *ddog_ffe_result_allocation_key(const struct FfeResult *r);
+int32_t ddog_ffe_result_reason(const struct FfeResult *r);
+int32_t ddog_ffe_result_error_code(const struct FfeResult *r);
+bool ddog_ffe_result_do_log(const struct FfeResult *r);
+void ddog_ffe_free_result(struct FfeResult *r);
 
 bool ddog_type_can_be_instrumented(const struct ddog_RemoteConfigState *remote_config,
                                    ddog_CharSlice typename_);

--- a/components-rs/ffe.rs
+++ b/components-rs/ffe.rs
@@ -1,0 +1,304 @@
+use datadog_ffe::rules_based::{
+    self as ffe, AssignmentReason, AssignmentValue, Attribute, Configuration, EvaluationContext,
+    EvaluationError, ExpectedFlagType, Str, UniversalFlagConfig,
+};
+use std::collections::HashMap;
+use std::ffi::{c_char, CStr, CString};
+use std::sync::{Arc, Mutex};
+
+/// Holds both the FFE configuration and a "changed" flag atomically behind a
+/// single Mutex. This avoids the race where another thread could observe
+/// `config` updated but `changed` still false (or vice-versa).
+///
+/// A `RwLock` would be more appropriate here (many readers via `ddog_ffe_evaluate`,
+/// rare writer via `store_config`), but PHP is single-threaded per process so
+/// contention is not a practical concern. Keeping a Mutex for simplicity.
+struct FfeState {
+    config: Option<Configuration>,
+    changed: bool,
+}
+
+lazy_static::lazy_static! {
+    static ref FFE_STATE: Mutex<FfeState> = Mutex::new(FfeState {
+        config: None,
+        changed: false,
+    });
+}
+
+/// Called by remote_config when a new FFE configuration arrives via RC.
+pub fn store_config(config: Configuration) {
+    if let Ok(mut state) = FFE_STATE.lock() {
+        state.config = Some(config);
+        state.changed = true;
+    }
+}
+
+/// Called by remote_config when an FFE configuration is removed.
+pub fn clear_config() {
+    if let Ok(mut state) = FFE_STATE.lock() {
+        state.config = None;
+        state.changed = true;
+    }
+}
+
+/// Load a UFC JSON config string directly into the FFE engine.
+/// Used by tests to load config without Remote Config.
+#[no_mangle]
+pub extern "C" fn ddog_ffe_load_config(json: *const c_char) -> bool {
+    if json.is_null() {
+        return false;
+    }
+    let json_str = match unsafe { CStr::from_ptr(json) }.to_str() {
+        Ok(s) => s,
+        Err(_) => return false,
+    };
+    match UniversalFlagConfig::from_json(json_str.as_bytes().to_vec()) {
+        Ok(ufc) => {
+            store_config(Configuration::from_server_response(ufc));
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+/// Check if FFE configuration is loaded.
+#[no_mangle]
+pub extern "C" fn ddog_ffe_has_config() -> bool {
+    FFE_STATE.lock().map(|s| s.config.is_some()).unwrap_or(false)
+}
+
+/// Check if FFE config has changed since last check.
+/// Resets the changed flag after reading.
+#[no_mangle]
+pub extern "C" fn ddog_ffe_config_changed() -> bool {
+    if let Ok(mut state) = FFE_STATE.lock() {
+        let was_changed = state.changed;
+        state.changed = false;
+        was_changed
+    } else {
+        false
+    }
+}
+
+/// Opaque handle for FFE evaluation results returned to C/PHP.
+pub struct FfeResult {
+    pub value_json: CString,
+    pub variant: Option<CString>,
+    pub allocation_key: Option<CString>,
+    pub reason: i32,
+    pub error_code: i32,
+    pub do_log: bool,
+}
+
+/// A single attribute passed from C/PHP for building an EvaluationContext.
+#[repr(C)]
+pub struct FfeAttribute {
+    pub key: *const c_char,
+    /// 0 = string, 1 = number, 2 = bool
+    pub value_type: i32,
+    pub string_value: *const c_char,
+    pub number_value: f64,
+    pub bool_value: bool,
+}
+
+/// Evaluate a feature flag using the stored Configuration.
+///
+/// Accepts structured attributes from C instead of a JSON blob.
+/// `targeting_key` may be null (no targeting key).
+/// `attributes` / `attributes_count` describe an array of `FfeAttribute`.
+/// Returns null if no config is loaded.
+#[no_mangle]
+pub extern "C" fn ddog_ffe_evaluate(
+    flag_key: *const c_char,
+    expected_type: i32,
+    targeting_key: *const c_char,
+    attributes: *const FfeAttribute,
+    attributes_count: usize,
+) -> *mut FfeResult {
+    let flag_key = match unsafe { CStr::from_ptr(flag_key) }.to_str() {
+        Ok(s) => s,
+        Err(_) => return std::ptr::null_mut(),
+    };
+
+    let expected_type = match expected_type {
+        0 => ExpectedFlagType::String,
+        1 => ExpectedFlagType::Integer,
+        2 => ExpectedFlagType::Float,
+        3 => ExpectedFlagType::Boolean,
+        4 => ExpectedFlagType::Object,
+        _ => return std::ptr::null_mut(),
+    };
+
+    // Build targeting key
+    let tk = if targeting_key.is_null() {
+        None
+    } else {
+        match unsafe { CStr::from_ptr(targeting_key) }.to_str() {
+            Ok(s) if !s.is_empty() => Some(Str::from(s)),
+            _ => None,
+        }
+    };
+
+    // Build attributes map from the C array
+    let mut attrs = HashMap::new();
+    if !attributes.is_null() && attributes_count > 0 {
+        let slice = unsafe { std::slice::from_raw_parts(attributes, attributes_count) };
+        for attr in slice {
+            if attr.key.is_null() {
+                continue;
+            }
+            let key = match unsafe { CStr::from_ptr(attr.key) }.to_str() {
+                Ok(s) => s,
+                Err(_) => continue,
+            };
+            let value = match attr.value_type {
+                0 => {
+                    // string
+                    if attr.string_value.is_null() {
+                        continue;
+                    }
+                    match unsafe { CStr::from_ptr(attr.string_value) }.to_str() {
+                        Ok(s) => Attribute::from(s),
+                        Err(_) => continue,
+                    }
+                }
+                1 => {
+                    // number
+                    Attribute::from(attr.number_value)
+                }
+                2 => {
+                    // bool
+                    Attribute::from(attr.bool_value)
+                }
+                _ => continue,
+            };
+            attrs.insert(Str::from(key), value);
+        }
+    }
+
+    let context = EvaluationContext::new(tk, Arc::new(attrs));
+
+    let state = match FFE_STATE.lock() {
+        Ok(s) => s,
+        Err(_) => return std::ptr::null_mut(),
+    };
+
+    let assignment = ffe::get_assignment(
+        state.config.as_ref(),
+        flag_key,
+        &context,
+        expected_type,
+        ffe::now(),
+    );
+
+    let result = match assignment {
+        Ok(a) => FfeResult {
+            value_json: CString::new(assignment_value_to_json(&a.value)).unwrap_or_default(),
+            variant: Some(CString::new(a.variation_key.as_str()).unwrap_or_default()),
+            allocation_key: Some(CString::new(a.allocation_key.as_str()).unwrap_or_default()),
+            reason: match a.reason {
+                AssignmentReason::Static => 0,
+                AssignmentReason::TargetingMatch => 2,
+                AssignmentReason::Split => 3,
+            },
+            error_code: 0,
+            do_log: a.do_log,
+        },
+        Err(err) => {
+            let (error_code, reason) = match &err {
+                EvaluationError::TypeMismatch { .. } => (1, 5),
+                EvaluationError::ConfigurationParseError => (2, 5),
+                EvaluationError::ConfigurationMissing => (6, 5),
+                EvaluationError::FlagUnrecognizedOrDisabled => (3, 1),
+                EvaluationError::FlagDisabled => (0, 4),
+                EvaluationError::DefaultAllocationNull => (0, 1),
+                _ => (7, 5),
+            };
+            FfeResult {
+                value_json: CString::new("null").unwrap_or_default(),
+                variant: None,
+                allocation_key: None,
+                reason,
+                error_code,
+                do_log: false,
+            }
+        }
+    };
+
+    Box::into_raw(Box::new(result))
+}
+
+#[no_mangle]
+pub extern "C" fn ddog_ffe_result_value(r: *const FfeResult) -> *const c_char {
+    if r.is_null() {
+        return std::ptr::null();
+    }
+    unsafe { &*r }.value_json.as_ptr()
+}
+
+#[no_mangle]
+pub extern "C" fn ddog_ffe_result_variant(r: *const FfeResult) -> *const c_char {
+    if r.is_null() {
+        return std::ptr::null();
+    }
+    unsafe { &*r }
+        .variant
+        .as_ref()
+        .map(|s| s.as_ptr())
+        .unwrap_or(std::ptr::null())
+}
+
+#[no_mangle]
+pub extern "C" fn ddog_ffe_result_allocation_key(r: *const FfeResult) -> *const c_char {
+    if r.is_null() {
+        return std::ptr::null();
+    }
+    unsafe { &*r }
+        .allocation_key
+        .as_ref()
+        .map(|s| s.as_ptr())
+        .unwrap_or(std::ptr::null())
+}
+
+#[no_mangle]
+pub extern "C" fn ddog_ffe_result_reason(r: *const FfeResult) -> i32 {
+    if r.is_null() {
+        return -1;
+    }
+    unsafe { &*r }.reason
+}
+
+#[no_mangle]
+pub extern "C" fn ddog_ffe_result_error_code(r: *const FfeResult) -> i32 {
+    if r.is_null() {
+        return -1;
+    }
+    unsafe { &*r }.error_code
+}
+
+#[no_mangle]
+pub extern "C" fn ddog_ffe_result_do_log(r: *const FfeResult) -> bool {
+    if r.is_null() {
+        return false;
+    }
+    unsafe { &*r }.do_log
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ddog_ffe_free_result(r: *mut FfeResult) {
+    if !r.is_null() {
+        drop(Box::from_raw(r));
+    }
+}
+
+fn assignment_value_to_json(value: &AssignmentValue) -> String {
+    match value {
+        AssignmentValue::String(s) => serde_json::to_string(s.as_str()).unwrap_or_default(),
+        AssignmentValue::Integer(i) => i.to_string(),
+        AssignmentValue::Float(f) => serde_json::Number::from_f64(*f)
+            .map(|n| n.to_string())
+            .unwrap_or_else(|| f.to_string()),
+        AssignmentValue::Boolean(b) => b.to_string(),
+        AssignmentValue::Json { raw, .. } => raw.get().to_string(),
+    }
+}

--- a/components-rs/lib.rs
+++ b/components-rs/lib.rs
@@ -5,6 +5,7 @@
 
 pub mod log;
 pub mod remote_config;
+pub mod ffe;
 pub mod sidecar;
 pub mod telemetry;
 pub mod bytes;

--- a/ext/configuration.h
+++ b/ext/configuration.h
@@ -264,6 +264,7 @@ enum ddtrace_sampling_rules_format {
     CONFIG(BOOL, DD_TRACE_RESOURCE_RENAMING_ENABLED, "false")                                                  \
     CONFIG(BOOL, DD_TRACE_RESOURCE_RENAMING_ALWAYS_SIMPLIFIED_ENDPOINT, "false")                               \
     CONFIG(BOOL, DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED, "false")                                      \
+    CONFIG(BOOL, DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED, "false")                                           \
     DD_INTEGRATIONS
 
 #ifndef _WIN32

--- a/ext/sidecar.c
+++ b/ext/sidecar.c
@@ -220,7 +220,7 @@ void ddtrace_sidecar_setup(bool appsec_activation, bool appsec_config) {
     ddtrace_set_non_resettable_sidecar_globals();
     ddtrace_set_resettable_sidecar_globals();
 
-    ddog_init_remote_config(get_global_DD_INSTRUMENTATION_TELEMETRY_ENABLED(), appsec_activation, appsec_config);
+    ddog_init_remote_config(get_global_DD_INSTRUMENTATION_TELEMETRY_ENABLED(), appsec_activation, appsec_config, get_global_DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED());
 
     ddtrace_sidecar = dd_sidecar_connection_factory();
     if (!ddtrace_sidecar) { // Something went wrong

--- a/src/DDTrace/FeatureFlags/ExposureCache.php
+++ b/src/DDTrace/FeatureFlags/ExposureCache.php
@@ -1,0 +1,117 @@
+<?php
+
+namespace DDTrace\FeatureFlags;
+
+/**
+ * LRU-based exposure event deduplication cache.
+ *
+ * Mirrors the canonical Java implementation (LRUExposureCache).
+ * Key = (flagKey, subjectId), Value = (variantKey, allocationKey).
+ * Returns true from add() when the event is new or its value changed,
+ * false when it's an exact duplicate. Even duplicates update the LRU
+ * position to keep hot entries from being evicted.
+ */
+class ExposureCache
+{
+    /** @var LRUCache */
+    private $cache;
+
+    /**
+     * @param int $capacity Maximum number of entries
+     */
+    public function __construct($capacity = 65536)
+    {
+        $this->cache = new LRUCache($capacity);
+    }
+
+    /**
+     * Add an exposure event to the cache.
+     *
+     * @param string $flagKey
+     * @param string $subjectId
+     * @param string $variantKey
+     * @param string $allocationKey
+     * @return bool true if the event is new or value changed, false if exact duplicate
+     */
+    public function add($flagKey, $subjectId, $variantKey, $allocationKey)
+    {
+        $key = self::makeKey($flagKey, $subjectId);
+        $newValue = self::makeValue($variantKey, $allocationKey);
+
+        // Always put (updates LRU position even for duplicates)
+        $oldValue = $this->cache->put($key, $newValue);
+
+        return $oldValue === null || $oldValue !== $newValue;
+    }
+
+    /**
+     * Get the cached value for a (flag, subject) pair.
+     *
+     * @param string $flagKey
+     * @param string $subjectId
+     * @return array|null [variantKey, allocationKey] or null if not found
+     */
+    public function get($flagKey, $subjectId)
+    {
+        $key = self::makeKey($flagKey, $subjectId);
+        $value = $this->cache->get($key);
+        if ($value === null) {
+            return null;
+        }
+        return self::parseValue($value);
+    }
+
+    /**
+     * Return the number of entries in the cache.
+     *
+     * @return int
+     */
+    public function size()
+    {
+        return $this->cache->size();
+    }
+
+    /**
+     * Clear all entries.
+     */
+    public function clear()
+    {
+        $this->cache->clear();
+    }
+
+    /**
+     * Build a composite key that avoids collision.
+     * Uses length-prefixing: "<len>:<flag>:<subject>"
+     */
+    private static function makeKey($flagKey, $subjectId)
+    {
+        $f = $flagKey !== null ? $flagKey : '';
+        $s = $subjectId !== null ? $subjectId : '';
+        return strlen($f) . ':' . $f . ':' . $s;
+    }
+
+    /**
+     * Build a composite value string.
+     */
+    private static function makeValue($variantKey, $allocationKey)
+    {
+        $v = $variantKey !== null ? $variantKey : '';
+        $a = $allocationKey !== null ? $allocationKey : '';
+        return strlen($v) . ':' . $v . ':' . $a;
+    }
+
+    /**
+     * Parse a composite value string back into [variantKey, allocationKey].
+     */
+    private static function parseValue($value)
+    {
+        $colonPos = strpos($value, ':');
+        if ($colonPos === false) {
+            return [$value, ''];
+        }
+        $len = (int) substr($value, 0, $colonPos);
+        $variant = substr($value, $colonPos + 1, $len);
+        $allocation = substr($value, $colonPos + 1 + $len + 1);
+        return [$variant, $allocation];
+    }
+}

--- a/src/DDTrace/FeatureFlags/ExposureWriter.php
+++ b/src/DDTrace/FeatureFlags/ExposureWriter.php
@@ -1,0 +1,173 @@
+<?php
+
+namespace DDTrace\FeatureFlags;
+
+/**
+ * Batches and sends feature flag exposure events to the Datadog Agent's EVP proxy.
+ */
+class ExposureWriter
+{
+    const MAX_BUFFER_SIZE = 1000;
+
+    /** @var array */
+    private $buffer = [];
+
+    /** @var string */
+    private $agentUrl;
+
+    public function __construct()
+    {
+        $this->agentUrl = $this->resolveAgentUrl();
+    }
+
+    /**
+     * Add an exposure event to the buffer.
+     *
+     * @param array $event Exposure event data
+     */
+    public function enqueue(array $event)
+    {
+        if (count($this->buffer) >= self::MAX_BUFFER_SIZE) {
+            return;
+        }
+        $this->buffer[] = $event;
+    }
+
+    /**
+     * Send all buffered exposure events as a batch to the EVP proxy.
+     */
+    public function flush()
+    {
+        if (empty($this->buffer)) {
+            return;
+        }
+
+        $events = $this->buffer;
+        $this->buffer = [];
+
+        $payload = [
+            'context' => [
+                'service' => $this->getConfigValue('DD_SERVICE', ''),
+                'env' => $this->getConfigValue('DD_ENV', ''),
+                'version' => $this->getConfigValue('DD_VERSION', ''),
+            ],
+            'exposures' => $events,
+        ];
+
+        $url = rtrim($this->agentUrl, '/') . '/evp_proxy/v2/api/v2/exposures';
+        $body = json_encode($payload);
+
+        $ch = curl_init($url);
+        if ($ch === false) {
+            return;
+        }
+
+        curl_setopt_array($ch, [
+            CURLOPT_POST => true,
+            CURLOPT_POSTFIELDS => $body,
+            CURLOPT_HTTPHEADER => [
+                'Content-Type: application/json',
+                'X-Datadog-EVP-Subdomain: event-platform-intake',
+            ],
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT_MS => 500,
+            CURLOPT_CONNECTTIMEOUT_MS => 100,
+        ]);
+
+        curl_exec($ch);
+        curl_close($ch);
+    }
+
+    /**
+     * Return the number of events currently in the buffer.
+     *
+     * @return int
+     */
+    public function getBufferCount()
+    {
+        return count($this->buffer);
+    }
+
+    /**
+     * Build a complete exposure event array.
+     *
+     * @param string $allocationKey
+     * @param string $flagKey
+     * @param string $variantKey
+     * @param string|null $targetingKey
+     * @param array $attributes
+     * @return array
+     */
+    public static function buildEvent(
+        $flagKey,
+        $variantKey,
+        $allocationKey,
+        $targetingKey = null,
+        array $attributes = []
+    ) {
+        return [
+            'timestamp' => (int)(microtime(true) * 1000),
+            'allocation' => ['key' => $allocationKey],
+            'flag' => ['key' => $flagKey],
+            'variant' => ['key' => $variantKey],
+            'subject' => [
+                'id' => $targetingKey ?? '',
+                'attributes' => $attributes,
+            ],
+        ];
+    }
+
+    /**
+     * Resolve the agent URL from environment configuration.
+     *
+     * Checks DD_TRACE_AGENT_URL first. If not set, constructs from
+     * DD_AGENT_HOST (default: localhost) and DD_TRACE_AGENT_PORT (default: 8126).
+     *
+     * @return string
+     */
+    private function resolveAgentUrl()
+    {
+        $agentUrl = $this->getConfigValue('DD_TRACE_AGENT_URL', '');
+        if ($agentUrl !== '') {
+            return rtrim($agentUrl, '/');
+        }
+
+        $host = $this->getConfigValue('DD_AGENT_HOST', 'localhost');
+        if ($host === '') {
+            $host = 'localhost';
+        }
+
+        $port = $this->getConfigValue('DD_TRACE_AGENT_PORT', '8126');
+        if ($port === '') {
+            $port = '8126';
+        }
+
+        return 'http://' . $host . ':' . $port;
+    }
+
+    /**
+     * Read a configuration value using dd_trace_env_config() if available,
+     * otherwise fall back to getenv().
+     *
+     * @param string $name
+     * @param string $default
+     * @return string
+     */
+    private function getConfigValue($name, $default = '')
+    {
+        if (function_exists('dd_trace_env_config')) {
+            $value = \dd_trace_env_config($name);
+            if ($value !== '' && $value !== false && $value !== null) {
+                return (string)$value;
+            }
+            return $default;
+        }
+
+        $value = getenv($name);
+        if ($value !== false && $value !== '') {
+            return $value;
+        }
+
+        return $default;
+    }
+}

--- a/src/DDTrace/FeatureFlags/LRUCache.php
+++ b/src/DDTrace/FeatureFlags/LRUCache.php
@@ -1,0 +1,124 @@
+<?php
+
+namespace DDTrace\FeatureFlags;
+
+/**
+ * Simple LRU (Least Recently Used) cache for exposure event deduplication.
+ *
+ * Uses an ordered associative array where the most recently accessed entries
+ * are moved to the end. When the cache exceeds capacity, entries are evicted
+ * from the front (least recently used).
+ */
+class LRUCache
+{
+    /** @var int */
+    private $maxSize;
+
+    /** @var array<string, mixed> */
+    private $cache = [];
+
+    /**
+     * @param int $maxSize Maximum number of entries in the cache
+     */
+    public function __construct($maxSize = 65536)
+    {
+        $this->maxSize = $maxSize;
+    }
+
+    /**
+     * Get a value from the cache by key.
+     *
+     * Accessing an entry promotes it to the most recently used position.
+     *
+     * @param string $key
+     * @return mixed|null The cached value, or null if not found
+     */
+    public function get($key)
+    {
+        if (!array_key_exists($key, $this->cache)) {
+            return null;
+        }
+
+        // Move to end (most recently used) by removing and re-adding
+        $value = $this->cache[$key];
+        unset($this->cache[$key]);
+        $this->cache[$key] = $value;
+
+        return $value;
+    }
+
+    /**
+     * Set a value in the cache.
+     *
+     * If the key already exists, the value is updated and the entry is promoted
+     * to the most recently used position. If the cache is at capacity, the least
+     * recently used entry is evicted.
+     *
+     * @param string $key
+     * @param mixed $value
+     */
+    public function set($key, $value)
+    {
+        // If key already exists, remove it first so it moves to the end
+        if (array_key_exists($key, $this->cache)) {
+            unset($this->cache[$key]);
+        }
+
+        $this->cache[$key] = $value;
+
+        // Evict least recently used entry if over capacity
+        if (count($this->cache) > $this->maxSize) {
+            reset($this->cache);
+            $evictKey = key($this->cache);
+            unset($this->cache[$evictKey]);
+        }
+    }
+
+    /**
+     * Put a value in the cache and return the previous value.
+     *
+     * Like set(), but returns the old value (or null if the key was not present).
+     * Always updates the LRU position, even when the value is unchanged.
+     *
+     * @param string $key
+     * @param mixed $value
+     * @return mixed|null The previous value, or null if the key was new
+     */
+    public function put($key, $value)
+    {
+        $oldValue = null;
+        if (array_key_exists($key, $this->cache)) {
+            $oldValue = $this->cache[$key];
+            unset($this->cache[$key]);
+        }
+
+        $this->cache[$key] = $value;
+
+        // Evict least recently used entry if over capacity
+        if (count($this->cache) > $this->maxSize) {
+            reset($this->cache);
+            $evictKey = key($this->cache);
+            unset($this->cache[$evictKey]);
+        }
+
+        return $oldValue;
+    }
+
+    /**
+     * Return the number of entries in the cache.
+     *
+     * @return int
+     */
+    public function size()
+    {
+        return count($this->cache);
+    }
+
+    /**
+     * Clear all entries from the cache.
+     */
+    public function clear()
+    {
+        $this->cache = [];
+    }
+}

--- a/src/DDTrace/FeatureFlags/Provider.php
+++ b/src/DDTrace/FeatureFlags/Provider.php
@@ -1,0 +1,285 @@
+<?php
+
+namespace DDTrace\FeatureFlags;
+
+/**
+ * Datadog Feature Flags and Experimentation (FFE) Provider.
+ *
+ * Evaluates feature flags using the native datadog-ffe engine from libdatadog.
+ * Flag configurations are received via Remote Config through the sidecar.
+ * Reports exposure events to the EVP proxy for analytics.
+ */
+class Provider
+{
+    private static $REASON_MAP = [
+        0 => 'STATIC',
+        1 => 'DEFAULT',
+        2 => 'TARGETING_MATCH',
+        3 => 'SPLIT',
+        4 => 'DISABLED',
+        5 => 'ERROR',
+    ];
+
+    private static $TYPE_MAP = [
+        'STRING'  => 0,
+        'INTEGER' => 1,
+        'NUMERIC' => 2,
+        'BOOLEAN' => 3,
+        'JSON'    => 4,
+    ];
+
+    /** @var ExposureWriter */
+    private $writer;
+
+    /** @var ExposureCache */
+    private $exposureCache;
+
+    /** @var bool */
+    private $enabled;
+
+    /** @var bool */
+    private $configLoaded = false;
+
+    /** @var bool */
+    private $shutdownRegistered = false;
+
+    /** @var Provider|null */
+    private static $instance = null;
+
+    public function __construct()
+    {
+        $this->writer = new ExposureWriter();
+        $this->exposureCache = new ExposureCache(65536);
+        $this->enabled = $this->isFeatureFlagEnabled();
+    }
+
+    /**
+     * Get the singleton instance.
+     */
+    public static function getInstance()
+    {
+        if (self::$instance === null) {
+            self::$instance = new self();
+        }
+        return self::$instance;
+    }
+
+    /**
+     * Reset the singleton (useful for testing).
+     */
+    public static function reset()
+    {
+        self::$instance = null;
+    }
+
+    /**
+     * Initialize the provider: load config from RC into the native engine.
+     */
+    public function start()
+    {
+        if (!$this->enabled) {
+            return false;
+        }
+        $this->checkNativeConfig();
+        $this->registerShutdown();
+        return true;
+    }
+
+    /**
+     * Register a shutdown function to auto-flush exposure events at request end.
+     */
+    private function registerShutdown()
+    {
+        if ($this->shutdownRegistered) {
+            return;
+        }
+        $writer = $this->writer;
+        register_shutdown_function(function () use ($writer) {
+            $writer->flush();
+        });
+        $this->shutdownRegistered = true;
+    }
+
+    /**
+     * Check if the native FFE configuration has been loaded or changed via Remote Config.
+     */
+    private function checkNativeConfig()
+    {
+        // Check if config changed since last check (covers both new config and removal)
+        if (\dd_trace_internal_fn('ffe_config_changed')) {
+            $hasConfig = \dd_trace_internal_fn('ffe_has_config');
+            if ($hasConfig && !$this->configLoaded) {
+                $this->configLoaded = true;
+            } elseif (!$hasConfig && $this->configLoaded) {
+                // Config was removed via RC
+                $this->configLoaded = false;
+                $this->exposureCache->clear();
+            }
+        } elseif (!$this->configLoaded && \dd_trace_internal_fn('ffe_has_config')) {
+            // First check — config was already loaded before provider started
+            $this->configLoaded = true;
+        }
+    }
+
+    /**
+     * Evaluate a feature flag using the native datadog-ffe engine.
+     *
+     * @param string $flagKey The flag key to evaluate
+     * @param string $variationType The expected variation type (STRING, BOOLEAN, INTEGER, NUMERIC, JSON)
+     * @param mixed $defaultValue The default value to return if evaluation fails
+     * @param string|null $targetingKey The targeting key (user/subject ID)
+     * @param array $attributes Additional context attributes
+     * @return array ['value' => mixed, 'reason' => string, 'variant' => string|null, 'allocation_key' => string|null]
+     */
+    public function evaluate($flagKey, $variationType, $defaultValue, $targetingKey, $attributes = [])
+    {
+        if (!$this->enabled) {
+            return ['value' => $defaultValue, 'reason' => 'DISABLED', 'variant' => null, 'allocation_key' => null];
+        }
+
+        // Ensure native config is loaded
+        $this->checkNativeConfig();
+
+        if (!$this->configLoaded) {
+            return ['value' => $defaultValue, 'reason' => 'DEFAULT', 'variant' => null, 'allocation_key' => null];
+        }
+
+        $typeId = isset(self::$TYPE_MAP[$variationType]) ? self::$TYPE_MAP[$variationType] : 0;
+
+        // Call the native evaluation engine with structured attributes
+        $result = \dd_trace_internal_fn('ffe_evaluate', $flagKey, $typeId,
+            $targetingKey, is_array($attributes) ? $attributes : []);
+
+        if ($result === null) {
+            return ['value' => $defaultValue, 'reason' => 'DEFAULT', 'variant' => null, 'allocation_key' => null];
+        }
+
+        $errorCode = isset($result['error_code']) ? (int)$result['error_code'] : 0;
+        $reason = isset($result['reason']) ? (int)$result['reason'] : 1;
+        $reasonStr = isset(self::$REASON_MAP[$reason]) ? self::$REASON_MAP[$reason] : 'DEFAULT';
+
+        // Error or no variant → return default
+        if ($errorCode !== 0 || $result['variant'] === null) {
+            return ['value' => $defaultValue, 'reason' => $reasonStr, 'variant' => null, 'allocation_key' => null];
+        }
+
+        // Parse the value from JSON
+        $value = $this->parseNativeValue($result['value_json'], $variationType, $defaultValue);
+
+        // Report exposure event (deduplicated via ExposureCache)
+        $doLog = !empty($result['do_log']);
+        if ($doLog && $result['variant'] !== null && $result['allocation_key'] !== null) {
+            $this->reportExposure(
+                $flagKey,
+                $result['variant'],
+                $result['allocation_key'],
+                $targetingKey,
+                $attributes
+            );
+        }
+
+        return [
+            'value' => $value,
+            'reason' => $reasonStr,
+            'variant' => $result['variant'],
+            'allocation_key' => $result['allocation_key'],
+        ];
+    }
+
+    /**
+     * Parse a native value JSON string into the correct PHP type.
+     */
+    private function parseNativeValue($valueJson, $variationType, $defaultValue)
+    {
+        if ($valueJson === null || $valueJson === 'null') {
+            return $defaultValue;
+        }
+
+        switch ($variationType) {
+            case 'BOOLEAN':
+                return $valueJson === 'true';
+            case 'INTEGER':
+                return (int)$valueJson;
+            case 'NUMERIC':
+                return (float)$valueJson;
+            case 'JSON':
+                $decoded = json_decode($valueJson, true);
+                return $decoded !== null ? $decoded : $defaultValue;
+            case 'STRING':
+            default:
+                // String values come as JSON-encoded strings (with quotes)
+                $decoded = json_decode($valueJson);
+                return is_string($decoded) ? $decoded : $valueJson;
+        }
+    }
+
+    /**
+     * Report a feature flag exposure event, deduplicated via ExposureCache.
+     */
+    private function reportExposure($flagKey, $variantKey, $allocationKey, $targetingKey, $attributes)
+    {
+        if (!$variantKey || !$allocationKey) {
+            return;
+        }
+
+        $subjectId = $targetingKey !== null ? $targetingKey : '';
+
+        // add() returns true for new events or when value changed, false for exact duplicates
+        if (!$this->exposureCache->add($flagKey, $subjectId, $variantKey, $allocationKey)) {
+            return;
+        }
+
+        $event = ExposureWriter::buildEvent(
+            $flagKey,
+            $variantKey,
+            $allocationKey,
+            $subjectId,
+            is_array($attributes) ? $attributes : []
+        );
+
+        $this->writer->enqueue($event);
+    }
+
+    /**
+     * Flush pending exposure events.
+     */
+    public function flush()
+    {
+        $this->writer->flush();
+    }
+
+    /**
+     * Clear the exposure cache.
+     */
+    public function clearExposureCache()
+    {
+        $this->exposureCache->clear();
+    }
+
+    /**
+     * Check if the feature flag provider is enabled via env var.
+     */
+    private function isFeatureFlagEnabled()
+    {
+        // Check env var first (most reliable across all SAPIs)
+        $envVal = getenv('DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED');
+        if ($envVal !== false) {
+            return strtolower($envVal) === 'true' || $envVal === '1';
+        }
+
+        // Fall back to INI config
+        if (function_exists('dd_trace_env_config')) {
+            return (bool)\dd_trace_env_config('DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED');
+        }
+
+        return false;
+    }
+
+    /**
+     * Check if config has been loaded into the native engine.
+     */
+    public function isReady()
+    {
+        return $this->configLoaded;
+    }
+}

--- a/src/DDTrace/OpenFeature/DataDogProvider.php
+++ b/src/DDTrace/OpenFeature/DataDogProvider.php
@@ -1,0 +1,126 @@
+<?php
+
+namespace DDTrace\OpenFeature;
+
+use DDTrace\FeatureFlags\Provider;
+use OpenFeature\implementation\provider\AbstractProvider;
+use OpenFeature\implementation\provider\ResolutionDetailsBuilder;
+use OpenFeature\interfaces\flags\EvaluationContext;
+use OpenFeature\interfaces\provider\Metadata;
+use OpenFeature\interfaces\provider\ResolutionDetails as ResolutionDetailsInterface;
+
+/**
+ * Datadog OpenFeature Provider.
+ *
+ * Implements the OpenFeature Provider interface for Datadog's
+ * Feature Flags and Experimentation (FFE) product.
+ *
+ * Usage:
+ *   use OpenFeature\API;
+ *   use DDTrace\OpenFeature\DataDogProvider;
+ *
+ *   API::setProvider(new DataDogProvider());
+ *   $client = API::getClient();
+ *   $value = $client->getBooleanValue('my-flag', false, $context);
+ *
+ * Requires: composer require open-feature/sdk
+ */
+class DataDogProvider extends AbstractProvider
+{
+    /** @var Provider */
+    private $ffeProvider;
+
+    public function __construct()
+    {
+        $this->ffeProvider = Provider::getInstance();
+        $this->ffeProvider->start();
+    }
+
+    public function getMetadata(): Metadata
+    {
+        return new class implements Metadata {
+            public function getName(): string
+            {
+                return 'Datadog';
+            }
+        };
+    }
+
+    public function resolveBooleanValue(
+        string $flagKey,
+        bool $defaultValue,
+        ?EvaluationContext $context = null
+    ): ResolutionDetailsInterface {
+        return $this->resolve($flagKey, 'BOOLEAN', $defaultValue, $context);
+    }
+
+    public function resolveStringValue(
+        string $flagKey,
+        string $defaultValue,
+        ?EvaluationContext $context = null
+    ): ResolutionDetailsInterface {
+        return $this->resolve($flagKey, 'STRING', $defaultValue, $context);
+    }
+
+    public function resolveIntegerValue(
+        string $flagKey,
+        int $defaultValue,
+        ?EvaluationContext $context = null
+    ): ResolutionDetailsInterface {
+        return $this->resolve($flagKey, 'INTEGER', $defaultValue, $context);
+    }
+
+    public function resolveFloatValue(
+        string $flagKey,
+        float $defaultValue,
+        ?EvaluationContext $context = null
+    ): ResolutionDetailsInterface {
+        return $this->resolve($flagKey, 'NUMERIC', $defaultValue, $context);
+    }
+
+    public function resolveObjectValue(
+        string $flagKey,
+        array $defaultValue,
+        ?EvaluationContext $context = null
+    ): ResolutionDetailsInterface {
+        return $this->resolve($flagKey, 'JSON', $defaultValue, $context);
+    }
+
+    /**
+     * @param mixed $defaultValue
+     */
+    private function resolve(
+        string $flagKey,
+        string $variationType,
+        $defaultValue,
+        ?EvaluationContext $context = null
+    ): ResolutionDetailsInterface {
+        $targetingKey = '';
+        $attributes = [];
+
+        if ($context !== null) {
+            $targetingKey = $context->getTargetingKey() ?? '';
+            $attrs = $context->getAttributes();
+            if ($attrs !== null) {
+                $attributes = $attrs->toArray();
+            }
+        }
+
+        $result = $this->ffeProvider->evaluate(
+            $flagKey,
+            $variationType,
+            $defaultValue,
+            $targetingKey,
+            $attributes
+        );
+
+        $builder = new ResolutionDetailsBuilder();
+        $builder->withValue($result['value']);
+
+        if (isset($result['reason'])) {
+            $builder->withReason($result['reason']);
+        }
+
+        return $builder->build();
+    }
+}

--- a/src/bridge/_files_tracer.php
+++ b/src/bridge/_files_tracer.php
@@ -40,4 +40,8 @@ return [
     __DIR__ . '/../DDTrace/Propagators/TextMap.php',
     __DIR__ . '/../DDTrace/ScopeManager.php',
     __DIR__ . '/../DDTrace/Tracer.php',
+    __DIR__ . '/../DDTrace/FeatureFlags/LRUCache.php',
+    __DIR__ . '/../DDTrace/FeatureFlags/ExposureCache.php',
+    __DIR__ . '/../DDTrace/FeatureFlags/ExposureWriter.php',
+    __DIR__ . '/../DDTrace/FeatureFlags/Provider.php',
 ];

--- a/tests/FeatureFlags/EvaluationTest.php
+++ b/tests/FeatureFlags/EvaluationTest.php
@@ -1,0 +1,182 @@
+<?php
+
+namespace DDTrace\Tests\FeatureFlags;
+
+use DDTrace\Tests\Common\BaseTestCase;
+
+final class EvaluationTest extends BaseTestCase
+{
+    private static $configLoaded = false;
+    private static $configFlagKeys = [];
+
+    public static function ddSetUpBeforeClass()
+    {
+        parent::ddSetUpBeforeClass();
+
+        if (!extension_loaded('ddtrace')) {
+            self::markTestSkipped('ddtrace extension not loaded');
+        }
+
+        $configPath = __DIR__ . '/fixtures/config/ufc-config.json';
+        $json = file_get_contents($configPath);
+        self::$configLoaded = \dd_trace_internal_fn('ffe_load_config', $json);
+        if (!self::$configLoaded) {
+            self::fail('Failed to load UFC config from ' . $configPath);
+        }
+
+        // Track which flags exist in the config so we can distinguish
+        // "flag not in config" from "flag exists but no matching allocation"
+        $config = json_decode($json, true);
+        if (isset($config['flags'])) {
+            self::$configFlagKeys = array_keys($config['flags']);
+        }
+    }
+
+    /**
+     * Map variation type string to the integer type ID expected by ffe_evaluate.
+     *   0 = string, 1 = integer, 2 = float, 3 = boolean, 4 = object (JSON)
+     */
+    private static function variationTypeToId($variationType)
+    {
+        $map = [
+            'STRING'  => 0,
+            'INTEGER' => 1,
+            'NUMERIC' => 2,
+            'BOOLEAN' => 3,
+            'JSON'    => 4,
+        ];
+        return isset($map[$variationType]) ? $map[$variationType] : -1;
+    }
+
+    /**
+     * Build the attributes array for ffe_evaluate from the test case attributes.
+     * Only scalar types (string, number, bool) are supported by the FFI bridge.
+     */
+    private static function buildAttributes(array $attrs)
+    {
+        $result = [];
+        foreach ($attrs as $key => $value) {
+            if (is_string($value) || is_numeric($value) || is_bool($value)) {
+                $result[$key] = $value;
+            }
+        }
+        return $result;
+    }
+
+    /**
+     * Parse the value_json string returned by ffe_evaluate based on the variation type.
+     */
+    private static function parseValueJson($valueJson, $variationType)
+    {
+        switch ($variationType) {
+            case 'STRING':
+                return json_decode($valueJson, true);
+            case 'INTEGER':
+                return (int) $valueJson;
+            case 'NUMERIC':
+                return (float) $valueJson;
+            case 'BOOLEAN':
+                return $valueJson === 'true';
+            case 'JSON':
+                return json_decode($valueJson, true);
+            default:
+                return json_decode($valueJson, true);
+        }
+    }
+
+    /**
+     * Data provider that scans all evaluation case fixture files and flattens
+     * every scenario into a [fileName, caseIndex, caseData] tuple.
+     */
+    public function provideEvaluationCases()
+    {
+        $casesDir = __DIR__ . '/fixtures/evaluation-cases';
+        $files = glob($casesDir . '/*.json');
+        $dataset = [];
+
+        foreach ($files as $filePath) {
+            $fileName = basename($filePath, '.json');
+            $cases = json_decode(file_get_contents($filePath), true);
+
+            foreach ($cases as $index => $case) {
+                $label = sprintf('%s#%d (%s)', $fileName, $index, $case['flag']);
+                $dataset[$label] = [$fileName, $index, $case];
+            }
+        }
+
+        return $dataset;
+    }
+
+    /**
+     * @dataProvider provideEvaluationCases
+     */
+    public function testEvaluation($fileName, $caseIndex, $case)
+    {
+        if (!self::$configLoaded) {
+            $this->markTestSkipped('UFC config was not loaded');
+        }
+
+        $flagKey = $case['flag'];
+        $variationType = $case['variationType'];
+        $typeId = self::variationTypeToId($variationType);
+        $targetingKey = isset($case['targetingKey']) ? $case['targetingKey'] : '';
+        $attributes = isset($case['attributes']) ? self::buildAttributes($case['attributes']) : [];
+        $defaultValue = isset($case['defaultValue']) ? $case['defaultValue'] : null;
+        $expectedValue = $case['result']['value'];
+
+        // Skip test cases that reference flags not present in the UFC config
+        // AND expect a non-default result (these require a different config).
+        if (!in_array($flagKey, self::$configFlagKeys) && $expectedValue !== $defaultValue) {
+            $this->markTestSkipped(
+                sprintf('Flag "%s" not in UFC config and expected non-default value', $flagKey)
+            );
+        }
+
+        $result = \dd_trace_internal_fn('ffe_evaluate', $flagKey, $typeId, $targetingKey, $attributes);
+
+        $this->assertNotNull(
+            $result,
+            sprintf('ffe_evaluate returned null for %s#%d', $fileName, $caseIndex)
+        );
+
+        $this->assertArrayHasKey('value_json', $result);
+
+        $errorCode = isset($result['error_code']) ? (int) $result['error_code'] : 0;
+
+        // When the evaluator returns an error, the Provider layer would return
+        // the defaultValue. If the expected result equals the defaultValue,
+        // verify the evaluator correctly returned an error (no match).
+        if ($errorCode !== 0 && $expectedValue === $defaultValue) {
+            // Evaluator correctly could not resolve — Provider returns default.
+            $this->assertTrue(true);
+            return;
+        }
+
+        // error_code=0 with reason=1 means DefaultAllocationNull (no matching
+        // allocation). Same Provider-level default behavior applies.
+        $reason = isset($result['reason']) ? (int) $result['reason'] : -1;
+        if ($errorCode === 0 && $reason === 1 && $expectedValue === $defaultValue) {
+            $this->assertTrue(true);
+            return;
+        }
+
+        $actualValue = self::parseValueJson($result['value_json'], $variationType);
+
+        if ($variationType === 'NUMERIC') {
+            $this->assertEquals(
+                $expectedValue,
+                $actualValue,
+                sprintf('Value mismatch for %s#%d (flag=%s)', $fileName, $caseIndex, $flagKey),
+                1e-10
+            );
+        } else {
+            $this->assertSame(
+                $expectedValue,
+                $actualValue,
+                sprintf('Value mismatch for %s#%d (flag=%s): expected %s, got %s',
+                    $fileName, $caseIndex, $flagKey,
+                    json_encode($expectedValue), json_encode($actualValue))
+            );
+        }
+    }
+}

--- a/tests/FeatureFlags/ExposureCacheTest.php
+++ b/tests/FeatureFlags/ExposureCacheTest.php
@@ -1,0 +1,183 @@
+<?php
+
+namespace DDTrace\Tests\FeatureFlags;
+
+require_once __DIR__ . '/../../src/DDTrace/FeatureFlags/LRUCache.php';
+require_once __DIR__ . '/../../src/DDTrace/FeatureFlags/ExposureCache.php';
+
+use DDTrace\FeatureFlags\ExposureCache;
+use DDTrace\Tests\Common\BaseTestCase;
+
+/**
+ * Tests for ExposureCache, matching the canonical Java LRUExposureCacheTest.
+ */
+final class ExposureCacheTest extends BaseTestCase
+{
+    public function testAddingElements()
+    {
+        $cache = new ExposureCache(5);
+        $added = $cache->add('flag', 'subject', 'variant', 'allocation');
+
+        $this->assertTrue($added);
+        $this->assertSame(1, $cache->size());
+    }
+
+    public function testAddingDuplicateEventsReturnsFalse()
+    {
+        $cache = new ExposureCache(5);
+        $cache->add('flag', 'subject', 'variant', 'allocation');
+        $duplicateAdded = $cache->add('flag', 'subject', 'variant', 'allocation');
+
+        $this->assertFalse($duplicateAdded);
+        $this->assertSame(1, $cache->size());
+    }
+
+    public function testAddingEventsWithSameKeyButDifferentDetailsUpdatesCache()
+    {
+        $cache = new ExposureCache(5);
+        $added1 = $cache->add('flag', 'subject', 'variant1', 'allocation1');
+        $added2 = $cache->add('flag', 'subject', 'variant2', 'allocation2');
+
+        $retrieved = $cache->get('flag', 'subject');
+
+        $this->assertTrue($added1);
+        $this->assertTrue($added2);
+        $this->assertSame(1, $cache->size());
+        $this->assertSame('variant2', $retrieved[0]);
+        $this->assertSame('allocation2', $retrieved[1]);
+    }
+
+    public function testLRUEvictionWhenCapacityExceeded()
+    {
+        $cache = new ExposureCache(2);
+        $cache->add('flag1', 'subject1', 'variant1', 'allocation1');
+        $cache->add('flag2', 'subject2', 'variant2', 'allocation2');
+        $cache->add('flag3', 'subject3', 'variant3', 'allocation3');
+
+        $this->assertSame(2, $cache->size());
+        $this->assertNull($cache->get('flag1', 'subject1'), 'event1 should be evicted');
+
+        $retrieved3 = $cache->get('flag3', 'subject3');
+        $this->assertNotNull($retrieved3);
+        $this->assertSame('variant3', $retrieved3[0]);
+        $this->assertSame('allocation3', $retrieved3[1]);
+    }
+
+    public function testSingleCapacityCache()
+    {
+        $cache = new ExposureCache(1);
+        $cache->add('flag1', 'subject1', 'variant1', 'allocation1');
+        $cache->add('flag2', 'subject2', 'variant2', 'allocation2');
+
+        $this->assertSame(1, $cache->size());
+    }
+
+    public function testZeroCapacityCache()
+    {
+        $cache = new ExposureCache(0);
+        $added = $cache->add('flag', 'subject', 'variant', 'allocation');
+
+        $this->assertTrue($added);
+        $this->assertSame(0, $cache->size());
+    }
+
+    public function testEmptyCacheSize()
+    {
+        $cache = new ExposureCache(5);
+        $this->assertSame(0, $cache->size());
+    }
+
+    public function testMultipleAdditionsWithSameFlagDifferentSubjects()
+    {
+        $cache = new ExposureCache(10);
+        $results = [];
+        for ($i = 0; $i < 5; $i++) {
+            $results[] = $cache->add('flag', "subject{$i}", 'variant', 'allocation');
+        }
+
+        $this->assertSame([true, true, true, true, true], $results);
+        $this->assertSame(5, $cache->size());
+    }
+
+    public function testMultipleAdditionsWithSameSubjectDifferentFlags()
+    {
+        $cache = new ExposureCache(10);
+        $results = [];
+        for ($i = 0; $i < 5; $i++) {
+            $results[] = $cache->add("flag{$i}", 'subject', 'variant', 'allocation');
+        }
+
+        $this->assertSame([true, true, true, true, true], $results);
+        $this->assertSame(5, $cache->size());
+    }
+
+    public function testKeyEqualityWithNullValues()
+    {
+        $cache = new ExposureCache(5);
+        $cache->add('', '', 'variant', 'allocation');
+        $duplicateAdded = $cache->add('', '', 'variant', 'allocation');
+
+        $this->assertFalse($duplicateAdded);
+        $this->assertSame(1, $cache->size());
+    }
+
+    public function testUpdatingExistingKeyMaintainsLRUPosition()
+    {
+        $cache = new ExposureCache(3);
+        $cache->add('flag1', 'subject1', 'variant1', 'allocation1');
+        $cache->add('flag2', 'subject2', 'variant2', 'allocation2');
+        $cache->add('flag3', 'subject3', 'variant3', 'allocation3');
+        // Update event1 with new details — moves it to most recent
+        $cache->add('flag1', 'subject1', 'variant2', 'allocation2');
+        // Should evict event2, not event1
+        $cache->add('flag4', 'subject4', 'variant4', 'allocation4');
+
+        $this->assertSame(3, $cache->size());
+
+        $retrieved1 = $cache->get('flag1', 'subject1');
+        $this->assertNotNull($retrieved1, 'event1 should be present (was updated)');
+        $this->assertSame('variant2', $retrieved1[0]);
+        $this->assertSame('allocation2', $retrieved1[1]);
+
+        $this->assertNull($cache->get('flag2', 'subject2'), 'event2 should be evicted');
+
+        $retrieved4 = $cache->get('flag4', 'subject4');
+        $this->assertNotNull($retrieved4);
+        $this->assertSame('variant4', $retrieved4[0]);
+    }
+
+    public function testDuplicateExposureKeepsSubjectHotInLRUOrder()
+    {
+        $cache = new ExposureCache(3);
+        // Fill cache
+        $added1 = $cache->add('flag1', 'subject1', 'variant1', 'allocation1');
+        $added2 = $cache->add('flag2', 'subject2', 'variant2', 'allocation2');
+        $added3 = $cache->add('flag3', 'subject3', 'variant3', 'allocation3');
+
+        // Duplicate exposure for subject1: should NOT change size, but SHOULD bump recency
+        $duplicateAdded = $cache->add('flag1', 'subject1', 'variant1', 'allocation1');
+
+        // Now push over capacity: the LRU entry (event2) should be evicted, not event1
+        $added4 = $cache->add('flag4', 'subject4', 'variant4', 'allocation4');
+
+        $this->assertTrue($added1);
+        $this->assertTrue($added2);
+        $this->assertTrue($added3);
+        $this->assertFalse($duplicateAdded, 'exact duplicate should return false');
+        $this->assertTrue($added4);
+
+        $this->assertSame(3, $cache->size());
+
+        // Hot subject1 should still be present (duplicate bumped its recency)
+        $retrieved1 = $cache->get('flag1', 'subject1');
+        $this->assertNotNull($retrieved1, 'hot subject1 should still be present');
+        $this->assertSame('variant1', $retrieved1[0]);
+        $this->assertSame('allocation1', $retrieved1[1]);
+
+        // subject2 should be evicted (it was LRU)
+        $this->assertNull($cache->get('flag2', 'subject2'), 'subject2 should be evicted');
+
+        // Newest subject4 should be present
+        $this->assertNotNull($cache->get('flag4', 'subject4'));
+    }
+}

--- a/tests/FeatureFlags/LRUCacheTest.php
+++ b/tests/FeatureFlags/LRUCacheTest.php
@@ -1,0 +1,169 @@
+<?php
+
+namespace DDTrace\Tests\FeatureFlags;
+
+require_once __DIR__ . '/../../src/DDTrace/FeatureFlags/LRUCache.php';
+
+use DDTrace\FeatureFlags\LRUCache;
+use DDTrace\Tests\Common\BaseTestCase;
+
+final class LRUCacheTest extends BaseTestCase
+{
+    public function testGetMissReturnsNull()
+    {
+        $cache = new LRUCache(10);
+        $this->assertNull($cache->get('nonexistent'));
+    }
+
+    public function testSetAndGet()
+    {
+        $cache = new LRUCache(10);
+        $cache->set('key1', 'value1');
+        $this->assertSame('value1', $cache->get('key1'));
+    }
+
+    public function testEviction()
+    {
+        $cache = new LRUCache(3);
+        $cache->set('a', 1);
+        $cache->set('b', 2);
+        $cache->set('c', 3);
+
+        // Cache is full; inserting a 4th should evict 'a' (least recently used)
+        $cache->set('d', 4);
+
+        $this->assertNull($cache->get('a'), 'Oldest entry should be evicted');
+        $this->assertSame(2, $cache->get('b'));
+        $this->assertSame(3, $cache->get('c'));
+        $this->assertSame(4, $cache->get('d'));
+    }
+
+    public function testAccessPromotesEntry()
+    {
+        $cache = new LRUCache(3);
+        $cache->set('a', 1);
+        $cache->set('b', 2);
+        $cache->set('c', 3);
+
+        // Access 'a' to promote it — now 'b' is the least recently used
+        $cache->get('a');
+
+        $cache->set('d', 4);
+
+        $this->assertNull($cache->get('b'), "'b' should be evicted as LRU");
+        $this->assertSame(1, $cache->get('a'), "'a' should survive after promotion");
+        $this->assertSame(3, $cache->get('c'));
+        $this->assertSame(4, $cache->get('d'));
+    }
+
+    public function testUpdateExistingKey()
+    {
+        $cache = new LRUCache(3);
+        $cache->set('a', 1);
+        $cache->set('b', 2);
+        $cache->set('c', 3);
+
+        // Update 'a' — this should promote it to most recently used
+        $cache->set('a', 100);
+
+        $this->assertSame(100, $cache->get('a'), 'Value should be updated');
+
+        // Now 'b' is LRU. Adding a new entry should evict 'b'.
+        $cache->set('d', 4);
+        $this->assertNull($cache->get('b'), "'b' should be evicted");
+        $this->assertSame(100, $cache->get('a'));
+    }
+
+    public function testClear()
+    {
+        $cache = new LRUCache(10);
+        $cache->set('a', 1);
+        $cache->set('b', 2);
+        $cache->clear();
+
+        $this->assertNull($cache->get('a'));
+        $this->assertNull($cache->get('b'));
+    }
+
+    public function testEvictionOrder()
+    {
+        $cache = new LRUCache(4);
+
+        // Insert a, b, c, d in order — LRU order: a, b, c, d
+        $cache->set('a', 1);
+        $cache->set('b', 2);
+        $cache->set('c', 3);
+        $cache->set('d', 4);
+
+        // Access 'b' and 'a' — LRU order is now: c, d, b, a
+        $cache->get('b');
+        $cache->get('a');
+
+        // Insert 'e' — should evict 'c' (the LRU) — order: d, b, a, e
+        $cache->set('e', 5);
+        $this->assertNull($cache->get('c'), "'c' should be evicted first");
+
+        // Insert 'f' — should evict 'd' (now the LRU) — order: b, a, e, f
+        $cache->set('f', 6);
+        $this->assertNull($cache->get('d'), "'d' should be evicted");
+
+        // b, a, e, f should still be present
+        $this->assertSame(2, $cache->get('b'));
+        $this->assertSame(1, $cache->get('a'));
+        $this->assertSame(5, $cache->get('e'));
+        $this->assertSame(6, $cache->get('f'));
+    }
+
+    public function testSizeOneCache()
+    {
+        $cache = new LRUCache(1);
+        $cache->set('a', 1);
+        $this->assertSame(1, $cache->get('a'));
+
+        $cache->set('b', 2);
+        $this->assertNull($cache->get('a'), 'Old entry should be evicted in size-1 cache');
+        $this->assertSame(2, $cache->get('b'));
+    }
+
+    public function testPutReturnsOldValue()
+    {
+        $cache = new LRUCache(10);
+        $old1 = $cache->put('a', 1);
+        $old2 = $cache->put('a', 2);
+
+        $this->assertNull($old1, 'First put should return null');
+        $this->assertSame(1, $old2, 'Second put should return old value');
+        $this->assertSame(2, $cache->get('a'));
+    }
+
+    public function testPutPromotesLRU()
+    {
+        $cache = new LRUCache(3);
+        $cache->put('a', 1);
+        $cache->put('b', 2);
+        $cache->put('c', 3);
+
+        // put 'a' again (same value) — should promote to most recent
+        $cache->put('a', 1);
+
+        // Adding 'd' should evict 'b' (LRU), not 'a'
+        $cache->put('d', 4);
+        $this->assertNull($cache->get('b'), "'b' should be evicted");
+        $this->assertSame(1, $cache->get('a'), "'a' should survive after put promotion");
+    }
+
+    public function testSize()
+    {
+        $cache = new LRUCache(10);
+        $this->assertSame(0, $cache->size());
+
+        $cache->set('a', 1);
+        $this->assertSame(1, $cache->size());
+
+        $cache->set('b', 2);
+        $this->assertSame(2, $cache->size());
+
+        $cache->clear();
+        $this->assertSame(0, $cache->size());
+    }
+}

--- a/tests/FeatureFlags/bootstrap.php
+++ b/tests/FeatureFlags/bootstrap.php
@@ -1,0 +1,25 @@
+<?php
+
+/**
+ * Lightweight bootstrap for running FeatureFlags tests without the ddtrace extension.
+ * The main tests/phpunit.xml bootstrap requires the extension; this one doesn't.
+ * Usage: php vendor/bin/phpunit --bootstrap tests/FeatureFlags/bootstrap.php tests/FeatureFlags/LRUCacheTest.php
+ */
+
+error_reporting(E_ALL);
+
+require dirname(__DIR__, 2) . '/vendor/autoload.php';
+
+$phpunitVersionParts = explode('.', \PHPUnit\Runner\Version::id());
+define('PHPUNIT_MAJOR', intval($phpunitVersionParts[0]));
+
+if (PHPUNIT_MAJOR >= 8) {
+    require dirname(__DIR__) . '/Common/MultiPHPUnitVersionAdapter_typed.php';
+} else {
+    require dirname(__DIR__) . '/Common/MultiPHPUnitVersionAdapter_untyped.php';
+}
+
+// Stub dd_trace_internal_fn if the extension is not loaded
+if (!function_exists('dd_trace_internal_fn')) {
+    function dd_trace_internal_fn() { return false; }
+}

--- a/tests/FeatureFlags/fixtures/config/ufc-config.json
+++ b/tests/FeatureFlags/fixtures/config/ufc-config.json
@@ -1,0 +1,3353 @@
+{
+  "createdAt": "2024-04-17T19:40:53.716Z",
+  "format": "SERVER",
+  "environment": {
+    "name": "Test"
+  },
+  "flags": {
+    "empty_flag": {
+      "key": "empty_flag",
+      "enabled": true,
+      "variationType": "STRING",
+      "variations": {},
+      "allocations": []
+    },
+    "disabled_flag": {
+      "key": "disabled_flag",
+      "enabled": false,
+      "variationType": "INTEGER",
+      "variations": {},
+      "allocations": []
+    },
+    "no_allocations_flag": {
+      "key": "no_allocations_flag",
+      "enabled": true,
+      "variationType": "JSON",
+      "variations": {
+        "control": {
+          "key": "control",
+          "value": {
+            "variant": "control"
+          }
+        },
+        "treatment": {
+          "key": "treatment",
+          "value": {
+            "variant": "treatment"
+          }
+        }
+      },
+      "allocations": []
+    },
+    "numeric_flag": {
+      "key": "numeric_flag",
+      "enabled": true,
+      "variationType": "NUMERIC",
+      "variations": {
+        "e": {
+          "key": "e",
+          "value": 2.7182818
+        },
+        "pi": {
+          "key": "pi",
+          "value": 3.1415926
+        }
+      },
+      "allocations": [
+        {
+          "key": "rollout",
+          "splits": [
+            {
+              "variationKey": "pi",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        }
+      ]
+    },
+    "regex-flag": {
+      "key": "regex-flag",
+      "enabled": true,
+      "variationType": "STRING",
+      "variations": {
+        "partial-example": {
+          "key": "partial-example",
+          "value": "partial-example"
+        },
+        "test": {
+          "key": "test",
+          "value": "test"
+        }
+      },
+      "allocations": [
+        {
+          "key": "partial-example",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "email",
+                  "operator": "MATCHES",
+                  "value": "@example\\.com"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "partial-example",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "test",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "email",
+                  "operator": "MATCHES",
+                  "value": ".*@test\\.com"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "test",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        }
+      ]
+    },
+    "numeric-one-of": {
+      "key": "numeric-one-of",
+      "enabled": true,
+      "variationType": "INTEGER",
+      "variations": {
+        "1": {
+          "key": "1",
+          "value": 1
+        },
+        "2": {
+          "key": "2",
+          "value": 2
+        },
+        "3": {
+          "key": "3",
+          "value": 3
+        }
+      },
+      "allocations": [
+        {
+          "key": "1-for-1",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "number",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "1"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "1",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "2-for-123456789",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "number",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "123456789"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "2",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "3-for-not-2",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "number",
+                  "operator": "NOT_ONE_OF",
+                  "value": [
+                    "2"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "3",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        }
+      ]
+    },
+    "boolean-one-of-matches": {
+      "key": "boolean-one-of-matches",
+      "enabled": true,
+      "variationType": "INTEGER",
+      "variations": {
+        "1": {
+          "key": "1",
+          "value": 1
+        },
+        "2": {
+          "key": "2",
+          "value": 2
+        },
+        "3": {
+          "key": "3",
+          "value": 3
+        },
+        "4": {
+          "key": "4",
+          "value": 4
+        },
+        "5": {
+          "key": "5",
+          "value": 5
+        }
+      },
+      "allocations": [
+        {
+          "key": "1-for-one-of",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "one_of_flag",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "1",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "2-for-matches",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "matches_flag",
+                  "operator": "MATCHES",
+                  "value": "true"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "2",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "3-for-not-one-of",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "not_one_of_flag",
+                  "operator": "NOT_ONE_OF",
+                  "value": [
+                    "false"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "3",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "4-for-not-matches",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "not_matches_flag",
+                  "operator": "NOT_MATCHES",
+                  "value": "false"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "4",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "5-for-matches-null",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "null_flag",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "null"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "5",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        }
+      ]
+    },
+    "empty_string_flag": {
+      "key": "empty_string_flag",
+      "enabled": true,
+      "comment": "Testing the empty string as a variation value",
+      "variationType": "STRING",
+      "variations": {
+        "empty_string": {
+          "key": "empty_string",
+          "value": ""
+        },
+        "non_empty": {
+          "key": "non_empty",
+          "value": "non_empty"
+        }
+      },
+      "allocations": [
+        {
+          "key": "allocation-empty",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "country",
+                  "operator": "MATCHES",
+                  "value": "US"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "empty_string",
+              "shards": [
+                {
+                  "salt": "allocation-empty-shards",
+                  "totalShards": 10000,
+                  "ranges": [
+                    {
+                      "start": 0,
+                      "end": 10000
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test",
+          "rules": [],
+          "splits": [
+            {
+              "variationKey": "non_empty",
+              "shards": [
+                {
+                  "salt": "allocation-empty-shards",
+                  "totalShards": 10000,
+                  "ranges": [
+                    {
+                      "start": 0,
+                      "end": 10000
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "doLog": true
+        }
+      ]
+    },
+    "kill-switch": {
+      "key": "kill-switch",
+      "enabled": true,
+      "variationType": "BOOLEAN",
+      "variations": {
+        "on": {
+          "key": "on",
+          "value": true
+        },
+        "off": {
+          "key": "off",
+          "value": false
+        }
+      },
+      "allocations": [
+        {
+          "key": "on-for-NA",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "country",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "US",
+                    "Canada",
+                    "Mexico"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "on",
+              "shards": [
+                {
+                  "salt": "some-salt",
+                  "totalShards": 10000,
+                  "ranges": [
+                    {
+                      "start": 0,
+                      "end": 10000
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "on-for-age-50+",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "age",
+                  "operator": "GTE",
+                  "value": 50
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "on",
+              "shards": [
+                {
+                  "salt": "some-salt",
+                  "totalShards": 10000,
+                  "ranges": [
+                    {
+                      "start": 0,
+                      "end": 10000
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "off-for-all",
+          "rules": [],
+          "splits": [
+            {
+              "variationKey": "off",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        }
+      ]
+    },
+    "comparator-operator-test": {
+      "key": "comparator-operator-test",
+      "enabled": true,
+      "variationType": "STRING",
+      "variations": {
+        "small": {
+          "key": "small",
+          "value": "small"
+        },
+        "medium": {
+          "key": "medium",
+          "value": "medium"
+        },
+        "large": {
+          "key": "large",
+          "value": "large"
+        }
+      },
+      "allocations": [
+        {
+          "key": "small-size",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "size",
+                  "operator": "LT",
+                  "value": 10
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "small",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "medum-size",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "size",
+                  "operator": "GTE",
+                  "value": 10
+                },
+                {
+                  "attribute": "size",
+                  "operator": "LTE",
+                  "value": 20
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "medium",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "large-size",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "size",
+                  "operator": "GT",
+                  "value": 25
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "large",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        }
+      ]
+    },
+    "start-and-end-date-test": {
+      "key": "start-and-end-date-test",
+      "enabled": true,
+      "variationType": "STRING",
+      "variations": {
+        "old": {
+          "key": "old",
+          "value": "old"
+        },
+        "current": {
+          "key": "current",
+          "value": "current"
+        },
+        "new": {
+          "key": "new",
+          "value": "new"
+        }
+      },
+      "allocations": [
+        {
+          "key": "old-versions",
+          "splits": [
+            {
+              "variationKey": "old",
+              "shards": []
+            }
+          ],
+          "endAt": "2002-10-31T09:00:00.594Z",
+          "doLog": true
+        },
+        {
+          "key": "future-versions",
+          "splits": [
+            {
+              "variationKey": "new",
+              "shards": []
+            }
+          ],
+          "startAt": "2052-10-31T09:00:00.594Z",
+          "doLog": true
+        },
+        {
+          "key": "current-versions",
+          "splits": [
+            {
+              "variationKey": "current",
+              "shards": []
+            }
+          ],
+          "startAt": "2022-10-31T09:00:00.594Z",
+          "endAt": "2050-10-31T09:00:00.594Z",
+          "doLog": true
+        }
+      ]
+    },
+    "null-operator-test": {
+      "key": "null-operator-test",
+      "enabled": true,
+      "variationType": "STRING",
+      "variations": {
+        "old": {
+          "key": "old",
+          "value": "old"
+        },
+        "new": {
+          "key": "new",
+          "value": "new"
+        }
+      },
+      "allocations": [
+        {
+          "key": "null-operator",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "size",
+                  "operator": "IS_NULL",
+                  "value": true
+                }
+              ]
+            },
+            {
+              "conditions": [
+                {
+                  "attribute": "size",
+                  "operator": "LT",
+                  "value": 10
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "old",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "not-null-operator",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "size",
+                  "operator": "IS_NULL",
+                  "value": false
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "new",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        }
+      ]
+    },
+    "new-user-onboarding": {
+      "key": "new-user-onboarding",
+      "enabled": true,
+      "variationType": "STRING",
+      "variations": {
+        "control": {
+          "key": "control",
+          "value": "control"
+        },
+        "red": {
+          "key": "red",
+          "value": "red"
+        },
+        "blue": {
+          "key": "blue",
+          "value": "blue"
+        },
+        "green": {
+          "key": "green",
+          "value": "green"
+        },
+        "yellow": {
+          "key": "yellow",
+          "value": "yellow"
+        },
+        "purple": {
+          "key": "purple",
+          "value": "purple"
+        }
+      },
+      "allocations": [
+        {
+          "key": "id rule",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "id",
+                  "operator": "MATCHES",
+                  "value": "zach"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "purple",
+              "shards": []
+            }
+          ],
+          "doLog": false
+        },
+        {
+          "key": "internal users",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "email",
+                  "operator": "MATCHES",
+                  "value": "@mycompany.com"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "green",
+              "shards": []
+            }
+          ],
+          "doLog": false
+        },
+        {
+          "key": "experiment",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "country",
+                  "operator": "NOT_ONE_OF",
+                  "value": [
+                    "US",
+                    "Canada",
+                    "Mexico"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "control",
+              "shards": [
+                {
+                  "salt": "traffic-new-user-onboarding-experiment",
+                  "totalShards": 10000,
+                  "ranges": [
+                    {
+                      "start": 0,
+                      "end": 6000
+                    }
+                  ]
+                },
+                {
+                  "salt": "split-new-user-onboarding-experiment",
+                  "totalShards": 10000,
+                  "ranges": [
+                    {
+                      "start": 0,
+                      "end": 5000
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "variationKey": "red",
+              "shards": [
+                {
+                  "salt": "traffic-new-user-onboarding-experiment",
+                  "totalShards": 10000,
+                  "ranges": [
+                    {
+                      "start": 0,
+                      "end": 6000
+                    }
+                  ]
+                },
+                {
+                  "salt": "split-new-user-onboarding-experiment",
+                  "totalShards": 10000,
+                  "ranges": [
+                    {
+                      "start": 5000,
+                      "end": 8000
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "variationKey": "yellow",
+              "shards": [
+                {
+                  "salt": "traffic-new-user-onboarding-experiment",
+                  "totalShards": 10000,
+                  "ranges": [
+                    {
+                      "start": 0,
+                      "end": 6000
+                    }
+                  ]
+                },
+                {
+                  "salt": "split-new-user-onboarding-experiment",
+                  "totalShards": 10000,
+                  "ranges": [
+                    {
+                      "start": 8000,
+                      "end": 10000
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "rollout",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "country",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "US",
+                    "Canada",
+                    "Mexico"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "blue",
+              "shards": [
+                {
+                  "salt": "split-new-user-onboarding-rollout",
+                  "totalShards": 10000,
+                  "ranges": [
+                    {
+                      "start": 0,
+                      "end": 8000
+                    }
+                  ]
+                }
+              ],
+              "extraLogging": {
+                "allocationvalue_type": "rollout",
+                "owner": "hippo"
+              }
+            }
+          ],
+          "doLog": true
+        }
+      ]
+    },
+    "integer-flag": {
+      "key": "integer-flag",
+      "enabled": true,
+      "variationType": "INTEGER",
+      "variations": {
+        "one": {
+          "key": "one",
+          "value": 1
+        },
+        "two": {
+          "key": "two",
+          "value": 2
+        },
+        "three": {
+          "key": "three",
+          "value": 3
+        }
+      },
+      "allocations": [
+        {
+          "key": "targeted allocation",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "country",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "US",
+                    "Canada",
+                    "Mexico"
+                  ]
+                }
+              ]
+            },
+            {
+              "conditions": [
+                {
+                  "attribute": "email",
+                  "operator": "MATCHES",
+                  "value": ".*@example.com"
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "three",
+              "shards": [
+                {
+                  "salt": "full-range-salt",
+                  "totalShards": 10000,
+                  "ranges": [
+                    {
+                      "start": 0,
+                      "end": 10000
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "50/50 split",
+          "rules": [],
+          "splits": [
+            {
+              "variationKey": "one",
+              "shards": [
+                {
+                  "salt": "split-numeric-flag-some-allocation",
+                  "totalShards": 10000,
+                  "ranges": [
+                    {
+                      "start": 0,
+                      "end": 5000
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "variationKey": "two",
+              "shards": [
+                {
+                  "salt": "split-numeric-flag-some-allocation",
+                  "totalShards": 10000,
+                  "ranges": [
+                    {
+                      "start": 5000,
+                      "end": 10000
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "doLog": true
+        }
+      ]
+    },
+    "json-config-flag": {
+      "key": "json-config-flag",
+      "enabled": true,
+      "variationType": "JSON",
+      "variations": {
+        "one": {
+          "key": "one",
+          "value": {
+            "integer": 1,
+            "string": "one",
+            "float": 1.0
+          }
+        },
+        "two": {
+          "key": "two",
+          "value": {
+            "integer": 2,
+            "string": "two",
+            "float": 2.0
+          }
+        },
+        "empty": {
+          "key": "empty",
+          "value": {}
+        }
+      },
+      "allocations": [
+        {
+          "key": "Optionally Force Empty",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "Force Empty",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "empty",
+              "shards": [
+                {
+                  "salt": "full-range-salt",
+                  "totalShards": 10000,
+                  "ranges": [
+                    {
+                      "start": 0,
+                      "end": 10000
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "50/50 split",
+          "rules": [],
+          "splits": [
+            {
+              "variationKey": "one",
+              "shards": [
+                {
+                  "salt": "traffic-json-flag",
+                  "totalShards": 10000,
+                  "ranges": [
+                    {
+                      "start": 0,
+                      "end": 10000
+                    }
+                  ]
+                },
+                {
+                  "salt": "split-json-flag",
+                  "totalShards": 10000,
+                  "ranges": [
+                    {
+                      "start": 0,
+                      "end": 5000
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "variationKey": "two",
+              "shards": [
+                {
+                  "salt": "traffic-json-flag",
+                  "totalShards": 10000,
+                  "ranges": [
+                    {
+                      "start": 0,
+                      "end": 10000
+                    }
+                  ]
+                },
+                {
+                  "salt": "split-json-flag",
+                  "totalShards": 10000,
+                  "ranges": [
+                    {
+                      "start": 5000,
+                      "end": 10000
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "doLog": true
+        }
+      ]
+    },
+    "special-characters": {
+      "key": "special-characters",
+      "enabled": true,
+      "variationType": "JSON",
+      "variations": {
+        "de": {
+          "key": "de",
+          "value": {
+            "a": "k\u00fcmmert",
+            "b": "sch\u00f6n"
+          }
+        },
+        "ua": {
+          "key": "ua",
+          "value": {
+            "a": "\u043f\u0456\u043a\u043b\u0443\u0432\u0430\u0442\u0438\u0441\u044f",
+            "b": "\u043b\u044e\u0431\u043e\u0432"
+          }
+        },
+        "zh": {
+          "key": "zh",
+          "value": {
+            "a": "\u7167\u987e",
+            "b": "\u6f02\u4eae"
+          }
+        },
+        "emoji": {
+          "key": "emoji",
+          "value": {
+            "a": "\ud83e\udd17",
+            "b": "\ud83c\udf38"
+          }
+        }
+      },
+      "allocations": [
+        {
+          "key": "allocation-test",
+          "splits": [
+            {
+              "variationKey": "de",
+              "shards": [
+                {
+                  "salt": "split-json-flag",
+                  "totalShards": 10000,
+                  "ranges": [
+                    {
+                      "start": 0,
+                      "end": 2500
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "variationKey": "ua",
+              "shards": [
+                {
+                  "salt": "split-json-flag",
+                  "totalShards": 10000,
+                  "ranges": [
+                    {
+                      "start": 2500,
+                      "end": 5000
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "variationKey": "zh",
+              "shards": [
+                {
+                  "salt": "split-json-flag",
+                  "totalShards": 10000,
+                  "ranges": [
+                    {
+                      "start": 5000,
+                      "end": 7500
+                    }
+                  ]
+                }
+              ]
+            },
+            {
+              "variationKey": "emoji",
+              "shards": [
+                {
+                  "salt": "split-json-flag",
+                  "totalShards": 10000,
+                  "ranges": [
+                    {
+                      "start": 7500,
+                      "end": 10000
+                    }
+                  ]
+                }
+              ]
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-default",
+          "splits": [
+            {
+              "variationKey": "de",
+              "shards": []
+            }
+          ],
+          "doLog": false
+        }
+      ]
+    },
+    "string_flag_with_special_characters": {
+      "key": "string_flag_with_special_characters",
+      "enabled": true,
+      "comment": "Testing the string with special characters and spaces",
+      "variationType": "STRING",
+      "variations": {
+        "string_with_spaces": {
+          "key": "string_with_spaces",
+          "value": " a b c d e f "
+        },
+        "string_with_only_one_space": {
+          "key": "string_with_only_one_space",
+          "value": " "
+        },
+        "string_with_only_multiple_spaces": {
+          "key": "string_with_only_multiple_spaces",
+          "value": "       "
+        },
+        "string_with_dots": {
+          "key": "string_with_dots",
+          "value": ".a.b.c.d.e.f."
+        },
+        "string_with_only_one_dot": {
+          "key": "string_with_only_one_dot",
+          "value": "."
+        },
+        "string_with_only_multiple_dots": {
+          "key": "string_with_only_multiple_dots",
+          "value": "......."
+        },
+        "string_with_comas": {
+          "key": "string_with_comas",
+          "value": ",a,b,c,d,e,f,"
+        },
+        "string_with_only_one_coma": {
+          "key": "string_with_only_one_coma",
+          "value": ","
+        },
+        "string_with_only_multiple_comas": {
+          "key": "string_with_only_multiple_comas",
+          "value": ",,,,,,,"
+        },
+        "string_with_colons": {
+          "key": "string_with_colons",
+          "value": ":a:b:c:d:e:f:"
+        },
+        "string_with_only_one_colon": {
+          "key": "string_with_only_one_colon",
+          "value": ":"
+        },
+        "string_with_only_multiple_colons": {
+          "key": "string_with_only_multiple_colons",
+          "value": ":::::::"
+        },
+        "string_with_semicolons": {
+          "key": "string_with_semicolons",
+          "value": ";a;b;c;d;e;f;"
+        },
+        "string_with_only_one_semicolon": {
+          "key": "string_with_only_one_semicolon",
+          "value": ";"
+        },
+        "string_with_only_multiple_semicolons": {
+          "key": "string_with_only_multiple_semicolons",
+          "value": ";;;;;;;"
+        },
+        "string_with_slashes": {
+          "key": "string_with_slashes",
+          "value": "/a/b/c/d/e/f/"
+        },
+        "string_with_only_one_slash": {
+          "key": "string_with_only_one_slash",
+          "value": "/"
+        },
+        "string_with_only_multiple_slashes": {
+          "key": "string_with_only_multiple_slashes",
+          "value": "///////"
+        },
+        "string_with_dashes": {
+          "key": "string_with_dashes",
+          "value": "-a-b-c-d-e-f-"
+        },
+        "string_with_only_one_dash": {
+          "key": "string_with_only_one_dash",
+          "value": "-"
+        },
+        "string_with_only_multiple_dashes": {
+          "key": "string_with_only_multiple_dashes",
+          "value": "-------"
+        },
+        "string_with_underscores": {
+          "key": "string_with_underscores",
+          "value": "_a_b_c_d_e_f_"
+        },
+        "string_with_only_one_underscore": {
+          "key": "string_with_only_one_underscore",
+          "value": "_"
+        },
+        "string_with_only_multiple_underscores": {
+          "key": "string_with_only_multiple_underscores",
+          "value": "_______"
+        },
+        "string_with_plus_signs": {
+          "key": "string_with_plus_signs",
+          "value": "+a+b+c+d+e+f+"
+        },
+        "string_with_only_one_plus_sign": {
+          "key": "string_with_only_one_plus_sign",
+          "value": "+"
+        },
+        "string_with_only_multiple_plus_signs": {
+          "key": "string_with_only_multiple_plus_signs",
+          "value": "+++++++"
+        },
+        "string_with_equal_signs": {
+          "key": "string_with_equal_signs",
+          "value": "=a=b=c=d=e=f="
+        },
+        "string_with_only_one_equal_sign": {
+          "key": "string_with_only_one_equal_sign",
+          "value": "="
+        },
+        "string_with_only_multiple_equal_signs": {
+          "key": "string_with_only_multiple_equal_signs",
+          "value": "======="
+        },
+        "string_with_dollar_signs": {
+          "key": "string_with_dollar_signs",
+          "value": "$a$b$c$d$e$f$"
+        },
+        "string_with_only_one_dollar_sign": {
+          "key": "string_with_only_one_dollar_sign",
+          "value": "$"
+        },
+        "string_with_only_multiple_dollar_signs": {
+          "key": "string_with_only_multiple_dollar_signs",
+          "value": "$$$$$$$"
+        },
+        "string_with_at_signs": {
+          "key": "string_with_at_signs",
+          "value": "@a@b@c@d@e@f@"
+        },
+        "string_with_only_one_at_sign": {
+          "key": "string_with_only_one_at_sign",
+          "value": "@"
+        },
+        "string_with_only_multiple_at_signs": {
+          "key": "string_with_only_multiple_at_signs",
+          "value": "@@@@@@@"
+        },
+        "string_with_amp_signs": {
+          "key": "string_with_amp_signs",
+          "value": "&a&b&c&d&e&f&"
+        },
+        "string_with_only_one_amp_sign": {
+          "key": "string_with_only_one_amp_sign",
+          "value": "&"
+        },
+        "string_with_only_multiple_amp_signs": {
+          "key": "string_with_only_multiple_amp_signs",
+          "value": "&&&&&&&"
+        },
+        "string_with_hash_signs": {
+          "key": "string_with_hash_signs",
+          "value": "#a#b#c#d#e#f#"
+        },
+        "string_with_only_one_hash_sign": {
+          "key": "string_with_only_one_hash_sign",
+          "value": "#"
+        },
+        "string_with_only_multiple_hash_signs": {
+          "key": "string_with_only_multiple_hash_signs",
+          "value": "#######"
+        },
+        "string_with_percentage_signs": {
+          "key": "string_with_percentage_signs",
+          "value": "%a%b%c%d%e%f%"
+        },
+        "string_with_only_one_percentage_sign": {
+          "key": "string_with_only_one_percentage_sign",
+          "value": "%"
+        },
+        "string_with_only_multiple_percentage_signs": {
+          "key": "string_with_only_multiple_percentage_signs",
+          "value": "%%%%%%%"
+        },
+        "string_with_tilde_signs": {
+          "key": "string_with_tilde_signs",
+          "value": "~a~b~c~d~e~f~"
+        },
+        "string_with_only_one_tilde_sign": {
+          "key": "string_with_only_one_tilde_sign",
+          "value": "~"
+        },
+        "string_with_only_multiple_tilde_signs": {
+          "key": "string_with_only_multiple_tilde_signs",
+          "value": "~~~~~~~"
+        },
+        "string_with_asterix_signs": {
+          "key": "string_with_asterix_signs",
+          "value": "*a*b*c*d*e*f*"
+        },
+        "string_with_only_one_asterix_sign": {
+          "key": "string_with_only_one_asterix_sign",
+          "value": "*"
+        },
+        "string_with_only_multiple_asterix_signs": {
+          "key": "string_with_only_multiple_asterix_signs",
+          "value": "*******"
+        },
+        "string_with_single_quotes": {
+          "key": "string_with_single_quotes",
+          "value": "'a'b'c'd'e'f'"
+        },
+        "string_with_only_one_single_quote": {
+          "key": "string_with_only_one_single_quote",
+          "value": "'"
+        },
+        "string_with_only_multiple_single_quotes": {
+          "key": "string_with_only_multiple_single_quotes",
+          "value": "'''''''"
+        },
+        "string_with_question_marks": {
+          "key": "string_with_question_marks",
+          "value": "?a?b?c?d?e?f?"
+        },
+        "string_with_only_one_question_mark": {
+          "key": "string_with_only_one_question_mark",
+          "value": "?"
+        },
+        "string_with_only_multiple_question_marks": {
+          "key": "string_with_only_multiple_question_marks",
+          "value": "???????"
+        },
+        "string_with_exclamation_marks": {
+          "key": "string_with_exclamation_marks",
+          "value": "!a!b!c!d!e!f!"
+        },
+        "string_with_only_one_exclamation_mark": {
+          "key": "string_with_only_one_exclamation_mark",
+          "value": "!"
+        },
+        "string_with_only_multiple_exclamation_marks": {
+          "key": "string_with_only_multiple_exclamation_marks",
+          "value": "!!!!!!!"
+        },
+        "string_with_opening_parentheses": {
+          "key": "string_with_opening_parentheses",
+          "value": "(a(b(c(d(e(f("
+        },
+        "string_with_only_one_opening_parenthese": {
+          "key": "string_with_only_one_opening_parenthese",
+          "value": "("
+        },
+        "string_with_only_multiple_opening_parentheses": {
+          "key": "string_with_only_multiple_opening_parentheses",
+          "value": "((((((("
+        },
+        "string_with_closing_parentheses": {
+          "key": "string_with_closing_parentheses",
+          "value": ")a)b)c)d)e)f)"
+        },
+        "string_with_only_one_closing_parenthese": {
+          "key": "string_with_only_one_closing_parenthese",
+          "value": ")"
+        },
+        "string_with_only_multiple_closing_parentheses": {
+          "key": "string_with_only_multiple_closing_parentheses",
+          "value": ")))))))"
+        }
+      },
+      "allocations": [
+        {
+          "key": "allocation-test-string_with_spaces",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_spaces",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_spaces",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_space",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_space",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_space",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_spaces",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_spaces",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_spaces",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_dots",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_dots",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_dots",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_dot",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_dot",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_dot",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_dots",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_dots",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_dots",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_comas",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_comas",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_comas",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_coma",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_coma",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_coma",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_comas",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_comas",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_comas",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_colons",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_colons",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_colons",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_colon",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_colon",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_colon",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_colons",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_colons",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_colons",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_semicolons",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_semicolons",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_semicolons",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_semicolon",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_semicolon",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_semicolon",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_semicolons",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_semicolons",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_semicolons",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_slashes",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_slashes",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_slashes",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_slash",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_slash",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_slash",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_slashes",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_slashes",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_slashes",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_dashes",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_dashes",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_dashes",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_dash",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_dash",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_dash",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_dashes",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_dashes",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_dashes",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_underscores",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_underscores",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_underscores",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_underscore",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_underscore",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_underscore",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_underscores",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_underscores",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_underscores",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_plus_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_plus_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_plus_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_plus_sign",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_plus_sign",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_plus_sign",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_plus_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_plus_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_plus_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_equal_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_equal_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_equal_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_equal_sign",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_equal_sign",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_equal_sign",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_equal_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_equal_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_equal_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_dollar_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_dollar_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_dollar_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_dollar_sign",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_dollar_sign",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_dollar_sign",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_dollar_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_dollar_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_dollar_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_at_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_at_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_at_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_at_sign",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_at_sign",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_at_sign",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_at_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_at_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_at_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_amp_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_amp_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_amp_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_amp_sign",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_amp_sign",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_amp_sign",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_amp_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_amp_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_amp_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_hash_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_hash_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_hash_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_hash_sign",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_hash_sign",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_hash_sign",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_hash_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_hash_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_hash_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_percentage_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_percentage_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_percentage_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_percentage_sign",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_percentage_sign",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_percentage_sign",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_percentage_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_percentage_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_percentage_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_tilde_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_tilde_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_tilde_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_tilde_sign",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_tilde_sign",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_tilde_sign",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_tilde_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_tilde_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_tilde_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_asterix_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_asterix_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_asterix_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_asterix_sign",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_asterix_sign",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_asterix_sign",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_asterix_signs",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_asterix_signs",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_asterix_signs",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_single_quotes",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_single_quotes",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_single_quotes",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_single_quote",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_single_quote",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_single_quote",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_single_quotes",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_single_quotes",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_single_quotes",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_question_marks",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_question_marks",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_question_marks",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_question_mark",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_question_mark",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_question_mark",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_question_marks",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_question_marks",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_question_marks",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_exclamation_marks",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_exclamation_marks",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_exclamation_marks",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_exclamation_mark",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_exclamation_mark",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_exclamation_mark",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_exclamation_marks",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_exclamation_marks",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_exclamation_marks",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_opening_parentheses",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_opening_parentheses",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_opening_parentheses",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_opening_parenthese",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_opening_parenthese",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_opening_parenthese",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_opening_parentheses",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_opening_parentheses",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_opening_parentheses",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_closing_parentheses",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_closing_parentheses",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_closing_parentheses",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_one_closing_parenthese",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_one_closing_parenthese",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_one_closing_parenthese",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "allocation-test-string_with_only_multiple_closing_parentheses",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "string_with_only_multiple_closing_parentheses",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "string_with_only_multiple_closing_parentheses",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        }
+      ]
+    },
+    "boolean-false-assignment": {
+      "key": "boolean-false-assignment",
+      "enabled": true,
+      "variationType": "BOOLEAN",
+      "variations": {
+        "false-variation": {
+          "key": "false-variation",
+          "value": false
+        },
+        "true-variation": {
+          "key": "true-variation",
+          "value": true
+        }
+      },
+      "allocations": [
+        {
+          "key": "disable-feature",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "should_disable_feature",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "true"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "false-variation",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "enable-feature",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "should_disable_feature",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "false"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "true-variation",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        }
+      ],
+      "totalShards": 10000
+    },
+    "empty-string-variation": {
+      "key": "empty-string-variation",
+      "enabled": true,
+      "variationType": "STRING",
+      "variations": {
+        "empty-content": {
+          "key": "empty-content",
+          "value": ""
+        },
+        "detailed-content": {
+          "key": "detailed-content",
+          "value": "detailed_content"
+        }
+      },
+      "allocations": [
+        {
+          "key": "minimal-content",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "content_type",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "minimal"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "empty-content",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "full-content",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "content_type",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "full"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "detailed-content",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        }
+      ],
+      "totalShards": 10000
+    },
+    "falsy-value-assignments": {
+      "key": "falsy-value-assignments",
+      "enabled": true,
+      "variationType": "INTEGER",
+      "variations": {
+        "zero-limit": {
+          "key": "zero-limit",
+          "value": 0
+        },
+        "premium-limit": {
+          "key": "premium-limit",
+          "value": 100
+        }
+      },
+      "allocations": [
+        {
+          "key": "free-tier-limit",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "plan_tier",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "free"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "zero-limit",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        },
+        {
+          "key": "premium-tier-limit",
+          "rules": [
+            {
+              "conditions": [
+                {
+                  "attribute": "plan_tier",
+                  "operator": "ONE_OF",
+                  "value": [
+                    "premium"
+                  ]
+                }
+              ]
+            }
+          ],
+          "splits": [
+            {
+              "variationKey": "premium-limit",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        }
+      ],
+      "totalShards": 10000
+    },
+    "empty-targeting-key-flag": {
+      "key": "empty-targeting-key-flag",
+      "enabled": true,
+      "variationType": "STRING",
+      "variations": {
+        "on": {
+          "key": "on",
+          "value": "on-value"
+        },
+        "off": {
+          "key": "off",
+          "value": "off-value"
+        }
+      },
+      "allocations": [
+        {
+          "key": "default-allocation",
+          "rules": [],
+          "splits": [
+            {
+              "variationKey": "on",
+              "shards": []
+            }
+          ],
+          "doLog": true
+        }
+      ]
+    },
+    "microsecond-date-test": {
+      "key": "microsecond-date-test",
+      "enabled": true,
+      "variationType": "STRING",
+      "variations": {
+        "expired": {
+          "key": "expired",
+          "value": "expired"
+        },
+        "active": {
+          "key": "active",
+          "value": "active"
+        },
+        "future": {
+          "key": "future",
+          "value": "future"
+        }
+      },
+      "allocations": [
+        {
+          "key": "expired-allocation",
+          "splits": [
+            {
+              "variationKey": "expired",
+              "shards": []
+            }
+          ],
+          "endAt": "2002-10-31T09:00:00.594321Z",
+          "doLog": true
+        },
+        {
+          "key": "future-allocation",
+          "splits": [
+            {
+              "variationKey": "future",
+              "shards": []
+            }
+          ],
+          "startAt": "2052-10-31T09:00:00.123456Z",
+          "doLog": true
+        },
+        {
+          "key": "active-allocation",
+          "splits": [
+            {
+              "variationKey": "active",
+              "shards": []
+            }
+          ],
+          "startAt": "2022-10-31T09:00:00.235982Z",
+          "endAt": "2050-10-31T09:00:00.987654Z",
+          "doLog": true
+        }
+      ]
+    }
+  }
+}

--- a/tests/FeatureFlags/fixtures/evaluation-cases/test-case-boolean-false-assignment.json
+++ b/tests/FeatureFlags/fixtures/evaluation-cases/test-case-boolean-false-assignment.json
@@ -1,0 +1,38 @@
+[
+  {
+    "flag": "boolean-false-assignment",
+    "variationType": "BOOLEAN",
+    "defaultValue": true,
+    "targetingKey": "alice",
+    "attributes": {
+      "should_disable_feature": true
+    },
+    "result": {
+      "value": false
+    }
+  },
+  {
+    "flag": "boolean-false-assignment",
+    "variationType": "BOOLEAN",
+    "defaultValue": true,
+    "targetingKey": "bob",
+    "attributes": {
+      "should_disable_feature": false
+    },
+    "result": {
+      "value": true
+    }
+  },
+  {
+    "flag": "boolean-false-assignment",
+    "variationType": "BOOLEAN",
+    "defaultValue": true,
+    "targetingKey": "charlie",
+    "attributes": {
+      "unknown_attribute": "value"
+    },
+    "result": {
+      "value": true
+    }
+  }
+]

--- a/tests/FeatureFlags/fixtures/evaluation-cases/test-case-boolean-one-of-matches.json
+++ b/tests/FeatureFlags/fixtures/evaluation-cases/test-case-boolean-one-of-matches.json
@@ -1,0 +1,192 @@
+[
+  {
+    "flag": "boolean-one-of-matches",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "alice",
+    "attributes": {
+      "one_of_flag": true
+    },
+    "result": {
+      "value": 1
+    }
+  },
+  {
+    "flag": "boolean-one-of-matches",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "bob",
+    "attributes": {
+      "one_of_flag": false
+    },
+    "result": {
+      "value": 0
+    }
+  },
+  {
+    "flag": "boolean-one-of-matches",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "charlie",
+    "attributes": {
+      "one_of_flag": "True"
+    },
+    "result": {
+      "value": 0
+    }
+  },
+  {
+    "flag": "boolean-one-of-matches",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "derek",
+    "attributes": {
+      "matches_flag": true
+    },
+    "result": {
+      "value": 2
+    }
+  },
+  {
+    "flag": "boolean-one-of-matches",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "erica",
+    "attributes": {
+      "matches_flag": false
+    },
+    "result": {
+      "value": 0
+    }
+  },
+  {
+    "flag": "boolean-one-of-matches",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "frank",
+    "attributes": {
+      "not_matches_flag": false
+    },
+    "result": {
+      "value": 0
+    }
+  },
+  {
+    "flag": "boolean-one-of-matches",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "george",
+    "attributes": {
+      "not_matches_flag": true
+    },
+    "result": {
+      "value": 4
+    }
+  },
+  {
+    "flag": "boolean-one-of-matches",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "haley",
+    "attributes": {
+      "not_matches_flag": "False"
+    },
+    "result": {
+      "value": 4
+    }
+  },
+  {
+    "flag": "boolean-one-of-matches",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "ivy",
+    "attributes": {
+      "not_one_of_flag": true
+    },
+    "result": {
+      "value": 3
+    }
+  },
+  {
+    "flag": "boolean-one-of-matches",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "julia",
+    "attributes": {
+      "not_one_of_flag": false
+    },
+    "result": {
+      "value": 0
+    }
+  },
+  {
+    "flag": "boolean-one-of-matches",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "kim",
+    "attributes": {
+      "not_one_of_flag": "False"
+    },
+    "result": {
+      "value": 3
+    }
+  },
+  {
+    "flag": "boolean-one-of-matches",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "lucas",
+    "attributes": {
+      "not_one_of_flag": "true"
+    },
+    "result": {
+      "value": 3
+    }
+  },
+  {
+    "flag": "boolean-one-of-matches",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "mike",
+    "attributes": {
+      "not_one_of_flag": "false"
+    },
+    "result": {
+      "value": 0
+    }
+  },
+  {
+    "flag": "boolean-one-of-matches",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "nicole",
+    "attributes": {
+      "null_flag": "null"
+    },
+    "result": {
+      "value": 5
+    }
+  },
+  {
+    "flag": "boolean-one-of-matches",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "owen",
+    "attributes": {
+      "null_flag": null
+    },
+    "result": {
+      "value": 0
+    }
+  },
+  {
+    "flag": "boolean-one-of-matches",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "pete",
+    "attributes": {},
+    "result": {
+      "value": 0
+    }
+  }
+]

--- a/tests/FeatureFlags/fixtures/evaluation-cases/test-case-comparator-operator-flag.json
+++ b/tests/FeatureFlags/fixtures/evaluation-cases/test-case-comparator-operator-flag.json
@@ -1,0 +1,64 @@
+[
+  {
+    "flag": "comparator-operator-test",
+    "variationType": "STRING",
+    "defaultValue": "unknown",
+    "targetingKey": "alice",
+    "attributes": {
+      "size": 5,
+      "country": "US"
+    },
+    "result": {
+      "value": "small"
+    }
+  },
+  {
+    "flag": "comparator-operator-test",
+    "variationType": "STRING",
+    "defaultValue": "unknown",
+    "targetingKey": "bob",
+    "attributes": {
+      "size": 10,
+      "country": "Canada"
+    },
+    "result": {
+      "value": "medium"
+    }
+  },
+  {
+    "flag": "comparator-operator-test",
+    "variationType": "STRING",
+    "defaultValue": "unknown",
+    "targetingKey": "charlie",
+    "attributes": {
+      "size": 25
+    },
+    "result": {
+      "value": "unknown"
+    }
+  },
+  {
+    "flag": "comparator-operator-test",
+    "variationType": "STRING",
+    "defaultValue": "unknown",
+    "targetingKey": "david",
+    "attributes": {
+      "size": 26
+    },
+    "result": {
+      "value": "large"
+    }
+  },
+  {
+    "flag": "comparator-operator-test",
+    "variationType": "STRING",
+    "defaultValue": "unknown",
+    "targetingKey": "elize",
+    "attributes": {
+      "country": "UK"
+    },
+    "result": {
+      "value": "unknown"
+    }
+  }
+]

--- a/tests/FeatureFlags/fixtures/evaluation-cases/test-case-disabled-flag.json
+++ b/tests/FeatureFlags/fixtures/evaluation-cases/test-case-disabled-flag.json
@@ -1,0 +1,40 @@
+[
+  {
+    "flag": "disabled_flag",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "alice",
+    "attributes": {
+      "email": "alice@mycompany.com",
+      "country": "US"
+    },
+    "result": {
+      "value": 0
+    }
+  },
+  {
+    "flag": "disabled_flag",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "bob",
+    "attributes": {
+      "email": "bob@example.com",
+      "country": "Canada"
+    },
+    "result": {
+      "value": 0
+    }
+  },
+  {
+    "flag": "disabled_flag",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "charlie",
+    "attributes": {
+      "age": 50
+    },
+    "result": {
+      "value": 0
+    }
+  }
+]

--- a/tests/FeatureFlags/fixtures/evaluation-cases/test-case-empty-flag.json
+++ b/tests/FeatureFlags/fixtures/evaluation-cases/test-case-empty-flag.json
@@ -1,0 +1,40 @@
+[
+  {
+    "flag": "empty_flag",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "alice",
+    "attributes": {
+      "email": "alice@mycompany.com",
+      "country": "US"
+    },
+    "result": {
+      "value": "default_value"
+    }
+  },
+  {
+    "flag": "empty_flag",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "bob",
+    "attributes": {
+      "email": "bob@example.com",
+      "country": "Canada"
+    },
+    "result": {
+      "value": "default_value"
+    }
+  },
+  {
+    "flag": "empty_flag",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "charlie",
+    "attributes": {
+      "age": 50
+    },
+    "result": {
+      "value": "default_value"
+    }
+  }
+]

--- a/tests/FeatureFlags/fixtures/evaluation-cases/test-case-empty-string-variation.json
+++ b/tests/FeatureFlags/fixtures/evaluation-cases/test-case-empty-string-variation.json
@@ -1,0 +1,38 @@
+[
+  {
+    "flag": "empty-string-variation",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "empty_user",
+    "attributes": {
+      "content_type": "minimal"
+    },
+    "result": {
+      "value": ""
+    }
+  },
+  {
+    "flag": "empty-string-variation",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "full_user",
+    "attributes": {
+      "content_type": "full"
+    },
+    "result": {
+      "value": "detailed_content"
+    }
+  },
+  {
+    "flag": "empty-string-variation",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "default_user",
+    "attributes": {
+      "content_type": "unknown"
+    },
+    "result": {
+      "value": "default_value"
+    }
+  }
+]

--- a/tests/FeatureFlags/fixtures/evaluation-cases/test-case-falsy-value-assignments.json
+++ b/tests/FeatureFlags/fixtures/evaluation-cases/test-case-falsy-value-assignments.json
@@ -1,0 +1,38 @@
+[
+  {
+    "flag": "falsy-value-assignments",
+    "variationType": "INTEGER",
+    "defaultValue": 999,
+    "targetingKey": "zero_user",
+    "attributes": {
+      "plan_tier": "free"
+    },
+    "result": {
+      "value": 0
+    }
+  },
+  {
+    "flag": "falsy-value-assignments",
+    "variationType": "INTEGER",
+    "defaultValue": 999,
+    "targetingKey": "premium_user",
+    "attributes": {
+      "plan_tier": "premium"
+    },
+    "result": {
+      "value": 100
+    }
+  },
+  {
+    "flag": "falsy-value-assignments",
+    "variationType": "INTEGER",
+    "defaultValue": 999,
+    "targetingKey": "unknown_user",
+    "attributes": {
+      "plan_tier": "trial"
+    },
+    "result": {
+      "value": 999
+    }
+  }
+]

--- a/tests/FeatureFlags/fixtures/evaluation-cases/test-case-flag-with-empty-string.json
+++ b/tests/FeatureFlags/fixtures/evaluation-cases/test-case-flag-with-empty-string.json
@@ -1,0 +1,24 @@
+[
+  {
+    "flag": "empty_string_flag",
+    "variationType": "STRING",
+    "defaultValue": "default",
+    "targetingKey": "alice",
+    "attributes": {
+      "country": "US"
+    },
+    "result": {
+      "value": ""
+    }
+  },
+  {
+    "flag": "empty_string_flag",
+    "variationType": "STRING",
+    "defaultValue": "default",
+    "targetingKey": "bob",
+    "attributes": {},
+    "result": {
+      "value": "non_empty"
+    }
+  }
+]

--- a/tests/FeatureFlags/fixtures/evaluation-cases/test-case-integer-flag.json
+++ b/tests/FeatureFlags/fixtures/evaluation-cases/test-case-integer-flag.json
@@ -1,0 +1,244 @@
+[
+  {
+    "flag": "integer-flag",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "alice",
+    "attributes": {
+      "email": "alice@mycompany.com",
+      "country": "US"
+    },
+    "result": {
+      "value": 3
+    }
+  },
+  {
+    "flag": "integer-flag",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "bob",
+    "attributes": {
+      "email": "bob@example.com",
+      "country": "Canada"
+    },
+    "result": {
+      "value": 3
+    }
+  },
+  {
+    "flag": "integer-flag",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "charlie",
+    "attributes": {
+      "age": 50
+    },
+    "result": {
+      "value": 2
+    }
+  },
+  {
+    "flag": "integer-flag",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "debra",
+    "attributes": {
+      "email": "test@test.com",
+      "country": "Mexico",
+      "age": 25
+    },
+    "result": {
+      "value": 3
+    }
+  },
+  {
+    "flag": "integer-flag",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "1",
+    "attributes": {},
+    "result": {
+      "value": 2
+    }
+  },
+  {
+    "flag": "integer-flag",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "2",
+    "attributes": {},
+    "result": {
+      "value": 2
+    }
+  },
+  {
+    "flag": "integer-flag",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "3",
+    "attributes": {},
+    "result": {
+      "value": 2
+    }
+  },
+  {
+    "flag": "integer-flag",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "4",
+    "attributes": {},
+    "result": {
+      "value": 2
+    }
+  },
+  {
+    "flag": "integer-flag",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "5",
+    "attributes": {},
+    "result": {
+      "value": 1
+    }
+  },
+  {
+    "flag": "integer-flag",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "6",
+    "attributes": {},
+    "result": {
+      "value": 2
+    }
+  },
+  {
+    "flag": "integer-flag",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "7",
+    "attributes": {},
+    "result": {
+      "value": 1
+    }
+  },
+  {
+    "flag": "integer-flag",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "8",
+    "attributes": {},
+    "result": {
+      "value": 1
+    }
+  },
+  {
+    "flag": "integer-flag",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "9",
+    "attributes": {},
+    "result": {
+      "value": 2
+    }
+  },
+  {
+    "flag": "integer-flag",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "10",
+    "attributes": {},
+    "result": {
+      "value": 2
+    }
+  },
+  {
+    "flag": "integer-flag",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "11",
+    "attributes": {},
+    "result": {
+      "value": 1
+    }
+  },
+  {
+    "flag": "integer-flag",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "12",
+    "attributes": {},
+    "result": {
+      "value": 1
+    }
+  },
+  {
+    "flag": "integer-flag",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "13",
+    "attributes": {},
+    "result": {
+      "value": 2
+    }
+  },
+  {
+    "flag": "integer-flag",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "14",
+    "attributes": {},
+    "result": {
+      "value": 1
+    }
+  },
+  {
+    "flag": "integer-flag",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "15",
+    "attributes": {},
+    "result": {
+      "value": 2
+    }
+  },
+  {
+    "flag": "integer-flag",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "16",
+    "attributes": {},
+    "result": {
+      "value": 2
+    }
+  },
+  {
+    "flag": "integer-flag",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "17",
+    "attributes": {},
+    "result": {
+      "value": 1
+    }
+  },
+  {
+    "flag": "integer-flag",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "18",
+    "attributes": {},
+    "result": {
+      "value": 1
+    }
+  },
+  {
+    "flag": "integer-flag",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "19",
+    "attributes": {},
+    "result": {
+      "value": 1
+    }
+  }
+]

--- a/tests/FeatureFlags/fixtures/evaluation-cases/test-case-kill-switch-flag.json
+++ b/tests/FeatureFlags/fixtures/evaluation-cases/test-case-kill-switch-flag.json
@@ -1,0 +1,290 @@
+[
+  {
+    "flag": "kill-switch",
+    "variationType": "BOOLEAN",
+    "defaultValue": false,
+    "targetingKey": "alice",
+    "attributes": {
+      "email": "alice@mycompany.com",
+      "country": "US"
+    },
+    "result": {
+      "value": true
+    }
+  },
+  {
+    "flag": "kill-switch",
+    "variationType": "BOOLEAN",
+    "defaultValue": false,
+    "targetingKey": "bob",
+    "attributes": {
+      "email": "bob@example.com",
+      "country": "Canada"
+    },
+    "result": {
+      "value": true
+    }
+  },
+  {
+    "flag": "kill-switch",
+    "variationType": "BOOLEAN",
+    "defaultValue": false,
+    "targetingKey": "barbara",
+    "attributes": {
+      "email": "barbara@example.com",
+      "country": "canada"
+    },
+    "result": {
+      "value": false
+    }
+  },
+  {
+    "flag": "kill-switch",
+    "variationType": "BOOLEAN",
+    "defaultValue": false,
+    "targetingKey": "charlie",
+    "attributes": {
+      "age": 40
+    },
+    "result": {
+      "value": false
+    }
+  },
+  {
+    "flag": "kill-switch",
+    "variationType": "BOOLEAN",
+    "defaultValue": false,
+    "targetingKey": "debra",
+    "attributes": {
+      "email": "test@test.com",
+      "country": "Mexico",
+      "age": 25
+    },
+    "result": {
+      "value": true
+    }
+  },
+  {
+    "flag": "kill-switch",
+    "variationType": "BOOLEAN",
+    "defaultValue": false,
+    "targetingKey": "1",
+    "attributes": {},
+    "result": {
+      "value": false
+    }
+  },
+  {
+    "flag": "kill-switch",
+    "variationType": "BOOLEAN",
+    "defaultValue": false,
+    "targetingKey": "2",
+    "attributes": {
+      "country": "Mexico"
+    },
+    "result": {
+      "value": true
+    }
+  },
+  {
+    "flag": "kill-switch",
+    "variationType": "BOOLEAN",
+    "defaultValue": false,
+    "targetingKey": "3",
+    "attributes": {
+      "country": "UK",
+      "age": 50
+    },
+    "result": {
+      "value": true
+    }
+  },
+  {
+    "flag": "kill-switch",
+    "variationType": "BOOLEAN",
+    "defaultValue": false,
+    "targetingKey": "4",
+    "attributes": {
+      "country": "Germany"
+    },
+    "result": {
+      "value": false
+    }
+  },
+  {
+    "flag": "kill-switch",
+    "variationType": "BOOLEAN",
+    "defaultValue": false,
+    "targetingKey": "5",
+    "attributes": {
+      "country": "Germany"
+    },
+    "result": {
+      "value": false
+    }
+  },
+  {
+    "flag": "kill-switch",
+    "variationType": "BOOLEAN",
+    "defaultValue": false,
+    "targetingKey": "6",
+    "attributes": {
+      "country": "Germany"
+    },
+    "result": {
+      "value": false
+    }
+  },
+  {
+    "flag": "kill-switch",
+    "variationType": "BOOLEAN",
+    "defaultValue": false,
+    "targetingKey": "7",
+    "attributes": {
+      "country": "US",
+      "age": 12
+    },
+    "result": {
+      "value": true
+    }
+  },
+  {
+    "flag": "kill-switch",
+    "variationType": "BOOLEAN",
+    "defaultValue": false,
+    "targetingKey": "8",
+    "attributes": {
+      "country": "Italy",
+      "age": 60
+    },
+    "result": {
+      "value": true
+    }
+  },
+  {
+    "flag": "kill-switch",
+    "variationType": "BOOLEAN",
+    "defaultValue": false,
+    "targetingKey": "9",
+    "attributes": {
+      "email": "email@email.com"
+    },
+    "result": {
+      "value": false
+    }
+  },
+  {
+    "flag": "kill-switch",
+    "variationType": "BOOLEAN",
+    "defaultValue": false,
+    "targetingKey": "10",
+    "attributes": {},
+    "result": {
+      "value": false
+    }
+  },
+  {
+    "flag": "kill-switch",
+    "variationType": "BOOLEAN",
+    "defaultValue": false,
+    "targetingKey": "11",
+    "attributes": {},
+    "result": {
+      "value": false
+    }
+  },
+  {
+    "flag": "kill-switch",
+    "variationType": "BOOLEAN",
+    "defaultValue": false,
+    "targetingKey": "12",
+    "attributes": {
+      "country": "US"
+    },
+    "result": {
+      "value": true
+    }
+  },
+  {
+    "flag": "kill-switch",
+    "variationType": "BOOLEAN",
+    "defaultValue": false,
+    "targetingKey": "13",
+    "attributes": {
+      "country": "Canada"
+    },
+    "result": {
+      "value": true
+    }
+  },
+  {
+    "flag": "kill-switch",
+    "variationType": "BOOLEAN",
+    "defaultValue": false,
+    "targetingKey": "14",
+    "attributes": {},
+    "result": {
+      "value": false
+    }
+  },
+  {
+    "flag": "kill-switch",
+    "variationType": "BOOLEAN",
+    "defaultValue": false,
+    "targetingKey": "15",
+    "attributes": {
+      "country": "Denmark"
+    },
+    "result": {
+      "value": false
+    }
+  },
+  {
+    "flag": "kill-switch",
+    "variationType": "BOOLEAN",
+    "defaultValue": false,
+    "targetingKey": "16",
+    "attributes": {
+      "country": "Norway"
+    },
+    "result": {
+      "value": false
+    }
+  },
+  {
+    "flag": "kill-switch",
+    "variationType": "BOOLEAN",
+    "defaultValue": false,
+    "targetingKey": "17",
+    "attributes": {
+      "country": "UK"
+    },
+    "result": {
+      "value": false
+    }
+  },
+  {
+    "flag": "kill-switch",
+    "variationType": "BOOLEAN",
+    "defaultValue": false,
+    "targetingKey": "18",
+    "attributes": {
+      "country": "UK"
+    },
+    "result": {
+      "value": false
+    }
+  },
+  {
+    "flag": "kill-switch",
+    "variationType": "BOOLEAN",
+    "defaultValue": false,
+    "targetingKey": "19",
+    "attributes": {
+      "country": "UK"
+    },
+    "result": {
+      "value": false
+    }
+  }
+]

--- a/tests/FeatureFlags/fixtures/evaluation-cases/test-case-microsecond-date-flag.json
+++ b/tests/FeatureFlags/fixtures/evaluation-cases/test-case-microsecond-date-flag.json
@@ -1,0 +1,36 @@
+[
+  {
+    "flag": "microsecond-date-test",
+    "variationType": "STRING",
+    "defaultValue": "unknown",
+    "targetingKey": "alice",
+    "attributes": {},
+    "result": {
+      "value": "active"
+    }
+  },
+  {
+    "flag": "microsecond-date-test",
+    "variationType": "STRING",
+    "defaultValue": "unknown",
+    "targetingKey": "bob",
+    "attributes": {
+      "country": "US"
+    },
+    "result": {
+      "value": "active"
+    }
+  },
+  {
+    "flag": "microsecond-date-test",
+    "variationType": "STRING",
+    "defaultValue": "unknown",
+    "targetingKey": "charlie",
+    "attributes": {
+      "version": "1.0.0"
+    },
+    "result": {
+      "value": "active"
+    }
+  }
+]

--- a/tests/FeatureFlags/fixtures/evaluation-cases/test-case-new-user-onboarding-flag.json
+++ b/tests/FeatureFlags/fixtures/evaluation-cases/test-case-new-user-onboarding-flag.json
@@ -1,0 +1,318 @@
+[
+  {
+    "flag": "new-user-onboarding",
+    "variationType": "STRING",
+    "defaultValue": "default",
+    "targetingKey": "alice",
+    "attributes": {
+      "email": "alice@mycompany.com",
+      "country": "US"
+    },
+    "result": {
+      "value": "green"
+    }
+  },
+  {
+    "flag": "new-user-onboarding",
+    "variationType": "STRING",
+    "defaultValue": "default",
+    "targetingKey": "bob",
+    "attributes": {
+      "email": "bob@example.com",
+      "country": "Canada"
+    },
+    "result": {
+      "value": "default"
+    }
+  },
+  {
+    "flag": "new-user-onboarding",
+    "variationType": "STRING",
+    "defaultValue": "default",
+    "targetingKey": "charlie",
+    "attributes": {
+      "age": 50
+    },
+    "result": {
+      "value": "default"
+    }
+  },
+  {
+    "flag": "new-user-onboarding",
+    "variationType": "STRING",
+    "defaultValue": "default",
+    "targetingKey": "debra",
+    "attributes": {
+      "email": "test@test.com",
+      "country": "Mexico",
+      "age": 25
+    },
+    "result": {
+      "value": "blue"
+    }
+  },
+  {
+    "flag": "new-user-onboarding",
+    "variationType": "STRING",
+    "defaultValue": "default",
+    "targetingKey": "zach",
+    "attributes": {
+      "email": "test@test.com",
+      "country": "Mexico",
+      "age": 25
+    },
+    "result": {
+      "value": "purple"
+    }
+  },
+  {
+    "flag": "new-user-onboarding",
+    "variationType": "STRING",
+    "defaultValue": "default",
+    "targetingKey": "zach",
+    "attributes": {
+      "id": "override-id",
+      "email": "test@test.com",
+      "country": "Mexico",
+      "age": 25
+    },
+    "result": {
+      "value": "blue"
+    }
+  },
+  {
+    "flag": "new-user-onboarding",
+    "variationType": "STRING",
+    "defaultValue": "default",
+    "targetingKey": "Zach",
+    "attributes": {
+      "email": "test@test.com",
+      "country": "Mexico",
+      "age": 25
+    },
+    "result": {
+      "value": "default"
+    }
+  },
+  {
+    "flag": "new-user-onboarding",
+    "variationType": "STRING",
+    "defaultValue": "default",
+    "targetingKey": "1",
+    "attributes": {},
+    "result": {
+      "value": "default"
+    }
+  },
+  {
+    "flag": "new-user-onboarding",
+    "variationType": "STRING",
+    "defaultValue": "default",
+    "targetingKey": "2",
+    "attributes": {
+      "country": "Mexico"
+    },
+    "result": {
+      "value": "blue"
+    }
+  },
+  {
+    "flag": "new-user-onboarding",
+    "variationType": "STRING",
+    "defaultValue": "default",
+    "targetingKey": "3",
+    "attributes": {
+      "country": "UK",
+      "age": 33
+    },
+    "result": {
+      "value": "control"
+    }
+  },
+  {
+    "flag": "new-user-onboarding",
+    "variationType": "STRING",
+    "defaultValue": "default",
+    "targetingKey": "4",
+    "attributes": {
+      "country": "Germany"
+    },
+    "result": {
+      "value": "red"
+    }
+  },
+  {
+    "flag": "new-user-onboarding",
+    "variationType": "STRING",
+    "defaultValue": "default",
+    "targetingKey": "5",
+    "attributes": {
+      "country": "Germany"
+    },
+    "result": {
+      "value": "yellow"
+    }
+  },
+  {
+    "flag": "new-user-onboarding",
+    "variationType": "STRING",
+    "defaultValue": "default",
+    "targetingKey": "6",
+    "attributes": {
+      "country": "Germany"
+    },
+    "result": {
+      "value": "yellow"
+    }
+  },
+  {
+    "flag": "new-user-onboarding",
+    "variationType": "STRING",
+    "defaultValue": "default",
+    "targetingKey": "7",
+    "attributes": {
+      "country": "US"
+    },
+    "result": {
+      "value": "blue"
+    }
+  },
+  {
+    "flag": "new-user-onboarding",
+    "variationType": "STRING",
+    "defaultValue": "default",
+    "targetingKey": "8",
+    "attributes": {
+      "country": "Italy"
+    },
+    "result": {
+      "value": "red"
+    }
+  },
+  {
+    "flag": "new-user-onboarding",
+    "variationType": "STRING",
+    "defaultValue": "default",
+    "targetingKey": "9",
+    "attributes": {
+      "email": "email@email.com"
+    },
+    "result": {
+      "value": "default"
+    }
+  },
+  {
+    "flag": "new-user-onboarding",
+    "variationType": "STRING",
+    "defaultValue": "default",
+    "targetingKey": "10",
+    "attributes": {},
+    "result": {
+      "value": "default"
+    }
+  },
+  {
+    "flag": "new-user-onboarding",
+    "variationType": "STRING",
+    "defaultValue": "default",
+    "targetingKey": "11",
+    "attributes": {},
+    "result": {
+      "value": "default"
+    }
+  },
+  {
+    "flag": "new-user-onboarding",
+    "variationType": "STRING",
+    "defaultValue": "default",
+    "targetingKey": "12",
+    "attributes": {
+      "country": "US"
+    },
+    "result": {
+      "value": "blue"
+    }
+  },
+  {
+    "flag": "new-user-onboarding",
+    "variationType": "STRING",
+    "defaultValue": "default",
+    "targetingKey": "13",
+    "attributes": {
+      "country": "Canada"
+    },
+    "result": {
+      "value": "blue"
+    }
+  },
+  {
+    "flag": "new-user-onboarding",
+    "variationType": "STRING",
+    "defaultValue": "default",
+    "targetingKey": "14",
+    "attributes": {},
+    "result": {
+      "value": "default"
+    }
+  },
+  {
+    "flag": "new-user-onboarding",
+    "variationType": "STRING",
+    "defaultValue": "default",
+    "targetingKey": "15",
+    "attributes": {
+      "country": "Denmark"
+    },
+    "result": {
+      "value": "yellow"
+    }
+  },
+  {
+    "flag": "new-user-onboarding",
+    "variationType": "STRING",
+    "defaultValue": "default",
+    "targetingKey": "16",
+    "attributes": {
+      "country": "Norway"
+    },
+    "result": {
+      "value": "control"
+    }
+  },
+  {
+    "flag": "new-user-onboarding",
+    "variationType": "STRING",
+    "defaultValue": "default",
+    "targetingKey": "17",
+    "attributes": {
+      "country": "UK"
+    },
+    "result": {
+      "value": "control"
+    }
+  },
+  {
+    "flag": "new-user-onboarding",
+    "variationType": "STRING",
+    "defaultValue": "default",
+    "targetingKey": "18",
+    "attributes": {
+      "country": "UK"
+    },
+    "result": {
+      "value": "default"
+    }
+  },
+  {
+    "flag": "new-user-onboarding",
+    "variationType": "STRING",
+    "defaultValue": "default",
+    "targetingKey": "19",
+    "attributes": {
+      "country": "UK"
+    },
+    "result": {
+      "value": "red"
+    }
+  }
+]

--- a/tests/FeatureFlags/fixtures/evaluation-cases/test-case-no-allocations-flag.json
+++ b/tests/FeatureFlags/fixtures/evaluation-cases/test-case-no-allocations-flag.json
@@ -1,0 +1,52 @@
+[
+  {
+    "flag": "no_allocations_flag",
+    "variationType": "JSON",
+    "defaultValue": {
+      "hello": "world"
+    },
+    "targetingKey": "alice",
+    "attributes": {
+      "email": "alice@mycompany.com",
+      "country": "US"
+    },
+    "result": {
+      "value": {
+        "hello": "world"
+      }
+    }
+  },
+  {
+    "flag": "no_allocations_flag",
+    "variationType": "JSON",
+    "defaultValue": {
+      "hello": "world"
+    },
+    "targetingKey": "bob",
+    "attributes": {
+      "email": "bob@example.com",
+      "country": "Canada"
+    },
+    "result": {
+      "value": {
+        "hello": "world"
+      }
+    }
+  },
+  {
+    "flag": "no_allocations_flag",
+    "variationType": "JSON",
+    "defaultValue": {
+      "hello": "world"
+    },
+    "targetingKey": "charlie",
+    "attributes": {
+      "age": 50
+    },
+    "result": {
+      "value": {
+        "hello": "world"
+      }
+    }
+  }
+]

--- a/tests/FeatureFlags/fixtures/evaluation-cases/test-case-null-operator-flag.json
+++ b/tests/FeatureFlags/fixtures/evaluation-cases/test-case-null-operator-flag.json
@@ -1,0 +1,64 @@
+[
+  {
+    "flag": "null-operator-test",
+    "variationType": "STRING",
+    "defaultValue": "default-null",
+    "targetingKey": "alice",
+    "attributes": {
+      "size": 5,
+      "country": "US"
+    },
+    "result": {
+      "value": "old"
+    }
+  },
+  {
+    "flag": "null-operator-test",
+    "variationType": "STRING",
+    "defaultValue": "default-null",
+    "targetingKey": "bob",
+    "attributes": {
+      "size": 10,
+      "country": "Canada"
+    },
+    "result": {
+      "value": "new"
+    }
+  },
+  {
+    "flag": "null-operator-test",
+    "variationType": "STRING",
+    "defaultValue": "default-null",
+    "targetingKey": "charlie",
+    "attributes": {
+      "size": null
+    },
+    "result": {
+      "value": "old"
+    }
+  },
+  {
+    "flag": "null-operator-test",
+    "variationType": "STRING",
+    "defaultValue": "default-null",
+    "targetingKey": "david",
+    "attributes": {
+      "size": 26
+    },
+    "result": {
+      "value": "new"
+    }
+  },
+  {
+    "flag": "null-operator-test",
+    "variationType": "STRING",
+    "defaultValue": "default-null",
+    "targetingKey": "elize",
+    "attributes": {
+      "country": "UK"
+    },
+    "result": {
+      "value": "old"
+    }
+  }
+]

--- a/tests/FeatureFlags/fixtures/evaluation-cases/test-case-numeric-flag.json
+++ b/tests/FeatureFlags/fixtures/evaluation-cases/test-case-numeric-flag.json
@@ -1,0 +1,40 @@
+[
+  {
+    "flag": "numeric_flag",
+    "variationType": "NUMERIC",
+    "defaultValue": 0.0,
+    "targetingKey": "alice",
+    "attributes": {
+      "email": "alice@mycompany.com",
+      "country": "US"
+    },
+    "result": {
+      "value": 3.1415926
+    }
+  },
+  {
+    "flag": "numeric_flag",
+    "variationType": "NUMERIC",
+    "defaultValue": 0.0,
+    "targetingKey": "bob",
+    "attributes": {
+      "email": "bob@example.com",
+      "country": "Canada"
+    },
+    "result": {
+      "value": 3.1415926
+    }
+  },
+  {
+    "flag": "numeric_flag",
+    "variationType": "NUMERIC",
+    "defaultValue": 0.0,
+    "targetingKey": "charlie",
+    "attributes": {
+      "age": 50
+    },
+    "result": {
+      "value": 3.1415926
+    }
+  }
+]

--- a/tests/FeatureFlags/fixtures/evaluation-cases/test-case-numeric-one-of.json
+++ b/tests/FeatureFlags/fixtures/evaluation-cases/test-case-numeric-one-of.json
@@ -1,0 +1,86 @@
+[
+  {
+    "flag": "numeric-one-of",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "alice",
+    "attributes": {
+      "number": 1
+    },
+    "result": {
+      "value": 1
+    }
+  },
+  {
+    "flag": "numeric-one-of",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "bob",
+    "attributes": {
+      "number": 2
+    },
+    "result": {
+      "value": 0
+    }
+  },
+  {
+    "flag": "numeric-one-of",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "charlie",
+    "attributes": {
+      "number": 3
+    },
+    "result": {
+      "value": 3
+    }
+  },
+  {
+    "flag": "numeric-one-of",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "derek",
+    "attributes": {
+      "number": 4
+    },
+    "result": {
+      "value": 3
+    }
+  },
+  {
+    "flag": "numeric-one-of",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "erica",
+    "attributes": {
+      "number": "1"
+    },
+    "result": {
+      "value": 1
+    }
+  },
+  {
+    "flag": "numeric-one-of",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "frank",
+    "attributes": {
+      "number": 1
+    },
+    "result": {
+      "value": 1
+    }
+  },
+  {
+    "flag": "numeric-one-of",
+    "variationType": "INTEGER",
+    "defaultValue": 0,
+    "targetingKey": "george",
+    "attributes": {
+      "number": 123456789
+    },
+    "result": {
+      "value": 2
+    }
+  }
+]

--- a/tests/FeatureFlags/fixtures/evaluation-cases/test-case-of-7-empty-targeting-key.json
+++ b/tests/FeatureFlags/fixtures/evaluation-cases/test-case-of-7-empty-targeting-key.json
@@ -1,0 +1,12 @@
+[
+  {
+    "flag": "empty-targeting-key-flag",
+    "variationType": "STRING",
+    "defaultValue": "default",
+    "targetingKey": "",
+    "attributes": {},
+    "result": {
+      "value": "on-value"
+    }
+  }
+]

--- a/tests/FeatureFlags/fixtures/evaluation-cases/test-case-regex-flag.json
+++ b/tests/FeatureFlags/fixtures/evaluation-cases/test-case-regex-flag.json
@@ -1,0 +1,53 @@
+[
+  {
+    "flag": "regex-flag",
+    "variationType": "STRING",
+    "defaultValue": "none",
+    "targetingKey": "alice",
+    "attributes": {
+      "version": "1.15.0",
+      "email": "alice@example.com"
+    },
+    "result": {
+      "value": "partial-example"
+    }
+  },
+  {
+    "flag": "regex-flag",
+    "variationType": "STRING",
+    "defaultValue": "none",
+    "targetingKey": "bob",
+    "attributes": {
+      "version": "0.20.1",
+      "email": "bob@test.com"
+    },
+    "result": {
+      "value": "test"
+    }
+  },
+  {
+    "flag": "regex-flag",
+    "variationType": "STRING",
+    "defaultValue": "none",
+    "targetingKey": "charlie",
+    "attributes": {
+      "version": "2.1.13"
+    },
+    "result": {
+      "value": "none"
+    }
+  },
+  {
+    "flag": "regex-flag",
+    "variationType": "STRING",
+    "defaultValue": "none",
+    "targetingKey": "derek",
+    "attributes": {
+      "version": "2.1.13",
+      "email": "derek@gmail.com"
+    },
+    "result": {
+      "value": "none"
+    }
+  }
+]

--- a/tests/FeatureFlags/fixtures/evaluation-cases/test-case-start-and-end-date-flag.json
+++ b/tests/FeatureFlags/fixtures/evaluation-cases/test-case-start-and-end-date-flag.json
@@ -1,0 +1,40 @@
+[
+  {
+    "flag": "start-and-end-date-test",
+    "variationType": "STRING",
+    "defaultValue": "unknown",
+    "targetingKey": "alice",
+    "attributes": {
+      "version": "1.15.0",
+      "country": "US"
+    },
+    "result": {
+      "value": "current"
+    }
+  },
+  {
+    "flag": "start-and-end-date-test",
+    "variationType": "STRING",
+    "defaultValue": "unknown",
+    "targetingKey": "bob",
+    "attributes": {
+      "version": "0.20.1",
+      "country": "Canada"
+    },
+    "result": {
+      "value": "current"
+    }
+  },
+  {
+    "flag": "start-and-end-date-test",
+    "variationType": "STRING",
+    "defaultValue": "unknown",
+    "targetingKey": "charlie",
+    "attributes": {
+      "version": "2.1.13"
+    },
+    "result": {
+      "value": "current"
+    }
+  }
+]

--- a/tests/FeatureFlags/fixtures/evaluation-cases/test-flag-that-does-not-exist.json
+++ b/tests/FeatureFlags/fixtures/evaluation-cases/test-flag-that-does-not-exist.json
@@ -1,0 +1,40 @@
+[
+  {
+    "flag": "flag-that-does-not-exist",
+    "variationType": "NUMERIC",
+    "defaultValue": 0.0,
+    "targetingKey": "alice",
+    "attributes": {
+      "email": "alice@mycompany.com",
+      "country": "US"
+    },
+    "result": {
+      "value": 0.0
+    }
+  },
+  {
+    "flag": "flag-that-does-not-exist",
+    "variationType": "NUMERIC",
+    "defaultValue": 0.0,
+    "targetingKey": "bob",
+    "attributes": {
+      "email": "bob@example.com",
+      "country": "Canada"
+    },
+    "result": {
+      "value": 0.0
+    }
+  },
+  {
+    "flag": "flag-that-does-not-exist",
+    "variationType": "NUMERIC",
+    "defaultValue": 0.0,
+    "targetingKey": "charlie",
+    "attributes": {
+      "age": 50
+    },
+    "result": {
+      "value": 0.0
+    }
+  }
+]

--- a/tests/FeatureFlags/fixtures/evaluation-cases/test-json-config-flag.json
+++ b/tests/FeatureFlags/fixtures/evaluation-cases/test-json-config-flag.json
@@ -1,0 +1,72 @@
+[
+  {
+    "flag": "json-config-flag",
+    "variationType": "JSON",
+    "defaultValue": {
+      "foo": "bar"
+    },
+    "targetingKey": "alice",
+    "attributes": {
+      "email": "alice@mycompany.com",
+      "country": "US"
+    },
+    "result": {
+      "value": {
+        "integer": 1,
+        "string": "one",
+        "float": 1.0
+      }
+    }
+  },
+  {
+    "flag": "json-config-flag",
+    "variationType": "JSON",
+    "defaultValue": {
+      "foo": "bar"
+    },
+    "targetingKey": "bob",
+    "attributes": {
+      "email": "bob@example.com",
+      "country": "Canada"
+    },
+    "result": {
+      "value": {
+        "integer": 2,
+        "string": "two",
+        "float": 2.0
+      }
+    }
+  },
+  {
+    "flag": "json-config-flag",
+    "variationType": "JSON",
+    "defaultValue": {
+      "foo": "bar"
+    },
+    "targetingKey": "charlie",
+    "attributes": {
+      "age": 50
+    },
+    "result": {
+      "value": {
+        "integer": 2,
+        "string": "two",
+        "float": 2.0
+      }
+    }
+  },
+  {
+    "flag": "json-config-flag",
+    "variationType": "JSON",
+    "defaultValue": {
+      "foo": "bar"
+    },
+    "targetingKey": "diana",
+    "attributes": {
+      "Force Empty": true
+    },
+    "result": {
+      "value": {}
+    }
+  }
+]

--- a/tests/FeatureFlags/fixtures/evaluation-cases/test-no-allocations-flag.json
+++ b/tests/FeatureFlags/fixtures/evaluation-cases/test-no-allocations-flag.json
@@ -1,0 +1,52 @@
+[
+  {
+    "flag": "no_allocations_flag",
+    "variationType": "JSON",
+    "defaultValue": {
+      "message": "Hello, world!"
+    },
+    "targetingKey": "alice",
+    "attributes": {
+      "email": "alice@mycompany.com",
+      "country": "US"
+    },
+    "result": {
+      "value": {
+        "message": "Hello, world!"
+      }
+    }
+  },
+  {
+    "flag": "no_allocations_flag",
+    "variationType": "JSON",
+    "defaultValue": {
+      "message": "Hello, world!"
+    },
+    "targetingKey": "bob",
+    "attributes": {
+      "email": "bob@example.com",
+      "country": "Canada"
+    },
+    "result": {
+      "value": {
+        "message": "Hello, world!"
+      }
+    }
+  },
+  {
+    "flag": "no_allocations_flag",
+    "variationType": "JSON",
+    "defaultValue": {
+      "message": "Hello, world!"
+    },
+    "targetingKey": "charlie",
+    "attributes": {
+      "age": 50
+    },
+    "result": {
+      "value": {
+        "message": "Hello, world!"
+      }
+    }
+  }
+]

--- a/tests/FeatureFlags/fixtures/evaluation-cases/test-special-characters.json
+++ b/tests/FeatureFlags/fixtures/evaluation-cases/test-special-characters.json
@@ -1,0 +1,54 @@
+[
+  {
+    "flag": "special-characters",
+    "variationType": "JSON",
+    "defaultValue": {},
+    "targetingKey": "ash",
+    "attributes": {},
+    "result": {
+      "value": {
+        "a": "kümmert",
+        "b": "schön"
+      }
+    }
+  },
+  {
+    "flag": "special-characters",
+    "variationType": "JSON",
+    "defaultValue": {},
+    "targetingKey": "ben",
+    "attributes": {},
+    "result": {
+      "value": {
+        "a": "піклуватися",
+        "b": "любов"
+      }
+    }
+  },
+  {
+    "flag": "special-characters",
+    "variationType": "JSON",
+    "defaultValue": {},
+    "targetingKey": "cameron",
+    "attributes": {},
+    "result": {
+      "value": {
+        "a": "照顾",
+        "b": "漂亮"
+      }
+    }
+  },
+  {
+    "flag": "special-characters",
+    "variationType": "JSON",
+    "defaultValue": {},
+    "targetingKey": "darryl",
+    "attributes": {},
+    "result": {
+      "value": {
+        "a": "🤗",
+        "b": "🌸"
+      }
+    }
+  }
+]

--- a/tests/FeatureFlags/fixtures/evaluation-cases/test-string-with-special-characters.json
+++ b/tests/FeatureFlags/fixtures/evaluation-cases/test-string-with-special-characters.json
@@ -1,0 +1,794 @@
+[
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_spaces",
+    "attributes": {
+      "string_with_spaces": true
+    },
+    "result": {
+      "value": " a b c d e f "
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_one_space",
+    "attributes": {
+      "string_with_only_one_space": true
+    },
+    "result": {
+      "value": " "
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_multiple_spaces",
+    "attributes": {
+      "string_with_only_multiple_spaces": true
+    },
+    "result": {
+      "value": "       "
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_dots",
+    "attributes": {
+      "string_with_dots": true
+    },
+    "result": {
+      "value": ".a.b.c.d.e.f."
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_one_dot",
+    "attributes": {
+      "string_with_only_one_dot": true
+    },
+    "result": {
+      "value": "."
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_multiple_dots",
+    "attributes": {
+      "string_with_only_multiple_dots": true
+    },
+    "result": {
+      "value": "......."
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_comas",
+    "attributes": {
+      "string_with_comas": true
+    },
+    "result": {
+      "value": ",a,b,c,d,e,f,"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_one_coma",
+    "attributes": {
+      "string_with_only_one_coma": true
+    },
+    "result": {
+      "value": ","
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_multiple_comas",
+    "attributes": {
+      "string_with_only_multiple_comas": true
+    },
+    "result": {
+      "value": ",,,,,,,"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_colons",
+    "attributes": {
+      "string_with_colons": true
+    },
+    "result": {
+      "value": ":a:b:c:d:e:f:"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_one_colon",
+    "attributes": {
+      "string_with_only_one_colon": true
+    },
+    "result": {
+      "value": ":"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_multiple_colons",
+    "attributes": {
+      "string_with_only_multiple_colons": true
+    },
+    "result": {
+      "value": ":::::::"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_semicolons",
+    "attributes": {
+      "string_with_semicolons": true
+    },
+    "result": {
+      "value": ";a;b;c;d;e;f;"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_one_semicolon",
+    "attributes": {
+      "string_with_only_one_semicolon": true
+    },
+    "result": {
+      "value": ";"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_multiple_semicolons",
+    "attributes": {
+      "string_with_only_multiple_semicolons": true
+    },
+    "result": {
+      "value": ";;;;;;;"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_slashes",
+    "attributes": {
+      "string_with_slashes": true
+    },
+    "result": {
+      "value": "/a/b/c/d/e/f/"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_one_slash",
+    "attributes": {
+      "string_with_only_one_slash": true
+    },
+    "result": {
+      "value": "/"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_multiple_slashes",
+    "attributes": {
+      "string_with_only_multiple_slashes": true
+    },
+    "result": {
+      "value": "///////"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_dashes",
+    "attributes": {
+      "string_with_dashes": true
+    },
+    "result": {
+      "value": "-a-b-c-d-e-f-"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_one_dash",
+    "attributes": {
+      "string_with_only_one_dash": true
+    },
+    "result": {
+      "value": "-"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_multiple_dashes",
+    "attributes": {
+      "string_with_only_multiple_dashes": true
+    },
+    "result": {
+      "value": "-------"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_underscores",
+    "attributes": {
+      "string_with_underscores": true
+    },
+    "result": {
+      "value": "_a_b_c_d_e_f_"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_one_underscore",
+    "attributes": {
+      "string_with_only_one_underscore": true
+    },
+    "result": {
+      "value": "_"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_multiple_underscores",
+    "attributes": {
+      "string_with_only_multiple_underscores": true
+    },
+    "result": {
+      "value": "_______"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_plus_signs",
+    "attributes": {
+      "string_with_plus_signs": true
+    },
+    "result": {
+      "value": "+a+b+c+d+e+f+"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_one_plus_sign",
+    "attributes": {
+      "string_with_only_one_plus_sign": true
+    },
+    "result": {
+      "value": "+"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_multiple_plus_signs",
+    "attributes": {
+      "string_with_only_multiple_plus_signs": true
+    },
+    "result": {
+      "value": "+++++++"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_equal_signs",
+    "attributes": {
+      "string_with_equal_signs": true
+    },
+    "result": {
+      "value": "=a=b=c=d=e=f="
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_one_equal_sign",
+    "attributes": {
+      "string_with_only_one_equal_sign": true
+    },
+    "result": {
+      "value": "="
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_multiple_equal_signs",
+    "attributes": {
+      "string_with_only_multiple_equal_signs": true
+    },
+    "result": {
+      "value": "======="
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_dollar_signs",
+    "attributes": {
+      "string_with_dollar_signs": true
+    },
+    "result": {
+      "value": "$a$b$c$d$e$f$"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_one_dollar_sign",
+    "attributes": {
+      "string_with_only_one_dollar_sign": true
+    },
+    "result": {
+      "value": "$"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_multiple_dollar_signs",
+    "attributes": {
+      "string_with_only_multiple_dollar_signs": true
+    },
+    "result": {
+      "value": "$$$$$$$"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_at_signs",
+    "attributes": {
+      "string_with_at_signs": true
+    },
+    "result": {
+      "value": "@a@b@c@d@e@f@"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_one_at_sign",
+    "attributes": {
+      "string_with_only_one_at_sign": true
+    },
+    "result": {
+      "value": "@"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_multiple_at_signs",
+    "attributes": {
+      "string_with_only_multiple_at_signs": true
+    },
+    "result": {
+      "value": "@@@@@@@"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_amp_signs",
+    "attributes": {
+      "string_with_amp_signs": true
+    },
+    "result": {
+      "value": "&a&b&c&d&e&f&"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_one_amp_sign",
+    "attributes": {
+      "string_with_only_one_amp_sign": true
+    },
+    "result": {
+      "value": "&"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_multiple_amp_signs",
+    "attributes": {
+      "string_with_only_multiple_amp_signs": true
+    },
+    "result": {
+      "value": "&&&&&&&"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_hash_signs",
+    "attributes": {
+      "string_with_hash_signs": true
+    },
+    "result": {
+      "value": "#a#b#c#d#e#f#"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_one_hash_sign",
+    "attributes": {
+      "string_with_only_one_hash_sign": true
+    },
+    "result": {
+      "value": "#"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_multiple_hash_signs",
+    "attributes": {
+      "string_with_only_multiple_hash_signs": true
+    },
+    "result": {
+      "value": "#######"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_percentage_signs",
+    "attributes": {
+      "string_with_percentage_signs": true
+    },
+    "result": {
+      "value": "%a%b%c%d%e%f%"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_one_percentage_sign",
+    "attributes": {
+      "string_with_only_one_percentage_sign": true
+    },
+    "result": {
+      "value": "%"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_multiple_percentage_signs",
+    "attributes": {
+      "string_with_only_multiple_percentage_signs": true
+    },
+    "result": {
+      "value": "%%%%%%%"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_tilde_signs",
+    "attributes": {
+      "string_with_tilde_signs": true
+    },
+    "result": {
+      "value": "~a~b~c~d~e~f~"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_one_tilde_sign",
+    "attributes": {
+      "string_with_only_one_tilde_sign": true
+    },
+    "result": {
+      "value": "~"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_multiple_tilde_signs",
+    "attributes": {
+      "string_with_only_multiple_tilde_signs": true
+    },
+    "result": {
+      "value": "~~~~~~~"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_asterix_signs",
+    "attributes": {
+      "string_with_asterix_signs": true
+    },
+    "result": {
+      "value": "*a*b*c*d*e*f*"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_one_asterix_sign",
+    "attributes": {
+      "string_with_only_one_asterix_sign": true
+    },
+    "result": {
+      "value": "*"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_multiple_asterix_signs",
+    "attributes": {
+      "string_with_only_multiple_asterix_signs": true
+    },
+    "result": {
+      "value": "*******"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_single_quotes",
+    "attributes": {
+      "string_with_single_quotes": true
+    },
+    "result": {
+      "value": "'a'b'c'd'e'f'"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_one_single_quote",
+    "attributes": {
+      "string_with_only_one_single_quote": true
+    },
+    "result": {
+      "value": "'"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_multiple_single_quotes",
+    "attributes": {
+      "string_with_only_multiple_single_quotes": true
+    },
+    "result": {
+      "value": "'''''''"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_question_marks",
+    "attributes": {
+      "string_with_question_marks": true
+    },
+    "result": {
+      "value": "?a?b?c?d?e?f?"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_one_question_mark",
+    "attributes": {
+      "string_with_only_one_question_mark": true
+    },
+    "result": {
+      "value": "?"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_multiple_question_marks",
+    "attributes": {
+      "string_with_only_multiple_question_marks": true
+    },
+    "result": {
+      "value": "???????"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_exclamation_marks",
+    "attributes": {
+      "string_with_exclamation_marks": true
+    },
+    "result": {
+      "value": "!a!b!c!d!e!f!"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_one_exclamation_mark",
+    "attributes": {
+      "string_with_only_one_exclamation_mark": true
+    },
+    "result": {
+      "value": "!"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_multiple_exclamation_marks",
+    "attributes": {
+      "string_with_only_multiple_exclamation_marks": true
+    },
+    "result": {
+      "value": "!!!!!!!"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_opening_parentheses",
+    "attributes": {
+      "string_with_opening_parentheses": true
+    },
+    "result": {
+      "value": "(a(b(c(d(e(f("
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_one_opening_parenthese",
+    "attributes": {
+      "string_with_only_one_opening_parenthese": true
+    },
+    "result": {
+      "value": "("
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_multiple_opening_parentheses",
+    "attributes": {
+      "string_with_only_multiple_opening_parentheses": true
+    },
+    "result": {
+      "value": "((((((("
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_closing_parentheses",
+    "attributes": {
+      "string_with_closing_parentheses": true
+    },
+    "result": {
+      "value": ")a)b)c)d)e)f)"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_one_closing_parenthese",
+    "attributes": {
+      "string_with_only_one_closing_parenthese": true
+    },
+    "result": {
+      "value": ")"
+    }
+  },
+  {
+    "flag": "string_flag_with_special_characters",
+    "variationType": "STRING",
+    "defaultValue": "default_value",
+    "targetingKey": "string_with_only_multiple_closing_parentheses",
+    "attributes": {
+      "string_with_only_multiple_closing_parentheses": true
+    },
+    "result": {
+      "value": ")))))))"
+    }
+  }
+]

--- a/tests/phpunit.xml
+++ b/tests/phpunit.xml
@@ -136,6 +136,9 @@
         <testsuite name="unit">
             <directory>./Unit/</directory>
         </testsuite>
+        <testsuite name="featureflags">
+            <directory>./FeatureFlags/</directory>
+        </testsuite>
     </testsuites>
 
     <coverage includeUncoveredFiles="false">


### PR DESCRIPTION
## Motivation

Add FFE support to dd-trace-php. PHP applications can evaluate feature flags delivered via Remote Config using the same `datadog-ffe` Rust engine used by Ruby and Python.

Stacked on [#3642](https://github.com/DataDog/dd-trace-php/pull/3642) (libdatadog bump).

## Changes

- **Rust FFI layer** (`components-rs/ffe.rs`): C-callable bridge to `datadog-ffe::rules_based` — config store, evaluate, result accessors
- **C extension** (`ext/ddtrace.c`): `ffe_evaluate`, `ffe_has_config`, `ffe_config_changed`, `ffe_load_config` internal functions that marshal PHP arrays to `FfeAttribute` structs
- **Remote Config** (`components-rs/remote_config.rs`): Register `FfeFlags` product + `FfeFlagConfigurationRules` capability; handle add/remove of FFE configs
- **PHP Provider** (`src/DDTrace/FeatureFlags/Provider.php`): Singleton that checks RC config state, calls native evaluate, parses JSON results, reports exposures
- **Exposure pipeline**: LRU dedup cache (65K entries) + batched writer to `/evp_proxy/v2/api/v2/exposures` (1000 event buffer cap)
- **OpenFeature adapter** (`src/DDTrace/OpenFeature/DataDogProvider.php`): Implements `AbstractProvider` for the `open-feature/sdk` composer package
- **Tests**: LRU cache unit tests, exposure cache unit tests, 220 evaluation correctness tests from JSON fixtures
- **Config**: `DD_EXPERIMENTAL_FLAGGING_PROVIDER_ENABLED` gating via X-macro in `ext/configuration.h`

## Decisions

**Evaluation in Rust, not PHP.** All flag evaluation (UFC parsing, targeting rules, shard hashing, allocation resolution) happens in `libdatadog`'s `datadog-ffe` crate via FFI. PHP only handles orchestration (config lifecycle, exposure dedup, HTTP transport). This matches Ruby and Python — no language re-implements evaluation logic.

**Global config behind `Mutex<FfeState>`.** The Rust FFE config is stored in a `lazy_static` global with a `Mutex`. PHP is single-threaded per process, so `RwLock` would be unnecessary complexity. The `changed` flag and `config` are bundled in one struct to avoid torn reads.

**Reuses existing RC pipeline.** FFE configs flow through the same sidecar → `ddog_process_remote_configs()` path as APM Tracing and Live Debugger. No new polling mechanism.

**Structured attributes, not JSON blobs.** The C extension converts PHP arrays into `FfeAttribute` structs (typed: string/number/bool) before calling Rust, avoiding JSON encode/decode overhead on the hot path.

**Exposure dedup uses length-prefixed composite keys.** Key = `len(flag):flag:subject`, value = `len(variant):variant:allocation`. Avoids collision from delimiters appearing in flag/subject strings.

**ExposureWriter caps at 1000 events per request.** Matches Ruby and Python. Flush via `register_shutdown_function`.

## Test Results

Unit tests (local, no extension):
```
243 tests, 75 assertions, 1 skipped (EvaluationTest requires extension)
```

Unit tests (Docker with extension):
```
243 tests, 735 assertions — all pass
```

System tests (FEATURE_FLAGGING_AND_EXPERIMENTATION, apache-mod-8.0):
```
13 tests, 0 failures, 0 errors, 1 xfail
12 passed, 1 skipped (exposure cache cross-request dedup — PHP shared-nothing arch)
```

Cross-language dogfood parity (6 flags, 6 SDKs):
```
ALL MATCH: boolean, float, integer, JSON, string flags across Go, Java, Node, PHP, Python, Ruby
```

## Companion PRs
- **libdatadog**: [DataDog/libdatadog#1532](https://github.com/DataDog/libdatadog/pull/1532)
- **system-tests**: [DataDog/system-tests#6243](https://github.com/DataDog/system-tests/pull/6243)
- **Reference impl**: [#3630](https://github.com/DataDog/dd-trace-php/pull/3630)

## LOC Breakdown (excluding Cargo.lock + JSON fixtures)
| Category | Lines |
|---|---|
| Rust FFI | 323 |
| C extension | 125 |
| PHP source | 829 |
| PHP tests | 559 |
| Wiring | 7 |
| **Total** | **1,843** |