### PR TITLE
refactor(profiling): ErrnoBackup::new is safe

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1337,6 +1337,7 @@ dependencies = [
  "rand_distr",
  "rustc-hash 1.1.0",
  "serde_json",
+ "static_assertions",
  "thiserror 2.0.12",
  "tracing",
  "tracing-subscriber",

--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -51,6 +51,7 @@ features = ["env-filter", "fmt", "smallvec", "std"]
 allocator-api2 = { version = "0.2", default-features = false, features = ["alloc"] }
 criterion = { version = "0.5.1" }
 datadog-php-profiling = { path = ".", features = ["test"] }
+static_assertions = "1"
 
 [target.'cfg(target_arch = "x86_64")'.dev-dependencies]
 criterion-perf-events = "0.4.0"


### PR DESCRIPTION
### Description

In code review, I noticed `ErrnoBackup::new` was safe, but it was already merged. So I fixed it, and added safety comments. We also verify that it is !Send, because it's not safe to write to another thread's errno, which would happen if we sent `ErrnoBackup` to another thread.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
