### PR TITLE
fix(ext): correct 'occured' -> 'occurred' in crashtracking_windows init log

### DIFF
--- a/ext/crashtracking_windows.c
+++ b/ext/crashtracking_windows.c
@@ -23,7 +23,7 @@ bool init_crash_tracking(void) {
     if (result) {
         LOG(TRACE, "Crashtracking is initialized");
     } else {
-        LOG(WARN, "An error occured while initializing crashtracking");
+        LOG(WARN, "An error occurred while initializing crashtracking");
     }
 
     ddog_endpoint_drop(agent_endpoint);


### PR DESCRIPTION
The Windows crashtracking initialization warning in `ext/crashtracking_windows.c:26` logged `An error occured while initializing crashtracking`. String-literal-only change in a `LOG(WARN, ...)` call.