### PR TITLE
ci(prof): update profiling ASAN runs

### DIFF
--- a/.github/workflows/prof_asan.yml
+++ b/.github/workflows/prof_asan.yml
@@ -62,7 +62,6 @@ jobs:
           set -eux
           switch-php nts-asan
           cd profiling/tests
-          jobs=$(getconf _NPROCESSORS_ONLN)
           cp -v $(php-config --prefix)/lib/php/build/run-tests.php .
           export DD_PROFILING_OUTPUT_PPROF=/tmp/pprof
-          php run-tests.php -j"${jobs}" --show-diff --asan -d extension=datadog-profiling.so phpt
+          php run-tests.php -j$(nproc) --show-diff --asan -d extension=datadog-profiling.so phpt


### PR DESCRIPTION
### Description

This PR:
- adds PHP 8.5 to ASAN tests
- fixes cache usage
- Updates `checkout` and `cache` action versions
- switch to use Datadog private runners to run ASAN not only on amd64 but also aarch64
- instruct `run-tests.php` to run tests in parallel
- don't reinstall nightly Rust, but use the nightly that is baked into the bookworm image

... bringing down CI time from ~10 minutes to ~5 minutes for the ASAN jobs.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
