### PR TITLE
ci: fix package-oci failure in parent pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -9,6 +9,11 @@ variables:
   GIT_SUBMODULE_STRATEGY: recursive
   # Only clone libdatadog submodule by default
   GIT_SUBMODULE_PATHS: libdatadog
+  # Suppress shared-pipeline jobs (package-oci and its downstream) in the
+  # parent pipeline. They run in the child pipeline (package-gen.yml) where
+  # package loader artifacts are available. Override to "false" in
+  # package-trigger so the child pipeline runs them correctly.
+  SKIP_SHARED_PIPELINE: "true"
   RELIABILITY_ENV_BRANCH:
     value: "master"
     description: "Run a specific datadog-reliability-env branch downstream"
@@ -97,11 +102,10 @@ package-trigger:
     GIT_SUBMODULE_PATHS: libdatadog appsec/third_party/cpp-base64 appsec/third_party/libddwaf appsec/third_party/msgpack-c
     NIGHTLY_BUILD: $NIGHTLY_BUILD
     RELIABILITY_ENV_BRANCH: $RELIABILITY_ENV_BRANCH
+    SKIP_SHARED_PIPELINE: "false"
 
-# package-oci runs in the child pipeline (package-gen.yml) with the correct
-# needs: [package loader] override. The parent pipeline doesn't have package
-# loader artifacts, so we suppress it here.
-package-oci:
+# requirements_json_test doesn't check SKIP_SHARED_PIPELINE, suppress explicitly
+requirements_json_test:
   rules:
     - when: never
 


### PR DESCRIPTION
## Root Cause

Commit a3409cd78 included `one-pipeline.locked.yml` in the parent pipeline to get the supported-configurations validation templates. This accidentally also brought in `package-oci` and its downstream jobs, which have no access to `package loader` artifacts in the parent pipeline.

`package-oci` is meant to run only in the **child pipeline** (via `package-trigger`) where `generate-package.php` provides the correct `needs: [package loader]` override.

## Fix

- Set `SKIP_SHARED_PIPELINE: "true"` globally to suppress shared-pipeline jobs in the parent pipeline.
- Override to `"false"` in `package-trigger` so the child pipeline still runs them correctly.
- Explicitly suppress `requirements_json_test` since it doesn't check `SKIP_SHARED_PIPELINE`.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.