### PR TITLE
build: publish to aws latest only on default branch

### DIFF
--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -1397,7 +1397,11 @@ foreach ($arch_targets as $arch) {
     VERSION="$(<VERSION)"
     [[ -z "${VERSION}" ]] && echo "VERSION file is empty or not present" && exit 1
     cd packages/ && aws s3 cp --recursive . "s3://dd-trace-php-builds/${VERSION}/"
-    aws s3 cp datadog-setup.php "s3://dd-trace-php-builds/latest/"
+    if [ "${CI_COMMIT_REF_NAME}" = "${CI_DEFAULT_BRANCH}" ]; then
+      aws s3 cp datadog-setup.php "s3://dd-trace-php-builds/latest/"
+    else
+      echo "Skipping latest upload for non-default branch: ${CI_COMMIT_REF_NAME} (default: ${CI_DEFAULT_BRANCH})"
+    fi
     echo "https://s3.us-east-1.amazonaws.com/dd-trace-php-builds/$(echo $VERSION | sed 's/+/%2B/')/datadog-setup.php"
   artifacts:
     paths:


### PR DESCRIPTION
### Description

When running benchmarks, we'll often push the "publish to public s3" button to build the artifacts to install. Then, we may configure a run like `library_version=local,dev` and prior to this patch, you will often end up testing against yourself, since you were the last to build! 

Dev should be the latest on the default branch, aka master.  Anything is very surprising, I think.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
