### PR TITLE
Fix stats computation state accidentally being persisted

### DIFF
--- a/ext/coms.c
+++ b/ext/coms.c
@@ -771,12 +771,6 @@ static struct curl_slist *dd_agent_headers_alloc(void) {
     dd_append_header(&list, "Datadog-Meta-Lang-Interpreter", sapi_module.name, strlen(sapi_module.name));
     dd_append_header(&list, "Datadog-Meta-Lang-Version", php_version_rt.ptr, php_version_rt.len);
     dd_append_header(&list, "Datadog-Meta-Tracer-Version", ZEND_STRL(PHP_DDTRACE_VERSION));
-    if (!get_global_DD_APM_TRACING_ENABLED() || (ddtrace_sidecar_for_signal && get_global_DD_TRACE_STATS_COMPUTATION_ENABLED() && ddog_agent_has_stats_computation())) {
-        dd_append_header(&list, "Datadog-Client-Computed-Stats", ZEND_STRL("true"));
-    }
-    if (ddtrace_sidecar_for_signal && get_global_DD_TRACE_STATS_COMPUTATION_ENABLED()) {
-        dd_append_header(&list, "Datadog-Client-Computed-Top-Level", ZEND_STRL("true"));
-    }
 
     ddog_CharSlice id = ddtrace_get_container_id();
     if (id.len) {
@@ -938,6 +932,12 @@ static void _dd_curl_set_headers(struct _writer_loop_data_t *writer, size_t trac
     struct curl_slist *headers = NULL;
     for (struct curl_slist *current = dd_agent_curl_headers; current; current = current->next) {
         headers = curl_slist_append(headers, current->data);
+    }
+    if (!get_global_DD_APM_TRACING_ENABLED() || (get_global_DD_TRACE_STATS_COMPUTATION_ENABLED() && ddog_agent_has_stats_computation())) {
+        headers = curl_slist_append(headers, "Datadog-Client-Computed-Stats: true");
+    }
+    if (get_global_DD_TRACE_STATS_COMPUTATION_ENABLED()) {
+        headers = curl_slist_append(headers, "Datadog-Client-Computed-Top-Level: true");
     }
     headers = curl_slist_append(headers, "Transfer-Encoding: chunked");
     headers = curl_slist_append(headers, "Content-Type: application/msgpack");


### PR DESCRIPTION
dd_agent_headers_alloc is persistent across all requests - moving to per-request headers fixes this.