### PR TITLE
fix: align Datadog-Client-Computed-Stats header with agent stats computation gate

### DIFF
--- a/ext/auto_flush.c
+++ b/ext/auto_flush.c
@@ -15,6 +15,7 @@
 #include "ddshared.h"
 #include "standalone_limiter.h"
 #include <main/SAPI.h>
+#include <components-rs/ddtrace.h>
 #include <components-rs/sidecar.h>
 
 ZEND_EXTERN_MODULE_GLOBALS(ddtrace);
@@ -57,7 +58,7 @@ ZEND_RESULT_CODE ddtrace_flush_tracer(bool force_on_startup, bool collect_cycles
                     .tracer_version = DDOG_CHARSLICE_C_BARE(PHP_DDTRACE_VERSION),
                     .lang_version = php_version_rt,
                     .client_computed_top_level = get_DD_TRACE_STATS_COMPUTATION_ENABLED(),
-                    .client_computed_stats = !get_global_DD_APM_TRACING_ENABLED() || get_DD_TRACE_STATS_COMPUTATION_ENABLED(),
+                    .client_computed_stats = !get_global_DD_APM_TRACING_ENABLED() || (get_DD_TRACE_STATS_COMPUTATION_ENABLED() && ddog_agent_has_stats_computation()),
                 },
                 .transport = DDTRACE_G(sidecar),
                 .instance_id = ddtrace_sidecar_instance_id,

--- a/ext/coms.c
+++ b/ext/coms.c
@@ -771,7 +771,7 @@ static struct curl_slist *dd_agent_headers_alloc(void) {
     dd_append_header(&list, "Datadog-Meta-Lang-Interpreter", sapi_module.name, strlen(sapi_module.name));
     dd_append_header(&list, "Datadog-Meta-Lang-Version", php_version_rt.ptr, php_version_rt.len);
     dd_append_header(&list, "Datadog-Meta-Tracer-Version", ZEND_STRL(PHP_DDTRACE_VERSION));
-    if (!get_global_DD_APM_TRACING_ENABLED() || (ddtrace_sidecar_for_signal && get_global_DD_TRACE_STATS_COMPUTATION_ENABLED())) {
+    if (!get_global_DD_APM_TRACING_ENABLED() || (ddtrace_sidecar_for_signal && get_global_DD_TRACE_STATS_COMPUTATION_ENABLED() && ddog_agent_has_stats_computation())) {
         dd_append_header(&list, "Datadog-Client-Computed-Stats", ZEND_STRL("true"));
     }
     if (ddtrace_sidecar_for_signal && get_global_DD_TRACE_STATS_COMPUTATION_ENABLED()) {


### PR DESCRIPTION
## Problem

Commit 68e11c7c8 ("Check for agent version in client side stats") added `ddog_agent_has_stats_computation()` as a gate in `serializer.c` to suppress stats computation when the agent doesn't report `client_drop_p0s: true`. However, the `Datadog-Client-Computed-Stats: true` HTTP header — sent with every trace payload — was not updated in two other locations:

- `ext/coms.c` (legacy background sender path)
- `ext/auto_flush.c` (sidecar sender path)

Both still check only `DD_TRACE_STATS_COMPUTATION_ENABLED` (an INI flag), so the header is sent as `true` even when the agent gate would suppress actual stats computation. The system test `TRACE_STATS_COMPUTATION_CLIENT_DROP_P0S_FALSE` fails on every CI pipeline as a result.

## Fix

Replace `get_global_DD_TRACE_STATS_COMPUTATION_ENABLED()` / `get_DD_TRACE_STATS_COMPUTATION_ENABLED()` with `ddog_agent_has_stats_computation()` in both locations, making the header consistent with the serializer gate.

Also adds `#include <components-rs/ddtrace.h>` to `ext/auto_flush.c` where the declaration was not yet visible.

## Test

System test: `TRACE_STATS_COMPUTATION_CLIENT_DROP_P0S_FALSE`