### PR TITLE
Block sidecar notification signal while sleeping

### DIFF
--- a/ext/handlers_signal.c
+++ b/ext/handlers_signal.c
@@ -81,6 +81,7 @@ static void dd_handle_signal(zif_handler original_function, INTERNAL_FUNCTION_PA
     x(pcntl_sigwaitinfo) \
     x(sleep) \
     x(usleep) \
+    x(time_nanosleep) \
 
 #define BLOCKMETH(x) \
     x(PDO, connect) \


### PR DESCRIPTION
Otherwise users may sleep a lot less than they expect.