### PR TITLE
ci: skip openssl bug79145.phpt on < 8.1

### DIFF
--- a/dockerfiles/ci/xfail_tests/7.3.list
+++ b/dockerfiles/ci/xfail_tests/7.3.list
@@ -421,3 +421,4 @@ ext/standard/tests/http/ghsa-hgf5-96fm-v528-003.phpt
 ext/standard/tests/http/ghsa-hgf5-96fm-v528-002.phpt
 ext/standard/tests/http/ghsa-hgf5-96fm-v528-001.phpt
 ext/standard/tests/http/ignore_errors.phpt
+ext/openssl/tests/bug79145.phpt

--- a/dockerfiles/ci/xfail_tests/8.0.list
+++ b/dockerfiles/ci/xfail_tests/8.0.list
@@ -565,3 +565,4 @@ ext/standard/tests/http/ghsa-hgf5-96fm-v528-002.phpt
 ext/standard/tests/http/ghsa-hgf5-96fm-v528-001.phpt
 ext/standard/tests/http/ignore_errors.phpt
 ext/standard/tests/general_functions/proc_open02.phpt
+ext/openssl/tests/bug79145.phpt

--- a/dockerfiles/ci/xfail_tests/README.md
+++ b/dockerfiles/ci/xfail_tests/README.md
@@ -120,6 +120,12 @@ Disabling the creation of the background sender thread the test passes (with a d
 
 See `ext/pcntl/tests/pcntl_unshare_01.phpt`.
 
+## `ext/openssl/tests/bug79145.phpt`
+
+Disabled on versions: `7.3`, `7.4`, `8.0`.
+
+This test verifies there is no memory leak in `openssl_get_publickey()` by looping 100,000 times. This is too slow sometimes, especially debug PHP build. The test was [rewritten in PHP 8.1](https://github.com/php/php-src/commit/6249172ae37f958f0a3ef92cb55d5bf7affa8214) to do a single warm-up call followed by one measured call, making it fast enough to run without a timeout. The test does not exist in PHP 7.2 and earlier.
+
 ## `ext/openssl/tests/bug74159.phpt`
 
 Disabled on versions: `7.2`.


### PR DESCRIPTION
### Description

This test loops many times and it's too slow sometimes causing the CI to be flaky. It was rewritten upstream in PHP 8.1 so we don't need to skip it on 8.1+.

This is a replacement of #3743, which I merged to the wrong base >.<

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
