### PR TITLE
Flush telemetry as well on anticipated sidecar shutdown

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2738,6 +2738,7 @@ dependencies = [
  "bytes",
  "cc",
  "const_format",
+ "criterion",
  "futures",
  "futures-core",
  "futures-util",

--- a/components-rs/common.h
+++ b/components-rs/common.h
@@ -1174,6 +1174,11 @@ typedef struct ddog_NativeFile {
   struct ddog_PlatformHandle_File *handle;
 } ddog_NativeFile;
 
+typedef struct ddog_SidecarFlushOptions {
+  bool traces_and_stats;
+  bool telemetry;
+} ddog_SidecarFlushOptions;
+
 typedef struct ddog_TracerHeaderTags {
   ddog_CharSlice lang;
   ddog_CharSlice lang_version;

--- a/components-rs/sidecar.h
+++ b/components-rs/sidecar.h
@@ -104,7 +104,8 @@ ddog_MaybeError ddog_sidecar_clear_inherited_listener(void);
 
 ddog_MaybeError ddog_sidecar_ping(struct ddog_SidecarTransport **transport);
 
-ddog_MaybeError ddog_sidecar_flush_traces(struct ddog_SidecarTransport **transport);
+ddog_MaybeError ddog_sidecar_flush(struct ddog_SidecarTransport **transport,
+                                   struct ddog_SidecarFlushOptions options);
 
 struct ddog_InstanceId *ddog_sidecar_instanceId_build(ddog_CharSlice session_id,
                                                       ddog_CharSlice runtime_id);

--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -1598,7 +1598,7 @@ static PHP_MSHUTDOWN_FUNCTION(ddtrace) {
     } else /* ! part of the if outside the ifdef */
 #endif
     if (get_global_DD_TRACE_FORCE_FLUSH_ON_SHUTDOWN() && DDTRACE_G(sidecar)) {
-        ddog_sidecar_flush_traces(&DDTRACE_G(sidecar));
+        ddog_sidecar_flush(&DDTRACE_G(sidecar), (ddog_SidecarFlushOptions){.traces_and_stats = true, .telemetry = true});
     }
 
     ddtrace_log_mshutdown();
@@ -3083,7 +3083,7 @@ PHP_FUNCTION(dd_trace_internal_fn) {
             } else
 #endif
             if (DDTRACE_G(sidecar)) {
-                ddtrace_ffi_try("Failed synchronously flushing traces", ddog_sidecar_flush_traces(&DDTRACE_G(sidecar)));
+                ddtrace_ffi_try("Failed synchronously flushing traces", ddog_sidecar_flush(&DDTRACE_G(sidecar), (ddog_SidecarFlushOptions){.traces_and_stats = true}));
             }
             RETVAL_TRUE;
 #ifndef _WIN32
@@ -3218,7 +3218,7 @@ PHP_FUNCTION(dd_trace_synchronous_flush) {
     } else
 #endif
     if (DDTRACE_G(sidecar)) {
-        ddtrace_ffi_try("Failed synchronously flushing traces", ddog_sidecar_flush_traces(&DDTRACE_G(sidecar)));
+        ddtrace_ffi_try("Failed synchronously flushing traces", ddog_sidecar_flush(&DDTRACE_G(sidecar), (ddog_SidecarFlushOptions){.traces_and_stats = true}));
     }
     RETURN_NULL();
 }

--- a/ext/signals.c
+++ b/ext/signals.c
@@ -363,7 +363,7 @@ static int dd_call_prev_handler(bool flush) {
     }
 
     if (flush) {
-        ddog_sidecar_flush_traces(&ddtrace_sidecar_for_signal);
+        ddog_sidecar_flush(&ddtrace_sidecar_for_signal, (ddog_SidecarFlushOptions){.traces_and_stats = true});
     }
 
     if (prev_handler == SIG_DFL) {


### PR DESCRIPTION
Otherwise telemetry might not end up flushed for shortlived sidecars.