### PR TITLE
Again improve symfony http.route resolution

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1543,7 +1543,7 @@ test_web_symfony_42: global_test_run_dependencies tests/Frameworks/Symfony/Versi
 	php tests/Frameworks/Symfony/Version_4_2/bin/console cache:clear --no-warmup --env=prod
 	$(call run_tests_debug,tests/Integrations/Symfony/V4_2)
 test_web_symfony_44: global_test_run_dependencies tests/Frameworks/Symfony/Version_4_4/composer.lock-php$(PHP_MAJOR_MINOR)
-	php tests/Frameworks/Symfony/Version_4_4/bin/console cache:clear --no-warmup --env=prod
+	php tests/Frameworks/Symfony/Version_4_4/bin/console cache:clear --env=prod
 	$(call run_tests_debug,--testsuite=symfony-44-test)
 test_web_symfony_50: global_test_run_dependencies
 	$(COMPOSER) --working-dir=tests/Frameworks/Symfony/Version_5_0 install # EOL; install from lock

--- a/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/Symfony62Tests.groovy
+++ b/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/Symfony62Tests.groovy
@@ -117,6 +117,31 @@ class Symfony62Tests {
 
     @Test
     @Order(8)
+    void 'http route for locale route'() {
+        HttpRequest req = container.buildReq('/caminho-dinamico/someValue').GET().build()
+        def trace = container.traceFromRequest(req, ofString()) { HttpResponse<String> re ->
+            assert re.statusCode() == 403
+            assert re.body().contains('blocked')
+        }
+
+        Span span = trace.first()
+        assert span.meta."http.route" == '/caminho-dinamico/{param01}'
+    }
+
+    @Test
+    @Order(9)
+    void 'http route for utf8 route'() {
+        HttpRequest req = container.buildReq('/café/espresso').GET().build()
+        def trace = container.traceFromRequest(req, ofString()) { HttpResponse<String> re ->
+            assert re.statusCode() == 200
+        }
+
+        Span span = trace.first()
+        assert span.meta."http.route" == '/café/{item}'
+    }
+
+    @Test
+    @Order(10)
     void 'symfony http route disabled'() {
         try {
             def res = CONTAINER.execInContainer(

--- a/appsec/tests/integration/src/test/www/symfony62/src/Controller/HomeController.php
+++ b/appsec/tests/integration/src/test/www/symfony62/src/Controller/HomeController.php
@@ -29,4 +29,12 @@ class HomeController extends AbstractController
             "Hi $param01!"
         );
     }
+
+    #[Route("/café/{item}", name: "utf8_route")]
+    public function utf8Action(Request $request, string $item)
+    {
+        return new Response(
+            "Café: $item"
+        );
+    }
 }

--- a/src/DDTrace/Integrations/Symfony/EndpointCatalog.php
+++ b/src/DDTrace/Integrations/Symfony/EndpointCatalog.php
@@ -44,9 +44,14 @@ class EndpointCatalog
             return null;
         }
 
-        $genFile = rtrim($cacheDir, '/\\') . DIRECTORY_SEPARATOR . 'url_generating_routes.php';
+        $base = rtrim($cacheDir, '/\\') . DIRECTORY_SEPARATOR;
+        // Symfony 5+ uses url_generating_routes.php; 4.3–4.4 uses UrlGenerator.php
+        $genFile = $base . 'url_generating_routes.php';
         if (!is_file($genFile)) {
-            return null;
+            $genFile = $base . 'UrlGenerator.php';
+            if (!is_file($genFile)) {
+                return null;
+            }
         }
 
         $gen = require $genFile;

--- a/src/DDTrace/Integrations/Symfony/EndpointCatalog.php
+++ b/src/DDTrace/Integrations/Symfony/EndpointCatalog.php
@@ -29,6 +29,41 @@ class EndpointCatalog
         return $memo = $fromCollection;
     }
 
