### PR TITLE
Fixup master compatibility of arg_info

### DIFF
--- a/ext/handlers_exception.c
+++ b/ext/handlers_exception.c
@@ -510,9 +510,19 @@ void ddtrace_exception_handlers_startup(void) {
         .function_name = zend_string_init_interned(ZEND_STRL("ddtrace_exception_handler"), 1),
         .num_args = 4,
         .required_num_args = 1,
+#if PHP_VERSION_ID < 80600
         .arg_info = (zend_internal_arg_info *)(arginfo_ddtrace_exception_or_error_handler + 1),
+#endif
         .handler = &zim_DDTrace_ExceptionOrErrorHandler_execute,
     };
+#if PHP_VERSION_ID >= 80600
+    uint32_t num_args = ddtrace_exception_or_error_handler.num_args + 1;
+    zend_arg_info *new_arg_info = pemalloc(sizeof(zend_arg_info) * num_args, 1);
+    for (uint32_t i = 0; i < num_args; i++) {
+        zend_convert_internal_arg_info(&new_arg_info[i], &arginfo_ddtrace_exception_or_error_handler[i], i == 0, true);
+    }
+    ddtrace_exception_or_error_handler.arg_info = new_arg_info + 1;
+#endif
 
     INIT_NS_CLASS_ENTRY(dd_exception_or_error_handler_ce, "DDTrace", "ExceptionHandler", NULL);
     dd_exception_or_error_handler_ce.type = ZEND_INTERNAL_CLASS;
@@ -619,6 +629,9 @@ void ddtrace_exception_handlers_startup(void) {
 }
 
 void ddtrace_exception_handlers_shutdown(void) {
+#if PHP_VERSION_ID >= 80600
+    zend_free_internal_arg_info(&ddtrace_exception_or_error_handler, true);
+#endif
     ddtrace_free_unregistered_class(&dd_exception_or_error_handler_ce);
     zend_hash_destroy(&ddtrace_exception_custom_create_object);
 }

--- a/ext/hook/uhook_otel.c
+++ b/ext/hook/uhook_otel.c
@@ -91,20 +91,22 @@ static bool dd_uhook_begin(zend_ulong invocation, zend_execute_data *execute_dat
             if (strkey) {
                 uint32_t num_args = fbc->common.num_args;
                 // As per zend_handle_named_arg()
-                if (EXPECTED(fbc->type == ZEND_USER_FUNCTION)
-                    || EXPECTED(fbc->common.fn_flags & ZEND_ACC_USER_ARG_INFO)) {
-                    for (uint32_t i = 0; i < num_args; i++) {
-                        zend_arg_info *arg_info = &fbc->op_array.arg_info[i];
-                        if (zend_string_equals(strkey, arg_info->name)) {
-                            arg_offset = i;
-                            found = true;
-                        }
-                    }
-                } else {
+#if PHP_VERSION_ID < 80600
+                if (UNEXPECTED(fbc->type != ZEND_USER_FUNCTION) && EXPECTED((fbc->common.fn_flags & ZEND_ACC_USER_ARG_INFO == 0))) {
                     for (uint32_t i = 0; i < num_args; i++) {
                         zend_internal_arg_info *arg_info = &fbc->internal_function.arg_info[i];
                         size_t len = strlen(arg_info->name);
                         if (zend_string_equals_cstr(strkey, arg_info->name, len)) {
+                            arg_offset = i;
+                            found = true;
+                        }
+                    }
+                } else
+#endif
+                {
+                    for (uint32_t i = 0; i < num_args; i++) {
+                        zend_arg_info *arg_info = &fbc->op_array.arg_info[i];
+                        if (zend_string_equals(strkey, arg_info->name)) {
                             arg_offset = i;
                             found = true;
                         }

--- a/ext/live_debugger.c
+++ b/ext/live_debugger.c
@@ -407,7 +407,12 @@ static void dd_log_probe_ensure_payload(dd_log_probe_dyn *dyn, dd_log_probe_def 
 
 static void dd_log_probe_capture_snapshot(ddog_DebuggerCapture *capture, dd_log_probe_def *def, zend_execute_data *execute_data) {
     const ddog_CaptureConfiguration *capture_config = def->parent.probe.probe.log.capture;
-    if (ZEND_USER_CODE(EX(func)->type)) {
+#if PHP_VERSION_ID < 80600
+    if (ZEND_USER_CODE(EX(func)->type))
+#else
+    if (ZEND_USER_CODE(EX(func)->type) || EX(func)->internal_function.arg_info)
+#endif
+    {
         zend_array *symbol_table = zend_rebuild_symbol_table();
         zend_string *symbol;
         zval *variable;
@@ -421,6 +426,7 @@ static void dd_log_probe_capture_snapshot(ddog_DebuggerCapture *capture, dd_log_
                 ddog_snapshot_add_field(capture, type, name_slice, capture_value);
             }
         } ZEND_HASH_FOREACH_END();
+#if PHP_VERSION_ID < 80600
     } else if (EX(func)->internal_function.arg_info) {
         uint32_t num_args = EX(func)->internal_function.num_args;
         for (uintptr_t i = 0; i < num_args; ++i) {
@@ -431,6 +437,7 @@ static void dd_log_probe_capture_snapshot(ddog_DebuggerCapture *capture, dd_log_
             ddtrace_create_capture_value(EX_VAR_NUM(i), &capture_value, capture_config, capture_config->max_reference_depth);
             ddog_snapshot_add_field(capture, DDOG_FIELD_TYPE_ARG, name_slice, capture_value);
         }
+#endif
     }
     if (hasThis()) {
         struct ddog_CaptureValue capture_value = {0};
@@ -977,7 +984,18 @@ static const void *dd_eval_fetch_identifier(void *ctx, const ddog_CharSlice *nam
     zend_execute_data *execute_data = eval_ctx->frame;
 
     if (EX(func)) {
-        if (ZEND_USER_CODE(EX(func)->type)) {
+#if PHP_VERSION_ID < 80600
+        if (!ZEND_USER_CODE(EX(func)->type)) {
+            int call_args = MIN(EX_NUM_ARGS(), EX(func)->common.num_args);
+            for (int i = 0; i < call_args; ++i) {
+                const char *argname = EX(func)->internal_function.arg_info[i].name;
+                if (zend_binary_strcmp(argname, strlen(argname), name->ptr, name->len) == 0) {
+                    return EX_VAR_NUM(i);
+                }
+            }
+        } else
+#endif
+        {
             zend_execute_data *current_execute_data = EG(current_execute_data);
             EG(current_execute_data) = execute_data;
             zend_array *symtable = zend_rebuild_symbol_table();
@@ -988,14 +1006,6 @@ static const void *dd_eval_fetch_identifier(void *ctx, const ddog_CharSlice *nam
             EG(current_execute_data) = current_execute_data;
             if (zvp) {
                 return zvp;
-            }
-        } else {
-            int call_args = MIN(EX_NUM_ARGS(), EX(func)->common.num_args);
-            for (int i = 0; i < call_args; ++i) {
-                const char *argname = EX(func)->internal_function.arg_info[i].name;
-                if (zend_binary_strcmp(argname, strlen(argname), name->ptr, name->len) == 0) {
-                    return EX_VAR_NUM(i);
-                }
             }
         }
     }


### PR DESCRIPTION
Arginfo in internal functions is now zend_arg_info instead of zend_internal_arg_info.