### PR TITLE
fix(ci): set ChocolateyInstall env var default for Windows runners

### DIFF
--- a/dockerfiles/verify_packages/verify_windows.ps1
+++ b/dockerfiles/verify_packages/verify_windows.ps1
@@ -1,5 +1,6 @@
 # to run manually: docker run --rm -ti -v $pwd\..\..:c:\app -w c:\app chocolatey/choco:latest-windows powershell.exe .\dockerfiles\verify_packages\verify_windows.ps1
 
+if (-not $env:ChocolateyInstall) { $env:ChocolateyInstall = 'C:\ProgramData\chocolatey' }
 Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
 
 choco install -y php


### PR DESCRIPTION
## Problem

The `verify windows` CI job was failing intermittently because `$env:ChocolateyInstall` is not set on persistent Windows runners where Chocolatey was pre-installed by the base image rather than installed by the CI script itself. This caused the Chocolatey profile import to fail.

## Fix

Add a one-line fallback that sets `$env:ChocolateyInstall` to the standard installation path (`C:\ProgramData\chocolatey`) if it is not already set. This is the well-known default path used by the Chocolatey installer and is safe to assume on any Windows machine where Chocolatey is installed.

## Impact

Minimal — only affects the `verify_windows.ps1` script. No production code changed. When `$env:ChocolateyInstall` is already set (fresh installs), the fallback has no effect.