### PR TITLE
fix(profiling): use Rust thread_local for ZendMMState on ZTS

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -90,8 +90,9 @@ package-trigger:
         job: "generate-templates"
       - local: .gitlab/benchmarks.yml
     strategy: depend
+    forward:
+      pipeline_variables: true
   variables:
     PARENT_PIPELINE_ID: $CI_PIPELINE_ID
     GIT_SUBMODULE_PATHS: libdatadog appsec/third_party/cpp-base64 appsec/third_party/libddwaf appsec/third_party/libddwaf-rust appsec/third_party/msgpack-c
     NIGHTLY_BUILD: $NIGHTLY_BUILD
-    RELIABILITY_ENV_BRANCH: $RELIABILITY_ENV_BRANCH

--- a/profiling/src/allocation/mod.rs
+++ b/profiling/src/allocation/mod.rs
@@ -4,7 +4,6 @@ pub use profiling_stats::*;
 
 use crate::bindings::{self as zend};
 use crate::config::SystemSettings;
-use crate::module_globals;
 use crate::profiling::Profiler;
 use crate::{RefCellExt, REQUEST_LOCALS};
 use core::cell::Cell;
@@ -28,20 +27,65 @@ use crate::allocation::allocation_ge84::ZendMMState;
 #[cfg(not(php_zend_mm_set_custom_handlers_ex))]
 use crate::allocation::allocation_le83::ZendMMState;
 
-/// Gets a pointer to the Cell<ZendMMState> from PHP globals.
+// ZTS: Use Rust's thread_local! for ZendMMState storage instead of PHP's TSRM
+// module globals. PHP's TSRM slot access via tsrmg_bulk() involves triple-pointer
+// dereference through tsrm_get_ls_cache(), which can return stale or wrong data
+// when FrankenPHP's thread lifecycle (ts_free_thread + pthread_create +
+// ts_resource) races with concurrent allocation hooks on other threads.
+// Rust's thread_local! uses the platform's native TLS (__thread on Linux),
+// which is always correct per-OS-thread without the indirection.
+// See: https://github.com/DataDog/dd-trace-php/issues/3729
+#[cfg(php_zts)]
+thread_local! {
+    static ZEND_MM_STATE: Cell<ZendMMState> = const { Cell::new(ZendMMState::new()) };
+}
+
+// NTS: Simple static, no threading concerns.
+#[cfg(not(php_zts))]
+static mut ZEND_MM_STATE: Cell<ZendMMState> = Cell::new(ZendMMState::new());
+
+/// Gets a pointer to the Cell<ZendMMState> for the current thread.
 ///
 /// # Safety
 ///
-/// Must uphold safety conditions of [`module_globals::get_profiler_globals`].
+/// For ZTS: safe to call from any thread — uses Rust's thread_local storage.
+/// For NTS: caller must ensure single-threaded access.
+#[cfg(not(php_zts))]
 #[inline]
 pub(crate) unsafe fn get_zend_mm_state() -> *mut Cell<ZendMMState> {
-    let globals = module_globals::get_profiler_globals();
-    ptr::addr_of_mut!((*globals).zend_mm_state)
+    ptr::addr_of_mut!(ZEND_MM_STATE)
 }
 
