### PR TITLE
ci: auto-retry infra-caused script failures via exit code 75 sentinel

### DIFF
--- a/.gitlab/generate-common.php
+++ b/.gitlab/generate-common.php
@@ -111,9 +111,8 @@ default:
       - api_failure
       - stuck_or_timeout_failure
       - job_execution_timeout
-      - script_failure
     exit_codes:
-      - 75  # EX_TEMPFAIL: transient infrastructure unavailability (service startup timeout, download failure, etc.)
+      - 75
 
 .all_targets: &all_minor_major_targets
 <?php

--- a/.gitlab/generate-common.php
+++ b/.gitlab/generate-common.php
@@ -111,6 +111,9 @@ default:
       - api_failure
       - stuck_or_timeout_failure
       - job_execution_timeout
+      - script_failure
+    exit_codes:
+      - 75  # EX_TEMPFAIL: transient infrastructure unavailability (service startup timeout, download failure, etc.)
 
 .all_targets: &all_minor_major_targets
 <?php

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -737,6 +737,29 @@ foreach ($xdebug_test_matrix as [$major_minor, $xdebug]):
 
 <?php endforeach; ?>
 
+# Validates exit_codes: [75] retry behaviour — remove after branch is merged
+"test-retry-exit-75":
+  stage: test
+  tags: [ "arch:amd64" ]
+  image: registry.ddbuild.io/images/mirror/php:8.2-cli
+  needs: []
+  script:
+    - exit 75
+  allow_failure: true
+  rules:
+    - if: $CI_COMMIT_REF_NAME == "leiyks/infra-failure-retry"
+
+"test-no-retry-exit-1":
+  stage: test
+  tags: [ "arch:amd64" ]
+  image: registry.ddbuild.io/images/mirror/php:8.2-cli
+  needs: []
+  script:
+    - exit 1
+  allow_failure: true
+  rules:
+    - if: $CI_COMMIT_REF_NAME == "leiyks/infra-failure-retry"
+
 "aggregate tested versions":
   stage: "aggregate versions"
   image: registry.ddbuild.io/images/dd-octo-sts-ci-base:2025.06-1

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -737,29 +737,6 @@ foreach ($xdebug_test_matrix as [$major_minor, $xdebug]):
 
 <?php endforeach; ?>
 
-# Validates exit_codes: [75] retry behaviour — remove after branch is merged
-"test-retry-exit-75":
-  stage: test
-  tags: [ "arch:amd64" ]
-  image: registry.ddbuild.io/images/mirror/php:8.2-cli
-  needs: []
-  script:
-    - exit 75
-  allow_failure: true
-  rules:
-    - if: $CI_COMMIT_REF_NAME == "leiyks/infra-failure-retry"
-
-"test-no-retry-exit-1":
-  stage: test
-  tags: [ "arch:amd64" ]
-  image: registry.ddbuild.io/images/mirror/php:8.2-cli
-  needs: []
-  script:
-    - exit 1
-  allow_failure: true
-  rules:
-    - if: $CI_COMMIT_REF_NAME == "leiyks/infra-failure-retry"
-
 "aggregate tested versions":
   stage: "aggregate versions"
   image: registry.ddbuild.io/images/dd-octo-sts-ci-base:2025.06-1

--- a/.gitlab/wait-for-service-ready.sh
+++ b/.gitlab/wait-for-service-ready.sh
@@ -115,7 +115,7 @@ if [ -n "${WAIT_FOR:-}" ]; then
     service_type="$(detect_service_type "${host}")"
 
     if ! wait_for_single_service "${host}" "${port}" "${service_type}" 30 5; then
-      exit 1
+      exit 75  # EX_TEMPFAIL: triggers infra-sentinel retry in GitLab CI
     fi
   done
 fi

--- a/.gitlab/wait-for-service-ready.sh
+++ b/.gitlab/wait-for-service-ready.sh
@@ -115,7 +115,7 @@ if [ -n "${WAIT_FOR:-}" ]; then
     service_type="$(detect_service_type "${host}")"
 
     if ! wait_for_single_service "${host}" "${port}" "${service_type}" 30 5; then
-      exit 75  # EX_TEMPFAIL: triggers infra-sentinel retry in GitLab CI
+      exit 75
     fi
   done
 fi


### PR DESCRIPTION
Service startup timeouts (Kafka, Zookeeper, etc.) exit with code 1, which GitLab classifies as `script_failure` — not covered by our runner-level retry rules. We don't want blanket `script_failure` retry as it hides real test flakiness.

GitLab's `retry: exit_codes:` is a standalone OR condition: jobs are retried if they exit with one of the listed codes, independently of `when:`. This means `exit_codes: [75]` retries only on exit code 75 — real test failures (`exit 1`) are never retried.

This PR introduces **exit code 75** (`EX_TEMPFAIL`) as an infra-failure sentinel:

- **`generate-common.php`**: add `exit_codes: [75]` to the global retry block — jobs exiting with the infra sentinel are retried up to 2×, all other failures are unaffected
- **`wait-for-service-ready.sh`**: `exit 1` → `exit 75` on service startup timeout (Kafka, Zookeeper, MySQL, Redis, etc.)

Verified on CI: `exit 75` → 3 attempts (retried twice); `exit 1` → 1 attempt only.

Any script that fails due to transient infra can adopt the same convention (`exit 75`) and will be picked up by the global rule automatically.