### PR TITLE
ci: fix SKIP_SHARED_PIPELINE leaking into reliability env pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -104,6 +104,10 @@ package-trigger:
     RELIABILITY_ENV_BRANCH: $RELIABILITY_ENV_BRANCH
     SKIP_SHARED_PIPELINE: "false"
 
+deploy_to_reliability_env:
+  variables:
+    SKIP_SHARED_PIPELINE: "false"
+
 # requirements_json_test doesn't check SKIP_SHARED_PIPELINE, suppress explicitly
 requirements_json_test:
   rules:


### PR DESCRIPTION
### Description

The global SKIP_SHARED_PIPELINE=true introduced in #3679 is passed by GitLab to all downstream pipelines, including the cross-project deploy_to_reliability_env trigger. This caused trigger_unpack to be suppressed in the reliability env pipeline, breaking the PHP demo jobs (FrankePHP, Shopware, Symfony, Laravel) that depend on it.

Fix: override deploy_to_reliability_env to explicitly pass SKIP_SHARED_PIPELINE=false, preventing the parent pipeline's suppression flag from affecting the downstream reliability env pipeline.

