### PR TITLE
ci: xfail sni_server tests due to expired certificates

### DIFF
--- a/dockerfiles/ci/xfail_tests/7.2.list
+++ b/dockerfiles/ci/xfail_tests/7.2.list
@@ -171,6 +171,8 @@ ext/openssl/tests/openssl_x509_checkpurpose_basic.phpt
 ext/openssl/tests/openssl_x509_parse_basic.phpt
 ext/openssl/tests/peer_verification.phpt
 ext/openssl/tests/san_peer_matching.phpt
+ext/openssl/tests/sni_server.phpt
+ext/openssl/tests/sni_server_key_cert.phpt
 ext/openssl/tests/session_meta_capture.phpt
 ext/openssl/tests/stream_crypto_flags_001.phpt
 ext/openssl/tests/stream_crypto_flags_002.phpt

--- a/dockerfiles/ci/xfail_tests/7.3.list
+++ b/dockerfiles/ci/xfail_tests/7.3.list
@@ -182,6 +182,8 @@ ext/openssl/tests/openssl_x509_checkpurpose_basic.phpt
 ext/openssl/tests/openssl_x509_parse_basic.phpt
 ext/openssl/tests/peer_verification.phpt
 ext/openssl/tests/san_peer_matching.phpt
+ext/openssl/tests/sni_server.phpt
+ext/openssl/tests/sni_server_key_cert.phpt
 ext/openssl/tests/session_meta_capture.phpt
 ext/openssl/tests/stream_crypto_flags_001.phpt
 ext/openssl/tests/stream_crypto_flags_002.phpt

--- a/dockerfiles/ci/xfail_tests/7.4.list
+++ b/dockerfiles/ci/xfail_tests/7.4.list
@@ -223,6 +223,8 @@ ext/openssl/tests/openssl_x509_checkpurpose_basic.phpt
 ext/openssl/tests/openssl_x509_parse_basic.phpt
 ext/openssl/tests/peer_verification.phpt
 ext/openssl/tests/san_peer_matching.phpt
+ext/openssl/tests/sni_server.phpt
+ext/openssl/tests/sni_server_key_cert.phpt
 ext/openssl/tests/session_meta_capture.phpt
 ext/openssl/tests/session_meta_capture_tlsv13.phpt
 ext/openssl/tests/stream_crypto_flags_001.phpt

--- a/dockerfiles/ci/xfail_tests/8.0.list
+++ b/dockerfiles/ci/xfail_tests/8.0.list
@@ -266,6 +266,8 @@ ext/openssl/tests/openssl_x509_free_basic.phpt
 ext/openssl/tests/openssl_x509_parse_basic.phpt
 ext/openssl/tests/peer_verification.phpt
 ext/openssl/tests/san_peer_matching.phpt
+ext/openssl/tests/sni_server.phpt
+ext/openssl/tests/sni_server_key_cert.phpt
 ext/openssl/tests/session_meta_capture.phpt
 ext/openssl/tests/session_meta_capture_tlsv13.phpt
 ext/openssl/tests/stream_crypto_flags_001.phpt

--- a/dockerfiles/ci/xfail_tests/8.1.list
+++ b/dockerfiles/ci/xfail_tests/8.1.list
@@ -87,6 +87,8 @@ ext/openssl/tests/openssl_peer_fingerprint_basic.phpt
 ext/openssl/tests/openssl_x509_checkpurpose_basic.phpt
 ext/openssl/tests/peer_verification.phpt
 ext/openssl/tests/san_peer_matching.phpt
+ext/openssl/tests/sni_server.phpt
+ext/openssl/tests/sni_server_key_cert.phpt
 ext/openssl/tests/session_meta_capture.phpt
 ext/openssl/tests/session_meta_capture_tlsv13.phpt
 ext/openssl/tests/stream_crypto_flags_001.phpt

--- a/dockerfiles/ci/xfail_tests/8.2.list
+++ b/dockerfiles/ci/xfail_tests/8.2.list
@@ -77,6 +77,8 @@ ext/openssl/tests/openssl_peer_fingerprint_basic.phpt
 ext/openssl/tests/openssl_x509_checkpurpose_basic.phpt
 ext/openssl/tests/peer_verification.phpt
 ext/openssl/tests/san_peer_matching.phpt
+ext/openssl/tests/sni_server.phpt
+ext/openssl/tests/sni_server_key_cert.phpt
 ext/openssl/tests/session_meta_capture.phpt
 ext/openssl/tests/session_meta_capture_tlsv13.phpt
 ext/openssl/tests/stream_crypto_flags_001.phpt

--- a/dockerfiles/ci/xfail_tests/8.3.list
+++ b/dockerfiles/ci/xfail_tests/8.3.list
@@ -75,6 +75,8 @@ ext/openssl/tests/openssl_peer_fingerprint_basic.phpt
 ext/openssl/tests/openssl_x509_checkpurpose_basic.phpt
 ext/openssl/tests/peer_verification.phpt
 ext/openssl/tests/san_peer_matching.phpt
+ext/openssl/tests/sni_server.phpt
+ext/openssl/tests/sni_server_key_cert.phpt
 ext/openssl/tests/session_meta_capture.phpt
 ext/openssl/tests/session_meta_capture_tlsv13.phpt
 ext/openssl/tests/stream_crypto_flags_001.phpt

--- a/dockerfiles/ci/xfail_tests/8.3.list
+++ b/dockerfiles/ci/xfail_tests/8.3.list
@@ -77,6 +77,7 @@ ext/openssl/tests/peer_verification.phpt
 ext/openssl/tests/san_peer_matching.phpt
 ext/openssl/tests/sni_server.phpt
 ext/openssl/tests/sni_server_key_cert.phpt
