### PR TITLE
ci: add optimized release PHP variant with debug symbols

### DIFF
--- a/dockerfiles/ci/bookworm/build-php.sh
+++ b/dockerfiles/ci/bookworm/build-php.sh
@@ -17,6 +17,11 @@ if [[ ${INSTALL_VERSION} == *asan* ]]; then
   export LDFLAGS='-fsanitize=address -shared-libasan'
 fi
 
+# Release variants: optimized with debug symbols (no --enable-debug)
+if [[ ${INSTALL_VERSION} == release-* ]]; then
+  export CFLAGS="${CFLAGS:-} -O2 -g"
+fi
+
 if [[ ${PHP_VERSION_ID} -le 73 ]]; then
   export CFLAGS="${CFLAGS:-} -Wno-implicit-function-declaration -DHAVE_POSIX_READDIR_R=1 -DHAVE_OLD_READDIR_R=0 -DTRUE=1 -DFALSE=0"
   export CXXFLAGS="-DTRUE=true -DFALSE=false"

--- a/dockerfiles/ci/bookworm/php-7.0/Dockerfile
+++ b/dockerfiles/ci/bookworm/php-7.0/Dockerfile
@@ -69,6 +69,8 @@ COPY --chown=circleci:circleci --from=php-debug-zts $PHP_INSTALL_DIR/debug-zts $
 COPY --chown=circleci:circleci --from=php-debug $PHP_INSTALL_DIR/debug $PHP_INSTALL_DIR/debug
 COPY --chown=circleci:circleci --from=php-nts $PHP_INSTALL_DIR/nts $PHP_INSTALL_DIR/nts
 COPY --chown=circleci:circleci --from=php-zts $PHP_INSTALL_DIR/zts $PHP_INSTALL_DIR/zts
+COPY --chown=circleci:circleci --from=php-release-nts $PHP_INSTALL_DIR/release-nts $PHP_INSTALL_DIR/release-nts
+COPY --chown=circleci:circleci --from=php-release-zts $PHP_INSTALL_DIR/release-zts $PHP_INSTALL_DIR/release-zts
 
 USER root
 

--- a/dockerfiles/ci/bookworm/php-7.1/Dockerfile
+++ b/dockerfiles/ci/bookworm/php-7.1/Dockerfile
@@ -70,6 +70,8 @@ COPY --chown=circleci:circleci --from=php-debug-zts $PHP_INSTALL_DIR/debug-zts $
 COPY --chown=circleci:circleci --from=php-debug $PHP_INSTALL_DIR/debug $PHP_INSTALL_DIR/debug
 COPY --chown=circleci:circleci --from=php-nts $PHP_INSTALL_DIR/nts $PHP_INSTALL_DIR/nts
 COPY --chown=circleci:circleci --from=php-zts $PHP_INSTALL_DIR/zts $PHP_INSTALL_DIR/zts
+COPY --chown=circleci:circleci --from=php-release-nts $PHP_INSTALL_DIR/release-nts $PHP_INSTALL_DIR/release-nts
+COPY --chown=circleci:circleci --from=php-release-zts $PHP_INSTALL_DIR/release-zts $PHP_INSTALL_DIR/release-zts
 
 USER root
 

--- a/dockerfiles/ci/bookworm/php-7.2/Dockerfile
+++ b/dockerfiles/ci/bookworm/php-7.2/Dockerfile
@@ -70,6 +70,8 @@ COPY --chown=circleci:circleci --from=php-debug-zts $PHP_INSTALL_DIR/debug-zts $
 COPY --chown=circleci:circleci --from=php-debug $PHP_INSTALL_DIR/debug $PHP_INSTALL_DIR/debug
 COPY --chown=circleci:circleci --from=php-nts $PHP_INSTALL_DIR/nts $PHP_INSTALL_DIR/nts
 COPY --chown=circleci:circleci --from=php-zts $PHP_INSTALL_DIR/zts $PHP_INSTALL_DIR/zts
