### PR TITLE
fix(exec): don't treat shell_exec() null return as an error

### DIFF
--- a/src/DDTrace/Integrations/Exec/ExecIntegration.php
+++ b/src/DDTrace/Integrations/Exec/ExecIntegration.php
@@ -255,8 +255,6 @@ class ExecIntegration extends Integration
                 $span->exception = $hook->exception;
             } elseif ($hook->returned === false) {
                 $span->meta[Tag::ERROR_MSG] = "$variant() returned false";
-            } elseif ($hook->returned === null && $variant === 'shell_exec') {
-                $span->meta[Tag::ERROR_MSG] = "shell_exec() returned null";
             } elseif (
                 !empty($retCodeArg) &&
                 isset($hook->args[$retCodeArg]) &&

--- a/tests/Integrations/Exec/ExecIntegrationTest.php
+++ b/tests/Integrations/Exec/ExecIntegrationTest.php
@@ -491,6 +491,32 @@ class ExecIntegrationTest extends IntegrationTestCase
     }
 
     /**
+     * shell_exec() returning null must NOT produce an error span.
+     *
+     * PHP docs state: "It is not possible to detect execution failures using
+     * this function." A null return means either no output was produced or the
+     * command failed — the two cases are indistinguishable. Flagging null as an
+     * error causes false-positive error spans for any intentionally silent
+     * command (e.g. Symfony's `stty 2>/dev/null`).
+     */
+    public function testShellExecNullReturnIsNotAnError()
+    {
+        $traces = $this->isolateTracer(function () {
+            // 'true' exits 0 with no output → shell_exec returns null.
+            $res = shell_exec('true');
+            $this->assertNull($res);
+        });
+
+        $this->assertSpans($traces, [
+            SpanAssertion::build('command_execution', $traces[0][0]['service'], 'system', 'sh')
+                ->withExactTags([
+                    'cmd.shell' => 'true',
+                    'component' => 'subprocess',
+                ])
+        ]);
+    }
+
+    /**
      * Test that the shell command is redacted.
      * @dataProvider allShellFunctionsProvider
      * @param $sf


### PR DESCRIPTION
## Summary

`shell_exec()` returning `null` was flagged as an error span. Per PHP docs, null means either no output **or** failure — the two are indistinguishable. This caused false-positive error spans for any silent command (e.g. Symfony's `stty 2>/dev/null`), which is especially disruptive with `DD_APM_FEATURES=error_rare_sample_tracer_drop` since those spans can't be sampled away.

A prior partial fix (`cff203464`) hooked two specific Symfony methods, but left the root defect in `postHookShell()` alive for all other callers.

## Changes

- Remove the `shell_exec() returned null` error condition from `postHookShell()` — the `false` return check above it covers genuine PHP-level failures
- Add `testShellExecNullReturnIsNotAnError`: asserts `shell_exec('true')` (null return, no output) produces a clean span with no error

Fixes: APMS-18967 / #3127