### PR TITLE
fix(profiling): crash due to AAS getenv

### DIFF
--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -310,8 +310,10 @@ extern "C" fn minit(_type: c_int, module_number: c_int) -> ZendResult {
         let _connector = libdd_common::connector::Connector::default();
     }
 
-    // Initialize the lazy lock holding the env var for new origin detection.
+    // Initialize the lazy locks holding the env vars for new origin detection,
+    // Azure App Services, and so on.
     _ = std::sync::LazyLock::force(&libdd_common::entity_id::DD_EXTERNAL_ENV);
+    _ = std::sync::LazyLock::force(&libdd_common::azure_app_services::AAS_METADATA);
 
     // Use a hybrid extension hack to load as a module but have the
     // zend_extension hooks available:


### PR DESCRIPTION
### Description

When the profiler uploads its payload, it looks at various environment variables related to Azure App Services (see `ProfilesExporter::new` in libdatadog, which calls `libdd_common::azure_app_services::AAS_METADATA`). The problem is that this is being done on a background thread, so if the main PHP thread changes the environment, such as a php-fpm `env`, then it can crash.

The fix in this case is simple: just force the lock during minit before we have any threads.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