+ext/openssl/tests/bug74796.phpt
 ext/openssl/tests/session_meta_capture.phpt
 ext/openssl/tests/session_meta_capture_tlsv13.phpt
 ext/openssl/tests/stream_crypto_flags_001.phpt

--- a/dockerfiles/ci/xfail_tests/8.4.list
+++ b/dockerfiles/ci/xfail_tests/8.4.list
@@ -80,6 +80,7 @@ ext/openssl/tests/peer_verification.phpt
 ext/openssl/tests/san_peer_matching.phpt
 ext/openssl/tests/sni_server.phpt
 ext/openssl/tests/sni_server_key_cert.phpt
+ext/openssl/tests/bug74796.phpt
 ext/openssl/tests/session_meta_capture.phpt
 ext/openssl/tests/session_meta_capture_tlsv13.phpt
 ext/openssl/tests/stream_crypto_flags_001.phpt

--- a/dockerfiles/ci/xfail_tests/8.4.list
+++ b/dockerfiles/ci/xfail_tests/8.4.list
@@ -78,6 +78,8 @@ ext/openssl/tests/openssl_peer_fingerprint_basic.phpt
 ext/openssl/tests/openssl_x509_checkpurpose_basic.phpt
 ext/openssl/tests/peer_verification.phpt
 ext/openssl/tests/san_peer_matching.phpt
+ext/openssl/tests/sni_server.phpt
+ext/openssl/tests/sni_server_key_cert.phpt
 ext/openssl/tests/session_meta_capture.phpt
 ext/openssl/tests/session_meta_capture_tlsv13.phpt
 ext/openssl/tests/stream_crypto_flags_001.phpt

--- a/dockerfiles/ci/xfail_tests/8.5.list
+++ b/dockerfiles/ci/xfail_tests/8.5.list
@@ -81,6 +81,7 @@ ext/openssl/tests/peer_verification.phpt
 ext/openssl/tests/san_peer_matching.phpt
 ext/openssl/tests/sni_server.phpt
 ext/openssl/tests/sni_server_key_cert.phpt
+ext/openssl/tests/bug74796.phpt
 ext/openssl/tests/session_meta_capture.phpt
 ext/openssl/tests/session_meta_capture_tlsv13.phpt
 ext/openssl/tests/stream_crypto_flags_001.phpt

--- a/dockerfiles/ci/xfail_tests/8.5.list
+++ b/dockerfiles/ci/xfail_tests/8.5.list
@@ -79,6 +79,8 @@ ext/openssl/tests/openssl_peer_fingerprint_basic.phpt
 ext/openssl/tests/openssl_x509_checkpurpose_basic.phpt
 ext/openssl/tests/peer_verification.phpt
 ext/openssl/tests/san_peer_matching.phpt
+ext/openssl/tests/sni_server.phpt
+ext/openssl/tests/sni_server_key_cert.phpt
 ext/openssl/tests/session_meta_capture.phpt
 ext/openssl/tests/session_meta_capture_tlsv13.phpt
 ext/openssl/tests/stream_crypto_flags_001.phpt

--- a/dockerfiles/ci/xfail_tests/README.md
+++ b/dockerfiles/ci/xfail_tests/README.md
@@ -242,9 +242,9 @@ Disabled on versions: `8.1+`.
 
 This test checks PHP's handling of excessively large QName prefix in SoapVar (a stress test for edge cases). With ddtrace loaded, the additional memory overhead causes the test to be killed before it can complete, due to hitting memory limits during the stress test.
 
-## `ext/openssl/tests/sni_server.phpt`, `ext/openssl/tests/sni_server_key_cert.phpt`
+## `ext/openssl/tests/sni_server.phpt`, `ext/openssl/tests/sni_server_key_cert.phpt`, `ext/openssl/tests/bug74796.phpt`
 
-Disabled on all versions.
+Disabled on all versions (where present).
 
-The bundled test certificates (`sni_server_*.pem`) expired on 2026-04-02. The TLS handshake fails because the client rejects the expired server certificates, causing `stream_socket_client` to return `false`. PHP 8.2–8.5 are the maintained branches and should receive a fix once upstream regenerates the certificates; remove the xfail entries for those versions when they do.
+The bundled test certificates expired on 2026-04-02. The TLS handshake fails because the client rejects the expired server certificates, causing `stream_socket_client` to return `false`.
 

--- a/dockerfiles/ci/xfail_tests/README.md
+++ b/dockerfiles/ci/xfail_tests/README.md
@@ -242,3 +242,9 @@ Disabled on versions: `8.1+`.
 
 This test checks PHP's handling of excessively large QName prefix in SoapVar (a stress test for edge cases). With ddtrace loaded, the additional memory overhead causes the test to be killed before it can complete, due to hitting memory limits during the stress test.
 
+## `ext/openssl/tests/sni_server.phpt`, `ext/openssl/tests/sni_server_key_cert.phpt`
+
+Disabled on all versions.
+
+The bundled test certificates (`sni_server_*.pem`) expired on 2026-04-02. The TLS handshake fails because the client rejects the expired server certificates, causing `stream_socket_client` to return `false`. PHP 8.2–8.5 are the maintained branches and should receive a fix once upstream regenerates the certificates; remove the xfail entries for those versions when they do.
+


### PR DESCRIPTION

### Description

The bundled sni_server_*.pem certificates expired on 2026-04-02, causing stream_socket_client() to return false and the tests to fail across all PHP versions.

This sort of conflicts with #3772, but it's not ready for merge.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
