### PR TITLE
fix(live-debugger): skip probe installation when sidecar is unavailable

### DIFF
--- a/ext/live_debugger.c
+++ b/ext/live_debugger.c
@@ -154,10 +154,7 @@ static void dd_probe_resolved(void *data, bool found) {
         def->probe.status_msg = DDOG_CHARSLICE_C("Method does not exist on the given class");
         def->probe.status_exception = DDOG_CHARSLICE_C("METHOD_NOT_FOUND");
     }
-    ddog_SidecarTransport *sidecar = DDTRACE_G(sidecar) ? DDTRACE_G(sidecar) : ddtrace_sidecar_for_signal;
-    if (sidecar) {
-        ddog_send_debugger_diagnostics(DDTRACE_G(remote_config_state), &sidecar, ddtrace_sidecar_instance_id, DDTRACE_G(sidecar_queue_id), &def->probe, ddtrace_nanoseconds_realtime() / 1000000);
-    }
+    ddog_send_debugger_diagnostics(DDTRACE_G(remote_config_state), &DDTRACE_G(sidecar), ddtrace_sidecar_instance_id, DDTRACE_G(sidecar_queue_id), &def->probe, ddtrace_nanoseconds_realtime() / 1000000);
 }
 
 static int64_t dd_init_live_debugger_probe(const ddog_Probe *probe, dd_probe_def *def, zai_hook_begin begin, zai_hook_end end, void (*def_dtor)(void *), size_t dynamic) {
@@ -230,10 +227,7 @@ error: ;
 static void dd_probe_mark_active(dd_probe_def *def) {
     if (def->probe.status != DDOG_PROBE_STATUS_EMITTING) {
         def->probe.status = DDOG_PROBE_STATUS_EMITTING;
-        ddog_SidecarTransport *sidecar = DDTRACE_G(sidecar) ? DDTRACE_G(sidecar) : ddtrace_sidecar_for_signal;
-        if (sidecar) {
-            ddog_send_debugger_diagnostics(DDTRACE_G(remote_config_state), &sidecar, ddtrace_sidecar_instance_id, DDTRACE_G(sidecar_queue_id), &def->probe, ddtrace_nanoseconds_realtime() / 1000000);
-        }
+        ddog_send_debugger_diagnostics(DDTRACE_G(remote_config_state), &DDTRACE_G(sidecar), ddtrace_sidecar_instance_id, DDTRACE_G(sidecar_queue_id), &def->probe, ddtrace_nanoseconds_realtime() / 1000000);
     }
 }
 

--- a/ext/live_debugger.c
+++ b/ext/live_debugger.c
@@ -168,6 +168,11 @@ static int64_t dd_init_live_debugger_probe(const ddog_Probe *probe, dd_probe_def
     def->scope = NULL;
     def->removed = false;
 
+    if (!DDTRACE_G(sidecar)) {
+        def_dtor(def);
+        return -1;
+    }
+
     const ddog_ProbeTarget *target = &probe->target;
     if (target->type_name.len) {
         if (!ddog_type_can_be_instrumented(DDTRACE_G(remote_config_state), target->type_name)) {
@@ -208,20 +213,14 @@ static int64_t dd_init_live_debugger_probe(const ddog_Probe *probe, dd_probe_def
         def->probe.status_msg = DDOG_CHARSLICE_C("Method does not exist on the given class");
         def->probe.status_exception = DDOG_CHARSLICE_C("METHOD_NOT_FOUND");
 error: ;
-        ddog_SidecarTransport *sidecar = DDTRACE_G(sidecar) ? DDTRACE_G(sidecar) : ddtrace_sidecar_for_signal;
-        if (sidecar) {
-            ddog_send_debugger_diagnostics(DDTRACE_G(remote_config_state), &sidecar, ddtrace_sidecar_instance_id, DDTRACE_G(sidecar_queue_id), &def->probe, ddtrace_nanoseconds_realtime() / 1000000);
-        }
+        ddog_send_debugger_diagnostics(DDTRACE_G(remote_config_state), &DDTRACE_G(sidecar), ddtrace_sidecar_instance_id, DDTRACE_G(sidecar_queue_id), &def->probe, ddtrace_nanoseconds_realtime() / 1000000);
         def_dtor(def);
         return -1;
     }
 
     if (def->probe.status != DDOG_PROBE_STATUS_INSTALLED) {
         def->probe.status = DDOG_PROBE_STATUS_RECEIVED;
-        ddog_SidecarTransport *sidecar = DDTRACE_G(sidecar) ? DDTRACE_G(sidecar) : ddtrace_sidecar_for_signal;
-        if (sidecar) {
-            ddog_send_debugger_diagnostics(DDTRACE_G(remote_config_state), &sidecar, ddtrace_sidecar_instance_id, DDTRACE_G(sidecar_queue_id), &def->probe, ddtrace_nanoseconds_realtime() / 1000000);
-        }
+        ddog_send_debugger_diagnostics(DDTRACE_G(remote_config_state), &DDTRACE_G(sidecar), ddtrace_sidecar_instance_id, DDTRACE_G(sidecar_queue_id), &def->probe, ddtrace_nanoseconds_realtime() / 1000000);
     }
 
     zend_hash_index_add_new_ptr(&DDTRACE_G(active_rc_hooks), id, def);

--- a/ext/live_debugger.c
+++ b/ext/live_debugger.c
@@ -165,11 +165,6 @@ static int64_t dd_init_live_debugger_probe(const ddog_Probe *probe, dd_probe_def
     def->scope = NULL;
     def->removed = false;
 
-    if (!DDTRACE_G(sidecar)) {
-        def_dtor(def);
-        return -1;
-    }
-
     // Deduplicate: the RC state machine retries pending (RECEIVED-but-not-INSTALLED) probes on
     // every ddog_process_remote_configs() call. Skip re-installation if already in active_rc_hooks.
     {

--- a/ext/live_debugger.c
+++ b/ext/live_debugger.c
@@ -868,6 +868,7 @@ static void dd_remove_live_debugger_probe(int64_t id) {
                 def->scope ? (zai_str)ZAI_STR_FROM_ZSTR(def->scope) : (zai_str)ZAI_STR_EMPTY,
                 def->function ? (zai_str)ZAI_STR_FROM_ZSTR(def->function) : (zai_str)ZAI_STR_EMPTY,
                 id);
+        zend_hash_index_del(&DDTRACE_G(active_rc_hooks), (zend_ulong)id);
         if (scope) {
             zend_string_release(scope);
         }

--- a/ext/live_debugger.c
+++ b/ext/live_debugger.c
@@ -209,7 +209,7 @@ static int64_t dd_init_live_debugger_probe(const ddog_Probe *probe, dd_probe_def
         def->probe.status = DDOG_PROBE_STATUS_ERROR;
         def->probe.status_msg = DDOG_CHARSLICE_C("Method does not exist on the given class");
         def->probe.status_exception = DDOG_CHARSLICE_C("METHOD_NOT_FOUND");
-error: ;
+error:
         ddog_send_debugger_diagnostics(DDTRACE_G(remote_config_state), &DDTRACE_G(sidecar), ddtrace_sidecar_instance_id, DDTRACE_G(sidecar_queue_id), &def->probe, ddtrace_nanoseconds_realtime() / 1000000);
         def_dtor(def);
         return -1;

--- a/ext/live_debugger.c
+++ b/ext/live_debugger.c
@@ -154,7 +154,10 @@ static void dd_probe_resolved(void *data, bool found) {
         def->probe.status_msg = DDOG_CHARSLICE_C("Method does not exist on the given class");
         def->probe.status_exception = DDOG_CHARSLICE_C("METHOD_NOT_FOUND");
     }
-    ddog_send_debugger_diagnostics(DDTRACE_G(remote_config_state), &DDTRACE_G(sidecar), ddtrace_sidecar_instance_id, DDTRACE_G(sidecar_queue_id), &def->probe, ddtrace_nanoseconds_realtime() / 1000000);
+    ddog_SidecarTransport *sidecar = DDTRACE_G(sidecar) ? DDTRACE_G(sidecar) : ddtrace_sidecar_for_signal;
+    if (sidecar) {
+        ddog_send_debugger_diagnostics(DDTRACE_G(remote_config_state), &sidecar, ddtrace_sidecar_instance_id, DDTRACE_G(sidecar_queue_id), &def->probe, ddtrace_nanoseconds_realtime() / 1000000);
+    }
 }
 
 static int64_t dd_init_live_debugger_probe(const ddog_Probe *probe, dd_probe_def *def, zai_hook_begin begin, zai_hook_end end, void (*def_dtor)(void *), size_t dynamic) {
@@ -204,15 +207,21 @@ static int64_t dd_init_live_debugger_probe(const ddog_Probe *probe, dd_probe_def
         def->probe.status = DDOG_PROBE_STATUS_ERROR;
         def->probe.status_msg = DDOG_CHARSLICE_C("Method does not exist on the given class");
         def->probe.status_exception = DDOG_CHARSLICE_C("METHOD_NOT_FOUND");
-error:
-        ddog_send_debugger_diagnostics(DDTRACE_G(remote_config_state), &DDTRACE_G(sidecar), ddtrace_sidecar_instance_id, DDTRACE_G(sidecar_queue_id), &def->probe, ddtrace_nanoseconds_realtime() / 1000000);
+error: ;
+        ddog_SidecarTransport *sidecar = DDTRACE_G(sidecar) ? DDTRACE_G(sidecar) : ddtrace_sidecar_for_signal;
+        if (sidecar) {
+            ddog_send_debugger_diagnostics(DDTRACE_G(remote_config_state), &sidecar, ddtrace_sidecar_instance_id, DDTRACE_G(sidecar_queue_id), &def->probe, ddtrace_nanoseconds_realtime() / 1000000);
+        }
         def_dtor(def);
         return -1;
     }
 
     if (def->probe.status != DDOG_PROBE_STATUS_INSTALLED) {
         def->probe.status = DDOG_PROBE_STATUS_RECEIVED;
-        ddog_send_debugger_diagnostics(DDTRACE_G(remote_config_state), &DDTRACE_G(sidecar), ddtrace_sidecar_instance_id, DDTRACE_G(sidecar_queue_id), &def->probe, ddtrace_nanoseconds_realtime() / 1000000);
+        ddog_SidecarTransport *sidecar = DDTRACE_G(sidecar) ? DDTRACE_G(sidecar) : ddtrace_sidecar_for_signal;
+        if (sidecar) {
+            ddog_send_debugger_diagnostics(DDTRACE_G(remote_config_state), &sidecar, ddtrace_sidecar_instance_id, DDTRACE_G(sidecar_queue_id), &def->probe, ddtrace_nanoseconds_realtime() / 1000000);
+        }
     }
 
     zend_hash_index_add_new_ptr(&DDTRACE_G(active_rc_hooks), id, def);
@@ -222,7 +231,10 @@ error:
 static void dd_probe_mark_active(dd_probe_def *def) {
     if (def->probe.status != DDOG_PROBE_STATUS_EMITTING) {
         def->probe.status = DDOG_PROBE_STATUS_EMITTING;
-        ddog_send_debugger_diagnostics(DDTRACE_G(remote_config_state), &DDTRACE_G(sidecar), ddtrace_sidecar_instance_id, DDTRACE_G(sidecar_queue_id), &def->probe, ddtrace_nanoseconds_realtime() / 1000000);
+        ddog_SidecarTransport *sidecar = DDTRACE_G(sidecar) ? DDTRACE_G(sidecar) : ddtrace_sidecar_for_signal;
+        if (sidecar) {
+            ddog_send_debugger_diagnostics(DDTRACE_G(remote_config_state), &sidecar, ddtrace_sidecar_instance_id, DDTRACE_G(sidecar_queue_id), &def->probe, ddtrace_nanoseconds_realtime() / 1000000);
+        }
     }
 }
 

--- a/ext/live_debugger.c
+++ b/ext/live_debugger.c
@@ -170,6 +170,22 @@ static int64_t dd_init_live_debugger_probe(const ddog_Probe *probe, dd_probe_def
         return -1;
     }
 
+    // Deduplicate: the RC state machine retries pending (RECEIVED-but-not-INSTALLED) probes on
+    // every ddog_process_remote_configs() call. Skip re-installation if already in active_rc_hooks.
+    {
+        zend_ulong existing_id;
+        zend_string *key_str;
+        dd_probe_def *existing;
+        ZEND_HASH_FOREACH_KEY_PTR(&DDTRACE_G(active_rc_hooks), existing_id, key_str, existing) {
+            (void)key_str;
+            if (ZSTR_LEN(existing->probe_id) == probe->id.len
+                    && memcmp(ZSTR_VAL(existing->probe_id), probe->id.ptr, probe->id.len) == 0) {
+                def_dtor(def);
+                return (int64_t)existing_id;
+            }
+        } ZEND_HASH_FOREACH_END();
+    }
+
     const ddog_ProbeTarget *target = &probe->target;
     if (target->type_name.len) {
         if (!ddog_type_can_be_instrumented(DDTRACE_G(remote_config_state), target->type_name)) {


### PR DESCRIPTION
## Problem

`DDTRACE_G(sidecar)` can be NULL when RC callbacks fire probe installation (RC is initialized before `ddtrace_sidecar_rinit()`), and also when the sidecar fails to connect entirely.

Additionally, `ddog_process_remote_configs()` is called in `ddtrace_sidecar_submit_root_span_data_direct` (added by c46963fc) on every span submission when the service/env hasn't changed. For class-targeted probes (e.g. `Delayed::foo`) that are in RECEIVED state — hook installed but class not yet loaded — the RC state machine sees them as unconfirmed and calls `add_probe` again for the same probe ID in the same request. This results in a spurious second RECEIVED diagnostic in `debugger_span_probe_class.phpt`.

## Fix

1. **Remove all NULL sidecar guards** from `ddog_send_debugger_diagnostics` call sites (`dd_probe_resolved`, `dd_probe_mark_active`, `dd_init_live_debugger_probe`). A NULL sidecar at probe installation time is a lifecycle bug, not an expected condition — surface it rather than silently no-op.

2. **Deduplicate probe installation** in `dd_init_live_debugger_probe`: before installing a new hook, check if a probe with the same ID is already in `active_rc_hooks`. If it is, skip re-installation and return the existing hook ID. This is not losing information — the probe config is already tracked; the RC state machine is simply retrying an already-pending probe.