### PR TITLE
ci: skip phpinfo language test on PHP <=8.1

### DIFF
--- a/dockerfiles/ci/xfail_tests/7.0.list
+++ b/dockerfiles/ci/xfail_tests/7.0.list
@@ -347,6 +347,7 @@ ext/standard/tests/general_functions/bug35229.phpt
 ext/standard/tests/general_functions/bug73973.phpt
 ext/standard/tests/general_functions/get_included_files.phpt
 ext/standard/tests/general_functions/gettype_settype_basic.phpt
+ext/standard/tests/general_functions/phpinfo.phpt
 ext/standard/tests/general_functions/print_r_64bit.phpt
 ext/standard/tests/general_functions/strval.phpt
 ext/standard/tests/general_functions/type.phpt

--- a/dockerfiles/ci/xfail_tests/7.1.list
+++ b/dockerfiles/ci/xfail_tests/7.1.list
@@ -375,6 +375,7 @@ ext/standard/tests/general_functions/bug35229.phpt
 ext/standard/tests/general_functions/bug73973.phpt
 ext/standard/tests/general_functions/get_included_files.phpt
 ext/standard/tests/general_functions/gettype_settype_basic.phpt
+ext/standard/tests/general_functions/phpinfo.phpt
 ext/standard/tests/general_functions/print_r_64bit.phpt
 ext/standard/tests/general_functions/strval.phpt
 ext/standard/tests/general_functions/type.phpt

--- a/dockerfiles/ci/xfail_tests/7.2.list
+++ b/dockerfiles/ci/xfail_tests/7.2.list
@@ -331,6 +331,7 @@ ext/standard/tests/file/lstat_stat_variation10.phpt
 ext/standard/tests/general_functions/bug73973.phpt
 ext/standard/tests/general_functions/get_included_files.phpt
 ext/standard/tests/general_functions/gettype_settype_basic.phpt
+ext/standard/tests/general_functions/phpinfo.phpt
 ext/standard/tests/general_functions/print_r_64bit.phpt
 ext/standard/tests/general_functions/strval.phpt
 ext/standard/tests/general_functions/type.phpt

--- a/dockerfiles/ci/xfail_tests/7.3.list
+++ b/dockerfiles/ci/xfail_tests/7.3.list
@@ -345,6 +345,7 @@ ext/standard/tests/file/lstat_stat_variation10.phpt
 ext/standard/tests/general_functions/bug73973.phpt
 ext/standard/tests/general_functions/get_included_files.phpt
 ext/standard/tests/general_functions/gettype_settype_basic.phpt
+ext/standard/tests/general_functions/phpinfo.phpt
 ext/standard/tests/general_functions/print_r_64bit.phpt
 ext/standard/tests/general_functions/strval.phpt
 ext/standard/tests/general_functions/type.phpt

--- a/dockerfiles/ci/xfail_tests/7.4.list
+++ b/dockerfiles/ci/xfail_tests/7.4.list
@@ -406,6 +406,7 @@ ext/standard/tests/file/lstat_stat_variation15.phpt
 ext/standard/tests/general_functions/bug73973.phpt
 ext/standard/tests/general_functions/get_included_files.phpt
 ext/standard/tests/general_functions/gettype_settype_basic.phpt
+ext/standard/tests/general_functions/phpinfo.phpt
 ext/standard/tests/general_functions/print_r_64bit.phpt
 ext/standard/tests/general_functions/proc_open_null.phpt
 ext/standard/tests/general_functions/proc_open_redirect.phpt

--- a/dockerfiles/ci/xfail_tests/8.0.list
+++ b/dockerfiles/ci/xfail_tests/8.0.list
@@ -470,6 +470,7 @@ ext/standard/tests/general_functions/floatval.phpt
 ext/standard/tests/general_functions/floatval_variation1.phpt
 ext/standard/tests/general_functions/get_included_files.phpt
 ext/standard/tests/general_functions/gettype_settype_basic.phpt
+ext/standard/tests/general_functions/phpinfo.phpt
 ext/standard/tests/general_functions/print_r.phpt
 ext/standard/tests/general_functions/print_r_64bit.phpt
 ext/standard/tests/general_functions/proc_open_null.phpt

--- a/dockerfiles/ci/xfail_tests/8.1.list
+++ b/dockerfiles/ci/xfail_tests/8.1.list
@@ -170,6 +170,7 @@ ext/standard/tests/general_functions/floatval.phpt
 ext/standard/tests/general_functions/floatval_variation1.phpt
 ext/standard/tests/general_functions/get_included_files.phpt
 ext/standard/tests/general_functions/gettype_settype_basic.phpt
+ext/standard/tests/general_functions/phpinfo.phpt
 ext/standard/tests/general_functions/print_r.phpt
 ext/standard/tests/general_functions/print_r_64bit.phpt
 ext/standard/tests/general_functions/proc_open_null.phpt

--- a/dockerfiles/ci/xfail_tests/README.md
+++ b/dockerfiles/ci/xfail_tests/README.md
@@ -150,6 +150,13 @@ Such tests were skipped before and are incredibly unstable on 5. It might be a C
 
 This test was flaky until it was [fixed in PHP 7.2](https://github.com/php/php-src/commit/f4474e5).
 
+## `ext/standard/tests/general_functions/phpinfo.phpt`
+
+* Disabled on versions: `7.0 --> 8.1`.
+* Upstream fix: [Reduce regex backtracking in phpinfo.phpt](https://github.com/php/php-src/commit/c4c45da4b96889348d86828c26225d113af14d21), which is present in PHP 8.2+.
+
+This test compares very large `phpinfo()` output. With tracer-specific modules and CI environment variables enabled, the output grows and older `%A`/`%a` patterns in this test can hit pathological backtracking and fail nondeterministically.
+
 ## `ext/standard/tests/streams/proc_open_bug69900.phpt`
 
 * Disabled on versions: `7.0+`.


### PR DESCRIPTION
### Description

phpinfo.phpt on PHP 7.0-8.1 use older `%A`/`%a` expectations. With large `phpinfo()` output (tracer modules + CI environment variables), those patterns can hit regex backtracking issues and then the diff fails to match cleanly, causing "flaky" test failures.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
