### PR TITLE
ci: move one-pipeline jobs to package child pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,7 +1,6 @@
 stages:
   - build
   - tests
-  - shared-pipeline
   - deploy
   - ci-build
 
@@ -9,11 +8,6 @@ variables:
   GIT_SUBMODULE_STRATEGY: recursive
   # Only clone libdatadog submodule by default
   GIT_SUBMODULE_PATHS: libdatadog
-  # Suppress shared-pipeline jobs (package-oci and its downstream) in the
-  # parent pipeline. They run in the child pipeline (package-gen.yml) where
-  # package loader artifacts are available. Override to "false" in
-  # package-trigger so the child pipeline runs them correctly.
-  SKIP_SHARED_PIPELINE: "true"
   RELIABILITY_ENV_BRANCH:
     value: "master"
     description: "Run a specific datadog-reliability-env branch downstream"
@@ -23,7 +17,6 @@ include:
   - project: DataDog/apm-reliability/libdatadog-build
     ref: 5826819695d93286569e70ed087ae6bf906ce2c3
     file: templates/ci_authenticated_job.yml
-  - local: .gitlab/one-pipeline.locked.yml
   - local: .gitlab/ci-images.yml
 
 generate-templates:
@@ -102,28 +95,3 @@ package-trigger:
     GIT_SUBMODULE_PATHS: libdatadog appsec/third_party/cpp-base64 appsec/third_party/libddwaf appsec/third_party/msgpack-c
     NIGHTLY_BUILD: $NIGHTLY_BUILD
     RELIABILITY_ENV_BRANCH: $RELIABILITY_ENV_BRANCH
-    SKIP_SHARED_PIPELINE: "false"
-
-deploy_to_reliability_env:
-  variables:
-    SKIP_SHARED_PIPELINE: "false"
-
-# requirements_json_test doesn't check SKIP_SHARED_PIPELINE, suppress explicitly
-requirements_json_test:
-  rules:
-    - when: never
-
-validate_supported_configurations_v2_local_file:
-  needs: []
-  extends: .validate_supported_configurations_v2_local_file
-  variables:
-    LOCAL_JSON_PATH: "metadata/supported-configurations.json"
-    BACKFILLED: "true"
-
-update_central_configurations_version_range_v2:
-  extends: .update_central_configurations_version_range_v2
-  variables:
-    LOCAL_REPO_NAME: "dd-trace-php"
-    LOCAL_JSON_PATH: "metadata/supported-configurations.json"
-    LANGUAGE_NAME: "php"
-    MULTIPLE_RELEASE_LINES: "false"

--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -96,6 +96,21 @@ include:
   - local: .gitlab/benchmarks.yml
 
 # One pipeline job overrides
+validate_supported_configurations_v2_local_file:
+  needs: []
+  extends: .validate_supported_configurations_v2_local_file
+  variables:
+    LOCAL_JSON_PATH: "metadata/supported-configurations.json"
+    BACKFILLED: "true"
+
+update_central_configurations_version_range_v2:
+  extends: .update_central_configurations_version_range_v2
+  variables:
+    LOCAL_REPO_NAME: "dd-trace-php"
+    LOCAL_JSON_PATH: "metadata/supported-configurations.json"
+    LANGUAGE_NAME: "php"
+    MULTIPLE_RELEASE_LINES: "false"
+
 configure_system_tests:
   variables:
     SYSTEM_TESTS_SCENARIOS_GROUPS: "simple_onboarding,simple_onboarding_profiling,simple_onboarding_appsec,lib-injection,lib-injection-profiling,docker-ssi"


### PR DESCRIPTION
## Summary

- Moves `validate_supported_configurations_v2_local_file` and `update_central_configurations_version_range_v2` from `.gitlab-ci.yml` to `generate-package.php` (the package child pipeline)
- Removes all `SKIP_SHARED_PIPELINE` workarounds from the parent pipeline

## Context

Commit `a3409cd78` added `- local: .gitlab/one-pipeline.locked.yml` to the parent pipeline (`.gitlab-ci.yml`) to get job templates needed by two supported-configurations validation jobs. This accidentally imported all shared-pipeline jobs (`package-oci`, `promote-oci-*`, `requirements_json_test`, etc.) into the parent pipeline, causing cascading failures.

Previous PRs #3679, #3682 and open PR #3687 applied `SKIP_SHARED_PIPELINE` band-aids to suppress those jobs. This PR addresses the root cause instead:

`generate-package.php` already includes `one-pipeline.locked.yml`, so the two concrete jobs naturally belong there. The parent pipeline no longer includes `one-pipeline.locked.yml` at all, so no suppression is needed.

**Supersedes #3687.**

## Test plan

- [ ] Verify `package-trigger` child pipeline runs `validate_supported_configurations_v2_local_file` and `update_central_configurations_version_range_v2`
- [ ] Verify `package-oci`, `promote-oci-*`, and `requirements_json_test` no longer appear in the parent pipeline
- [ ] Verify nightly/scheduled pipelines no longer fail with unexpected job failures