+
+    /**
+     * Looks up the path template for a given route name from the compiled
+     * url_generating_routes.php file. Returns null if the file is missing
+     * or the route is not found.
+     *
+     * This never falls back to getRouteCollection().
+     */
+    public static function pathForRoute($routeName, ContainerInterface $container)
+    {
+        $cacheDir = self::getCacheDir($container);
+        if ($cacheDir === null) {
+            return null;
+        }
+
+        $genFile = rtrim($cacheDir, '/\\') . DIRECTORY_SEPARATOR . 'url_generating_routes.php';
+        if (!is_file($genFile)) {
+            return null;
+        }
+
+        $gen = require $genFile;
+        if (!is_array($gen) || !isset($gen[$routeName])) {
+            return null;
+        }
+
+        $routeData = $gen[$routeName];
+        $tokens = isset($routeData[3]) ? $routeData[3] : null;
+        if (!is_array($tokens)) {
+            return null;
+        }
+
+        return self::tokensToPathTemplate($tokens);
+    }
+
+
     private static function getCacheDir(ContainerInterface $container)
     {
         if ($container->hasParameter('kernel.cache_dir')) {

--- a/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
@@ -12,7 +12,6 @@ use DDTrace\Util\Normalizer;
 use Symfony\Component\DependencyInjection\ContainerInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpKernel\KernelEvents;
-use Symfony\Contracts\Cache\ItemInterface;
 
 class SymfonyIntegration extends Integration
 {
@@ -422,16 +421,6 @@ class SymfonyIntegration extends Integration
         );
 
         if (\dd_trace_env_config('DD_TRACE_SYMFONY_HTTP_ROUTE')) {
-            /**
-             * Resolves the http.route tag for a given route name by looking up
-             * the route path in a cached map of all routes.
-             *
-             * Caching strategy:
-             * - Caches the entire route path map under a single key: '_datadog.symfony.route_paths'
-             * - Stores: ['mtime' => timestamp, 'paths' => ['route_name' => '/path', ...]]
-             * - Invalidates cache when Symfony's compiled routes file is newer than cached mtime
-             * - Falls back gracefully if cache.app is unavailable (no http.route tag)
-             */
             $handle_http_route = static function($route_name, $request, $rootSpan) {
                 if (self::$kernel === null) {
                     return;
@@ -439,87 +428,13 @@ class SymfonyIntegration extends Integration
 
                 /** @var ContainerInterface $container */
                 $container = self::$kernel->getContainer();
+                $path = EndpointCatalog::pathForRoute($route_name, $container);
 
-                try {
-                    $cache = $container->get('cache.app');
-                } catch (\Exception $e) {
-                    return;
-                }
-
-                if (!\method_exists($cache, 'getItem')) {
-                    return;
-                }
-
-                /** @var \Symfony\Bundle\FrameworkBundle\Routing\Router $router */
-                try {
-                    $router = $container->get('router');
-                } catch (\Exception $e) {
-                    return;
-                }
-
-                // Get the compiled routes file mtime for cache invalidation
-                $compiledRoutesMtime = null;
-                $cacheDir = \method_exists($router, 'getOption') ? $router->getOption('cache_dir') : null;
-                if ($cacheDir !== null) {
-                    $compiledRoutesFile = $cacheDir . '/url_generating_routes.php';
-                    if (\file_exists($compiledRoutesFile)) {
-                        $compiledRoutesMtime = @\filemtime($compiledRoutesFile);
-                    }
-                }
-
-                $cacheKey = '_datadog.symfony.route_paths';
-                /** @var ItemInterface $item */
-                $item = $cache->getItem($cacheKey);
-                $cachedData = $item->isHit() ? $item->get() : null;
-
-                $routePathMap = null;
-                $needsRebuild = true;
-
-                if (\is_array($cachedData) && isset($cachedData['paths']) && \is_array($cachedData['paths'])) {
-                    // Check if cache is still valid
-                    if ($compiledRoutesMtime === null) {
-                        // No compiled file to check against - cache is valid
-                        $needsRebuild = false;
-                        $routePathMap = $cachedData['paths'];
-                    } elseif (isset($cachedData['mtime']) && $cachedData['mtime'] >= $compiledRoutesMtime) {
-                        // Cached data is newer than or equal to compiled routes - cache is valid
-                        $needsRebuild = false;
-                        $routePathMap = $cachedData['paths'];
-                    }
-                    // Otherwise: compiled routes file is newer, rebuild cache
-                }
-
-                if ($needsRebuild) {
-                    $startTime = \function_exists('hrtime') ? \hrtime(true) : null;
-
-                    $routePathMap = [];
-                    $routeCollection = $router->getRouteCollection();
-                    foreach ($routeCollection->all() as $name => $route) {
-                        $routePathMap[$name] = $route->getPath();
-                    }
-
-                    if ($startTime !== null) {
-                        $durationNanoseconds = \hrtime(true) - $startTime;
-                        $durationMicroseconds = (int)($durationNanoseconds / 1000);
-                        $rootSpan->metrics['_dd.symfony.route.map_build_duration_us'] = $durationMicroseconds;
-                    }
-
-                    $item->set([
-                        'mtime' => \time(),
-                        'paths' => $routePathMap,
-                    ]);
-                    $cache->save($item);
-                }
-
-                // Look up the route path
-                $path = null;
-                if (isset($routePathMap[$route_name])) {
-                    $path = $routePathMap[$route_name];
-                } else {
-                    // Try with locale suffix (Symfony i18n routing convention)
+                // Try with locale suffix (Symfony i18n routing convention)
+                if ($path === null) {
                     $locale = $request->get('_locale');
-                    if ($locale !== null && isset($routePathMap[$route_name . '.' . $locale])) {
-                        $path = $routePathMap[$route_name . '.' . $locale];
+                    if ($locale !== null) {
+                        $path = EndpointCatalog::pathForRoute($route_name . '.' . $locale, $container);
                     }
                 }
 

--- a/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_3/CommonScenariosTest.php
@@ -52,7 +52,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                     )->withExactTags([
                         'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@simpleAction',
                         'symfony.route.name' => 'simple',
-                        'http.route' => '/simple',
+
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost/simple?key=value&<redacted>',
                         'http.status_code' => '200',
@@ -91,7 +91,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                     )->withExactTags([
                         'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@simpleViewAction',
                         'symfony.route.name' => 'simple_view',
-                        'http.route' => '/simple_view',
+
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost/simple_view?key=value&<redacted>',
                         'http.status_code' => '200',
@@ -139,7 +139,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                     )->withExactTags([
                         'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@errorAction',
                         'symfony.route.name' => 'error',
-                        'http.route' => '/error',
+
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost/error?key=value&<redacted>',
                         'http.status_code' => '500',

--- a/tests/Integrations/Symfony/V3_3/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V3_3/TraceSearchConfigTest.php
@@ -42,7 +42,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                 )->withExactTags([
                     'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@simpleAction',
                     'symfony.route.name' => 'simple',
-                    'http.route' => '/simple',
+
                     'http.method' => 'GET',
                     'http.url' => 'http://localhost/simple',
                     'http.status_code' => '200',

--- a/tests/Integrations/Symfony/V3_4/AutofinishedTracesSymfony34Test.php
+++ b/tests/Integrations/Symfony/V3_4/AutofinishedTracesSymfony34Test.php
@@ -36,7 +36,7 @@ class AutofinishedTracesSymfony34Test extends WebFrameworkTestCase
             )->withExactTags([
                 'symfony.route.action' => 'AppBundle\Controller\HomeController@actionBeingTerminatedByExit',
                 'symfony.route.name' => 'terminated_by_exit',
-                'http.route' => '/terminated_by_exit',
+
                 'http.method' => 'GET',
                 'http.url' => 'http://localhost/terminated_by_exit',
                 'http.status_code' => '200',

--- a/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V3_4/CommonScenariosTest.php
@@ -59,7 +59,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                     )->withExactTags([
                         'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@simpleAction',
                         'symfony.route.name' => 'simple',
-                        'http.route' => '/simple',
+
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost/simple?key=value&<redacted>',
                         'http.status_code' => '200',
@@ -98,7 +98,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                     )->withExactTags([
                         'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@simpleViewAction',
                         'symfony.route.name' => 'simple_view',
-                        'http.route' => '/simple_view',
+
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost/simple_view?key=value&<redacted>',
                         'http.status_code' => '200',
@@ -148,7 +148,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         ->withExactTags([
                             'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@errorAction',
                             'symfony.route.name' => 'error',
-                            'http.route' => '/error',
+
                             'http.method' => 'GET',
                             'http.url' => 'http://localhost/error?key=value&<redacted>',
                             'http.status_code' => '500',

--- a/tests/Integrations/Symfony/V3_4/TemplateEnginesTest.php
+++ b/tests/Integrations/Symfony/V3_4/TemplateEnginesTest.php
@@ -29,7 +29,7 @@ class TemplateEnginesTest extends WebFrameworkTestCase
             )->withExactTags([
                 'symfony.route.action' => 'AppBundle\Controller\HomeController@indexAction',
                 'symfony.route.name' => 'alternate_templating',
-                'http.route' => '/alternate_templating',
+
                 'http.method' => 'GET',
                 'http.url' => 'http://localhost/alternate_templating',
                 'http.status_code' => '200',

--- a/tests/Integrations/Symfony/V3_4/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V3_4/TraceSearchConfigTest.php
@@ -42,7 +42,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                 )->withExactTags([
                     'symfony.route.action' => 'AppBundle\Controller\CommonScenariosController@simpleAction',
                     'symfony.route.name' => 'simple',
-                    'http.route' => '/simple',
+
                     'http.method' => 'GET',
                     'http.url' => 'http://localhost/simple',
                     'http.status_code' => '200',

--- a/tests/Integrations/Symfony/V4_0/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_0/CommonScenariosTest.php
@@ -55,7 +55,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                     )->withExactTags([
                         'symfony.route.action' => 'App\Controller\CommonScenariosController@simpleAction',
                         'symfony.route.name' => 'simple',
-                        'http.route' => '/simple',
+
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost/simple?key=value&<redacted>',
                         'http.status_code' => '200',
@@ -94,7 +94,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                     )->withExactTags([
                         'symfony.route.action' => 'App\Controller\CommonScenariosController@simpleViewAction',
                         'symfony.route.name' => 'simple_view',
-                        'http.route' => '/simple_view',
+
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost/simple_view?key=value&<redacted>',
                         'http.status_code' => '200',
@@ -142,7 +142,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                     )->withExactTags([
                         'symfony.route.action' => 'App\Controller\CommonScenariosController@errorAction',
                         'symfony.route.name' => 'error',
-                        'http.route' => '/error',
+
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost/error?key=value&<redacted>',
                         'http.status_code' => '500',

--- a/tests/Integrations/Symfony/V4_0/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V4_0/TraceSearchConfigTest.php
@@ -42,7 +42,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                 )->withExactTags([
                     'symfony.route.action' => 'App\Controller\CommonScenariosController@simpleAction',
                     'symfony.route.name' => 'simple',
-                    'http.route' => '/simple',
+
                     'http.method' => 'GET',
                     'http.url' => 'http://localhost/simple',
                     'http.status_code' => '200',

--- a/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
+++ b/tests/Integrations/Symfony/V4_2/CommonScenariosTest.php
@@ -55,7 +55,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                     )->withExactTags([
                         'symfony.route.action' => 'App\Controller\CommonScenariosController@simpleAction',
                         'symfony.route.name' => 'simple',
-                        'http.route' => '/simple',
+
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost/simple?key=value&<redacted>',
                         'http.status_code' => '200',
@@ -94,7 +94,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                     )->withExactTags([
                         'symfony.route.action' => 'App\Controller\CommonScenariosController@simpleViewAction',
                         'symfony.route.name' => 'simple_view',
-                        'http.route' => '/simple_view',
+
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost/simple_view?key=value&<redacted>',
                         'http.status_code' => '200',
@@ -142,7 +142,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                     )->withExactTags([
                         'symfony.route.action' => 'App\Controller\CommonScenariosController@errorAction',
                         'symfony.route.name' => 'error',
-                        'http.route' => '/error',
+
                         'http.method' => 'GET',
                         'http.url' => 'http://localhost/error?key=value&<redacted>',
                         'http.status_code' => '500',

--- a/tests/Integrations/Symfony/V4_2/TraceSearchConfigTest.php
+++ b/tests/Integrations/Symfony/V4_2/TraceSearchConfigTest.php
@@ -42,7 +42,7 @@ class TraceSearchConfigTest extends WebFrameworkTestCase
                 )->withExactTags([
                     'symfony.route.action' => 'App\Controller\CommonScenariosController@simpleAction',
                     'symfony.route.name' => 'simple',
-                    'http.route' => '/simple',
+
                     'http.method' => 'GET',
                     'http.url' => 'http://localhost/simple',
                     'http.status_code' => '200',


### PR DESCRIPTION
Turns out it's quite feasible to resolve at runtime the route path from the route name using files in the Symfony cache dir. Not only that, but that strategy was already being used in EndpointCatalog.php.

This fixes a performance issue -- avoid the deserializaiton and possible transfer from Redis of the full route collection cache on every request.

The routing data is in PHP files and with opcache it's basically just one big compile-time variable.

### Description

<!---
Any description you feel is relevant and gives more background to this PR, if necessary.
-->

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
