### PR TITLE
Add dynamic instrumentation and exception replay to startup logging

### DIFF
--- a/ext/startup_logging.c
+++ b/ext/startup_logging.c
@@ -185,6 +185,8 @@ static void _dd_get_startup_config(HashTable *ht) {
     _dd_add_assoc_bool(ht, ZEND_STRL("enabled_from_env"), get_DD_TRACE_ENABLED());
     _dd_add_assoc_string(ht, ZEND_STRL("opcache.file_cache"), _dd_get_ini(ZEND_STRL("opcache.file_cache")));
     _dd_add_assoc_bool(ht, ZEND_STRL("sidecar_trace_sender"), get_global_DD_TRACE_SIDECAR_TRACE_SENDER());
+    _dd_add_assoc_bool(ht, ZEND_STRL("dynamic_instrumentation_enabled"), get_global_DD_DYNAMIC_INSTRUMENTATION_ENABLED());
+    _dd_add_assoc_bool(ht, ZEND_STRL("exception_replay_enabled"), get_global_DD_EXCEPTION_REPLAY_ENABLED());
 
     _dd_add_assoc_bool(ht, ZEND_STRL("loaded_by_ssi"), ddtrace_loaded_by_ssi);
 }

--- a/tests/ext/startup_logging.phpt
+++ b/tests/ext/startup_logging.phpt
@@ -51,4 +51,6 @@ report_hostname_on_root_span: false
 traced_internal_functions: null
 enabled_from_env: true
 opcache.file_cache: null
+dynamic_instrumentation_enabled: false
+exception_replay_enabled: false
 loaded_by_ssi: false

--- a/tests/ext/startup_logging_json.phpt
+++ b/tests/ext/startup_logging_json.phpt
@@ -52,5 +52,7 @@ report_hostname_on_root_span: false
 traced_internal_functions: null
 enabled_from_env: true
 opcache.file_cache: null
+dynamic_instrumentation_enabled: false
+exception_replay_enabled: false
 loaded_by_ssi: false
 datadog.trace.sources_path_reachable: false


### PR DESCRIPTION
### Description

The startup configuration JSON now includes the status of `DD_DYNAMIC_INSTRUMENTATION_ENABLED` and `DD_EXCEPTION_REPLAY_ENABLED`, making it easier to verify these features are configured correctly when the tracer starts up.

**Changes:**
- Added `dynamic_instrumentation_enabled` field to startup logging output
- Added `exception_replay_enabled` field to startup logging output
- Updated tests to expect the new fields

**Example output:**
```json
{
  ...
  "sidecar_trace_sender": true,
  "dynamic_instrumentation_enabled": false,
  "exception_replay_enabled": false,
  "loaded_by_ssi": false
}
```

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.