### PR TITLE
ci: suppress promote-oci jobs that bypass SKIP_SHARED_PIPELINE

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -108,6 +108,18 @@ deploy_to_reliability_env:
   variables:
     SKIP_SHARED_PIPELINE: "false"
 
+promote-oci-to-staging:
+  rules:
+    - when: never
+
+promote-oci-to-prod-beta:
+  rules:
+    - when: never
+
+promote-oci-to-prod:
+  rules:
+    - when: never
+
 # requirements_json_test doesn't check SKIP_SHARED_PIPELINE, suppress explicitly
 requirements_json_test:
   rules:


### PR DESCRIPTION
### Description

promote-oci-to-staging fires on NIGHTLY_BUILD=true, and promote-oci-to-prod-beta and promote-oci-to-prod fire on tag rules, before the SKIP_SHARED_PIPELINE check. Their dependencies (package-oci, oci-internal-publish, publishing-gate) are suppressed in the parent pipeline, causing pipeline validation failures.

These jobs run correctly in the child pipeline (package-gen.yml).