### PR TITLE
appsec/zts: fix assertion violations on cfg-related logging

### DIFF
--- a/appsec/src/extension/configuration.c
+++ b/appsec/src/extension/configuration.c
@@ -187,6 +187,7 @@ bool dd_config_minit(int module_number)
     // using the arduous way of accessing the decoded_value directly from
     // zai_config_memoized_entries.
     zai_config_first_time_rinit(false);
+    dd_log_startup_after_cfg();
 #ifdef TESTING
     _register_testing_objects();
 #endif

--- a/appsec/src/extension/ddappsec.c
+++ b/appsec/src/extension/ddappsec.c
@@ -205,11 +205,11 @@ static PHP_MINIT_FUNCTION(ddappsec)
 
     dd_phpobj_startup(module_number);
 
+    dd_log_startup_before_cfg();
+
     if (!dd_config_minit(module_number)) {
         return FAILURE;
     }
-
-    dd_log_startup();
 
 #ifdef TESTING
     _register_testing_objects();

--- a/appsec/src/extension/logging.c
+++ b/appsec/src/extension/logging.c
@@ -38,6 +38,7 @@ __thread char _dd_strerror_buf[1024]; // NOLINT
 const int _dd_size_source_prefix = sizeof(__FILE__) - sizeof("logging.c");
 
 static atomic_bool _initialized;
+bool _dd_log_config_ready;
 // mutex used for two purpose:
 //  * initialization (we do it lazily on first log message, not MINIT)
 //  * avoid two threads writing lines to the log file the same time
@@ -82,14 +83,19 @@ static void _dd_log_errf(const char *format, ...)
     va_end(args);
 }
 
-void dd_log_startup(void)
+void dd_log_startup_before_cfg(void)
 {
 #ifdef ZTS
     _mutex = tsrm_mutex_alloc();
 #endif
 
     _find_strerror_r();
+}
 
+void dd_log_startup_after_cfg(void)
+{
+    _dd_log_config_ready = true;
+    atomic_store_explicit(&_initialized, false, memory_order_release);
 #ifdef TESTING
     _register_testing_objects();
 #endif
@@ -117,7 +123,7 @@ static void _find_strerror_r(void)
 static void _ensure_init(void)
 {
 #ifdef ZTS
-    /* assert: mlog is not called before dd_log_startup */
+    /* assert: dd_log_startup_before_cfg() must precede any mlog call */
     assert(_mutex != NULL);
 #endif
 
@@ -144,6 +150,11 @@ static void _ensure_init(void)
 
 static dd_result _do_dd_log_init(void) // guarded by mutex
 {
+    if (!_dd_log_config_ready) {
+        _log_strategy = log_use_php_err_rep;
+        return dd_success;
+    }
+
     const char *path = ""; // compiler can't tell it's always used initialized
     zend_string *log_file = get_global_DD_APPSEC_LOG_FILE();
 
@@ -493,6 +504,7 @@ void dd_log_shutdown(void)
     _mlog_fd = -1;
     _log_strategy = log_use_nothing;
     atomic_store(&_initialized, false);
+    _dd_log_config_ready = false;
 }
 
 const char *nonnull _strerror_r(int err, char *nonnull buf, size_t buflen)

--- a/appsec/src/extension/logging.h
+++ b/appsec/src/extension/logging.h
@@ -24,6 +24,7 @@ typedef enum {
 
 // these are only in the header to support the macros/inline functions
 extern const int _dd_size_source_prefix;
+extern bool _dd_log_config_ready;
 #ifdef ZTS
 #    define STRERROR_R_BUF_SIZE 1024
 extern __thread char _dd_strerror_buf[STRERROR_R_BUF_SIZE];
@@ -31,11 +32,15 @@ extern __thread char _dd_strerror_buf[STRERROR_R_BUF_SIZE];
 
 static inline dd_log_level_t dd_log_level(void)
 {
+    if (!_dd_log_config_ready) {
+        return dd_log_warning;
+    }
     return (dd_log_level_t)(runtime_config_first_init ? get_DD_APPSEC_LOG_LEVEL()
                                                       : get_global_DD_APPSEC_LOG_LEVEL());
 }
 
-void dd_log_startup(void);
+void dd_log_startup_before_cfg(void);
+void dd_log_startup_after_cfg(void);
 void dd_log_shutdown(void);
 const char *nonnull _strerror_r(int err, char *nonnull buf, size_t buflen);
 


### PR DESCRIPTION
Fixes [APPSEC-62461] and also, to the extent that it's even reachable, the logging statement:

configuration.c:180 — mlog(dd_log_fatal, "Unable to load configuration.")

### Description

<!---
Any description you feel is relevant and gives more background to this PR, if necessary.
-->

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.


[APPSEC-62461]: https://datadoghq.atlassian.net/browse/APPSEC-62461?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