### PR TITLE
Continuously integrate libdatadog via scheduled job

### DIFF
--- a/.github/chainguard/gitlab-ci-libdatadog-latest.sts.yaml
+++ b/.github/chainguard/gitlab-ci-libdatadog-latest.sts.yaml
@@ -1,0 +1,7 @@
+issuer: https://gitlab.ddbuild.io
+
+subject_pattern: "project_path:DataDog/apm-reliability/dd-trace-php:ref_type:(branch|tag):ref:.*"
+
+permissions:
+  contents: write
+  pull_requests: write

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,6 @@
 **/vendor
 !/ext/vendor
-tmp/build_extension/
+tmp/
 composer.lock*
 **/core*
 .DS_Store

--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -25,16 +25,41 @@ generate-templates:
   tags: [ "arch:amd64" ]
   needs: []
   script:
-    - php ./.gitlab/generate-package.php | tee .gitlab/package-gen.yml
-    - php ./.gitlab/generate-tracer.php | tee .gitlab/tracer-gen.yml
-    - php ./.gitlab/generate-appsec.php | tee .gitlab/appsec-gen.yml
+    - |
+      touch libdatadog.env  # always present so dotenv artifact never errors
+      # On libdatadog CI schedule: fetch the latest SHA from GitHub, export it so
+      # generate-common.php can embed it directly in compilation job before_scripts.
+      if [ "${SCHEDULED_LIBDATADOG_LATEST:-}" = "true" ]; then
+        set -x
+        apt update
+        apt install -y git
+        LIBDATADOG_PINNED_SHA=$(git ls-tree HEAD libdatadog | awk '{print $3}')
+        LIBDATADOG_OVERRIDE_SHA=$(git ls-remote https://github.com/DataDog/libdatadog main | cut -f1)
+        export LIBDATADOG_OVERRIDE_SHA LIBDATADOG_PINNED_SHA
+        printf 'LIBDATADOG_OVERRIDE_SHA=%s\nLIBDATADOG_PINNED_SHA=%s\n' "$LIBDATADOG_OVERRIDE_SHA" "$LIBDATADOG_PINNED_SHA" >> libdatadog.env
+        if [ "$LIBDATADOG_OVERRIDE_SHA" = "$LIBDATADOG_PINNED_SHA" ]; then
+          echo 'LIBDATADOG_NO_CHANGES=true'  >> libdatadog.env
+        else
+          echo 'LIBDATADOG_NO_CHANGES=false' >> libdatadog.env
+        fi
+      elif [ "${CI_COMMIT_BRANCH:-}" = "bot/libdatadog-latest" ]; then
+        # Feedback run after a bot commit: the submodule already points to the tested SHA.
+        # Don't export — generate-common.php must not inject fetch/checkout (no-op anyway).
+        LIBDATADOG_SHA=$(git ls-tree HEAD libdatadog | awk '{print $3}')
+        printf 'LIBDATADOG_OVERRIDE_SHA=%s\nLIBDATADOG_FEEDBACK_RUN=true\n' "$LIBDATADOG_SHA" >> libdatadog.env
+      fi
+    - php ./.gitlab/generate-package.php  | tee .gitlab/package-gen.yml
+    - php ./.gitlab/generate-tracer.php   | tee .gitlab/tracer-gen.yml
+    - php ./.gitlab/generate-appsec.php   | tee .gitlab/appsec-gen.yml
     - php ./.gitlab/generate-profiler.php | tee .gitlab/profiler-gen.yml
-    - php ./.gitlab/generate-shared.php | tee .gitlab/shared-gen.yml
+    - php ./.gitlab/generate-shared.php   | tee .gitlab/shared-gen.yml
   variables:
     GIT_SUBMODULE_STRATEGY: none
   artifacts:
     paths:
       - .gitlab/*-gen.yml
+    reports:
+      dotenv: libdatadog.env
 
 tracer-trigger:
   stage: tests
@@ -96,3 +121,33 @@ package-trigger:
     PARENT_PIPELINE_ID: $CI_PIPELINE_ID
     GIT_SUBMODULE_PATHS: libdatadog appsec/third_party/cpp-base64 appsec/third_party/libddwaf appsec/third_party/libddwaf-rust appsec/third_party/msgpack-c
     NIGHTLY_BUILD: $NIGHTLY_BUILD
+
+# Runs after the full CI completes.  Triggered in two situations:
+#   1. Scheduled libdatadog CI run (SCHEDULED_LIBDATADOG_LATEST=true)
+#   2. Push to bot/libdatadog-latest by the bot — feeds CI results back so we can verify whether Claude's fixes actually worked.  The [no-ci-feedback] marker in bot commits prevents triggering a third run.
+analyze-and-create-pr:
+  stage: deploy
+  rules:
+    - if: $SCHEDULED_LIBDATADOG_LATEST == "true"
+      when: always
+    - if: '$CI_COMMIT_BRANCH == "bot/libdatadog-latest" && $CI_COMMIT_AUTHOR =~ /github-actions\[bot\]/ && $CI_COMMIT_MESSAGE !~ /\[no-ci-feedback\]/'
+      when: always
+    - when: never
+  needs:
+    - job: generate-templates
+      artifacts: true
+    - tracer-trigger
+    - appsec-trigger
+    - profiler-trigger
+    - shared-trigger
+    - package-trigger
+  trigger:
+    include:
+      - local: .gitlab/libdatadog-latest.yml
+    strategy: depend
+  variables:
+    LIBDATADOG_OVERRIDE_SHA: $LIBDATADOG_OVERRIDE_SHA
+    LIBDATADOG_PINNED_SHA: $LIBDATADOG_PINNED_SHA
+    LIBDATADOG_NO_CHANGES: $LIBDATADOG_NO_CHANGES
+    LIBDATADOG_FEEDBACK_RUN: $LIBDATADOG_FEEDBACK_RUN
+    PARENT_PIPELINE_ID: $CI_PIPELINE_ID

--- a/.gitlab/generate-common.php
+++ b/.gitlab/generate-common.php
@@ -99,6 +99,63 @@ function windows_git_setup_with_packages() {
 <?php
 }
 
+// When LIBDATADOG_OVERRIDE_SHA is set in the environment (injected by generate-templates
+// on a libdatadog CI schedule run), capture the entire generated YAML and burn the
+// literal SHA into the before_script of every compilation job.  On normal CI runs the
+// env var is absent and the YAML is emitted unchanged with zero overhead.
+$_libdatadog_sha = getenv('LIBDATADOG_OVERRIDE_SHA') ?: '';
+ob_start();
+register_shutdown_function(function () use ($_libdatadog_sha) {
+    $yaml = ob_get_clean();
+
+    if ($_libdatadog_sha === '') {
+        echo $yaml;
+        return;
+    }
+
+    $step  = <<<STEP
+    - git -C libdatadog fetch --depth=1 origin "$_libdatadog_sha" 2>&1
+    - git -C libdatadog checkout FETCH_HEAD
+STEP;
+
+    // Scripts whose presence in a job block means the job compiles Rust from libdatadog.
+    $compile_scripts = [
+        'compile_extension.sh',
+        'build-sidecar.sh',
+        'build-tracing.sh',
+        'build-tracing-asan.sh',
+        'build-profiler.sh',
+    ];
+
+    // Split into top-level YAML blocks (each starts at column 0).
+    $blocks = preg_split('/(?=^[^\s])/m', $yaml, -1, PREG_SPLIT_NO_EMPTY);
+
+    $result = '';
+    foreach ($blocks as $block) {
+        $needs_override = false;
+        foreach ($compile_scripts as $script) {
+            if (str_contains($block, $script)) {
+                $needs_override = true;
+                break;
+            }
+        }
+
+        if ($needs_override) {
+            if (preg_match('/^  before_script:/m', $block)) {
+                // Prepend to an existing before_script list.
+                $block = preg_replace('/^  before_script:/m', "  before_script:\n$step", $block, 1);
+            } elseif (preg_match('/^  script:/m', $block)) {
+                // No before_script — create one immediately before script:.
+                $block = preg_replace('/^  script:/m', "  before_script:\n$step\n  script:", $block, 1);
+            }
+        }
+
+        $result .= $block;
+    }
+
+    echo $result;
+});
+
 ?>
 default:
   retry:

--- a/.gitlab/libdatadog-latest-prompt.md
+++ b/.gitlab/libdatadog-latest-prompt.md
@@ -1,0 +1,93 @@
+# libdatadog Continuous Integration Analysis
+
+You are analyzing whether the latest libdatadog is API-compatible with dd-trace-php and adapting the code if necessary.
+
+## Your task
+
+1. Read the CI summary and failure traces from the artifacts directory
+2. Classify each failure as: API change to fix / libdatadog bug to report / flaky test
+3. For API changes: edit the dd-trace-php Rust source files to adapt
+4. Write a comprehensive REPORT.md summarising what you found and did
+
+## Important constraints
+
+- You **cannot** run cargo, make, or any other build/test commands. There is no Rust compiler available. Reason about changes from the error messages and source code alone.
+- Do **not** edit anything under the `libdatadog/` source directory.
+- Do **not** skip existing code just to satisfy tests, do not comment out failing tests, do not downgrade trait bounds or version requirements to hide incompatibilities.
+
+## Input files to read first
+
+- `tmp/artifacts/ci_summary.txt` — list of all failed jobs across ALL sub-pipelines (tracer, appsec, profiler, shared, package) plus trace tails for compilation/build failures
+- `tmp/artifacts/traces/` — directory of full trace files for compilation failures (each file is named after the job and contains the last ~15 KB of its log)
+- `tmp/artifacts/libdatadog_changelog.txt` — git log of new commits since the pinned SHA
+- `tmp/artifacts/all_failures.json` — structured list of every failed job
+
+The **new** libdatadog source tree is in the `libdatadog/` directory relative to the project root.
+
+## Classification rules
+
+### Fix (API changes in libdatadog)
+
+These are expected during libdatadog development and should be adapted:
+
+- A type, function, method, or module was renamed → update all call sites
+- A function signature changed (new parameters, changed return type) → update call sites
+- A struct gained required fields → add them with sensible defaults
+- A struct lost fields → remove all references
+- A trait gained required methods → implement them
+- An enum variant was renamed or added → update match arms and constructors
+- A public re-export moved to a different path → update `use` statements
+
+Look up the new API in the `libdatadog/` source tree to get the correct names and signatures before editing.
+
+### Report but do NOT fix (libdatadog bugs or design issues)
+
+Do not try to work around these — report them in `tmp/REPORT.md` and leave the code broken:
+
+- A panic or unexpected behaviour coming from *inside* libdatadog (not from our code calling it incorrectly)
+- A regression where functionality that previously worked no longer does (and there is no obvious new API to call instead)
+- An API change so large it would require significant redesign of our architecture
+
+### Ignore (test flakiness or unrelated failures)
+
+- Failures that mention timing, sleep, race condition, or `flaky`
+- Failures in tests completely unrelated to libdatadog (e.g., pure PHP test infrastructure)
+- A single failure in a test where the log shows an external resource issue
+
+## Writing REPORT.md
+
+Always create/overwrite `tmp/REPORT.md` in the project root. Use this structure:
+
+```markdown
+# libdatadog Integration Report
+
+**libdatadog SHA**: <full SHA from Environment section>
+**Analysis date**: <today>
+
+## Overall status
+
+<!-- One of: ✅ Clean update | ⚠️ Adapted (API changes fixed) | ❌ Blocking issues remain -->
+
+## Build & test summary
+
+<!-- What passed, what failed, overall picture across all sub-pipelines -->
+
+## Non-trivial changes made
+
+<!-- For each file changed: path, what changed, and why -->
+<!-- If nothing was changed: "No code changes required." -->
+
+## Identified libdatadog issues
+
+<!-- Bugs or design problems in libdatadog that we should NOT work around.
+     For each: symptom, affected libdatadog code path, why it is a libdatadog bug. -->
+<!-- If none: "None identified." -->
+
+## Flaky / ignored failures
+
+<!-- Failures that appear flaky or unrelated to libdatadog changes. -->
+<!-- If none: "None." -->
+```
+
+Write the report even if the CI passed cleanly — status is "✅ Clean update" and sections
+are brief.

--- a/.gitlab/libdatadog-latest.yml
+++ b/.gitlab/libdatadog-latest.yml
@@ -1,0 +1,350 @@
+stages:
+  - analyze
+
+"analyze and create pr":
+  stage: analyze
+  image: registry.ddbuild.io/images/dd-octo-sts-ci-base:2025.06-1
+  tags: ["arch:amd64"]
+  timeout: 5h # large timeout because retries can sometimes take a long time
+  when: always
+  id_tokens:
+    DDOCTOSTS_ID_TOKEN:
+      aud: dd-octo-sts
+  script:
+    - |
+      set -xuo pipefail
+      git config --global --add safe.directory "${CI_PROJECT_DIR}"
+      git config --global --add safe.directory "${CI_PROJECT_DIR}/libdatadog"
+      git config --global user.email "41898282+github-actions[bot]@users.noreply.github.com"
+      git config --global user.name "github-actions[bot]"
+
+      if [ "${LIBDATADOG_NO_CHANGES:-false}" = "true" ]; then
+        echo "libdatadog is already at the latest commit — nothing to do."
+        exit 0
+      fi
+
+      LIBDATADOG_SHA="${LIBDATADOG_OVERRIDE_SHA}"
+      LIBDATADOG_PINNED="${LIBDATADOG_PINNED_SHA}"
+      echo "libdatadog: ${LIBDATADOG_PINNED:0:8} → ${LIBDATADOG_SHA:0:8}"
+
+      # Obtain a short-lived GitLab project access token (api + read_repository scope)
+      # via the BTI CI API.  Authentication to BTI uses a Vault-issued JWT for the
+      # 'sdm' audience — the same Vault proxy that Emissary injects (VAULT_ADDR).
+      _vault_jwt() {
+        local audience="$1"
+        if [ -n "${VAULT_ADDR:-}" ]; then
+          curl -sf -H "X-Vault-Request: true" \
+            "${VAULT_ADDR}/v1/identity/oidc/token/${audience}" | jq -r '.data.token' 2>/dev/null \
+            && return 0
+        fi
+        if [ -n "${DD_DATACENTER:-}" ]; then
+          curl -sf -H "X-Vault-Request: true" \
+            "https://vault.${DD_DATACENTER}/v1/identity/oidc/token/${audience}" | jq -r '.data.token' 2>/dev/null \
+            && return 0
+        fi
+        return 1
+      }
+      BTI_JWT=$(_vault_jwt sdm) || {
+        echo "ERROR: Could not obtain a BTI JWT (VAULT_ADDR=${VAULT_ADDR:-unset}, DD_DATACENTER=${DD_DATACENTER:-unset})." >&2
+        exit 1
+      }
+      GITLAB_TOKEN=$(curl -sf \
+        -H "Authorization: Bearer ${BTI_JWT}" \
+        "https://bti-ci-api.us1.ddbuild.io/internal/ci/gitlab/token?owner=DataDog&repository=dd-trace-php" \
+        | jq -r '.token')
+      GITLAB_API="https://gitlab.ddbuild.io/api/v4"
+
+      mkdir -p tmp/artifacts/traces
+
+      # collect failed jobs from a child pipeline (up to 3 pages)
+      collect_failures() {
+        local child_id="$1" trigger_name="$2"
+        local failed_jobs="[]"
+        for page in 1 2 3; do
+          page_data=$(curl -sf -H "PRIVATE-TOKEN: ${GITLAB_TOKEN}" \
+            "${GITLAB_API}/projects/${CI_PROJECT_ID}/pipelines/${child_id}/jobs?per_page=100&page=${page}" \
+            || echo "[]")
+          page_failed=$(echo "${page_data}" | jq '[.[] | select(.status == "failed")]')
+          failed_jobs=$(jq -n --argjson a "${failed_jobs}" --argjson b "${page_failed}" '$a + $b')
+          [ "$(echo "${page_data}" | jq 'length')" -lt 100 ] && break
+        done
+        echo "${failed_jobs}" | jq --arg t "${trigger_name}" '[.[] | . + {trigger: $t}]'
+      }
+
+      # wait for a single job to leave its running/pending states
+      wait_for_job() {
+        local job_id="$1" label="$2"
+        while true; do
+          status=$(curl -sf -H "PRIVATE-TOKEN: ${GITLAB_TOKEN}" \
+            "${GITLAB_API}/projects/${CI_PROJECT_ID}/jobs/${job_id}" \
+            | jq -r '.status')
+          case "${status}" in
+            running|pending|created|waiting_for_resource|preparing)
+              sleep 20 ;;
+            *)
+              echo "  ${label}: ${status}"
+              break ;;
+          esac
+        done
+      }
+
+      echo "Collecting CI results from parent pipeline ${PARENT_PIPELINE_ID}..."
+
+      curl -sf -H "PRIVATE-TOKEN: ${GITLAB_TOKEN}" \
+        "${GITLAB_API}/projects/${CI_PROJECT_ID}/pipelines/${PARENT_PIPELINE_ID}/bridges?per_page=100" \
+        -o tmp/artifacts/bridges.json
+
+      echo "[]" > tmp/artifacts/all_failures.json
+
+      while IFS=$'\t' read -r child_id child_status trigger_name; do
+        echo ""
+        echo "=== ${trigger_name} (pipeline ${child_id}) status: ${child_status} ==="
+        failures=$(collect_failures "${child_id}" "${trigger_name}")
+        count=$(echo "${failures}" | jq 'length')
+        if [ "${count}" = "0" ]; then
+          echo "  No failures."
+          continue
+        fi
+        echo "  Failed jobs (${count}):"
+        echo "${failures}" | jq -r '.[] | "    - \(.name)"'
+        all=$(cat tmp/artifacts/all_failures.json)
+        jq -n --argjson a "${all}" --argjson b "${failures}" '$a + $b' > tmp/artifacts/all_failures.json
+      done < <(jq -r '.[] | select(.downstream_pipeline != null)
+                      | [(.downstream_pipeline.id | tostring),
+                        (.downstream_pipeline.status // "unknown"),
+                        .name]
+                      | @tsv' \
+        tmp/artifacts/bridges.json)
+
+      TOTAL_FAILURES=$(jq 'length' tmp/artifacts/all_failures.json)
+      echo ""
+      echo "Initial failures: ${TOTAL_FAILURES}"
+
+      # Retry once if fewer than 10 failures (avoids flaky tests)
+      if [ "${TOTAL_FAILURES}" -gt 0 ] && [ "${TOTAL_FAILURES}" -lt 10 ]; then
+        echo "Retrying ${TOTAL_FAILURES} failed job(s) to filter flakiness..."
+        echo "" > tmp/artifacts/retried_jobs.tsv
+
+        while IFS= read -r job_json; do
+          orig_id=$(echo "${job_json}" | jq -r '.id')
+          trigger=$(echo "${job_json}" | jq -r '.trigger')
+          name=$(echo "${job_json}"   | jq -r '.name')
+          new_job=$(curl -sf -X POST -H "PRIVATE-TOKEN: ${GITLAB_TOKEN}" \
+            "${GITLAB_API}/projects/${CI_PROJECT_ID}/jobs/${orig_id}/retry" || echo "{}")
+          new_id=$(echo "${new_job}" | jq -r '.id // empty')
+          if [ -n "${new_id}" ]; then
+            printf '%s\t%s\t%s\n' "${new_id}" "${trigger}" "${name}" \
+              >> tmp/artifacts/retried_jobs.tsv
+            echo "  Retried: ${name} → job ${new_id}"
+          else
+            echo "  Could not retry: ${name} (skipping)"
+          fi
+        done < <(jq -c '.[]' tmp/artifacts/all_failures.json)
+
+        echo "Waiting for retried jobs..."
+        while IFS=$'\t' read -r retried_id trigger name; do
+          [ -z "${retried_id}" ] && continue
+          wait_for_job "${retried_id}" "${name}"
+        done < tmp/artifacts/retried_jobs.tsv
+
+        # Rebuild failure list from jobs that still failed after retry
+        echo "[]" > tmp/artifacts/all_failures.json
+        while IFS=$'\t' read -r retried_id trigger name; do
+          [ -z "${retried_id}" ] && continue
+          job_data=$(curl -sf -H "PRIVATE-TOKEN: ${GITLAB_TOKEN}" \
+            "${GITLAB_API}/projects/${CI_PROJECT_ID}/jobs/${retried_id}" || echo "{}")
+          status=$(echo "${job_data}" | jq -r '.status')
+          if [ "${status}" = "failed" ]; then
+            entry=$(echo "${job_data}" | jq --arg t "${trigger}" '. + {trigger: $t}')
+            all=$(cat tmp/artifacts/all_failures.json)
+            jq -n --argjson a "${all}" --argjson b "[${entry}]" '$a + $b' > tmp/artifacts/all_failures.json
+          fi
+        done < tmp/artifacts/retried_jobs.tsv
+
+        TOTAL_FAILURES=$(jq 'length' tmp/artifacts/all_failures.json)
+        echo "Failures after retry: ${TOTAL_FAILURES}"
+      fi
+
+      # Build the CI summary
+      {
+        echo "Total persistent failures: ${TOTAL_FAILURES}"
+        echo ""
+        jq -r '.[] | "[\(.trigger)] \(.name)"' tmp/artifacts/all_failures.json
+      } > tmp/artifacts/ci_summary.txt
+
+      BUILD_STATUS="$([ "${TOTAL_FAILURES}" = "0" ] \
+        && echo "✅ all passed" || echo "❌ ${TOTAL_FAILURES} job(s) failed")"
+
+      # Clone libdatadog at the tested SHA
+      git -C libdatadog checkout "${LIBDATADOG_SHA}"
+      (git -C libdatadog log --oneline "${LIBDATADOG_PINNED}..HEAD" 2>/dev/null | head -200 || git -C libdatadog log --oneline -100) > tmp/artifacts/libdatadog_changelog.txt
+
+      if [ "${TOTAL_FAILURES}" = "0" ]; then
+        # Clean update: write a brief report and skip Claude
+        echo "All CI jobs passed — skipping Claude analysis."
+        printf '# libdatadog Integration Report\n\n## Overall status\n\n✅ Clean update — all CI jobs passed.\n\n## Build & test summary\n\nAll sub-pipelines (tracer, appsec, profiler, shared, package) passed.\nNo code changes required.\n\n## Non-trivial changes made\n\nNone.\n\n## Identified libdatadog issues\n\nNone.\n\n## Flaky / ignored failures\n\nNone.\n' > tmp/REPORT.md
+      else
+        # Failures remain: download traces and run Claude
+        compile_keywords="compile build sidecar tracing profil appsec"
+        while IFS= read -r job_json; do
+          job_name=$(echo "${job_json}" | jq -r '.name')
+          job_id=$(echo "${job_json}"   | jq -r '.id')
+          trigger=$(echo "${job_json}"  | jq -r '.trigger')
+          jname_lower=$(echo "${job_name}" | tr '[:upper:]' '[:lower:]')
+          is_compile=false
+          for kw in ${compile_keywords}; do
+            [[ "${jname_lower}" == *"${kw}"* ]] && is_compile=true && break
+          done
+          if [ "${is_compile}" = "true" ]; then
+            safe=$(echo "${jname_lower}" | tr '/ ' '-_' | cut -c1-60)
+            trace_file="tmp/artifacts/traces/${safe}_${job_id}.txt"
+            echo "" && echo "--- trace: ${job_name} (${trigger}) ---"
+            trace=$(curl -sf -H "PRIVATE-TOKEN: ${GITLAB_TOKEN}" \
+              "${GITLAB_API}/projects/${CI_PROJECT_ID}/jobs/${job_id}/trace" \
+              || echo "[trace unavailable]")
+            { echo "=== ${job_name} (trigger: ${trigger}) ==="; echo "${trace}" | tail -c 15360; } \
+              > "${trace_file}"
+            echo "${trace}" | tail -c 2000
+          fi
+        done < <(jq -c '.[]' tmp/artifacts/all_failures.json)
+
+        # Install Claude (nvm — no root required)
+        if ! command -v claude &>/dev/null; then
+          export NVM_DIR="${HOME}/.nvm"
+          curl -fsSL https://raw.githubusercontent.com/nvm-sh/nvm/v0.39.7/install.sh | bash - 2>&1
+          . "${NVM_DIR}/nvm.sh"
+          nvm install --lts --no-progress 2>&1
+          npm install -g @anthropic-ai/claude-code 2>&1
+        fi
+
+        AI_GATEWAY_TOKEN=$(_vault_jwt rapid-ai-platform) || {
+          echo "ERROR: Could not obtain an AI Gateway token (VAULT_ADDR=${VAULT_ADDR:-unset}, DD_DATACENTER=${DD_DATACENTER:-unset})." >&2
+          exit 1
+        }
+
+        export ANTHROPIC_API_KEY=not-set
+        export ANTHROPIC_BASE_URL="https://ai-gateway.us1.ddbuild.io"
+        export ANTHROPIC_CUSTOM_HEADERS="$(printf '%s\n' \
+          "source: dd-trace-php-libdatadog-ci" \
+          "org-id: 2" \
+          "provider: anthropic" \
+          "claude-code: true" \
+          "Authorization: Bearer ${AI_GATEWAY_TOKEN}")"
+
+        PROMPT_CONTEXT="## Environment
+        - dd-trace-php source: ${CI_PROJECT_DIR}
+        - New libdatadog source: ${CI_PROJECT_DIR}/libdatadog
+        - libdatadog SHA: ${LIBDATADOG_SHA}
+        - Full CI result: ${BUILD_STATUS}
+        - CI summary: tmp/artifacts/ci_summary.txt
+        - Compilation failure traces: tmp/artifacts/traces/
+        - libdatadog changelog: tmp/artifacts/libdatadog_changelog.txt
+        - CI pipeline: ${CI_PIPELINE_URL}"
+        PROMPT_BODY=$(cat .gitlab/libdatadog-latest-prompt.md)
+
+        set +e
+        claude \
+          --allowedTools "Read,Glob,Grep,Edit,Write" \
+          --permission-mode bypassPermissions \
+          --max-turns 50 \
+          -p "${PROMPT_CONTEXT}
+
+        ${PROMPT_BODY}" 2>&1 | tee tmp/artifacts/claude_output.txt
+        CLAUDE_EXIT=$?
+        set -e
+        echo "Claude exit code: ${CLAUDE_EXIT}"
+      fi
+
+      # Get GitHub token via dd-octo-sts
+      dd-octo-sts debug --scope DataDog/dd-trace-php --policy gitlab-ci-libdatadog-latest
+      dd-octo-sts token --scope DataDog/dd-trace-php --policy gitlab-ci-libdatadog-latest > tmp/github_token.txt
+      GITHUB_TOKEN=$(cat tmp/github_token.txt)
+      export GITHUB_TOKEN GH_TOKEN="${GITHUB_TOKEN}"
+
+      # Commit: submodule pointer + any Claude edits
+      TARGET_BRANCH="bot/libdatadog-latest"
+      git checkout -B "${TARGET_BRANCH}"
+
+      git add -A
+
+      # Feedback runs append [no-ci-feedback] so the next push doesn't trigger
+      # another analyze-and-create-pr, breaking the potential infinite loop.
+      FEEDBACK_MARKER="${LIBDATADOG_FEEDBACK_RUN:+' [no-ci-feedback]'}"
+      COMMIT_MSG="libdatadog update to ${LIBDATADOG_SHA:0:8}${FEEDBACK_MARKER}
+
+      Automated update by CI pipeline ${CI_PIPELINE_URL}
+
+      Full CI result: ${BUILD_STATUS}"
+
+      if ! git diff --cached --quiet; then
+        git commit -m "${COMMIT_MSG}" \
+          --author="github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+        git push --force \
+          "https://x-access-token:${GITHUB_TOKEN}@github.com/DataDog/dd-trace-php.git" \
+          "HEAD:${TARGET_BRANCH}"
+      elif [ -z "${LIBDATADOG_FEEDBACK_RUN:-}" ]; then
+        # Original schedule run with no code changes: still push the submodule bump.
+        git commit --allow-empty -m "${COMMIT_MSG}" \
+          --author="github-actions[bot] <41898282+github-actions[bot]@users.noreply.github.com>"
+        git push --force \
+          "https://x-access-token:${GITHUB_TOKEN}@github.com/DataDog/dd-trace-php.git" \
+          "HEAD:${TARGET_BRANCH}"
+      else
+        echo "Feedback run with no code changes — updating PR description only."
+      fi
+
+      # Create or update the PR
+      REPORT_BODY=$(cat tmp/REPORT.md 2>/dev/null \
+        || echo "*(Claude did not produce a report — see \`tmp/artifacts/claude_output.txt\` in the CI pipeline.)*")
+
+      PR_TITLE="libdatadog update to ${LIBDATADOG_SHA:0:8}"
+      if [ -n "${LIBDATADOG_PINNED}" ]; then
+        SHA_TABLE="| | SHA |
+      |---|---|
+      | Previous | \`${LIBDATADOG_PINNED}\` |
+      | New | \`${LIBDATADOG_SHA}\` |"
+      else
+        SHA_TABLE="**SHA**: \`${LIBDATADOG_SHA}\`"
+      fi
+      PR_BODY="## Summary
+
+      Automated update of the libdatadog submodule to the latest HEAD.
+
+      ${SHA_TABLE}
+
+      **Full CI result**: ${BUILD_STATUS}
+      **CI pipeline**: ${CI_PIPELINE_URL}
+
+      ---
+
+      ${REPORT_BODY}
+
+      ---
+      /cc @bwoebi"
+
+      PR_NUMBER=$(gh pr list \
+        --repo DataDog/dd-trace-php \
+        --head "${TARGET_BRANCH}" \
+        --json number \
+        --jq '.[0].number' 2>/dev/null || echo "")
+
+      if [ -z "${PR_NUMBER}" ]; then
+        gh pr create \
+          --repo DataDog/dd-trace-php \
+          --base master \
+          --head "${TARGET_BRANCH}" \
+          --title "${PR_TITLE}" \
+          --body "${PR_BODY}"
+      else
+        gh pr edit "${PR_NUMBER}" \
+          --repo DataDog/dd-trace-php \
+          --title "${PR_TITLE}" \
+          --body "${PR_BODY}"
+      fi
+  after_script:
+    - if [[ -f tmp/github_token.txt ]]; then dd-octo-sts revoke -t "$(cat tmp/github_token.txt)" || true; fi
+  artifacts:
+    paths:
+      - tmp/REPORT.md
+      - tmp/artifacts/
+    when: always


### PR DESCRIPTION
Adding a pipeline which will be called on `master` with `SCHEDULED_LIBDATADOG_LATEST=true` variable every night.

This makes sure that we get early / quick insights when a change on libdatadog breaks the dd-trace-php build:
- Run the master branch CI with the latest main commit of libdatadog
- Pull all pipeline failures
- Retry them to avoid flakiness polluting claudes work
- Have claude analyze the remaining failures (with focus on compile fails, then everything else)
- Create a PR with the changes
- CI will naturally run again on that PR (it's a new branch, so...)
- Claude will verify the results of that pipeline too (i.e. verify its own fixes, possibly fixing secondary issues after initial compilation failure results) and push additional fixes as needed
- A human looks at the PR and merges / decides on further action.

It works, see https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-php/-/jobs/1629546146. Also see the attached artifact, which claude generated on that pipeline:

```
# libdatadog Integration Report

**libdatadog SHA**: 243aec1b5450b7edb546b5a59e5f80ab79abed08
**Analysis date**: 2026-04-24

## Overall status

✅ Clean update

## Build & test summary

CI ran across appsec, tracer, profiler, shared, and package
sub-pipelines. One job failed:

- `[appsec-trigger] check libxml2 version` — marked `allow_failure:
  true` in the pipeline configuration, so it is non-blocking.

No Rust compilation traces were produced (the `artifacts/traces/`
directory is empty), confirming that all Rust/C build steps succeeded.

## Non-trivial changes made

No code changes required.

The five commits in this update do not alter any public FFI surface
used by dd-trace-php:

| Commit | Description | Impact on dd-trace-php |
|--------|-------------|------------------------|
| `243aec1b5` | fix(libdd-common): fix `--all-features` build condition | Build/test only; no API change |
| `6b026965d` | fix(sidecar)!: Prefer session-id for remote config | Internal sidecar server change; FFI unchanged (see below) |
| `cf8c1cfa0` | build(profiling): rustc-hash 2.1.2 | Dependency version bump; no API change |
| `950562bb1` | ci: fix unbound variable | CI script fix; no code change |
| `27aa92cfe` | feat(libdd-trace-utils): reject empty `datadog-client-computed-stats` header value | Backward-compatible behaviour fix; dd-trace-php already sends a non-empty value when the flag is true |

### Detail: `fix(sidecar)!` — internal server change

The `!` (breaking) marker applies to libdatadog's own internal API.
The change removes the `instance_id` parameter from
`RuntimeInfo::update_remote_config` in
`datadog-sidecar/src/service/runtime_info.rs` and routes remote-config
subscriptions via `session_id` instead of `instance_id.runtime_id`.
This is purely server-side routing logic inside the sidecar process.

The public C FFI functions that dd-trace-php calls —
`ddog_sidecar_instanceId_build`, `ddog_sidecar_session_set_config`, and
all remote-config reader/writer functions — are **unchanged**. No
call sites in `components-rs/`, `appsec/helper-rust/`, or other
dd-trace-php Rust crates need to be updated.

## Identified libdatadog issues

None identified.

## Flaky / ignored failures

- `[appsec-trigger] check libxml2 version` — checks that the host
  system's libxml2 meets a minimum version requirement. This is an
  environment/infrastructure constraint unrelated to the libdatadog
  changes in this update, and is already marked `allow_failure: true`
  in the pipeline.
```

The octo sts token permissions are still missing on master, so can't test pushing yet, but at least it gets right up to that point.