### PR TITLE
ci: make verify jobs retryable for transient infra failures (exit 75)

### DIFF
--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -1007,8 +1007,8 @@ endforeach;
 <?php dockerhub_login() ?>
     - mkdir build
     - mv packages build
-    - apk add --no-cache ca-certificates # see https://support.circleci.com/hc/en-us/articles/360016505753-Resolve-Certificate-Signed-By-Unknown-Authority-error-in-Alpine-images?flash_digest=39b76521a337cecacac0cc10cb28f3747bb5fc6a
-    - apk add curl ${INSTALL_PACKAGES:-}
+    - apk add --no-cache ca-certificates || exit 75 # see https://support.circleci.com/hc/en-us/articles/360016505753-Resolve-Certificate-Signed-By-Unknown-Authority-error-in-Alpine-images?flash_digest=39b76521a337cecacac0cc10cb28f3747bb5fc6a
+    - apk add curl ${INSTALL_PACKAGES:-} || exit 75
 
 "verify centos":
   extends: .verify_job
@@ -1050,8 +1050,8 @@ endforeach;
         echo "yum update failed (attempt $i/3), retrying in 5 seconds..."
         sleep 5
         if [ $i -eq 3 ]; then
-          echo "yum update failed after 3 attempts, exiting"
-          exit 1
+          echo "yum update failed after 3 attempts, signaling retry (exit 75)"
+          exit 75
         fi
       done
 
@@ -1075,8 +1075,8 @@ endforeach;
 <?php dockerhub_login() ?>
     - mkdir build
     - mv packages build
-    - apt update
-    - apt-get install -y curl
+    - apt-get update || exit 75
+    - apt-get install -y curl || exit 75
 
 <?php foreach ([["8.1", "arm64", "aarch64"], ["7.0", "amd64", "x86_64"]] as [$major_minor, $arch, $pkgprefix]): ?>
 "verify .tar.gz: [<?= $arch ?>]":
@@ -1131,7 +1131,23 @@ endforeach;
     mkdir build
     move packages build
   script:
