### PR TITLE
fix(ci): fix test optimization upload broken by datadog-ci v5.13.0 requiring Node >= 20

### DIFF
--- a/.gitlab/generate-appsec.php
+++ b/.gitlab/generate-appsec.php
@@ -131,7 +131,7 @@ stages:
   after_script:
     - mkdir -p "${CI_PROJECT_DIR}/artifacts"
     - find appsec/tests/integration/build/test-results -name "*.xml" -exec cp --parents '{}' "${CI_PROJECT_DIR}/artifacts/" \;
-    - .gitlab/upload-junit-to-datadog.sh "test.source.file:appsec/"
+    - .gitlab/silent-upload-junit-to-datadog.sh "test.source.file:appsec/"
   artifacts:
     reports:
       junit: "artifacts/**/test-results/**/TEST-*.xml"

--- a/.gitlab/silent-upload-junit-to-datadog.sh
+++ b/.gitlab/silent-upload-junit-to-datadog.sh
@@ -4,5 +4,5 @@ OUTFILE=/tmp/datadog-junit-upload.txt
 if [[ $? -ne 0 ]]; then
   cat $OUTFILE
 else
-  grep -E '(^\* |Warning:|Error:|ReferenceError:|=== )' $OUTFILE || true
+  grep -E '^\* ' $OUTFILE
 fi

--- a/.gitlab/silent-upload-junit-to-datadog.sh
+++ b/.gitlab/silent-upload-junit-to-datadog.sh
@@ -1,8 +1,10 @@
 #!/bin/bash
 OUTFILE=/tmp/datadog-junit-upload.txt
 "$(dirname -- "${BASH_SOURCE[0]}")"/upload-junit-to-datadog.sh "$@" >$OUTFILE 2>&1
-if [[ $? -ne 0 ]]; then
+rc=$?
+if [[ $rc -ne 0 ]]; then
   cat $OUTFILE
 else
   grep -E '^\* ' $OUTFILE
 fi
+exit $rc

--- a/.gitlab/silent-upload-junit-to-datadog.sh
+++ b/.gitlab/silent-upload-junit-to-datadog.sh
@@ -4,5 +4,5 @@ OUTFILE=/tmp/datadog-junit-upload.txt
 if [[ $? -ne 0 ]]; then
   cat $OUTFILE
 else
-  grep -E '^\* ' $OUTFILE
+  grep -E '(^\* |Warning:|Error:|ReferenceError:|=== )' $OUTFILE || true
 fi

--- a/.gitlab/upload-junit-to-datadog.sh
+++ b/.gitlab/upload-junit-to-datadog.sh
@@ -215,8 +215,8 @@ echo "Current directory: $(pwd)"
 echo "Running command: ${datadog_ci_cmd} junit upload --service \"${DD_SERVICE}\" --max-concurrency 20 --verbose --tags git.repository_url:https://github.com/DataDog/dd-trace-php ${tags_args} ${xpath_tags_args} ${files_array[*]}"
 
 if ! ${datadog_ci_cmd} junit upload --service "${DD_SERVICE}" --max-concurrency 20 --verbose --tags "git.repository_url:https://github.com/DataDog/dd-trace-php" ${tags_args} ${xpath_tags_args} "${files_array[@]}"; then
-  echo "Warning: Failed to upload JUnit files" >&2
-  exit 0
+  echo "Error: Failed to upload JUnit files" >&2
+  exit 1
 fi
 
 echo "=== JUnit upload completed ==="

--- a/.gitlab/upload-junit-to-datadog.sh
+++ b/.gitlab/upload-junit-to-datadog.sh
@@ -142,9 +142,9 @@ export DATADOG_API_KEY
 # Determine which datadog-ci method to use
 datadog_ci_cmd=""
 
-# Prefer npm/npx if available and node version is recent enough (>=16)
+# Prefer npm/npx if available and node version is recent enough (>=20, required by @datadog/datadog-ci >= 5.13.0)
 node_version="$(node --version 2>/dev/null | sed 's/^v//' | cut -d. -f1)"
-if [ -n "$node_version" ] && [ "$node_version" -ge 16 ] 2>/dev/null && { command -v npx &> /dev/null || command -v npm &> /dev/null; }; then
+if [ -n "$node_version" ] && [ "$node_version" -ge 20 ] 2>/dev/null && { command -v npx &> /dev/null || command -v npm &> /dev/null; }; then
   echo "Using npx to run datadog-ci (node v${node_version})"
   datadog_ci_cmd="npx --yes @datadog/datadog-ci"
 else


### PR DESCRIPTION
## Problem

Test optimization uploads have been silently failing on all CI jobs since `@datadog/datadog-ci@5.13.0` was released, which bumped the minimum Node.js requirement to `>=20`. CI runners use Node 18, causing a hard crash:

\`\`\`
npm WARN EBADENGINE   package: '@datadog/datadog-ci@5.13.0',
npm WARN EBADENGINE   required: { node: '>=20' },
npm WARN EBADENGINE   current: { node: 'v18.20.4', npm: '9.2.0' }

ReferenceError: File is not defined
\`\`\`

Because `upload-junit-to-datadog.sh` exited 0 even on failure, and `silent-upload-junit-to-datadog.sh` didn't propagate the exit code, the failure was completely invisible in CI output.

## Fix

- **`upload-junit-to-datadog.sh`**: Raise the npx node version check from `>=16` to `>=20`. On Node 18 the script now falls back to the standalone binary (which has no Node version constraint) instead of invoking npx with a version that crashes at startup. Also exit 1 (instead of 0) when `datadog-ci` actually fails to upload.
- **`silent-upload-junit-to-datadog.sh`**: Propagate the exit code from the inner script so failures are visible in CI logs and jobs fail as expected.