### PR TITLE
Allow dumping shm data directly for inspection

### DIFF
--- a/components-rs/Cargo.toml
+++ b/components-rs/Cargo.toml
@@ -18,6 +18,7 @@ datadog-ipc = { path = "../libdatadog/datadog-ipc" }
 datadog-remote-config = { path = "../libdatadog/datadog-remote-config" }
 datadog-sidecar = { path = "../libdatadog/datadog-sidecar" }
 datadog-sidecar-ffi = { path = "../libdatadog/datadog-sidecar-ffi" }
+libdd-data-pipeline = { path = "../libdatadog/libdd-data-pipeline" }
 libdd-tinybytes = { path = "../libdatadog/libdd-tinybytes" }
 libdd-trace-utils = { path = "../libdatadog/libdd-trace-utils" }
 libdd-trace-stats = { path = "../libdatadog/libdd-trace-stats" }

--- a/components-rs/agent_info.rs
+++ b/components-rs/agent_info.rs
@@ -11,7 +11,23 @@
 use crate::stats::apply_concentrator_config;
 use datadog_sidecar::service::agent_info::AgentInfoReader;
 use libdd_common_ffi::slice::CharSlice;
+use libdd_data_pipeline::agent_info::schema::AgentInfoStruct;
 use std::ffi::c_char;
+use std::ffi::CString;
+
+fn info_to_concentrator_config(info: &AgentInfoStruct) {
+    apply_concentrator_config(
+        info.peer_tags.as_deref().unwrap_or(&[]).to_owned(),
+        info.span_kinds_stats_computed.as_deref().unwrap_or(&[]).to_owned(),
+        info.filter_tags.as_ref().and_then(|f| f.require.as_deref()).unwrap_or(&[]).to_owned(),
+        info.filter_tags.as_ref().and_then(|f| f.reject.as_deref()).unwrap_or(&[]).to_owned(),
+        info.filter_tags_regex.as_ref().and_then(|f| f.require.as_deref()).unwrap_or(&[]).to_owned(),
+        info.filter_tags_regex.as_ref().and_then(|f| f.reject.as_deref()).unwrap_or(&[]).to_owned(),
+        info.ignore_resources.as_deref().unwrap_or(&[]).to_owned(),
+        info.client_drop_p0s.unwrap_or(false),
+        info.version.as_deref(),
+    );
+}
 
 /// Read all agent /info data in one SHM read and apply env, container-hash and concentrator
 /// config atomically.
@@ -49,18 +65,31 @@ pub unsafe extern "C" fn ddog_apply_agent_info(
             } else {
                 *container_hash_out = CharSlice::empty();
             }
-            apply_concentrator_config(
-                info.peer_tags.as_deref().unwrap_or(&[]).to_owned(),
-                info.span_kinds_stats_computed.as_deref().unwrap_or(&[]).to_owned(),
-                info.filter_tags.as_ref().and_then(|f| f.require.as_deref()).unwrap_or(&[]).to_owned(),
-                info.filter_tags.as_ref().and_then(|f| f.reject.as_deref()).unwrap_or(&[]).to_owned(),
-                info.filter_tags_regex.as_ref().and_then(|f| f.require.as_deref()).unwrap_or(&[]).to_owned(),
-                info.filter_tags_regex.as_ref().and_then(|f| f.reject.as_deref()).unwrap_or(&[]).to_owned(),
-                info.ignore_resources.as_deref().unwrap_or(&[]).to_owned(),
-                info.client_drop_p0s.unwrap_or(false),
-                info.version.as_deref(),
-            );
+            info_to_concentrator_config(info);
         }
