### PR TITLE
ci(prof): fix "argument unused during compilation" warning

### DIFF
--- a/.github/workflows/prof_correctness.yml
+++ b/.github/workflows/prof_correctness.yml
@@ -47,13 +47,16 @@ jobs:
 
       - name: Build profiler
         run: |
-          echo "deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main" | sudo tee -a /etc/apt/sources.list
-          echo "deb-src http://apt.llvm.org/jammy/ llvm-toolchain-jammy-17 main" | sudo tee -a /etc/apt/sources.list
-          curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
-          curl https://apt.llvm.org/llvm-snapshot.gpg.key | sudo tee /etc/apt/trusted.gpg.d/apt.llvm.org.asc
-          sudo apt remove -y clang-*
+          codename="$(lsb_release -cs)"
+          curl -fsSL https://apt.llvm.org/llvm-snapshot.gpg.key | sudo gpg --dearmor -o /usr/share/keyrings/llvm-archive-keyring.gpg
+          echo "deb [signed-by=/usr/share/keyrings/llvm-archive-keyring.gpg] http://apt.llvm.org/${codename}/ llvm-toolchain-${codename}-19 main" | sudo tee /etc/apt/sources.list.d/llvm.list
           sudo apt-get update
-          sudo apt install -y clang-17
+          sudo apt-get install -y clang-19 lld-19
+          sudo update-alternatives --install /usr/bin/clang clang /usr/bin/clang-19 100
+          sudo update-alternatives --install /usr/bin/clang++ clang++ /usr/bin/clang++-19 100
+          sudo update-alternatives --install /usr/bin/ld.lld ld.lld /usr/bin/ld.lld-19 100
+          clang --version
+          ld.lld --version
           cd profiling
           version_number=$(awk -F' = ' '$1 == "channel" { gsub(/"/, "", $2); print $2 }' rust-toolchain.toml)
           curl https://sh.rustup.rs -sSf | sh -s -- --profile minimal -y --default-toolchain "$version_number"

--- a/profiling/build.rs
+++ b/profiling/build.rs
@@ -170,7 +170,6 @@ fn build_zend_php_ffis(
                 .chain([Path::new("../zend_abstract_interface")])
                 .chain([Path::new("../")]),
         )
-        .flag_if_supported("-fuse-ld=lld")
         .flag_if_supported("-std=c11")
         .flag_if_supported("-std=c17");
     #[cfg(feature = "test")]


### PR DESCRIPTION
### Description

When compiling the profiler we see a lot of these lines:

```
warning: datadog-php-profiling@0.0.0: clang: warning: argument unused during compilation: '-fuse-ld=lld' [-Wunused-command-line-argument]
```

This stems from this line in `build.rs`:

https://github.com/DataDog/dd-trace-php/blob/0d2b2ffe3ff8c19c521abacfeba57d589a51fe9c/profiling/build.rs#L173

Afaik the `build.rs` is "only" used to compile and not for linking step, so this `-fuse-ld=lld` might not belong there anyway?

Additionally I am updating llvm to 19 for the prof-correctness job, just because it matches the `rustc -Vv` LLVM version:

```
$ rustc -vV   
rustc 1.84.1 (e71f9a9a9 2025-01-27)
binary: rustc
commit-hash: e71f9a9a98b0faf423844bf0ba7438f29dc27d58
commit-date: 2025-01-27
host: aarch64-apple-darwin
release: 1.84.1
LLVM version: 19.1.5
```

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
