### PR TITLE
fix: enforce span limit in curl_multi_exec and DDTrace\start_span code paths

### DIFF
--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -3214,7 +3214,7 @@ static inline void dd_start_span(INTERNAL_FUNCTION_PARAMETERS) {
 
     ddtrace_span_data *span;
 
-    if (get_DD_TRACE_ENABLED() && !ddtrace_tracer_is_limited()) {
+    if (get_DD_TRACE_ENABLED()) {
         span = ddtrace_open_span(DDTRACE_USER_SPAN);
     } else {
         span = ddtrace_init_dummy_span();
@@ -3224,7 +3224,7 @@ static inline void dd_start_span(INTERNAL_FUNCTION_PARAMETERS) {
         span->start = (uint64_t)(start_time_seconds * ZEND_NANO_IN_SEC);
     }
 
-    if (get_DD_TRACE_ENABLED() && !ddtrace_tracer_is_limited()) {
+    if (get_DD_TRACE_ENABLED()) {
         ddtrace_observe_opened_span(span);
     }
 
@@ -3238,7 +3238,7 @@ PHP_FUNCTION(DDTrace_start_span) {
 
 /* {{{ proto string DDTrace\start_trace_span() */
 PHP_FUNCTION(DDTrace_start_trace_span) {
-    if (get_DD_TRACE_ENABLED() && !ddtrace_tracer_is_limited()) {
+    if (get_DD_TRACE_ENABLED()) {
         ddtrace_span_stack *stack = ddtrace_init_root_span_stack();
         ddtrace_switch_span_stack(stack);
         GC_DELREF(&stack->std); // We don't retain a ref to it, it's now the active_stack

--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -3214,7 +3214,7 @@ static inline void dd_start_span(INTERNAL_FUNCTION_PARAMETERS) {
 
     ddtrace_span_data *span;
 
-    if (get_DD_TRACE_ENABLED()) {
+    if (get_DD_TRACE_ENABLED() && !ddtrace_tracer_is_limited()) {
         span = ddtrace_open_span(DDTRACE_USER_SPAN);
     } else {
         span = ddtrace_init_dummy_span();
@@ -3224,7 +3224,7 @@ static inline void dd_start_span(INTERNAL_FUNCTION_PARAMETERS) {
         span->start = (uint64_t)(start_time_seconds * ZEND_NANO_IN_SEC);
     }
 
-    if (get_DD_TRACE_ENABLED()) {
+    if (get_DD_TRACE_ENABLED() && !ddtrace_tracer_is_limited()) {
         ddtrace_observe_opened_span(span);
     }
 
@@ -3238,7 +3238,7 @@ PHP_FUNCTION(DDTrace_start_span) {
 
 /* {{{ proto string DDTrace\start_trace_span() */
 PHP_FUNCTION(DDTrace_start_trace_span) {
-    if (get_DD_TRACE_ENABLED()) {
+    if (get_DD_TRACE_ENABLED() && !ddtrace_tracer_is_limited()) {
         ddtrace_span_stack *stack = ddtrace_init_root_span_stack();
         ddtrace_switch_span_stack(stack);
         GC_DELREF(&stack->std); // We don't retain a ref to it, it's now the active_stack

--- a/ext/handlers_curl.c
+++ b/ext/handlers_curl.c
@@ -135,7 +135,7 @@ static void dd_multi_inject_headers(zend_object *mh) {
     if (handles && zend_hash_num_elements(handles) > 0) {
         zend_object *ch;
         ZEND_HASH_FOREACH_PTR(handles, ch) {
-            if (DDTRACE_G(curl_multi_injecting_spans) && Z_TYPE(DDTRACE_G(curl_multi_injecting_spans)->val) == IS_ARRAY) {
+            if (!ddtrace_tracer_is_limited() && DDTRACE_G(curl_multi_injecting_spans) && Z_TYPE(DDTRACE_G(curl_multi_injecting_spans)->val) == IS_ARRAY) {
                 ddtrace_span_data *span = ddtrace_open_span(DDTRACE_INTERNAL_SPAN);
                 dd_inject_distributed_tracing_headers(ch);
                 ddtrace_observe_opened_span(span);

--- a/ext/handlers_curl_php7.c
+++ b/ext/handlers_curl_php7.c
@@ -158,7 +158,7 @@ static int dd_inject_distributed_tracing_headers(zval *ch) {
 }
 
 static int dd_inject_distributed_tracing_headers_multi(zval *ch) {
-    if (DDTRACE_G(curl_multi_injecting_spans) && Z_TYPE(DDTRACE_G(curl_multi_injecting_spans)->val) == IS_ARRAY) {
+    if (!ddtrace_tracer_is_limited() && DDTRACE_G(curl_multi_injecting_spans) && Z_TYPE(DDTRACE_G(curl_multi_injecting_spans)->val) == IS_ARRAY) {
         ddtrace_span_data *span = ddtrace_open_span(DDTRACE_INTERNAL_SPAN);
         int ret = dd_inject_distributed_tracing_headers(ch);
         ddtrace_close_span(span);


### PR DESCRIPTION
## Summary

`DD_TRACE_SPANS_LIMIT` was correctly enforced in the hook system (`uhook.c`, `uhook_legacy.c`, `uhook_attributes.c`) but bypassed in the `curl_multi_exec` code paths, causing unbounded span creation and OOM when curl multi is called repeatedly (e.g. AWS SDK SQS workloads on ECS Fargate).

Fixes APMS-18744.

### Root cause

- **`dd_multi_inject_headers()`** (`ext/handlers_curl.c`): PHP 8 curl multi creates one `DDTRACE_INTERNAL_SPAN` per handle on every `curl_multi_exec` call without checking the limit. With ~100k SQS calls (each using curl multi internally), this produced 100k+ unconstrained spans — the primary cause of the reported OOM.
- **`dd_inject_distributed_tracing_headers_multi()`** (`ext/handlers_curl_php7.c`): same issue on PHP 7.

### Fix

Add `!ddtrace_tracer_is_limited()` guards to both curl multi paths. When the span limit is reached, the paths fall through to header injection only (no span created) — distributed tracing propagation is preserved, only span tracking is skipped.