+COPY --chown=circleci:circleci --from=php-release-nts $PHP_INSTALL_DIR/release-nts $PHP_INSTALL_DIR/release-nts
+COPY --chown=circleci:circleci --from=php-release-zts $PHP_INSTALL_DIR/release-zts $PHP_INSTALL_DIR/release-zts
 
 USER root
 

--- a/dockerfiles/ci/bookworm/php-7.3/Dockerfile
+++ b/dockerfiles/ci/bookworm/php-7.3/Dockerfile
@@ -63,6 +63,8 @@ COPY --chown=circleci:circleci --from=php-debug-zts $PHP_INSTALL_DIR/debug-zts $
 COPY --chown=circleci:circleci --from=php-debug $PHP_INSTALL_DIR/debug $PHP_INSTALL_DIR/debug
 COPY --chown=circleci:circleci --from=php-nts $PHP_INSTALL_DIR/nts $PHP_INSTALL_DIR/nts
 COPY --chown=circleci:circleci --from=php-zts $PHP_INSTALL_DIR/zts $PHP_INSTALL_DIR/zts
+COPY --chown=circleci:circleci --from=php-release-nts $PHP_INSTALL_DIR/release-nts $PHP_INSTALL_DIR/release-nts
+COPY --chown=circleci:circleci --from=php-release-zts $PHP_INSTALL_DIR/release-zts $PHP_INSTALL_DIR/release-zts
 
 USER root
 

--- a/dockerfiles/ci/bookworm/php-7.4/Dockerfile
+++ b/dockerfiles/ci/bookworm/php-7.4/Dockerfile
@@ -69,6 +69,8 @@ COPY --chown=circleci:circleci --from=php-debug-zts-asan $PHP_INSTALL_DIR/debug-
 COPY --chown=circleci:circleci --from=php-debug $PHP_INSTALL_DIR/debug $PHP_INSTALL_DIR/debug
 COPY --chown=circleci:circleci --from=php-nts $PHP_INSTALL_DIR/nts $PHP_INSTALL_DIR/nts
 COPY --chown=circleci:circleci --from=php-zts $PHP_INSTALL_DIR/zts $PHP_INSTALL_DIR/zts
+COPY --chown=circleci:circleci --from=php-release-nts $PHP_INSTALL_DIR/release-nts $PHP_INSTALL_DIR/release-nts
+COPY --chown=circleci:circleci --from=php-release-zts $PHP_INSTALL_DIR/release-zts $PHP_INSTALL_DIR/release-zts
 
 USER root
 

--- a/dockerfiles/ci/bookworm/php-8.0/Dockerfile
+++ b/dockerfiles/ci/bookworm/php-8.0/Dockerfile
@@ -75,6 +75,8 @@ COPY --chown=circleci:circleci --from=php-debug-zts-asan $PHP_INSTALL_DIR/debug-
 COPY --chown=circleci:circleci --from=php-debug $PHP_INSTALL_DIR/debug $PHP_INSTALL_DIR/debug
 COPY --chown=circleci:circleci --from=php-nts $PHP_INSTALL_DIR/nts $PHP_INSTALL_DIR/nts
 COPY --chown=circleci:circleci --from=php-zts $PHP_INSTALL_DIR/zts $PHP_INSTALL_DIR/zts
+COPY --chown=circleci:circleci --from=php-release-nts $PHP_INSTALL_DIR/release-nts $PHP_INSTALL_DIR/release-nts
+COPY --chown=circleci:circleci --from=php-release-zts $PHP_INSTALL_DIR/release-zts $PHP_INSTALL_DIR/release-zts
 
 USER root
 

--- a/dockerfiles/ci/bookworm/php-8.1/Dockerfile
+++ b/dockerfiles/ci/bookworm/php-8.1/Dockerfile
@@ -70,12 +70,27 @@ COPY build-extensions.sh /home/circleci
 RUN /home/circleci/build-extensions.sh
 RUN cp /tmp/build-php/sapi/cli/php-asan $PHP_INSTALL_DIR/debug-zts-asan/bin/php
 