-/// Macros for accessing ZendMMState from PHP globals.
-/// These are shared between PHP 8.3- and 8.4+ implementations.
-/// They are exported at the crate root and can be used in submodules.
+/// Macros for accessing ZendMMState.
+/// ZTS builds use Rust's thread_local!, NTS builds use a static.
+
+// --- ZTS macros: access via thread_local! ---
+#[cfg(php_zts)]
+#[macro_export]
+macro_rules! tls_zend_mm_state_copy {
+    () => {
+        $crate::allocation::ZEND_MM_STATE.get()
+    };
+}
+
+#[cfg(php_zts)]
+#[macro_export]
+macro_rules! tls_zend_mm_state_get {
+    ($x:ident) => {
+        $crate::allocation::ZEND_MM_STATE.get().$x
+    };
+}
+
+#[cfg(php_zts)]
+#[macro_export]
+macro_rules! tls_zend_mm_state_set {
+    ($x:expr) => {
+        $crate::allocation::ZEND_MM_STATE.set($x)
+    };
+}
+
+// --- NTS macros: access via static ---
+#[cfg(not(php_zts))]
 #[macro_export]
 macro_rules! tls_zend_mm_state_copy {
     () => {
@@ -49,6 +93,7 @@ macro_rules! tls_zend_mm_state_copy {
     };
 }
 
+#[cfg(not(php_zts))]
 #[macro_export]
 macro_rules! tls_zend_mm_state_get {
     ($x:ident) => {
@@ -56,6 +101,7 @@ macro_rules! tls_zend_mm_state_get {
     };
 }
 
+#[cfg(not(php_zts))]
 #[macro_export]
 macro_rules! tls_zend_mm_state_set {
     ($x:expr) => {{

--- a/profiling/src/module_globals.rs
+++ b/profiling/src/module_globals.rs
@@ -1,18 +1,27 @@
 use crate::allocation;
-use core::cell::Cell;
 use core::ffi::c_void;
 use core::ptr;
 
-#[cfg(php_zend_mm_set_custom_handlers_ex)]
+#[cfg(not(php_zts))]
+use core::cell::Cell;
+#[cfg(all(not(php_zts), php_zend_mm_set_custom_handlers_ex))]
 use crate::allocation::allocation_ge84::ZendMMState;
-#[cfg(not(php_zend_mm_set_custom_handlers_ex))]
+#[cfg(all(not(php_zts), not(php_zend_mm_set_custom_handlers_ex)))]
 use crate::allocation::allocation_le83::ZendMMState;
 
 #[repr(C)]
 pub struct ProfilerGlobals {
-    /// Wrapped in `Cell` to prevent torn reads/writes when allocation hooks
-    /// are called re-entrantly during `rinit()`/`rshutdown()`.
+    /// In ZTS builds, ZendMMState is stored in Rust's thread_local! (see
+    /// allocation/mod.rs) instead of here, to avoid TSRM pointer arithmetic
+    /// races under FrankenPHP's thread lifecycle. This field is only used
+    /// in NTS builds.
+    #[cfg(not(php_zts))]
     pub zend_mm_state: Cell<ZendMMState>,
+
+    /// Padding to keep the struct non-zero-sized for ZTS builds so TSRM
+    /// still allocates a slot (needed for ginit/gshutdown callbacks).
+    #[cfg(php_zts)]
+    _padding: u8,
 }
 
 /// We need TSRM to call into GINIT and GSHUTDOWN to observe spawning and
@@ -85,13 +94,8 @@ pub unsafe extern "C" fn ginit(_globals_ptr: *mut c_void) {
     #[cfg(php_zts)]
     crate::timeline::timeline_ginit();
 
-    // Initialize ZendMMState in PHP globals for ZTS builds. For NTS builds,
-    // this was already done in its const initializer.
-    #[cfg(php_zts)]
-    {
-        let globals = _globals_ptr.cast::<ProfilerGlobals>();
-        (*globals).zend_mm_state = Cell::new(ZendMMState::new());
-    }
+    // ZendMMState is initialized via Rust's thread_local! const initializer
+    // for ZTS builds, so no TSRM-based init needed here.
 
     // SAFETY: this is called in thread ginit as expected, and no other places.
     allocation::ginit();


### PR DESCRIPTION
## Context

[#3729 (comment)](https://github.com/DataDog/dd-trace-php/issues/3729#issuecomment-4309302658) — reproducer, CI test matrix, and root cause analysis.

## The bug

PR #3608 moved `ZendMMState` from Rust's `thread_local!` into PHP's TSRM module globals. The TSRM access path (`tsrmg_bulk` → `tsrm_get_ls_cache` → triple-pointer dereference) races with FrankenPHP's thread lifecycle (`ts_free_thread` + `pthread_create` + `ts_resource`), causing cross-thread reads of partially-written `ZendMMState`.

Since `ZendMMState` contains function pointers (`alloc`, `realloc`, `free`), a corrupt read calls a garbage pointer:

```
memory allocation of 3420891154821048684 bytes failed   (exit code 133 / SIGABRT)
```

## The fix

Revert `ZendMMState` storage to Rust's `thread_local!` for ZTS builds. This is what 1.16.0 used — the platform's native TLS (`__thread` on Linux), which gives each OS thread its own isolated copy without TSRM pointer indirection.

The TSRM module globals registration (`ginit`/`gshutdown`) is preserved for thread lifecycle observation (timeline profiling). Only the `ZendMMState` storage location changes.

### Changes

**`profiling/src/allocation/mod.rs`**
- ZTS: `ZendMMState` stored in `thread_local!` with direct `.get()`/`.set()` access
- NTS: unchanged (static with pointer access)
- Macros split by `#[cfg(php_zts)]` to use the correct storage

**`profiling/src/module_globals.rs`**
- `ProfilerGlobals` no longer contains `ZendMMState` on ZTS (padding byte keeps struct non-zero for TSRM slot allocation)
- `ginit` no longer initializes `ZendMMState` in the TSRM slot (Rust's `thread_local!` const initializer handles it)
- ZTS-only imports removed

## Evidence

CI-verified reproducer: [dd-trace-php-crash-repro](https://github.com/jamesmehorter/dd-trace-php-crash-repro)

| Test | Result |
|---|---|
| No dd-trace-php | Survived |
| 1.16.0 (appsec + profiling) | Survived |
| **1.17.0 (appsec + profiling)** | **CRASHED** |
| **1.18.0 (appsec + profiling)** | **CRASHED** |
| 1.18.0 trace only | Survived |
| 1.18.0 trace + appsec | Survived |
| **1.18.0 trace + profiling** | **CRASHED** |

Debug-symbol builds suppress the crash (memory layout shift), confirming heap corruption.

Fixes #3729