### PR TITLE
Fix nightly reliability env deploys

### DIFF
--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -1433,7 +1433,7 @@ foreach ($arch_targets as $arch) {
   image: registry.ddbuild.io/ci/libdatadog-build/ci_docker_base:67145216
   tags: [ "arch:amd64" ]
   rules:
-    - if: $CI_PIPELINE_SOURCE == "schedule" && $NIGHTLY_BUILD
+    - if: $NIGHTLY_BUILD
       when: on_success
     - if: $CI_COMMIT_REF_NAME =~ /^ddtrace-/
       when: on_success


### PR DESCRIPTION
### Description

This PR fixes the incorrect rule around nightly deploys. The `CI_PIPELINE_SOURCE` of a _child_ pipeline is never `schedule`.

<!---
Any description you feel is relevant and gives more background to this PR, if necessary.
-->

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