+FROM build AS php-release-nts
+ARG TARGETPLATFORM
+RUN /home/circleci/build-php.sh $TARGETPLATFORM $PHP_INSTALL_DIR release-nts $PHP_VERSION
+COPY build-extensions.sh /home/circleci
+RUN /home/circleci/build-extensions.sh
+
+
+FROM build AS php-release-zts
+ARG TARGETPLATFORM
+RUN /home/circleci/build-php.sh $TARGETPLATFORM $PHP_INSTALL_DIR release-zts $PHP_VERSION
+COPY build-extensions.sh /home/circleci
+RUN /home/circleci/build-extensions.sh
+
 FROM base AS final
 COPY --chown=circleci:circleci --from=src $PHP_SRC_DIR $PHP_SRC_DIR
 COPY --chown=circleci:circleci --from=php-debug-zts-asan $PHP_INSTALL_DIR/debug-zts-asan $PHP_INSTALL_DIR/debug-zts-asan
 COPY --chown=circleci:circleci --from=php-debug $PHP_INSTALL_DIR/debug $PHP_INSTALL_DIR/debug
 COPY --chown=circleci:circleci --from=php-nts $PHP_INSTALL_DIR/nts $PHP_INSTALL_DIR/nts
 COPY --chown=circleci:circleci --from=php-zts $PHP_INSTALL_DIR/zts $PHP_INSTALL_DIR/zts
+COPY --chown=circleci:circleci --from=php-release-nts $PHP_INSTALL_DIR/release-nts $PHP_INSTALL_DIR/release-nts
+COPY --chown=circleci:circleci --from=php-release-zts $PHP_INSTALL_DIR/release-zts $PHP_INSTALL_DIR/release-zts
 
 USER root
 

--- a/dockerfiles/ci/bookworm/php-8.2/Dockerfile
+++ b/dockerfiles/ci/bookworm/php-8.2/Dockerfile
@@ -68,12 +68,27 @@ COPY build-extensions.sh /home/circleci
 RUN /home/circleci/build-extensions.sh
 RUN cp /tmp/build-php/sapi/cli/php-asan $PHP_INSTALL_DIR/debug-zts-asan/bin/php
 
+FROM build AS php-release-nts
+ARG TARGETPLATFORM
+RUN /home/circleci/build-php.sh $TARGETPLATFORM $PHP_INSTALL_DIR release-nts $PHP_VERSION
+COPY build-extensions.sh /home/circleci
+RUN /home/circleci/build-extensions.sh
+
+
+FROM build AS php-release-zts
+ARG TARGETPLATFORM
+RUN /home/circleci/build-php.sh $TARGETPLATFORM $PHP_INSTALL_DIR release-zts $PHP_VERSION
+COPY build-extensions.sh /home/circleci
+RUN /home/circleci/build-extensions.sh
+
 FROM base AS final
 COPY --chown=circleci:circleci --from=src $PHP_SRC_DIR $PHP_SRC_DIR
 COPY --chown=circleci:circleci --from=php-debug-zts-asan $PHP_INSTALL_DIR/debug-zts-asan $PHP_INSTALL_DIR/debug-zts-asan
 COPY --chown=circleci:circleci --from=php-debug $PHP_INSTALL_DIR/debug $PHP_INSTALL_DIR/debug
 COPY --chown=circleci:circleci --from=php-nts $PHP_INSTALL_DIR/nts $PHP_INSTALL_DIR/nts
 COPY --chown=circleci:circleci --from=php-zts $PHP_INSTALL_DIR/zts $PHP_INSTALL_DIR/zts
+COPY --chown=circleci:circleci --from=php-release-nts $PHP_INSTALL_DIR/release-nts $PHP_INSTALL_DIR/release-nts
+COPY --chown=circleci:circleci --from=php-release-zts $PHP_INSTALL_DIR/release-zts $PHP_INSTALL_DIR/release-zts
 
 USER root
 

