### PR TITLE
fix(stats): don't feed inferred proxy spans to client-side stats concentrator

### DIFF
--- a/ext/serializer.c
+++ b/ext/serializer.c
@@ -1535,13 +1535,6 @@ ddog_SpanBytes *ddtrace_serialize_span_to_rust_span(ddtrace_span_data *span, ddo
 
 
         if (!span_sampling_applied && DDTRACE_G(sidecar) && get_DD_TRACE_STATS_COMPUTATION_ENABLED() && ddog_agent_has_stats_computation()) {
-            if (inferred_span) {
-                // Inferred span won't be serialized, so feed it to the concentrator here.
-                ddtrace_span_precomputed inferred_pre;
-                ddtrace_precompute_span(inferred_span, &inferred_pre);
-                ddtrace_feed_span_to_concentrator(inferred_span, &inferred_pre);
-                ddtrace_free_span_precomputed(&inferred_pre);
-            }
             ddtrace_feed_span_to_concentrator(span, &pre);
             ddtrace_free_span_precomputed(&pre);
             return NULL;


### PR DESCRIPTION
## Problem

The `System Tests: [tracer-release]` CI job was failing because client-side stats were reporting 10 hits instead of 5 for 5 HTTP requests. This broke the system test assertion `ok_hits == ok_top_hits == 5`.

## Root Cause

The early-exit stats computation block in `ext/serializer.c` was feeding both the root span AND the inferred proxy span (API Gateway Tracing) to the stats concentrator. The inferred span has no `http.method` or `http.endpoint` in its meta, creating a separate aggregation bucket. With 5 requests:
- Root span bucket: 5 hits (http.method=GET, http.endpoint=/stats-unique)
- Inferred span bucket: 5 hits (empty http.method, empty http.endpoint)

Total: 10 hits instead of 5.

## Fix

Remove the inferred span from the early-exit stats path. Inferred spans are proxy-level spans (API Gateway Tracing) that don't represent real service calls and should not be included in client-side stats. The root span already captures the full request statistics.

## Analysis

The `if (inferred_span)` block was added in #3756 (Implement stats computation) with the comment *"Inferred span won't be serialized, so feed it to the concentrator here."* The intent was to compensate for the fact that the early-exit path returns `NULL` before the normal inferred span serialization at line 1829. However, inferred spans should not be in the concentrator at all — they are proxy-level spans without meaningful `http.method`/`http.endpoint` tags, and feeding them creates a spurious aggregation bucket.

## Testing

The system test `Test_Client_Stats::test_client_stats` in `~/git/system-tests/tests/stats/test_stats.py` should now pass with `ok_hits == 5`.