### PR TITLE
ci: test system-tests agent_interface_timeout fix for flaky PHP tests

### DIFF
--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -1236,7 +1236,7 @@ endforeach;
       pip install -U pip virtualenv
 <?php dockerhub_login() ?>
     - /tmp/vault kv get --format=json "kv/k8s/gitlab-runner/dd-trace-php/datadoghq-api-key" 2>/dev/null | python3 -c "import sys,json;print(json.load(sys.stdin)['data']['data']['key'])" > /tmp/.dd-api-key 2>/dev/null || true
-    - git clone https://github.com/DataDog/system-tests.git
+    - git clone --branch maxim/fix-php-config-tests-use-library-interface https://github.com/DataDog/system-tests.git
     - mv packages/{datadog-setup.php,dd-library-php-*x86_64-linux-gnu.tar.gz} system-tests/binaries
     - cd system-tests
     - ./build.sh $BUILD_SH_ARGS


### PR DESCRIPTION
## DO NOT MERGE - Test branch

Testing a system-tests fix for consistently failing PHP tests in `[tracer-release]`:
- `Test_Config_HttpServerErrorStatuses_FeatureFlagCustom::test_status_code_200`
- `Test_Config_HttpServerErrorStatuses_FeatureFlagCustom::test_status_code_202`
- `Test_Config_UnifiedServiceTagging_CustomService::test_specified_service_name`
- `Test_Basic::test_main` (IPv6)

### Root cause hypothesis
PHP's libdatadog sidecar buffers traces for up to 5s (`DEFAULT_FLUSH_INTERVAL_MS=5000`) before sending to the agent. The agent then needs ~10s to flush to the backend. The default 5s `agent_interface_timeout` in system-tests isn't enough for this chain.

Other languages send traces directly (no sidecar), so they don't hit this timing issue.

### What this tests
Points system-tests at branch `maxim/fix-php-config-tests-use-library-interface` which increases `agent_interface_timeout` from 5s to 15s for `TRACING_CONFIG_NONDEFAULT` and `IPV6` scenarios.

System-tests PR: https://github.com/DataDog/system-tests/pull/6670

### How to validate
1. Trigger `[tracer-release]` manually from this branch
2. Check if the 3 TRACING_CONFIG_NONDEFAULT + 1 IPV6 tests pass