### PR TITLE
fix(ci): ignore google/protobuf security advisories in pre-8.1 OTel composer

### DIFF
--- a/tests/OpenTelemetry/composer-pre-8.1.json
+++ b/tests/OpenTelemetry/composer-pre-8.1.json
@@ -6,5 +6,13 @@
         "open-telemetry/opentelemetry-logger-monolog": "^1.0",
         "open-telemetry/exporter-otlp": "^1.0"
     },
-    "minimum-stability": "stable"
+    "minimum-stability": "stable",
+    "config": {
+        "audit": {
+            "ignore": {
+                "PKSA-tcfz-w4fm-hhk9": "test-only transitive dep via gen-otlp-protobuf on legacy PHP path, not in production",
+                "PKSA-yqjh-6qvh-g493": "test-only transitive dep via gen-otlp-protobuf on legacy PHP path, not in production"
+            }
+        }
+    }
 }


### PR DESCRIPTION
## Summary

- `test_opentelemetry_1: [7.4]` and `test_opentelemetry_1: [8.0]` have been failing consistently across all master pipelines for the past 2+ days
- Root cause: `open-telemetry/exporter-otlp ^1.0` was added to `tests/OpenTelemetry/composer-pre-8.1.json` in 4bdc71f. On PHP <8.1, it can only resolve to `<=1.0.4`, which transitively depends on `google/protobuf ^3.3` (via `gen-otlp-protobuf`)
- Two security advisories (`PKSA-tcfz-w4fm-hhk9`, `PKSA-yqjh-6qvh-g493`) now block Composer from installing `google/protobuf`, with no viable path: older `gen-otlp-protobuf` needs the blocked protobuf, newer versions require PHP ^8.0
- Fix: add `config.audit.ignore` for these two advisories in the pre-8.1 test composer file — `google/protobuf` is a test-only transitive dependency, not shipped in production

## Test plan

- [ ] `test_opentelemetry_1: [7.4]` passes on CI
- [ ] `test_opentelemetry_1: [8.0]` passes on CI