### PR TITLE
fix(laravel): use route URI instead of unnamed_route in resource name

### DIFF
--- a/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
+++ b/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
@@ -122,7 +122,13 @@ class LaravelIntegration extends Integration
                 $routeName = self::normalizeRouteName($route->getName());
 
                 if (dd_trace_env_config("DD_HTTP_SERVER_ROUTE_BASED_NAMING")) {
-                    $rootSpan->resource = $route->getActionName() . ' ' . $routeName;
+                    if ($routeName !== self::UNNAMED_ROUTE) {
+                        $rootSpan->resource = $route->getActionName() . ' ' . $routeName;
+                    } elseif (method_exists($route, 'uri')) {
+                        $rootSpan->resource = $route->getActionName() . ' ' . $route->uri();
+                    } else {
+                        $rootSpan->resource = $route->getActionName() . ' ' . self::UNNAMED_ROUTE;
+                    }
                 }
 
                 $rootSpan->meta['laravel.route.name'] = $routeName;

--- a/tests/Integrations/Laravel/V8_x/RouteCachingTest.php
+++ b/tests/Integrations/Laravel/V8_x/RouteCachingTest.php
@@ -36,7 +36,7 @@ class RouteCachingTest extends WebFrameworkTestCase
                     'laravel.request',
                     'Laravel',
                     'web',
