### PR TITLE
Set PHP-specific injection package size ratchet

### DIFF
--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -91,6 +91,10 @@ stages:
 variables:
   CARGO_HOME: "${CI_PROJECT_DIR}/.cache/cargo"
 
+  # One pipeline injection package size ratchet
+  OCI_PACKAGE_MAX_SIZE_BYTES: 150_000_000
+  LIB_INJECTION_IMAGE_MAX_SIZE_BYTES: 210_000_000
+
 include:
   - local: .gitlab/one-pipeline.locked.yml
   - local: .gitlab/benchmarks.yml


### PR DESCRIPTION
### Description

<!---
Any description you feel is relevant and gives more background to this PR, if necessary.
-->

Due to [a change PHP-side](https://github.com/DataDog/dd-trace-php/pull/3573) libdatadog was bumped to v29. This version bump caused PHP images to blow past their previous limit. 

Simultaneously, [changes to the `datadog-package`](https://github.com/DataDog/datadog-packages/commit/2e178346124a3a88edd4e055ef5ca60d1a610b8c#diff-33ef32bf6c23acb95f5902d7097b7a1d5128ca061167ec0716715b0b9eeaa5f6L82-R79) binary were picked up. Notably the `github.com/klauspost/compress/zstd` dependency was bumped from 1.17.4 to 1.18.1. This bump included in 1.17.5 a default value change for the compression context size, [downscaled from 32MB to 8MB](https://github.com/klauspost/compress/pull/913) (fixing compatibility with browsers like Chrome), causing drastic changes in compression results.

Unbeknownst to the second change, PHP therefore updated the global limits, attributing the size change to the libdatadog bump (which was true, but not for the whole of it):
- Container image limit [changed from 190MB to 250MB](https://github.com/DataDog/libdatadog-build/pull/186)
- OCI package limit [changed from 130MB to 160MB](https://github.com/DataDog/libdatadog-build/pull/187)

This allowed a change to slip through to other languages, where the new `datadog-package` binary caused regressions in package size _without_ change to the inputs. Due to the wildly differing sizes of packages across languages the regression is silent, rendering the size threshold ratchet moot.

To combat such silently creeping regressions, this PR introduces language-specific thresholds for the ratchet  through [one pipeline overrides](https://github.com/DataDog/libdatadog-build/blob/09c7352ba84397d1c5b624608c7f6cd93905d6fa/templates/one-pipeline.yml#L47-L53)

Note: `datadog-package` was fixed in https://github.com/DataDog/datadog-packages/pull/64 which may take some time to trickle down.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