--- a/dockerfiles/ci/bookworm/php-8.3/Dockerfile
+++ b/dockerfiles/ci/bookworm/php-8.3/Dockerfile
@@ -86,6 +86,19 @@ FROM build AS php-nts-asan
   RUN /home/circleci/build-extensions.sh
   RUN mv /tmp/build-php/sapi/cli/php-asan $PHP_INSTALL_DIR/nts-asan/bin/php
 
+FROM build AS php-release-nts
+ARG TARGETPLATFORM
+RUN /home/circleci/build-php.sh $TARGETPLATFORM $PHP_INSTALL_DIR release-nts $PHP_VERSION
+COPY build-extensions.sh /home/circleci
+RUN /home/circleci/build-extensions.sh
+
+
+FROM build AS php-release-zts
+ARG TARGETPLATFORM
+RUN /home/circleci/build-php.sh $TARGETPLATFORM $PHP_INSTALL_DIR release-zts $PHP_VERSION
+COPY build-extensions.sh /home/circleci
+RUN /home/circleci/build-extensions.sh
+
 FROM base AS final
 COPY --chown=circleci:circleci --from=src $PHP_SRC_DIR $PHP_SRC_DIR
 COPY --chown=circleci:circleci --from=php-debug-zts-asan $PHP_INSTALL_DIR/debug-zts-asan $PHP_INSTALL_DIR/debug-zts-asan
@@ -93,6 +106,8 @@ COPY --chown=circleci:circleci --from=php-nts-asan $PHP_INSTALL_DIR/nts-asan $PH
 COPY --chown=circleci:circleci --from=php-debug $PHP_INSTALL_DIR/debug $PHP_INSTALL_DIR/debug
 COPY --chown=circleci:circleci --from=php-nts $PHP_INSTALL_DIR/nts $PHP_INSTALL_DIR/nts
 COPY --chown=circleci:circleci --from=php-zts $PHP_INSTALL_DIR/zts $PHP_INSTALL_DIR/zts
+COPY --chown=circleci:circleci --from=php-release-nts $PHP_INSTALL_DIR/release-nts $PHP_INSTALL_DIR/release-nts
+COPY --chown=circleci:circleci --from=php-release-zts $PHP_INSTALL_DIR/release-zts $PHP_INSTALL_DIR/release-zts
 
 USER root
 

--- a/dockerfiles/ci/bookworm/php-8.4/Dockerfile
+++ b/dockerfiles/ci/bookworm/php-8.4/Dockerfile
@@ -84,6 +84,18 @@ FROM build AS php-nts-asan
   RUN /home/circleci/build-extensions.sh
   RUN mv /tmp/build-php/sapi/cli/php-asan $PHP_INSTALL_DIR/nts-asan/bin/php
 
+FROM build AS php-release-nts
+ARG TARGETPLATFORM
+RUN /home/circleci/build-php.sh $TARGETPLATFORM $PHP_INSTALL_DIR release-nts $PHP_VERSION
+COPY build-extensions.sh /home/circleci
+RUN /home/circleci/build-extensions.sh
+
+FROM build AS php-release-zts
+ARG TARGETPLATFORM
+RUN /home/circleci/build-php.sh $TARGETPLATFORM $PHP_INSTALL_DIR release-zts $PHP_VERSION
+COPY build-extensions.sh /home/circleci
+RUN /home/circleci/build-extensions.sh
+
 FROM base AS final
 COPY --chown=circleci:circleci --from=src $PHP_SRC_DIR $PHP_SRC_DIR
 COPY --chown=circleci:circleci --from=php-debug-zts-asan $PHP_INSTALL_DIR/debug-zts-asan $PHP_INSTALL_DIR/debug-zts-asan
