### PR TITLE
Emit env var names in telemetry config

### DIFF
--- a/ext/telemetry.c
+++ b/ext/telemetry.c
@@ -158,7 +158,8 @@ void ddtrace_telemetry_finalize() {
 #if ZTS
             ini = zend_hash_find_ptr(EG(ini_directives), ini->name);
 #endif
-            if (!zend_string_equals_literal(ini->name, "datadog.trace.enabled")) { // datadog.trace.enabled is meaningless: always off at rshutdown
+            if (cfg->names[0].len != sizeof("DD_TRACE_ENABLED") - 1
+                || memcmp(cfg->names[0].ptr, "DD_TRACE_ENABLED", sizeof("DD_TRACE_ENABLED") - 1) != 0) { // DD_TRACE_ENABLED is meaningless: always off at rshutdown
                 ddog_ConfigurationOrigin origin = DDOG_CONFIGURATION_ORIGIN_ENV_VAR;
                 switch (cfg->name_index) {
                     case ZAI_CONFIG_ORIGIN_DEFAULT:
@@ -176,9 +177,7 @@ void ddtrace_telemetry_finalize() {
                     && !zend_string_equals_cstr(ini->value, cfg->default_encoded_value.ptr, cfg->default_encoded_value.len)) {
                     origin = cfg->name_index >= ZAI_CONFIG_ORIGIN_MODIFIED ? DDOG_CONFIGURATION_ORIGIN_ENV_VAR : DDOG_CONFIGURATION_ORIGIN_CODE;
                 }
-                ddog_CharSlice name = dd_zend_string_to_CharSlice(ini->name);
-                name.len -= strlen("datadog.");
-                name.ptr += strlen("datadog.");
+                ddog_CharSlice name = (ddog_CharSlice){.ptr = cfg->names[0].ptr, .len = cfg->names[0].len};
                 ddog_CharSlice config_id = (ddog_CharSlice) {.len = cfg->config_id.len, .ptr = cfg->config_id.ptr};
                 ddog_sidecar_telemetry_enqueueConfig_buffer(buffer, name, dd_zend_string_to_CharSlice(ini->value), origin, config_id);
             }

--- a/tests/ext/appsec/sca_flag_is_sent_01.phpt
+++ b/tests/ext/appsec/sca_flag_is_sent_01.phpt
@@ -19,7 +19,7 @@ sca_test.inc
 --EXPECT--
 array(5) {
   ["name"]=>
-  string(22) "DD_APPSEC_SCA_ENABLED"
+  string(21) "DD_APPSEC_SCA_ENABLED"
   ["value"]=>
   string(5) "false"
   ["origin"]=>

--- a/tests/ext/appsec/sca_flag_is_sent_01.phpt
+++ b/tests/ext/appsec/sca_flag_is_sent_01.phpt
@@ -19,7 +19,7 @@ sca_test.inc
 --EXPECT--
 array(5) {
   ["name"]=>
-  string(18) "appsec.sca_enabled"
+  string(22) "DD_APPSEC_SCA_ENABLED"
   ["value"]=>
   string(5) "false"
   ["origin"]=>

--- a/tests/ext/appsec/sca_flag_is_sent_02.phpt
+++ b/tests/ext/appsec/sca_flag_is_sent_02.phpt
@@ -20,7 +20,7 @@ sca_test.inc
 --EXPECT--
 array(5) {
   ["name"]=>
-  string(22) "DD_APPSEC_SCA_ENABLED"
+  string(21) "DD_APPSEC_SCA_ENABLED"
   ["value"]=>
   string(4) "true"
   ["origin"]=>

--- a/tests/ext/appsec/sca_flag_is_sent_02.phpt
+++ b/tests/ext/appsec/sca_flag_is_sent_02.phpt
@@ -20,7 +20,7 @@ sca_test.inc
 --EXPECT--
 array(5) {
   ["name"]=>
-  string(18) "appsec.sca_enabled"
+  string(22) "DD_APPSEC_SCA_ENABLED"
   ["value"]=>
   string(4) "true"
   ["origin"]=>

--- a/tests/ext/appsec/sca_flag_is_sent_03.phpt
+++ b/tests/ext/appsec/sca_flag_is_sent_03.phpt
@@ -20,7 +20,7 @@ sca_test.inc
 --EXPECT--
 array(5) {
   ["name"]=>
-  string(18) "appsec.sca_enabled"
+  string(22) "DD_APPSEC_SCA_ENABLED"
   ["value"]=>
   string(5) "false"
   ["origin"]=>

--- a/tests/ext/appsec/sca_flag_is_sent_03.phpt
+++ b/tests/ext/appsec/sca_flag_is_sent_03.phpt
@@ -20,7 +20,7 @@ sca_test.inc
 --EXPECT--
 array(5) {
   ["name"]=>
-  string(22) "DD_APPSEC_SCA_ENABLED"
+  string(21) "DD_APPSEC_SCA_ENABLED"
   ["value"]=>
   string(5) "false"
   ["origin"]=>

--- a/tests/ext/appsec/sca_flag_is_sent_04.phpt
+++ b/tests/ext/appsec/sca_flag_is_sent_04.phpt
@@ -20,7 +20,7 @@ sca_test.inc
 --EXPECT--
 array(5) {
   ["name"]=>
-  string(18) "appsec.sca_enabled"
+  string(22) "DD_APPSEC_SCA_ENABLED"
   ["value"]=>
   string(1) "1"
   ["origin"]=>

--- a/tests/ext/appsec/sca_flag_is_sent_04.phpt
+++ b/tests/ext/appsec/sca_flag_is_sent_04.phpt
@@ -20,7 +20,7 @@ sca_test.inc
 --EXPECT--
 array(5) {
   ["name"]=>
-  string(22) "DD_APPSEC_SCA_ENABLED"
+  string(21) "DD_APPSEC_SCA_ENABLED"
   ["value"]=>
   string(1) "1"
   ["origin"]=>

--- a/tests/ext/appsec/sca_flag_is_sent_05.phpt
+++ b/tests/ext/appsec/sca_flag_is_sent_05.phpt
@@ -20,7 +20,7 @@ sca_test.inc
 --EXPECT--
 array(5) {
   ["name"]=>
-  string(22) "DD_APPSEC_SCA_ENABLED"
+  string(21) "DD_APPSEC_SCA_ENABLED"
   ["value"]=>
   string(1) "0"
   ["origin"]=>

--- a/tests/ext/appsec/sca_flag_is_sent_05.phpt
+++ b/tests/ext/appsec/sca_flag_is_sent_05.phpt
@@ -20,7 +20,7 @@ sca_test.inc
 --EXPECT--
 array(5) {
   ["name"]=>
-  string(18) "appsec.sca_enabled"
+  string(22) "DD_APPSEC_SCA_ENABLED"
   ["value"]=>
   string(1) "0"
   ["origin"]=>

--- a/tests/ext/appsec/sca_test.inc
+++ b/tests/ext/appsec/sca_test.inc
@@ -34,7 +34,7 @@ for ($i = 0; $i < 300; ++$i) {
                 return false;
             }
             foreach($json["payload"]["configuration"] as $configuration) {
-                if (strpos($configuration["name"], "sca_enabled") !== false) {
+                if (stripos($configuration["name"], "sca_enabled") !== false) {
                     var_dump($configuration);
                     return true;
                 }

--- a/tests/ext/library_config/fleet_config.phpt
+++ b/tests/ext/library_config/fleet_config.phpt
@@ -58,7 +58,7 @@ for ($i = 0; $i < 100; ++$i) {
                         }
 
                         var_dump(array_values(array_filter($cfg, function ($c) {
-                            return in_array($c["name"], ['service', 'env', 'dynamic_instrumentation.enabled', 'trace.spans_limit', 'trace.generate_root_span']);
+                            return in_array($c["name"], ['DD_SERVICE', 'DD_ENV', 'DD_DYNAMIC_INSTRUMENTATION_ENABLED', 'DD_TRACE_SPANS_LIMIT', 'DD_TRACE_GENERATE_ROOT_SPAN']);
                         })));
                         break 3;
                     }
@@ -81,7 +81,7 @@ array(5) {
   [0]=>
   array(5) {
     ["name"]=>
-    string(3) "env"
+    string(6) "DD_ENV"
     ["value"]=>
     string(21) "env_from_fleet_config"
     ["origin"]=>
@@ -94,7 +94,7 @@ array(5) {
   [1]=>
   array(5) {
     ["name"]=>
-    string(7) "service"
+    string(10) "DD_SERVICE"
     ["value"]=>
     string(25) "service_from_fleet_config"
     ["origin"]=>
@@ -107,7 +107,7 @@ array(5) {
   [2]=>
   array(5) {
     ["name"]=>
-    string(24) "trace.generate_root_span"
+    string(27) "DD_TRACE_GENERATE_ROOT_SPAN"
     ["value"]=>
     string(4) "true"
     ["origin"]=>
@@ -120,7 +120,7 @@ array(5) {
   [3]=>
   array(5) {
     ["name"]=>
-    string(17) "trace.spans_limit"
+    string(20) "DD_TRACE_SPANS_LIMIT"
     ["value"]=>
     string(2) "42"
     ["origin"]=>
@@ -133,7 +133,7 @@ array(5) {
   [4]=>
   array(5) {
     ["name"]=>
-    string(31) "dynamic_instrumentation.enabled"
+    string(34) "DD_DYNAMIC_INSTRUMENTATION_ENABLED"
     ["value"]=>
     string(4) "true"
     ["origin"]=>

--- a/tests/ext/library_config/local_config.phpt
+++ b/tests/ext/library_config/local_config.phpt
@@ -58,7 +58,7 @@ for ($i = 0; $i < 100; ++$i) {
                         }
 
                         var_dump(array_values(array_filter($cfg, function ($c) {
-                            return in_array($c["name"], ['service', 'env', 'dynamic_instrumentation.enabled', 'trace.spans_limit', 'trace.generate_root_span']);
+                            return in_array($c["name"], ['DD_SERVICE', 'DD_ENV', 'DD_DYNAMIC_INSTRUMENTATION_ENABLED', 'DD_TRACE_SPANS_LIMIT', 'DD_TRACE_GENERATE_ROOT_SPAN']);
                         })));
                         break 3;
                     }
@@ -81,7 +81,7 @@ array(5) {
   [0]=>
   array(5) {
     ["name"]=>
-    string(3) "env"
+    string(6) "DD_ENV"
     ["value"]=>
     string(21) "env_from_local_config"
     ["origin"]=>
@@ -94,7 +94,7 @@ array(5) {
   [1]=>
   array(5) {
     ["name"]=>
-    string(7) "service"
+    string(10) "DD_SERVICE"
     ["value"]=>
     string(25) "service_from_local_config"
     ["origin"]=>
@@ -107,7 +107,7 @@ array(5) {
   [2]=>
   array(5) {
     ["name"]=>
-    string(24) "trace.generate_root_span"
+    string(27) "DD_TRACE_GENERATE_ROOT_SPAN"
     ["value"]=>
     string(4) "true"
     ["origin"]=>
@@ -120,7 +120,7 @@ array(5) {
   [3]=>
   array(5) {
     ["name"]=>
-    string(17) "trace.spans_limit"
+    string(20) "DD_TRACE_SPANS_LIMIT"
     ["value"]=>
     string(2) "42"
     ["origin"]=>
@@ -133,7 +133,7 @@ array(5) {
   [4]=>
   array(5) {
     ["name"]=>
-    string(31) "dynamic_instrumentation.enabled"
+    string(34) "DD_DYNAMIC_INSTRUMENTATION_ENABLED"
     ["value"]=>
     string(4) "true"
     ["origin"]=>

--- a/tests/ext/telemetry/config.phpt
+++ b/tests/ext/telemetry/config.phpt
@@ -48,7 +48,7 @@ for ($i = 0; $i < 300; ++$i) {
                     if ($json["request_type"] == "app-client-configuration-change") {
                         $cfg = $json["payload"]["configuration"];
                         print_r(array_values(array_filter($cfg, function ($c) {
-                            return $c["origin"] == "env_var" && $c["name"] != "trace.sources_path" && $c["name"] != "trace.sidecar_trace_sender";
+                            return $c["origin"] == "env_var" && $c["name"] != "DD_TRACE_SOURCES_PATH" && $c["name"] != "DD_TRACE_SIDECAR_TRACE_SENDER";
                         })));
                         var_dump(count(array_filter($cfg, function ($c) {
                             return $c["origin"] == "default";
@@ -74,7 +74,7 @@ Array
 (
     [0] => Array
         (
-            [name] => trace.agent_url
+            [name] => DD_TRACE_AGENT_URL
             [value] => file://%s/config-telemetry.out
             [origin] => env_var
             [config_id] => 
@@ -83,7 +83,7 @@ Array
 
     [1] => Array
         (
-            [name] => instrumentation_telemetry_enabled
+            [name] => DD_INSTRUMENTATION_TELEMETRY_ENABLED
             [value] => 1
             [origin] => env_var
             [config_id] => 
@@ -92,7 +92,7 @@ Array
 
     [2] => Array
         (
-            [name] => trace.ignore_agent_sampling_rates
+            [name] => DD_TRACE_IGNORE_AGENT_SAMPLING_RATES
             [value] => 1
             [origin] => env_var
             [config_id] => 
@@ -101,7 +101,7 @@ Array
 
     [3] => Array
         (
-            [name] => trace.generate_root_span
+            [name] => DD_TRACE_GENERATE_ROOT_SPAN
             [value] => 0
             [origin] => env_var
             [config_id] => 
@@ -110,7 +110,7 @@ Array
 
     [4] => Array
         (
-            [name] => trace.git_metadata_enabled
+            [name] => DD_TRACE_GIT_METADATA_ENABLED
             [value] => 0
             [origin] => env_var
             [config_id] => 
@@ -119,7 +119,7 @@ Array
 
     [5] => Array
         (
-            [name] => experimental_propagate_process_tags_enabled
+            [name] => DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED
             [value] => 0
             [origin] => env_var
             [config_id] => 


### PR DESCRIPTION
## Summary
- Telemetry config names now use the canonical environment variable name (e.g. `DD_TRACE_GENERATE_ROOT_SPAN`) instead of the INI-derived dot notation (e.g. `trace.generate_root_span`)
- Uses `cfg->names[0]` directly from the memoized config entry, which is the original env var name from the `CONFIG()` macro definitions
- No performance impact — `names[0]` is a stack-allocated buffer already in memory

## Motivation
The backend automatically opens PRs that map config telemetry based on the config registry. Previously, PHP emitted INI-derived names like `trace.generate_root_span` which don't match the env var names in the registry, so those auto-generated PRs couldn't map PHP configs correctly. By emitting the standard env var name (e.g. `DD_TRACE_GENERATE_ROOT_SPAN`), the auto-generated backend PRs can map PHP configs without issues.

## Companion PR
- System tests: https://github.com/DataDog/system-tests/pull/6747

## Test plan
- [x] `tests/ext/telemetry/config.phpt` — verifies telemetry config names are emitted as env var names
- [x] `tests/ext/library_config/fleet_config.phpt` — verifies fleet stable config telemetry names
- [x] `tests/ext/library_config/local_config.phpt` — verifies local stable config telemetry names
- [x] `tests/ext/appsec/sca_flag_is_sent_*.phpt` (5 tests) — verifies SCA config telemetry names
- All tests pass locally in Docker (`php-8.3_bookworm-6`, debug build)

🤖 Generated with [Claude Code](https://claude.com/claude-code)