### PR TITLE
fix(tracing): intern process_tags.serialized to avoid ZTS refcount race

### DIFF
--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -1415,6 +1415,25 @@ void ddtrace_init_known_strings(void) {
 }
 #endif
 
+// Refcount helpers wired into Rust via ddog_init_span_func. They no-op on
+// interned (= GC_IMMUTABLE) zend_strings so process-wide shared strings
+// don't get racing non-atomic ++/-- on their refcount when fed into
+// convert_to_bytes from multiple ZTS threads concurrently. Naming mirrors
+// Zend's GC_TRY_ADDREF / GC_TRY_DELREF convention. Note we call the full
+// zend_string_release (not GC_TRY_DELREF) on the non-interned path so the
+// underlying allocation is freed when the refcount hits zero.
+static void dd_zend_string_try_addref(zend_string *s) {
+    if (!ZSTR_IS_INTERNED(s)) {
+        zend_string_addref(s);
+    }
+}
+
+static void dd_zend_string_try_release(zend_string *s) {
+    if (!ZSTR_IS_INTERNED(s)) {
+        zend_string_release(s);
+    }
+}
+
 static PHP_MINIT_FUNCTION(ddtrace) {
     UNUSED(type);
     zval *php_version = zend_get_constant_str(ZEND_STRL("PHP_VERSION"));
@@ -1425,7 +1444,7 @@ static PHP_MINIT_FUNCTION(ddtrace) {
         return FAILURE;
     }
 
-    ddog_init_span_func((void *)zend_string_release, (void *)zend_string_addref, ddtrace_zend_string_init);
+    ddog_init_span_func((void *)dd_zend_string_try_release, (void *)dd_zend_string_try_addref, ddtrace_zend_string_init);
 
     ddtrace_active_sapi = datadog_php_sapi_from_name(datadog_php_string_view_from_cstr(sapi_module.name));
 

--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -1415,25 +1415,6 @@ void ddtrace_init_known_strings(void) {
 }
 #endif
 
-// Refcount helpers wired into Rust via ddog_init_span_func. They no-op on
-// interned (= GC_IMMUTABLE) zend_strings so process-wide shared strings
-// don't get racing non-atomic ++/-- on their refcount when fed into
-// convert_to_bytes from multiple ZTS threads concurrently. Naming mirrors
-// Zend's GC_TRY_ADDREF / GC_TRY_DELREF convention. Note we call the full
-// zend_string_release (not GC_TRY_DELREF) on the non-interned path so the
-// underlying allocation is freed when the refcount hits zero.
-static void dd_zend_string_try_addref(zend_string *s) {
-    if (!ZSTR_IS_INTERNED(s)) {
-        zend_string_addref(s);
-    }
-}
-
-static void dd_zend_string_try_release(zend_string *s) {
-    if (!ZSTR_IS_INTERNED(s)) {
-        zend_string_release(s);
-    }
-}
-
 static PHP_MINIT_FUNCTION(ddtrace) {
     UNUSED(type);
     zval *php_version = zend_get_constant_str(ZEND_STRL("PHP_VERSION"));
@@ -1444,7 +1425,7 @@ static PHP_MINIT_FUNCTION(ddtrace) {
         return FAILURE;
     }
 
-    ddog_init_span_func((void *)dd_zend_string_try_release, (void *)dd_zend_string_try_addref, ddtrace_zend_string_init);
+    ddog_init_span_func((void *)zend_string_release, (void *)zend_string_addref, ddtrace_zend_string_init);
 
     ddtrace_active_sapi = datadog_php_sapi_from_name(datadog_php_string_view_from_cstr(sapi_module.name));
 

--- a/ext/process_tags.c
+++ b/ext/process_tags.c
@@ -55,6 +55,10 @@ static void clear_process_tags(void) {
     }
 
     if (process_tags.serialized) {
+        // Counterpart to the IS_STR_INTERNED flag set in serialize_process_tags:
+        // zend_string_release no-ops on interned strings, so clear the flag
+        // first to actually free the underlying persistent allocation.
+        GC_DEL_FLAGS(process_tags.serialized, IS_STR_INTERNED);
         zend_string_release(process_tags.serialized);
     }
 
@@ -255,6 +259,11 @@ static void serialize_process_tags(void) {
     if (buf.s) {
         smart_str_0(&buf);
         process_tags.serialized = zend_string_init(ZSTR_VAL(buf.s), ZSTR_LEN(buf.s), 1);
+        // Process-wide shared string. Mark interned (= GC_IMMUTABLE) so the
+        // refcount helpers in convert_to_bytes treat it as immutable and
+        // skip the non-atomic ++/-- that would otherwise race across ZTS
+        // threads and corrupt the refcount.
+        GC_ADD_FLAGS(process_tags.serialized, IS_STR_INTERNED);
     }
 
     smart_str_free(&buf);

--- a/ext/process_tags.c
+++ b/ext/process_tags.c
@@ -259,10 +259,12 @@ static void serialize_process_tags(void) {
     if (buf.s) {
         smart_str_0(&buf);
         process_tags.serialized = zend_string_init(ZSTR_VAL(buf.s), ZSTR_LEN(buf.s), 1);
-        // Process-wide shared string. Mark interned (= GC_IMMUTABLE) so the
-        // refcount helpers in convert_to_bytes treat it as immutable and
+        // Process-wide shared string: pre-compute h (interned strings are
+        // expected to have it set; callers may read ZSTR_H() raw) then mark
+        // interned (= GC_IMMUTABLE) so the convert_to_bytes refcount helpers
         // skip the non-atomic ++/-- that would otherwise race across ZTS
-        // threads and corrupt the refcount.
+        // threads.
+        zend_string_hash_val(process_tags.serialized);
         GC_ADD_FLAGS(process_tags.serialized, IS_STR_INTERNED);
     }
 

--- a/ext/process_tags.c
+++ b/ext/process_tags.c
@@ -55,9 +55,7 @@ static void clear_process_tags(void) {
     }
 
     if (process_tags.serialized) {
-        // Counterpart to the IS_STR_INTERNED flag set in serialize_process_tags:
-        // zend_string_release no-ops on interned strings, so clear the flag
-        // first to actually free the underlying persistent allocation.
+        // Counterpart to the IS_STR_INTERNED flag set in serialize_process_tags
         GC_DEL_FLAGS(process_tags.serialized, IS_STR_INTERNED);
         zend_string_release(process_tags.serialized);
     }
@@ -259,11 +257,7 @@ static void serialize_process_tags(void) {
     if (buf.s) {
         smart_str_0(&buf);
         process_tags.serialized = zend_string_init(ZSTR_VAL(buf.s), ZSTR_LEN(buf.s), 1);
-        // Process-wide shared string: pre-compute h (interned strings are
-        // expected to have it set; callers may read ZSTR_H() raw) then mark
-        // interned (= GC_IMMUTABLE) so the convert_to_bytes refcount helpers
-        // skip the non-atomic ++/-- that would otherwise race across ZTS
-        // threads.
+        // Intern to avoid races with string touched by refcounting; but just the flag, no need for the whole persisting ceremony
         zend_string_hash_val(process_tags.serialized);
         GC_ADD_FLAGS(process_tags.serialized, IS_STR_INTERNED);
     }


### PR DESCRIPTION
SCP-11166

### Description

Should help with #3729.

ext/process_tags.c stores a single process-wide zend_string at first-request init (zend_string_init persistent=1) and shares it across all ZTS threads. Every span serialization on a first-span path passes that pointer to Rust, which calls back into PHP's zend_string_addref/zend_string_release through ddog_init_span_func to manage a refcount on its Bytes wrapper. Those ops are non-atomic ++/-- on a single shared field; under FrankenPHP + PHP 8.4 ZTS with concurrent worker threads at load, the races produce torn refcount values, premature frees, and use-after-free reads of process_tags.serialized during convert_zend_to_bytes_string -> String::from_utf8_lossy, surfacing as SIGSEGV / SIGABRT / "memory allocation of <huge> bytes failed" / glibc "double free or corruption".

Mark the string IS_STR_INTERNED (= GC_IMMUTABLE) on creation so the refcount helpers see it as immutable and skip the ++/--. Clear the flag in clear_process_tags before the release so the persistent allocation is actually freed at module shutdown.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
