### PR TITLE
ci: add allow_failure to all manual jobs to prevent pipeline hanging

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -33,8 +33,10 @@ workflow:
     interruptible: true
   - if: $CI_COMMIT_REF_NAME == "master"
     when: manual
+    allow_failure: true
     interruptible: false
   - when: manual
+    allow_failure: true
     interruptible: true
 
 .benchmarks-appsec-rules: &benchmarks-appsec-rules
@@ -54,8 +56,10 @@ workflow:
     interruptible: true
   - if: $CI_COMMIT_REF_NAME == "master"
     when: manual
+    allow_failure: true
     interruptible: false
   - when: manual
+    allow_failure: true
     interruptible: true
 
 .benchmarks-tracer-rules: &benchmarks-tracer-rules
@@ -67,8 +71,10 @@ workflow:
     interruptible: true
   - if: $CI_COMMIT_REF_NAME == "master"
     when: manual
+    allow_failure: true
     interruptible: false
   - when: manual
+    allow_failure: true
     interruptible: true
 
 .on-master-or-nightly-benchmarks-or-release-always-and-not-interruptible: &on-master-or-nightly-benchmarks-or-release-always-and-not-interruptible
@@ -79,6 +85,7 @@ workflow:
 .macrobenchmarks-rules: &macrobenchmarks-rules
   - <<: *on-master-or-nightly-benchmarks-or-release-always-and-not-interruptible
   - when: manual
+    allow_failure: true
     interruptible: true
 
 .pre-release-performance-quality-gates-rules: &pre-release-performance-quality-gates-rules

--- a/.gitlab/ci-images.yml
+++ b/.gitlab/ci-images.yml
@@ -12,6 +12,7 @@ CentOS:
   stage: ci-build
   rules:
     - when: manual
+      allow_failure: true
   needs: []
   tags: ["arch:amd64"]
   timeout: 4h
@@ -40,6 +41,7 @@ Alpine:
   stage: ci-build
   rules:
     - when: manual
+      allow_failure: true
   needs: []
   tags: ["arch:amd64"]
   timeout: 4h
@@ -68,6 +70,7 @@ Bookworm:
   stage: ci-build
   rules:
     - when: manual
+      allow_failure: true
   needs: []
   tags: ["arch:amd64"]
   timeout: 4h
@@ -98,6 +101,7 @@ Buster:
   stage: ci-build
   rules:
     - when: manual
+      allow_failure: true
   needs: []
   tags: ["arch:amd64"]
   timeout: 4h

--- a/.gitlab/generate-appsec.php
+++ b/.gitlab/generate-appsec.php
@@ -241,6 +241,7 @@ stages:
       - ARCH: ["amd64", "arm64"]
   rules:
     - when: manual
+      allow_failure: true
   needs: []
   script:
     - cd appsec/tests/integration

--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -1364,6 +1364,7 @@ endforeach;
     - if: $CI_COMMIT_REF_NAME == "master" && $CI_PIPELINE_SOURCE != "schedule"
       when: on_success
     - when: manual
+      allow_failure: true
   needs:
     - job: "prepare code"
       artifacts: true
@@ -1436,6 +1437,7 @@ foreach ($arch_targets as $arch) {
 
 deploy_to_reliability_env:
   stage: shared-pipeline
+  allow_failure: true
   needs:
     - job: "bundle for reliability env"
   rules:

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -767,3 +767,4 @@ foreach ($xdebug_test_matrix as [$major_minor, $xdebug]):
     - if: $CI_COMMIT_REF_NAME == "master"
       when: always
     - when: manual
+      allow_failure: true


### PR DESCRIPTION
### Description

Manual jobs without allow_failure block pipeline completion by default. This causes pipelines to stay in "running" state indefinitely even when all actual jobs have completed, because GitLab waits for manual jobs to be triggered.

Added `|allow_failure: true` to all manual jobs:
- CI image builds (CentOS, Alpine, Bookworm, Buster)
- Benchmarks (tracer, profiling, appsec)
- Macrobenchmarks
- Package deployment jobs
- AppSec docker image pushes
- Tested versions collection

Also added allow_failure to the deploy_to_reliability_env trigger job to prevent hanging when downstream pipelines don't complete.

This allows pipelines to complete successfully while keeping manual jobs available for optional execution.