@@ -91,6 +103,8 @@ COPY --chown=circleci:circleci --from=php-nts-asan $PHP_INSTALL_DIR/nts-asan $PH
 COPY --chown=circleci:circleci --from=php-debug $PHP_INSTALL_DIR/debug $PHP_INSTALL_DIR/debug
 COPY --chown=circleci:circleci --from=php-nts $PHP_INSTALL_DIR/nts $PHP_INSTALL_DIR/nts
 COPY --chown=circleci:circleci --from=php-zts $PHP_INSTALL_DIR/zts $PHP_INSTALL_DIR/zts
+COPY --chown=circleci:circleci --from=php-release-nts $PHP_INSTALL_DIR/release-nts $PHP_INSTALL_DIR/release-nts
+COPY --chown=circleci:circleci --from=php-release-zts $PHP_INSTALL_DIR/release-zts $PHP_INSTALL_DIR/release-zts
 
 USER root
 

--- a/dockerfiles/ci/bookworm/php-8.5/Dockerfile
+++ b/dockerfiles/ci/bookworm/php-8.5/Dockerfile
@@ -84,6 +84,19 @@ FROM build AS php-nts-asan
   RUN /home/circleci/build-extensions.sh
   RUN mv /tmp/build-php/sapi/cli/php-asan $PHP_INSTALL_DIR/nts-asan/bin/php
 
+FROM build AS php-release-nts
+ARG TARGETPLATFORM
+RUN /home/circleci/build-php.sh $TARGETPLATFORM $PHP_INSTALL_DIR release-nts $PHP_VERSION
+COPY build-extensions.sh /home/circleci
+RUN /home/circleci/build-extensions.sh
+
+
+FROM build AS php-release-zts
+ARG TARGETPLATFORM
+RUN /home/circleci/build-php.sh $TARGETPLATFORM $PHP_INSTALL_DIR release-zts $PHP_VERSION
+COPY build-extensions.sh /home/circleci
+RUN /home/circleci/build-extensions.sh
+
 FROM base AS final
 COPY --chown=circleci:circleci --from=src $PHP_SRC_DIR $PHP_SRC_DIR
 COPY --chown=circleci:circleci --from=php-debug-zts-asan $PHP_INSTALL_DIR/debug-zts-asan $PHP_INSTALL_DIR/debug-zts-asan
@@ -91,6 +104,8 @@ COPY --chown=circleci:circleci --from=php-nts-asan $PHP_INSTALL_DIR/nts-asan $PH
 COPY --chown=circleci:circleci --from=php-debug $PHP_INSTALL_DIR/debug $PHP_INSTALL_DIR/debug
 COPY --chown=circleci:circleci --from=php-nts $PHP_INSTALL_DIR/nts $PHP_INSTALL_DIR/nts
 COPY --chown=circleci:circleci --from=php-zts $PHP_INSTALL_DIR/zts $PHP_INSTALL_DIR/zts
+COPY --chown=circleci:circleci --from=php-release-nts $PHP_INSTALL_DIR/release-nts $PHP_INSTALL_DIR/release-nts
+COPY --chown=circleci:circleci --from=php-release-zts $PHP_INSTALL_DIR/release-zts $PHP_INSTALL_DIR/release-zts
 
 USER root
 


### PR DESCRIPTION
### Description

Add two new PHP variants to all bookworm CI images:
- 'release-nts': Optimized non-thread-safe with debug symbols
- 'release-zts': Optimized Zend thread-safe with debug symbols

Both variants provide:
- Full -O2 optimization for production performance
- Debug symbols (-g flag) for profiling and debugging
- No --enable-debug flag (avoids debug build overhead)

These variants are optimized for benchmarking and profiling scenarios where
both performance and symbol availability are required.

Changes:
- Modified build-php.sh to set CFLAGS="-O2 -g" for release-* variants
- Added php-release-nts and php-release-zts build stages to all PHP version
  Dockerfiles (7.0-8.5)
- Added both variants to final image in /opt/php/release-nts and
  /opt/php/release-zts

Usage:
  switch-php release-nts   # For non-thread-safe builds
  switch-php release-zts   # For thread-safe builds
