### PR TITLE
tests: fix sidecar agent-info timing races in request-replayer and live-debugger tests

### DIFF
--- a/tests/ext/live-debugger/debugger_metric_probe.phpt
+++ b/tests/ext/live-debugger/debugger_metric_probe.phpt
@@ -34,6 +34,11 @@ $span = await_probe_installation(function() {
     return \DDTrace\start_span(); // submit span data
 });
 
+// Give the sidecar a moment to fully wire the probe before invoking foo().
+// await_probe_installation() detects the hook install but the sidecar may still be
+// finalising the DogStatsD endpoint binding on first use.
+usleep(100000); // 100 ms
+
 foo();
 
 $server->dump(1);

--- a/tests/ext/request-replayer/client_side_stats_peer_tags.phpt
+++ b/tests/ext/request-replayer/client_side_stats_peer_tags.phpt
@@ -39,16 +39,10 @@ include __DIR__ . '/../includes/request_replayer.inc';
 
 $rr = new RequestReplayer();
 
-// Flush a dummy trace and wait for the sidecar to process it.  The sidecar polls the agent
-// /info endpoint on the same interval, so by the time we return here it will have written
-// the peer_tags from the agent info (set in SKIPIF) to the shared-memory segment that
-// ddog_apply_agent_info_concentrator_config reads.
-$dummy = \DDTrace\start_trace_span();
-$dummy->name = "dummy";
-$dummy->service = "dummy-service";
-\DDTrace\close_span();
-dd_trace_internal_fn('synchronous_flush');
-$rr->waitForDataAndReplay();
+// Block until the sidecar has received and applied the agent /info response (which carries
+// peer_tags set in SKIPIF). This ensures ddog_apply_agent_info_concentrator_config() will
+// pick up the peer_tags from the SHM segment before the concentrator processes our span.
+dd_trace_internal_fn('await_agent_info');
 
 // Now create the span whose stats we want to inspect. When this span is fed to the
 // concentrator, ddog_apply_agent_info_concentrator_config() is called first, picks up

--- a/tests/ext/request-replayer/client_side_stats_trace_filters.phpt
+++ b/tests/ext/request-replayer/client_side_stats_trace_filters.phpt
@@ -8,7 +8,8 @@ if (PHP_VERSION_ID >= 80100) {
     echo "nocache\n";
 }
 // Configure the request-replayer to return these filter rules from the /info endpoint.
-// The sidecar will pick them up on its next poll cycle (triggered by the dummy flush below).
+// The sidecar will pick them up on its next poll cycle; await_agent_info() in --FILE--
+// blocks until the sidecar has applied the config before any test spans are flushed.
 //
 // Filters configured:
 //   filter_tags.require:        filter_required:yes
@@ -60,15 +61,10 @@ include __DIR__ . '/../includes/request_replayer.inc';
 
 $rr = new RequestReplayer();
 
-// Flush a dummy trace so the sidecar polls /info and picks up the filter config that was
-// written to the request-replayer in SKIPIF.  By the time waitForDataAndReplay() returns
-// the sidecar has had at least one poll cycle.
-$dummy = \DDTrace\start_trace_span();
-$dummy->name  = 'dummy';
-$dummy->service = 'dummy-service';
-\DDTrace\close_span();
-dd_trace_internal_fn('synchronous_flush');
-$rr->waitForDataAndReplay();
+// Block until the sidecar has received and applied the agent /info response (which carries
+// the filter_tags / filter_tags_regex / ignore_resources config set in SKIPIF). This
+// guarantees the filter rules are in place before any test spans are flushed.
+dd_trace_internal_fn('await_agent_info');
 
 // Each test case is a separate root span (= separate trace), because trace filters are
 // evaluated per trace (root span properties / tags).
@@ -123,11 +119,9 @@ makeSpan('op.blocked.regex_require', 'GET /other4', [
 
 dd_trace_internal_fn('synchronous_flush');
 
-// Capture ALL trace requests from the second flush before consuming them.
-// The first flush's data was already consumed by waitForDataAndReplay() above, so only
-// second-flush requests remain.  Poll until at least one trace request arrives, then
-// collect everything that arrived in that batch.
-$secondFlushTraces = [];
+// Capture ALL trace requests from this flush before consuming them.
+// Poll until at least one trace request arrives, then collect everything in that batch.
+$flushTraces = [];
 for ($i = 0; $i < 1000; $i++) {
     usleep(50000);  // 50 ms  (same interval as RequestReplayer::flushInterval)
     $reqs = $rr->replayAllRequests() ?? [];
@@ -135,14 +129,14 @@ for ($i = 0; $i < 1000; $i++) {
         return strpos($r['uri'] ?? '', 'traces') !== false;
     }));
     if (!empty($traces)) {
-        $secondFlushTraces = $traces;
+        $flushTraces = $traces;
         break;
     }
 }
 
 // Extract span names from every trace request in this flush.
 $namesInTraces = [];
