### PR TITLE
tests(appsec): wait for sidecar telemetry ready before TelemetryTests

### DIFF
--- a/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/TelemetryTests.groovy
+++ b/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/TelemetryTests.groovy
@@ -62,6 +62,17 @@ class TelemetryTests {
                    export  DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS=1;
                    php-fpm -y /etc/php-fpm.conf -c /etc/php/php-rc.ini''')
         assert res.exitCode == 0
+
+        // Wait for the helper/sidecar to fully connect and flush its initial waf.init
+        // telemetry before releasing any test. Without this, a slow sidecar startup
+        // exhausts the first test's 60s polling window before any metric arrives,
+        // causing all 9 ordered tests to fail in sequence.
+        log.info('Waiting for sidecar to emit waf.init telemetry (up to 60s)...')
+        TelemetryHelpers.waitForMetrics(CONTAINER, 60) { List<TelemetryHelpers.GenerateMetrics> messages ->
+            def allSeries = messages.collectMany { it.series }
+            allSeries.any { it.name == 'waf.init' }
+        }
+        log.info('Sidecar telemetry ready — waf.init received.')
     }
 
     /**
@@ -118,7 +129,9 @@ class TelemetryTests {
         TelemetryHelpers.Metric workerCount
 
 
-        TelemetryHelpers.waitForMetrics(CONTAINER, 30) { List<TelemetryHelpers.GenerateMetrics> messages ->
+        // 60s: @BeforeAll may have consumed the first waf.init batch (10s metric interval),
+        // so this test needs enough headroom to catch the next emission cycle.
+        TelemetryHelpers.waitForMetrics(CONTAINER, 60) { List<TelemetryHelpers.GenerateMetrics> messages ->
             def allSeries = messages.collectMany { it.series }
             wafInit = allSeries.find { it.name == 'waf.init' }
             // Rust helper has +1 tag (helper_runtime), C++ doesn't


### PR DESCRIPTION
## Problem

`TelemetryTests` share a single Docker container across 9 ordered tests. The `@BeforeAll` restarts php-fpm, but if the helper-rust sidecar startup is slow, the first test's 30s polling window expires before `waf.init` telemetry arrives. All 9 tests then fail in sequence (30s apart, perfectly timed out).

## Fix

Add a startup health-check in `@BeforeAll` that waits for `waf.init` telemetry before releasing the first test, and increase the first test's timeout to 60s (it bears the full startup cost). This removes the race between sidecar startup and the first test's poll window.