### PR TITLE
Set helper container resource limits for Guaranteed QoS on profiling tests

### DIFF
--- a/.gitlab/generate-profiler.php
+++ b/.gitlab/generate-profiler.php
@@ -22,6 +22,10 @@ foreach ($profiler_minor_major_targets as $version) {
     KUBERNETES_CPU_LIMIT: 3
     KUBERNETES_MEMORY_REQUEST: 6Gi
     KUBERNETES_MEMORY_LIMIT: 6Gi
+    KUBERNETES_HELPER_CPU_REQUEST: 1
+    KUBERNETES_HELPER_CPU_LIMIT: 1
+    KUBERNETES_HELPER_MEMORY_REQUEST: 2Gi
+    KUBERNETES_HELPER_MEMORY_LIMIT: 2Gi
     CARGO_TARGET_DIR: /mnt/ramdisk/cargo # ramdisk??
     libdir: /tmp/datadog-profiling
   parallel:


### PR DESCRIPTION
## Summary
- The shared GitLab runner pool leaves helper container limits unset by default (`substitutions.bzl` in dd-source sets `{helpers.cpuLimit}` and `{helpers.memoryLimit}` to empty strings)
- This causes profiling test pods to be **Burstable** QoS even when the build container has matching requests and limits (`KUBERNETES_CPU_REQUEST == KUBERNETES_CPU_LIMIT`)
- Adds `KUBERNETES_HELPER_CPU_LIMIT` and `KUBERNETES_HELPER_MEMORY_LIMIT` (matching the existing requests of cpu: 1, memory: 2Gi) so all containers have requests == limits → **Guaranteed** QoS

## Impact
- Profiling test pods will get Guaranteed QoS class, ensuring proper CPU cgroup enforcement
- This fixes the issue where `nproc` reports the node's full CPU count (e.g. 66) instead of the requested 3 CPUs, which causes tools to spawn too many parallel jobs
- The helper and init-permissions containers will now have their CPU limits enforced

## Test plan
- [ ] Run a profiling test job and verify `qosClass: Guaranteed` in the pod spec
- [ ] Verify `nproc` reports the correct CPU count (3) instead of the node's total

🤖 Generated with [Claude Code](https://claude.com/claude-code)