### PR TITLE
fix(appsec): fix inverted metric registration refresh condition in helper-rust

### DIFF
--- a/appsec/helper-rust/src/telemetry/sidecar.rs
+++ b/appsec/helper-rust/src/telemetry/sidecar.rs
@@ -394,7 +394,7 @@ impl<'a> TelemetrySidecarMetricSubmitter<'a> {
 
         let needs_registration = last_registration_time
             .get()
-            .is_none_or(|i| i.elapsed() < METRICS_REGISTRATION_REFRESH);
+            .is_none_or(|i| i.elapsed() >= METRICS_REGISTRATION_REFRESH);
         if needs_registration {
             if let Err(err) = super::register_known_metrics(sidecar_settings, telemetry_settings) {
                 warning!("Failed to register known metrics: {}", err);


### PR DESCRIPTION
## Problem

The `helper-rust integration coverage` CI job was failing: 9 `TelemetryTests` failed with `assert wafInit != null` and `Expected to find rc::asm_dd::exception log`.

The root cause was a logic inversion in the `needs_registration` predicate in `appsec/helper-rust/src/telemetry/sidecar.rs`. The condition `i.elapsed() < METRICS_REGISTRATION_REFRESH` returned `true` (needs re-registration) when the elapsed time was LESS than 25 minutes — effectively re-registering known metrics on every single `submit_metric` call. This redundant re-registration interfered with the sidecar's metric point accumulation, preventing `generate-metrics` messages from being flushed to the mock agent within the 30s test window.

## Fix

One-character fix: change `<` to `>=` so the condition only re-registers when the last registration was more than 25 minutes ago (the intended behavior).

## Impact

Low — only affects the metric registration refresh rate in the appsec helper-rust telemetry path. No production behavior change for correctly initialized agents; the previous behavior was always re-registering which is functionally equivalent but caused test timing failures.