### PR TITLE
re-enable renovate with 14-day cooldown

### DIFF
--- a/tests/Frameworks/Laminas/Mvc/Version_3_3/renovate.json
+++ b/tests/Frameworks/Laminas/Mvc/Version_3_3/renovate.json
@@ -1,0 +1,10 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": [
+    "local>laminas/.github:renovate-config"
+  ],
+  "constraints": {
+    "php": "^7.4"
+  },
+  "minimumReleaseAge": "14 days"
+}

--- a/tests/Frameworks/Laminas/Mvc/Version_3_3/renovate.json.disabled
+++ b/tests/Frameworks/Laminas/Mvc/Version_3_3/renovate.json.disabled
@@ -1,9 +1,0 @@
-{
-    "$schema": "https://docs.renovatebot.com/renovate-schema.json",
-    "extends": [
-        "local>laminas/.github:renovate-config"
-    ],
-    "constraints": {
-        "php": "^7.4"
-    }
-}


### PR DESCRIPTION
> [!NOTE]
> **Merge only if this is still needed and your repo is not managed by ADMS.**
> If your repository is already managed by ADMS, feel free to close or ignore this PR.

---

We are adding a mandatory 14-day cooldown (`minimumReleaseAge`) on dependencies to reduce the risk of zero-day vulnerabilities.

Please expect PRs that re-enable updaters and introduce the cooldown setting. If you notice any configurations that were not disabled on your repos, please ensure a cooldown is added.

If your repository is already managed by ADMS and no longer requires these configurations, feel free to close or ignore the PR.