### PR TITLE
build(profiling): allow list of undefined symbols on macOS

### DIFF
--- a/profiling/.cargo/config.toml
+++ b/profiling/.cargo/config.toml
@@ -1,9 +1,0 @@
-[target.x86_64-apple-darwin]
-# Leaving syntax here in case we decide to list them all specifically
-#rustflags = ["-C", "link-args=-Wl,-U,_zend_register_extension -Wl,-U,_zend_getenv -Wl,-U,_sapi_module -Wl,-U,_executor_globals"]
-rustflags = ["-C", "link-args=-undefined dynamic_lookup"]
-
-[target.aarch64-apple-darwin]
-# Leaving syntax here in case we decide to list them all specifically
-#rustflags = ["-C", "link-args=-Wl,-U,_zend_register_extension -Wl,-U,_zend_getenv -Wl,-U,_sapi_module -Wl,-U,_executor_globals"]
-rustflags = ["-C", "link-args=-undefined dynamic_lookup"]

--- a/profiling/build.rs
+++ b/profiling/build.rs
@@ -54,6 +54,7 @@ fn main() {
     cfg_php_major_version(vernum);
     cfg_php_feature_flags(vernum);
     cfg_zts();
+    apple_linker_flags();
 }
 
 fn php_config_vernum() -> u64 {
@@ -458,5 +459,159 @@ int main() {
 
     if zts_value == "1" {
         println!("cargo:rustc-cfg=php_zts");
+    }
+}
+
+/// On macOS (Apple targets), the cdylib has undefined symbols that are
+/// resolved at load time by the PHP process. In debug builds, LTO is off
+/// which produces more unresolved symbols--we fall back to
+/// `-undefined dynamic_lookup` for debug builds.
+///
+/// To regenerate the symbol list after adding new PHP/C API calls:
+///   1. Edit the profile != release check to always be true e.g. if true {
+///   2. Build a release: `cargo build -p datadog-php-profiling --release`
+///   3. Extract symbols:
+///      `nm -u target/release/libdatadog_php_profiling.dylib | sort -u |
+///       grep -v '^$\|^ERROR\|dyld_stub' | sed 's/^/-Wl,-U,/' | tr '\n' ' '`
+///   4. Update the ALLOWED_UNDEFINED_SYMBOLS list below.
+///
+/// ## Why list the symbols manually?
+///
+/// On several branches I've wanted to test out no_panic for things that I
+/// want to be sure cannot panic. For instance, the opcache persist hook is
+/// called while holding a lock in shared memory, it would be bad to panic
+/// there. Its technique is incompatible with -undefined dynamic_lookup.
+///
+/// It also serves as an audit list. I have caught symbols I did not expect
+/// slipping in during these experiments (due to AI).
+fn apple_linker_flags() {
+    let target = env::var("TARGET").unwrap_or_default();
+    if !target.contains("apple") {
+        return;
+    }
+
+    let profile = env::var("PROFILE").unwrap_or_default();
+    if profile != "release" {
+        // Debug builds: allow all undefined symbols.
+        println!("cargo:rustc-cdylib-link-arg=-undefined");
+        println!("cargo:rustc-cdylib-link-arg=dynamic_lookup");
+        return;
+    }
+
+    // Release builds: explicitly allow only PHP/Zend symbols that are
+    // resolved at load time from the PHP binary. System symbols (libc,
+    // libSystem, CoreFoundation, Security, etc.) are resolved by the
+    // linker from their respective libraries/frameworks. This way, any
+    // NEW undefined symbol — such as a no_panic sentinel — causes a
+    // linker error.
+    //
+    // Note: on macOS, symbols get a leading underscore, so `_efree` in C
+    // becomes `__efree` here, and `__zend_malloc` becomes `___zend_malloc`.
+    const ALLOWED_UNDEFINED_SYMBOLS: &[&str] = &[
+        // Zend memory allocator
+        "___zend_malloc",
+        "__efree",
+        "__emalloc",
+        "__emalloc_40",
+        "__emalloc_48",
+        "__emalloc_56",
+        "__emalloc_large",
+        "__zend_handle_numeric_str_ex",
+        "__zend_hash_init",
+        "__zend_mm_alloc",
+        "__zend_mm_free",
+        "__zend_mm_realloc",
+        // Zend globals
+        "_compiler_globals",
+        "_core_globals",
+        "_executor_globals",
+        "_module_registry",
+        // Zend engine APIs
+        "_cfg_get_entry",
+        "_display_ini_entries",
+        "_gc_collect_cycles",
+        "_instanceof_function_slow",
+        "_is_zend_mm",
+        "_rc_dtor_func",
+        "_zend_accel_schedule_restart_hook",
+        "_zend_alter_ini_entry_ex",
+        "_zend_ce_throwable",
+        "_zend_compile_file",
+        "_zend_compile_string",
+        "_zend_empty_string",
+        "_zend_extensions",
+        "_zend_flf_functions",
+        "_zend_gc_get_status",
+        "_zend_get_executed_filename_ex",
+        "_zend_get_executed_lineno",
+        "_zend_get_extension",
+        "_zend_get_internal_function_extension_handles",
+        "_zend_get_op_array_extension_handles",
+        "_zend_get_resource_handle",
+        "_zend_hash_add",
+        "_zend_hash_add_empty_element",
+        "_zend_hash_destroy",
+        "_zend_hash_find",
+        "_zend_hash_index_update",
+        "_zend_hash_next_index_insert",
+        "_zend_hash_str_add",
+        "_zend_hash_str_find",
+        "_zend_hash_update",
+        "_zend_ini_boolean_displayer_cb",
+        "_zend_ini_get_value",
+        "_zend_ini_parse_bool",
+        "_zend_ini_parse_quantity",
+        "_zend_ini_string",
+        "_zend_interned_strings_switch_storage",
+        "_zend_interrupt_function",
+        "_zend_known_strings",
+        "_zend_mm_gc",
+        "_zend_mm_get_custom_handlers_ex",
+        "_zend_mm_get_heap",
+        "_zend_mm_set_custom_handlers_ex",
+        "_zend_mm_shutdown",
+        "_zend_new_interned_string",
+        "_zend_observer_error_register",
+        "_zend_post_startup_cb",
+        "_zend_register_extension",
+        "_zend_register_ini_entries",
+        "_zend_str_tolower",
+        "_zend_string_init_interned",
+        "_zend_strtod",
+        "_zend_throw_exception_hook",
+        "_zend_write",
+        "_zval_internal_ptr_dtor",
+        "_zval_ptr_dtor",
+        // PHP APIs
+        "_php_during_module_startup",
+        "_php_get_module_initialized",
+        "_php_info_print_table_end",
+        "_php_info_print_table_row",
+        "_php_info_print_table_start",
+        "_php_json_encode",
+        "_php_json_parse",
+        "_php_json_parser_init",
+        "_php_json_serializable_ce",
+        "_php_version",
+        "_php_version_id",
+        // SAPI
+        "_sapi_getenv",
+        "_sapi_globals",
+        "_sapi_module",
+        // TSRM (ZTS builds only; harmless to list on NTS — they simply
+        // won't appear as undefined)
+        "_tsrm_get_ls_cache",
+        "_tsrm_set_new_thread_end_handler",
+        // ZTS globals offsets (replace direct globals on ZTS)
+        "_compiler_globals_offset",
+        "_core_globals_offset",
+        "_executor_globals_offset",
+        "_sapi_globals_offset",
+        // Zend parameter error (may appear with certain PHP versions/features)
+        "_zend_wrong_parameters_none_error",
+    ];
+
+    for sym in ALLOWED_UNDEFINED_SYMBOLS {
+        println!("cargo:rustc-cdylib-link-arg=-Wl,-U,{sym}");
     }
 }


### PR DESCRIPTION
### Description

Uses a list of symbols on macOS to allow to be undefined. They are undefined because they are provided by the PHP engine, which does not provide a libzend.so or similar for us to link to. They are provided by the SAPI that our profiler is linked into.

Before this patch, we used linker flags `-undefined dynamic_lookup`, set in `profiling/.cargo/config.toml`. This allows all undefined symbols to pass through without issue. In several different branches, I experimented with using the [`no_panic` crate](https://docs.rs/no-panic/latest/no_panic/):

> If the function does panic (or the compiler fails to prove that the function cannot panic), the program fails to compile with a linker error that identifies the function name.

The problem is that this technique isn't compatible with allowing undefined symbols unconditionally!

Additionally, the list of symbols serves as an audit list.

### Reviewer checklist
- [x] Test coverage seems ok.
- [x] Appropriate labels assigned.