-                    'App\Http\Controllers\RouteCachingController@unnamed unnamed_route'
+                    'App\Http\Controllers\RouteCachingController@unnamed unnamed-route'
                 )
                     ->withExactTags([
                         'laravel.route.name' => 'unnamed_route',
@@ -84,7 +84,7 @@ class RouteCachingTest extends WebFrameworkTestCase
                     'laravel.request',
                     'Laravel',
                     'web',
-                    'App\Http\Controllers\RouteCachingController@unnamed unnamed_route'
+                    'App\Http\Controllers\RouteCachingController@unnamed unnamed-route'
                 )
                     ->withExactTags([
                         'laravel.route.name' => 'unnamed_route',

--- a/tests/snapshots/tests.integrations.laravel.apigw_test.test_laravel_inferred_proxy_exception.json
+++ b/tests/snapshots/tests.integrations.laravel.apigw_test.test_laravel_inferred_proxy_exception.json
@@ -30,7 +30,7 @@
      {
        "name": "laravel.request",
        "service": "my_service",
-       "resource": "App\\Http\\Controllers\\CommonSpecsController@error unnamed_route",
+       "resource": "App\\Http\\Controllers\\CommonSpecsController@error error",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,

--- a/tests/snapshots/tests.integrations.laravel.latest.common_scenarios_test.test_scenario_get_with_exception.json
+++ b/tests/snapshots/tests.integrations.laravel.latest.common_scenarios_test.test_scenario_get_with_exception.json
@@ -2,7 +2,7 @@
   {
     "name": "laravel.request",
     "service": "my_service",
-    "resource": "App\\Http\\Controllers\\CommonSpecsController@error unnamed_route",
+    "resource": "App\\Http\\Controllers\\CommonSpecsController@error error",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 5879388483676493807,

--- a/tests/snapshots/tests.integrations.laravel.latest.common_scenarios_test.test_scenario_get_with_view.json
+++ b/tests/snapshots/tests.integrations.laravel.latest.common_scenarios_test.test_scenario_get_with_view.json
@@ -2,7 +2,7 @@
   {
     "name": "laravel.request",
     "service": "my_service",
-    "resource": "App\\Http\\Controllers\\CommonSpecsController@simple_view unnamed_route",
+    "resource": "App\\Http\\Controllers\\CommonSpecsController@simple_view simple_view",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 13950427361689200115,

--- a/tests/snapshots/tests.integrations.laravel.octane.apigw_test.test_inferred_proxy_exception.json
+++ b/tests/snapshots/tests.integrations.laravel.octane.apigw_test.test_inferred_proxy_exception.json
@@ -29,7 +29,7 @@
      {
        "name": "laravel.request",
        "service": "swoole_test_app",
-       "resource": "App\\Http\\Controllers\\CommonSpecsController@error unnamed_route",
+       "resource": "App\\Http\\Controllers\\CommonSpecsController@error error",
        "trace_id": 0,
        "span_id": 2,
        "parent_id": 1,

--- a/tests/snapshots/tests.integrations.laravel.v10_x.common_scenarios_test.test_scenario_get_with_exception.json
+++ b/tests/snapshots/tests.integrations.laravel.v10_x.common_scenarios_test.test_scenario_get_with_exception.json
@@ -2,7 +2,7 @@
   {
     "name": "laravel.request",
     "service": "my_service",
-    "resource": "App\\Http\\Controllers\\CommonSpecsController@error unnamed_route",
+    "resource": "App\\Http\\Controllers\\CommonSpecsController@error error",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 14785377647724168590,

--- a/tests/snapshots/tests.integrations.laravel.v10_x.common_scenarios_test.test_scenario_get_with_view.json
+++ b/tests/snapshots/tests.integrations.laravel.v10_x.common_scenarios_test.test_scenario_get_with_view.json
@@ -2,7 +2,7 @@
   {
     "name": "laravel.request",
     "service": "my_service",
-    "resource": "App\\Http\\Controllers\\CommonSpecsController@simple_view unnamed_route",
+    "resource": "App\\Http\\Controllers\\CommonSpecsController@simple_view simple_view",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 833116231812134410,

--- a/tests/snapshots/tests.integrations.laravel.v11_x.common_scenarios_test.test_scenario_get_with_exception.json
+++ b/tests/snapshots/tests.integrations.laravel.v11_x.common_scenarios_test.test_scenario_get_with_exception.json
@@ -2,7 +2,7 @@
   {
     "name": "laravel.request",
     "service": "my_service",
-    "resource": "App\\Http\\Controllers\\CommonSpecsController@error unnamed_route",
+    "resource": "App\\Http\\Controllers\\CommonSpecsController@error error",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 7417571401826106684,

--- a/tests/snapshots/tests.integrations.laravel.v11_x.common_scenarios_test.test_scenario_get_with_view.json
+++ b/tests/snapshots/tests.integrations.laravel.v11_x.common_scenarios_test.test_scenario_get_with_view.json
@@ -2,7 +2,7 @@
   {
     "name": "laravel.request",
     "service": "my_service",
-    "resource": "App\\Http\\Controllers\\CommonSpecsController@simple_view unnamed_route",
+    "resource": "App\\Http\\Controllers\\CommonSpecsController@simple_view simple_view",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 11570399397149531429,

--- a/tests/snapshots/tests.integrations.laravel.v5_7.common_scenarios_test.test_scenario_get_dynamic_route.json
+++ b/tests/snapshots/tests.integrations.laravel.v5_7.common_scenarios_test.test_scenario_get_dynamic_route.json
@@ -2,7 +2,7 @@
   {
     "name": "laravel.request",
     "service": "laravel_test_app",
-    "resource": "App\\Http\\Controllers\\CommonSpecsController@dynamicRoute unnamed_route",
+    "resource": "App\\Http\\Controllers\\CommonSpecsController@dynamicRoute dynamic_route/{param01}/static/{param02?}",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 8491564511610816344,

--- a/tests/snapshots/tests.integrations.laravel.v5_7.common_scenarios_test.test_scenario_get_with_exception.json
+++ b/tests/snapshots/tests.integrations.laravel.v5_7.common_scenarios_test.test_scenario_get_with_exception.json
@@ -2,7 +2,7 @@
   {
     "name": "laravel.request",
     "service": "laravel_test_app",
-    "resource": "App\\Http\\Controllers\\CommonSpecsController@error unnamed_route",
+    "resource": "App\\Http\\Controllers\\CommonSpecsController@error error",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 11638207704594054193,

--- a/tests/snapshots/tests.integrations.laravel.v5_7.common_scenarios_test.test_scenario_get_with_view.json
+++ b/tests/snapshots/tests.integrations.laravel.v5_7.common_scenarios_test.test_scenario_get_with_view.json
@@ -2,7 +2,7 @@
   {
     "name": "laravel.request",
     "service": "laravel_test_app",
-    "resource": "App\\Http\\Controllers\\CommonSpecsController@simple_view unnamed_route",
+    "resource": "App\\Http\\Controllers\\CommonSpecsController@simple_view simple_view",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 17417893670227081443,

--- a/tests/snapshots/tests.integrations.laravel.v5_8.common_scenarios_test.test_scenario_get_dynamic_route.json
+++ b/tests/snapshots/tests.integrations.laravel.v5_8.common_scenarios_test.test_scenario_get_dynamic_route.json
@@ -2,7 +2,7 @@
   {
     "name": "laravel.request",
     "service": "laravel_test_app",
-    "resource": "App\\Http\\Controllers\\CommonSpecsController@dynamicRoute unnamed_route",
+    "resource": "App\\Http\\Controllers\\CommonSpecsController@dynamicRoute dynamic_route/{param01}/static/{param02?}",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 16982091743140843000,

--- a/tests/snapshots/tests.integrations.laravel.v5_8.common_scenarios_test.test_scenario_get_with_exception.json
+++ b/tests/snapshots/tests.integrations.laravel.v5_8.common_scenarios_test.test_scenario_get_with_exception.json
@@ -2,7 +2,7 @@
   {
     "name": "laravel.request",
     "service": "laravel_test_app",
-    "resource": "App\\Http\\Controllers\\CommonSpecsController@error unnamed_route",
+    "resource": "App\\Http\\Controllers\\CommonSpecsController@error error",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 2860973756877146746,

--- a/tests/snapshots/tests.integrations.laravel.v5_8.common_scenarios_test.test_scenario_get_with_view.json
+++ b/tests/snapshots/tests.integrations.laravel.v5_8.common_scenarios_test.test_scenario_get_with_view.json
@@ -2,7 +2,7 @@
   {
     "name": "laravel.request",
     "service": "laravel_test_app",
-    "resource": "App\\Http\\Controllers\\CommonSpecsController@simple_view unnamed_route",
+    "resource": "App\\Http\\Controllers\\CommonSpecsController@simple_view simple_view",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 12604606052329515364,

--- a/tests/snapshots/tests.integrations.laravel.v8_x.common_scenarios_test.test_scenario_get_dynamic_route.json
+++ b/tests/snapshots/tests.integrations.laravel.v8_x.common_scenarios_test.test_scenario_get_dynamic_route.json
@@ -2,7 +2,7 @@
   {
     "name": "laravel.request",
     "service": "laravel_test_app",
-    "resource": "App\\Http\\Controllers\\CommonSpecsController@dynamicRoute unnamed_route",
+    "resource": "App\\Http\\Controllers\\CommonSpecsController@dynamicRoute dynamic_route/{param01}/static/{param02?}",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 619982517647425679,

--- a/tests/snapshots/tests.integrations.laravel.v8_x.common_scenarios_test.test_scenario_get_with_exception.json
+++ b/tests/snapshots/tests.integrations.laravel.v8_x.common_scenarios_test.test_scenario_get_with_exception.json
@@ -2,7 +2,7 @@
   {
     "name": "laravel.request",
     "service": "laravel_test_app",
-    "resource": "App\\Http\\Controllers\\CommonSpecsController@error unnamed_route",
+    "resource": "App\\Http\\Controllers\\CommonSpecsController@error error",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 13974093062283399257,

--- a/tests/snapshots/tests.integrations.laravel.v8_x.common_scenarios_test.test_scenario_get_with_view.json
+++ b/tests/snapshots/tests.integrations.laravel.v8_x.common_scenarios_test.test_scenario_get_with_view.json
@@ -2,7 +2,7 @@
   {
     "name": "laravel.request",
     "service": "laravel_test_app",
-    "resource": "App\\Http\\Controllers\\CommonSpecsController@simple_view unnamed_route",
+    "resource": "App\\Http\\Controllers\\CommonSpecsController@simple_view simple_view",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 11697810065757930131,

--- a/tests/snapshots/tests.integrations.laravel.v9_x.common_scenarios_test.test_scenario_get_with_exception.json
+++ b/tests/snapshots/tests.integrations.laravel.v9_x.common_scenarios_test.test_scenario_get_with_exception.json
@@ -2,7 +2,7 @@
   {
     "name": "laravel.request",
     "service": "my_service",
-    "resource": "App\\Http\\Controllers\\CommonSpecsController@error unnamed_route",
+    "resource": "App\\Http\\Controllers\\CommonSpecsController@error error",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 12507063039839161923,

--- a/tests/snapshots/tests.integrations.laravel.v9_x.common_scenarios_test.test_scenario_get_with_view.json
+++ b/tests/snapshots/tests.integrations.laravel.v9_x.common_scenarios_test.test_scenario_get_with_view.json
@@ -2,7 +2,7 @@
   {
     "name": "laravel.request",
     "service": "my_service",
-    "resource": "App\\Http\\Controllers\\CommonSpecsController@simple_view unnamed_route",
+    "resource": "App\\Http\\Controllers\\CommonSpecsController@simple_view simple_view",
     "trace_id": 0,
     "span_id": 1,
     "parent_id": 460992100878085912,


### PR DESCRIPTION
## Summary

When `DD_HTTP_SERVER_ROUTE_BASED_NAMING` is enabled (default), routes defined without a `->name()` call produced resource names like:

```
App\Http\Controllers\API\v1\Apps\AppsController@getStripeConnectionToken unnamed_route
```

For unnamed routes, the `unnamed_route` suffix is now replaced with the actual route URI:

```
App\Http\Controllers\API\v1\Apps\AppsController@getStripeConnectionToken stripe/connection
```

Named routes are fully unaffected.

Fixes APMS-18982.

## Root cause

`LaravelIntegration::findRoute` sets the resource to `{action} {routeName}`. For routes defined with the old string syntax (`Route::get('path', 'Controller@method')`) or any route without `->name()`, `normalizeRouteName()` returns the constant `'unnamed_route'`. There was no fallback — the literal string ended up in the resource.