-    - Set-ExecutionPolicy Bypass -Scope Process -Force; [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072; iex ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1')) # chocolatey install
+    - |
+      $maxAttempts = 3
+      for ($attempt = 1; $attempt -le $maxAttempts; $attempt++) {
+          try {
+              Set-ExecutionPolicy Bypass -Scope Process -Force
+              [System.Net.ServicePointManager]::SecurityProtocol = [System.Net.ServicePointManager]::SecurityProtocol -bor 3072
+              Invoke-Expression ((New-Object System.Net.WebClient).DownloadString('https://community.chocolatey.org/install.ps1'))
+              break
+          } catch {
+              Write-Host "Chocolatey install attempt $attempt/$maxAttempts failed: $_"
+              if ($attempt -eq $maxAttempts) {
+                  Write-Host "Infrastructure failure: Chocolatey download failed after $maxAttempts attempts, signaling retry (exit 75)"
+                  exit 75
+              }
+              Start-Sleep -Seconds 15
+          }
+      }
     - .\dockerfiles\verify_packages\verify_windows.ps1
 
 "pecl tests":

--- a/dockerfiles/verify_packages/alpine/install.sh
+++ b/dockerfiles/verify_packages/alpine/install.sh
@@ -2,13 +2,30 @@
 
 set -e
 
+# Retry a command up to 3 times with 10s backoff before signaling infra failure.
+# All failures in this script are infrastructure failures (package downloads,
+# network), not test failures — so exhausted retries exit 75 (EX_TEMPFAIL)
+# to trigger GitLab's infra-retry rule rather than marking the job as failed.
+retry_or_tempfail() {
+    local n=1
+    until "$@"; do
+        if [ "$n" -ge 3 ]; then
+            echo "Infrastructure command failed after $n attempts, signaling retry (exit 75): $*" >&2
+            exit 75
+        fi
+        echo "Command failed (attempt $n/3): $* — retrying in 10s..." >&2
+        n=$((n + 1))
+        sleep 10
+    done
+}
+
 mkdir -p /run/nginx
 
-apk add --no-cache nginx curl
+retry_or_tempfail apk add --no-cache nginx curl
 
 # Installing php
 if [ ! -z "${PHP_PACKAGE}" ]; then
-    apk add --no-cache ${PHP_PACKAGE}
+    retry_or_tempfail apk add --no-cache ${PHP_PACKAGE}
 fi
 
 # Preparing PHP
@@ -44,7 +61,7 @@ if [ "$INSTALL_TYPE" = "native_package" ]; then
     apk add --no-cache $(pwd)/build/packages/*$(uname -m)*.apk --allow-untrusted
 else
     echo "Installing dd-trace-php using the new PHP installer"
-    apk add --no-cache libgcc
+    retry_or_tempfail apk add --no-cache libgcc
     installable_bundle=$(find "$(pwd)/build/packages" -maxdepth 1 -name "dd-library-php-*-$(uname -m)-linux-musl.tar.gz")
     $PHP_BIN datadog-setup.php --file "$installable_bundle" --php-bin all --enable-appsec
 fi

--- a/dockerfiles/verify_packages/centos/install.sh
+++ b/dockerfiles/verify_packages/centos/install.sh
@@ -11,7 +11,8 @@ function do_retry() {
     ! "$@"
   do
     if ! ((--RETRIES)); then
-      return 1
+      echo "Infrastructure command failed after 3 attempts, signaling retry (exit 75): $*" >&2
+      exit 75
     fi
     echo "Retry attempt $ATTEMPT failed, waiting 5 seconds before retry $((ATTEMPT + 1))..."
     sleep 5

--- a/dockerfiles/verify_packages/debian/install.sh
+++ b/dockerfiles/verify_packages/debian/install.sh
@@ -40,7 +40,7 @@ sed -i 's/*:80/127.0.0.1:8081/' /etc/apache2/sites-enabled/000-default.conf
 if [ "${INSTALL_MODE}" = "native" ]; then
     retry_or_tempfail apt-get install -y ${PHP_PACKAGE}
 elif [ "${INSTALL_MODE}" = "sury" ]; then
-    retry_or_tempfail curl -sSL -o /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
+    retry_or_tempfail curl -sSfL -o /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
     sh -c 'echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
     retry_or_tempfail apt-get update
     retry_or_tempfail apt-get install -y \

--- a/dockerfiles/verify_packages/debian/install.sh
+++ b/dockerfiles/verify_packages/debian/install.sh
@@ -2,9 +2,26 @@
 
 set -e
 
+# Retry a command up to 3 times with 10s backoff before signaling infra failure.
+# All failures in this script are infrastructure failures (package downloads,
+# network), not test failures — so exhausted retries exit 75 (EX_TEMPFAIL)
+# to trigger GitLab's infra-retry rule rather than marking the job as failed.
+retry_or_tempfail() {
+    local n=1
+    until "$@"; do
+        if [ "$n" -ge 3 ]; then
+            echo "Infrastructure command failed after $n attempts, signaling retry (exit 75): $*" >&2
+            exit 75
+        fi
+        echo "Command failed (attempt $n/3): $* — retrying in 10s..." >&2
+        n=$((n + 1))
+        sleep 10
+    done
+}
+
 # Common installations
-apt update
-apt install -y \
+retry_or_tempfail apt-get update
+retry_or_tempfail apt-get install -y \
     apt-transport-https \
     lsb-release \
     ca-certificates \
@@ -21,12 +38,12 @@ sed -i 's/*:80/127.0.0.1:8081/' /etc/apache2/sites-enabled/000-default.conf
 
 # Installing php
 if [ "${INSTALL_MODE}" = "native" ]; then
-    apt-get install -y ${PHP_PACKAGE}
+    retry_or_tempfail apt-get install -y ${PHP_PACKAGE}
 elif [ "${INSTALL_MODE}" = "sury" ]; then
-    curl -sSL -o /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
+    retry_or_tempfail curl -sSL -o /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
     sh -c 'echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
-    apt update
-    apt install -y \
+    retry_or_tempfail apt-get update
+    retry_or_tempfail apt-get install -y \
         php${PHP_VERSION}-cli \
         php${PHP_VERSION}-curl \
         php${PHP_VERSION}-fpm \
@@ -34,7 +51,7 @@ elif [ "${INSTALL_MODE}" = "sury" ]; then
         WWW_CONF=/etc/php/${PHP_VERSION}/fpm/pool.d/www.conf
         PHP_FPM_BIN=php-fpm${PHP_VERSION}
     if [ "${PHP_VERSION}" != "8.5" ]; then
-        apt install -y \
+        retry_or_tempfail apt-get install -y \
             php${PHP_VERSION}-opcache
     fi
 else

--- a/dockerfiles/verify_packages/tar_gz/install.sh
+++ b/dockerfiles/verify_packages/tar_gz/install.sh
@@ -32,7 +32,7 @@ retry_or_tempfail apt-get install -y \
     procps \
     gnupg
 
-retry_or_tempfail curl -sSL -o /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
+retry_or_tempfail curl -sSfL -o /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
 sh -c 'echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
 retry_or_tempfail apt-get update
 retry_or_tempfail apt-get install -y \

--- a/dockerfiles/verify_packages/tar_gz/install.sh
+++ b/dockerfiles/verify_packages/tar_gz/install.sh
@@ -2,9 +2,26 @@
 
 set -e
 
+# Retry a command up to 3 times with 10s backoff before signaling infra failure.
+# All failures in this script are infrastructure failures (package downloads,
+# network), not test failures — so exhausted retries exit 75 (EX_TEMPFAIL)
+# to trigger GitLab's infra-retry rule rather than marking the job as failed.
+retry_or_tempfail() {
+    local n=1
+    until "$@"; do
+        if [ "$n" -ge 3 ]; then
+            echo "Infrastructure command failed after $n attempts, signaling retry (exit 75): $*" >&2
+            exit 75
+        fi
+        echo "Command failed (attempt $n/3): $* — retrying in 10s..." >&2
+        n=$((n + 1))
+        sleep 10
+    done
+}
+
 # Common installations
-apt update
-apt install -y \
+retry_or_tempfail apt-get update
+retry_or_tempfail apt-get install -y \
     apt-transport-https \
     lsb-release \
     ca-certificates \
@@ -15,10 +32,10 @@ apt install -y \
     procps \
     gnupg
 
-curl -sSL -o /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
+retry_or_tempfail curl -sSL -o /etc/apt/trusted.gpg.d/php.gpg https://packages.sury.org/php/apt.gpg
 sh -c 'echo "deb https://packages.sury.org/php/ $(lsb_release -sc) main" > /etc/apt/sources.list.d/php.list'
-apt update
-apt install -y \
+retry_or_tempfail apt-get update
+retry_or_tempfail apt-get install -y \
     php${PHP_VERSION}-cli \
     php${PHP_VERSION}-curl \
     php${PHP_VERSION}-fpm \


### PR DESCRIPTION
## Problem

Verify jobs (`verify alpine`, `verify debian`, `verify centos`, `verify windows`, `verify .tar.gz`) fail intermittently due to network-level infra issues:
- Package manager commands (`apt-get`, `apk add`, `yum install`) hit transient network errors
- Windows Chocolatey install gets HTTP 504 from community.chocolatey.org

These jobs exit with code 1, which GitLab classifies as `script_failure` — not retried by our existing runner-level retry rules.

## Fix

Extend the existing exit-75 retry mechanism (from `.gitlab/wait-for-service-ready.sh`) to verify job install scripts:

- `alpine/install.sh`: add `|| exit 75` to all `apk add` network calls (local `.apk` file installs are left unchanged)
- `debian/install.sh`: add `|| exit 75` to `apt-get update`, `apt-get install`, and `curl` (sury GPG key fetch) calls; switch `apt` → `apt-get` for non-interactive consistency
- `tar_gz/install.sh`: same treatment as debian
- `centos/install.sh`: update existing `do_retry()` to `exit 75` (instead of `return 1`) when retries are exhausted — the function already retries 3 times internally before giving up
- `generate-package.php` (verify centos before_script): change `exit 1` → `exit 75` in the yum update retry loop
- `generate-package.php` (verify alpine before_script): add `|| exit 75` to `apk add` calls in the YAML before_script
- `generate-package.php` (verify debian before_script): add `|| exit 75` to `apt-get update` and `apt-get install` calls
- `generate-package.php` (verify windows): wrap Chocolatey download in a PowerShell retry loop (3 attempts, 15s sleep) with `exit 75` on network exception

`verify.sh` (the actual test) is unchanged — its `exit 1` on test failures is correct and should never become 75.

## Notes

- `one-pipeline.locked.yml` is generated in CI (via `generate-templates` job), not locally — no manual regeneration needed
- The centos `do_retry()` already retried 3 times before this change; the only change is the terminal exit code (1 → 75)
- Local file operations (`dpkg -i`, `rpm -ivh` with local files, `apk add *.apk`) are intentionally not wrapped — those can only fail if the build artifact is corrupt, which is a real failure