+    }
+}
+
+/// Serialize the current cached agent info as a JSON string.
+/// Returns NULL if no info has been read yet.
+/// The returned pointer must be freed with `ddog_agent_info_json_free`.
+#[no_mangle]
+pub unsafe extern "C" fn ddog_agent_info_as_json(reader: &mut AgentInfoReader) -> *mut c_char {
+    let (changed, info) = reader.read();
+    if let Some(info) = info {
+        if changed {
+            info_to_concentrator_config(info);
+        }
+        CString::new(serde_json::to_string(info).unwrap()).unwrap().into_raw()
+    } else {
+        std::ptr::null_mut()
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ddog_agent_info_json_free(ptr: *mut c_char) {
+    if !ptr.is_null() {
+        drop(unsafe { CString::from_raw(ptr) });
     }
 }
 
@@ -81,16 +110,6 @@ pub unsafe extern "C" fn ddog_apply_agent_info_concentrator_config(
         return;
     }
     if let Some(info) = info {
-        apply_concentrator_config(
-            info.peer_tags.as_deref().unwrap_or(&[]).to_owned(),
-            info.span_kinds_stats_computed.as_deref().unwrap_or(&[]).to_owned(),
-            info.filter_tags.as_ref().and_then(|f| f.require.as_deref()).unwrap_or(&[]).to_owned(),
-            info.filter_tags.as_ref().and_then(|f| f.reject.as_deref()).unwrap_or(&[]).to_owned(),
-            info.filter_tags_regex.as_ref().and_then(|f| f.require.as_deref()).unwrap_or(&[]).to_owned(),
-            info.filter_tags_regex.as_ref().and_then(|f| f.reject.as_deref()).unwrap_or(&[]).to_owned(),
-            info.ignore_resources.as_deref().unwrap_or(&[]).to_owned(),
-            info.client_drop_p0s.unwrap_or(false),
-            info.version.as_deref(),
-        );
+        info_to_concentrator_config(info);
     }
 }

--- a/components-rs/ddtrace.h
+++ b/components-rs/ddtrace.h
@@ -83,6 +83,9 @@ void ddog_apply_agent_info(struct ddog_AgentInfoReader *reader,
  */
 void ddog_apply_agent_info_concentrator_config(struct ddog_AgentInfoReader *reader);
 
+char *ddog_agent_info_as_json(struct ddog_AgentInfoReader *reader);
+void ddog_agent_info_json_free(char *ptr);
+
 bool ddog_shall_log(enum ddog_Log category);
 
 void ddog_set_error_log_level(bool once);
@@ -103,6 +106,9 @@ struct ddog_RemoteConfigState *ddog_init_remote_config_state(const struct ddog_E
                                                              bool di_enabled);
 
 const char *ddog_remote_config_get_path(const struct ddog_RemoteConfigState *remote_config);
+
+char *ddog_remote_config_get_loaded_configs(const struct ddog_RemoteConfigState *remote_config);
+void ddog_remote_config_loaded_configs_free(char *ptr);
 
 bool ddog_process_remote_configs(struct ddog_RemoteConfigState *remote_config);
 

--- a/components-rs/remote_config.rs
+++ b/components-rs/remote_config.rs
@@ -483,6 +483,45 @@ fn remove_config(remote_config: &mut RemoteConfigState, debugger: &LiveDebugging
     }
 }
 
+/// Returns all loaded remote config entries as a JSON object:
+///   { "config_id": "content_summary", ... }
+/// For live debugger entries the value is the probe ID (or "service_config").
+/// For dynamic config entries the value is "apm_tracing".
+/// The returned pointer must be freed with `ddog_remote_config_loaded_configs_free`.
+#[no_mangle]
+pub extern "C" fn ddog_remote_config_get_loaded_configs(remote_config: &RemoteConfigState) -> *mut c_char {
+    let mut entries: Vec<(String, String)> = Vec::new();
+
+    for (config_id, boxed) in &remote_config.live_debugger.active {
+        let value = match &boxed.0 {
+            LiveDebuggingData::Probe(p) => format!(r#"{{"type":"probe","id":"{}"}}"#, p.id),
+            LiveDebuggingData::ServiceConfiguration(sc) => format!(r#"{{"type":"service_config","id":"{}"}}"#, sc.id),
+        };
+        entries.push((config_id.clone(), value));
+    }
+
+    for config_id in remote_config.dynamic_config.active_configs.keys() {
+        entries.push((config_id.clone(), r#"{"type":"apm_tracing"}"#.to_string()));
+    }
+
+    entries.sort_unstable_by(|a, b| a.0.cmp(&b.0));
+
+    let json_pairs: Vec<String> = entries
+        .into_iter()
+        .map(|(k, v)| format!(r#"{}:{}"#, serde_json::to_string(&k).unwrap_or_default(), v))
+        .collect();
+    let json = format!("{{{}}}", json_pairs.join(","));
+
+    std::ffi::CString::new(json).unwrap_or_default().into_raw()
+}
+
+#[no_mangle]
+pub extern "C" fn ddog_remote_config_loaded_configs_free(ptr: *mut c_char) {
+    if !ptr.is_null() {
+        drop(unsafe { std::ffi::CString::from_raw(ptr) });
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn ddog_type_can_be_instrumented(
     remote_config: &RemoteConfigState,

--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -3136,13 +3136,56 @@ PHP_FUNCTION(dd_trace_internal_fn) {
             uint32_t waited = 0;
             while (!ddog_is_agent_info_ready() && waited < timeout_ms) {
                 // Actively read the SHM so we pick up the update the sidecar wrote.
-                if (DDTRACE_G(agent_info_reader)) {
-                    ddog_apply_agent_info_concentrator_config(DDTRACE_G(agent_info_reader));
-                }
+                ddtrace_apply_agent_info();
                 usleep(10000); // 10ms
                 waited += 10;
             }
             RETVAL_BOOL(ddog_is_agent_info_ready());
+        } else if (FUNCTION_NAME_MATCHES("get_loaded_remote_configs")) {
+            // Returns a PHP array mapping loaded RC config IDs to their content summary.
+            // e.g. ["datadog/2/LIVE_DEBUGGING/logProbe_log.../config" => ["type"=>"probe","id"=>"log..."]]
+            if (DDTRACE_G(remote_config_state)) {
+                char *rc_json = ddog_remote_config_get_loaded_configs(DDTRACE_G(remote_config_state));
+                if (zai_json_decode_assoc_safe(return_value, rc_json, strlen(rc_json), 128, false) != SUCCESS) {
+                    array_init(return_value);
+                }
+                ddog_remote_config_loaded_configs_free(rc_json);
+            } else {
+                array_init(return_value);
+            }
+            return;
+        } else if (FUNCTION_NAME_MATCHES("get_agent_info")) {
+            // Returns a PHP array decoded from the agent /info JSON payload.
+            if (DDTRACE_G(agent_info_reader)) {
+                char *info_json = ddog_agent_info_as_json(DDTRACE_G(agent_info_reader));
+                if (info_json) {
+                    if (zai_json_decode_assoc_safe(return_value, info_json, strlen(info_json), 128, false) != SUCCESS) {
+                        array_init(return_value);
+                    }
+                    ddog_agent_info_json_free(info_json);
+                } else {
+                    array_init(return_value);
+                }
+            } else {
+                array_init(return_value);
+            }
+            return;
+        } else if (FUNCTION_NAME_MATCHES("get_agent_sampling_config")) {
+            // Returns a PHP array decoded from the agent sampling/remote-config JSON payload.
+            if (DDTRACE_G(agent_config_reader)) {
+                ddog_CharSlice agent_rc_data = {0};
+                ddog_agent_remote_config_read(DDTRACE_G(agent_config_reader), &agent_rc_data);
+                if (agent_rc_data.len > 0) {
+                    if (zai_json_decode_assoc_safe(return_value, agent_rc_data.ptr, (int)agent_rc_data.len, 128, false) != SUCCESS) {
+                        array_init(return_value);
+                    }
+                } else {
+                    array_init(return_value);
+                }
+            } else {
+                array_init(return_value);
+            }
+            return;
         }
     }
 }

--- a/tests/ext/shm_data_internal_fns.phpt
+++ b/tests/ext/shm_data_internal_fns.phpt
@@ -1,0 +1,138 @@
+--TEST--
+get_loaded_remote_configs, get_agent_info, get_agent_sampling_config return correct content
+--SKIPIF--
+<?php include __DIR__ . '/includes/skipif_no_dev_env.inc'; ?>
+<?php if (getenv('USE_ZEND_ALLOC') === '0' && !getenv('SKIP_ASAN')) die('skip: valgrind is too slow for timing-sensitive RC polling'); ?>
+<?php if (PHP_VERSION_ID < 70400) die("skip: Before PHP 7.4, the skip-task would cause the sidecar to fetch the info already."); ?>
+<?php
+if (PHP_VERSION_ID >= 80100) {
+    echo "nocache\n";
+}
+// Set agent /info BEFORE the test process starts so the sidecar fetches our data on first poll.
+file_get_contents('http://request-replayer/set-agent-info', false, stream_context_create([
+    'http' => [
+        'method'  => 'PUT',
+        'header'  => ['Content-Type: application/json',
+                      'X-Datadog-Test-Session-Token: remote-config/shm_data_internal_fns'],
+        'content' => json_encode([
+            'version'         => '7.99.0-test',
+            'client_drop_p0s' => true,
+            'peer_tags'       => ['db.instance'],
+        ]),
+    ],
+]));
+?>
+--ENV--
+DD_AGENT_HOST=request-replayer
+DD_TRACE_AGENT_PORT=80
+DD_TRACE_AGENT_FLUSH_INTERVAL=333
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
+DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS=0.01
+DD_TRACE_SIDECAR_TRACE_SENDER=1
+DD_DYNAMIC_INSTRUMENTATION_ENABLED=1
+DD_TRACE_IGNORE_AGENT_SAMPLING_RATES=0
+--INI--
+datadog.service=shm_data_test
+datadog.env=test
+datadog.trace.agent_test_session_token=remote-config/shm_data_internal_fns
+--FILE--
+<?php
+
+require __DIR__ . '/remote_config/remote_config.inc';
+include __DIR__ . '/includes/request_replayer.inc';
+
+reset_request_replayer();
+$rr = new RequestReplayer();
+$rr->replayRequest(); // consume any leftover traces from startup
+
+dd_trace_internal_fn('await_agent_info', 5000);
+$info = dd_trace_internal_fn('get_agent_info');
+var_dump(is_array($info));
+var_dump($info['version']         ?? 'missing');
+var_dump($info['client_drop_p0s'] ?? false);
+var_dump(in_array('db.instance', $info['peer_tags'] ?? []));
+
+$rr->setResponse(['rate_by_service' => [
+    'service:,env:'                  => 0.5,
+    'service:shm_data_test,env:test' => 1.0,
+]]);
+
+\DDTrace\start_span();
+\DDTrace\close_span();
+dd_trace_internal_fn('synchronous_flush'); // ensure sidecar sends immediately
+$rr->waitForDataAndReplay();
+
+for ($i = 0; $i < 50; $i++) {
+    $sampling = dd_trace_internal_fn('get_agent_sampling_config');
+    if (!empty($sampling)) { break; }
+    usleep(100000);
+}
+var_dump(is_array($sampling));
+var_dump(isset($sampling['rate_by_service']));
+var_dump((float)($sampling['rate_by_service']['service:shm_data_test,env:test'] ?? -1));
+
+$apmPath = put_dynamic_config_file(['tracing_sample_rate' => 0.5], 'shm_data_test', 'test');
+$probeId = "log1a2b3c4d-0000-0000-0000-000000000001";
+put_rc_file(
+    "datadog/2/LIVE_DEBUGGING/logProbe_{$probeId}/config",
+    json_encode([
+        "id"             => $probeId,
+        "version"        => 0,
+        "type"           => "LOG_PROBE",
+        "language"       => "php",
+        "where"          => ["typeName" => "Foo", "methodName" => "bar"],
+        "segments"       => [],
+        "captureSnapshot" => false,
+    ])
+);
+
+\DDTrace\start_span(); // keep request alive for VM interrupt
+
+// config_ids are the unique parts of the path, not full paths; search by entry type/id.
+$apmFound = $probeFound = false;
+for ($i = 0; $i < 40 && !($apmFound && $probeFound); $i++) {
+    $loaded = dd_trace_internal_fn('get_loaded_remote_configs');
+    foreach ($loaded as $entry) {
+        if (($entry['type'] ?? '') === 'apm_tracing')                                  { $apmFound   = true; }
+        if (($entry['type'] ?? '') === 'probe' && ($entry['id'] ?? '') === $probeId)   { $probeFound = true; }
+    }
+    if (!$apmFound || !$probeFound) { usleep(250000); }
+}
+
+var_dump($apmFound   ? 'APM_TRACING found' : 'APM_TRACING NOT found');
+var_dump($probeFound ? 'probe found'       : 'probe NOT found');
+
+foreach ($loaded as $entry) {
+    if (($entry['type'] ?? '') === 'apm_tracing') { var_dump($entry['type']); break; }
+}
+foreach ($loaded as $entry) {
+    if (($entry['type'] ?? '') === 'probe' && ($entry['id'] ?? '') === $probeId) {
+        var_dump($entry['type']);
+        var_dump($entry['id'] === $probeId);
+        break;
+    }
+}
+
+del_rc_file($apmPath);
+del_rc_file("datadog/2/LIVE_DEBUGGING/logProbe_{$probeId}/config");
+
+?>
+--CLEAN--
+<?php
+require __DIR__ . '/remote_config/remote_config.inc';
+reset_request_replayer();
+?>
+--EXPECT--
+bool(true)
+string(11) "7.99.0-test"
+bool(true)
+bool(true)
+bool(true)
+bool(true)
+float(1)
+string(17) "APM_TRACING found"
+string(11) "probe found"
+string(11) "apm_tracing"
+string(5) "probe"
+bool(true)


### PR DESCRIPTION
This allows directly inspecting and analyzing the contents of data stored in SHM for debugging/testing purposes.