### PR TITLE
ci(appsec): guaranteed QoS for test appsec extension jobs

### DIFF
--- a/.gitlab/generate-appsec.php
+++ b/.gitlab/generate-appsec.php
@@ -71,8 +71,13 @@ stages:
   image: registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:php-${PHP_MAJOR_MINOR}_bookworm-6
   variables:
     KUBERNETES_CPU_REQUEST: 3
-    KUBERNETES_MEMORY_REQUEST: 4Gi
-    KUBERNETES_MEMORY_LIMIT: 4Gi
+    KUBERNETES_CPU_LIMIT: 3
+    KUBERNETES_MEMORY_REQUEST: 6Gi
+    KUBERNETES_MEMORY_LIMIT: 6Gi
+    KUBERNETES_HELPER_CPU_REQUEST: 1
+    KUBERNETES_HELPER_CPU_LIMIT: 1
+    KUBERNETES_HELPER_MEMORY_REQUEST: 3Gi
+    KUBERNETES_HELPER_MEMORY_LIMIT: 3Gi
   parallel:
     matrix:
       - PHP_MAJOR_MINOR: *all_minor_major_targets


### PR DESCRIPTION
### Description

Increase memory from 4Gi to 6Gi and set CPU/memory limits equal to requests (including helper container) to achieve Guaranteed QoS, preventing OOM kills on the test-appsec-extension jobs.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