-foreach ($secondFlushTraces as $req) {
+foreach ($flushTraces as $req) {
     $body = json_decode($req['body'] ?? '', true);
     if (!is_array($body)) continue;
     if (isset($body['chunks'])) {
@@ -170,9 +164,8 @@ foreach (array_keys($namesInTraces) as $n) {
 }
 
 // Wait for a stats payload that contains our service.
-// Stats from the second flush arrive a few seconds after waitForDataAndReplay() returns;
-// use a matcher so we wait for the right payload rather than returning the first one
-// (which contains the dummy span from the first flush).
+// Use a matcher to wait for the right payload rather than returning the first one
+// (SKIPIF may have generated earlier requests under this token).
 $statsRequest = $rr->waitForStats(function ($request) {
     $payload = json_decode($request['body'], true);
     foreach ($payload['Stats'] ?? [] as $bucket) {

--- a/tests/ext/request-replayer/dd_trace_agent_env.phpt
+++ b/tests/ext/request-replayer/dd_trace_agent_env.phpt
@@ -36,12 +36,10 @@ $rr = new RequestReplayer();
 
 $span = \DDTrace\start_span();
 
-// make sure sidecar keeps up with us
-$start = microtime(true);
-\DDTrace\start_trace_span();
-\DDTrace\close_span();
-$rr->waitForDataAndReplay();
-usleep(floor(microtime(true) - $start) * 100000);
+// Block until the sidecar has received and applied the agent /info response (which carries
+// default_env set in SKIPIF). This ensures $span->env reflects the agent-provided env
+// before we read it.
+dd_trace_internal_fn('await_agent_info');
 
 \DDTrace\close_span();
 var_dump($span->env);


### PR DESCRIPTION
## Problem

Several tests that rely on the sidecar having applied agent-info before flushing spans have a timing race: the sidecar polls agent info on its own interval, and if the test's flush sequence runs before the sidecar has polled, the expected values are not yet in place.

This was worsened by commit 68e11c7c8 ("Check for agent version in client side stats") which changed the agent-info polling path and made the races more frequent.

Affected tests:
- `tests/ext/request-replayer/client_side_stats_trace_filters.phpt` — dummy span flush could complete before filter config (filter_tags, filter_tags_regex, ignore_resources) was applied by the sidecar
- `tests/ext/request-replayer/client_side_stats_peer_tags.phpt` — dummy span flush could complete before peer_tags config was applied
- `tests/ext/request-replayer/dd_trace_agent_env.phpt` — `usleep(floor(microtime(true) - $start) * 100000)` is effectively a no-op (floor of ~0.003 = 0), leaving a window where default_env isn't applied yet
- `tests/ext/live-debugger/debugger_metric_probe.phpt` — sidecar may still be finalising DogStatsD endpoint binding when `foo()` fires immediately after probe installation

## Fix

- **client_side_stats_peer_tags.phpt** and **client_side_stats_trace_filters.phpt**: replace the unreliable dummy-flush + `waitForDataAndReplay()` warm-up with `dd_trace_internal_fn('await_agent_info')`, which is the same primitive already used in `client_side_stats.phpt` (added in 68e11c7c8). This polls `ddog_is_agent_info_ready()` (with active SHM reads) until the sidecar has received and applied the `/info` response, up to a 5-second timeout.

- **dd_trace_agent_env.phpt**: replace the broken `usleep(floor(microtime(true) - $start) * 100000)` sleep (which always evaluates to 0 since `$start` was just set) with `dd_trace_internal_fn('await_agent_info')`.

- **debugger_metric_probe.phpt**: add a 100 ms `usleep` after `await_probe_installation()` returns to give the sidecar time to finish wiring the DogStatsD endpoint before `foo()` is called and the metric fires.

## Notes

- `dynamic_config_update.phpt` is intentionally not touched.
- No production code changes — test-only fix.