### PR TITLE
Propagate session_id via env

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1468,6 +1468,7 @@ dependencies = [
  "libdd-common",
  "libdd-common-ffi",
  "libdd-crashtracker-ffi",
+ "libdd-data-pipeline",
  "libdd-library-config-ffi",
  "libdd-telemetry",
  "libdd-telemetry-ffi",
@@ -2711,7 +2712,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-capabilities"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -2721,7 +2722,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-capabilities-impl"
-version = "0.1.0"
+version = "1.0.0"
 dependencies = [
  "bytes",
  "http",
@@ -2732,7 +2733,7 @@ dependencies = [
 
 [[package]]
 name = "libdd-common"
-version = "3.0.2"
+version = "4.0.0"
 dependencies = [
  "anyhow",
  "bytes",

--- a/Makefile
+++ b/Makefile
@@ -580,6 +580,7 @@ TEST_INTEGRATIONS_70 := \
 	test_integrations_guzzle5 \
 	test_integrations_guzzle6 \
 	test_integrations_pcntl \
+	test_integrations_exec \
 	test_integrations_phpredis3 \
 	test_integrations_phpredis4 \
 	test_integrations_phpredis5 \
@@ -624,6 +625,7 @@ TEST_INTEGRATIONS_71 := \
 	test_integrations_guzzle5 \
 	test_integrations_guzzle6 \
 	test_integrations_pcntl \
+	test_integrations_exec \
 	test_integrations_phpredis3 \
 	test_integrations_phpredis4 \
 	test_integrations_phpredis5 \
@@ -679,6 +681,7 @@ TEST_INTEGRATIONS_72 := \
 	test_integrations_guzzle6 \
 	test_integrations_guzzle_latest \
 	test_integrations_pcntl \
+	test_integrations_exec \
 	test_integrations_phpredis3 \
 	test_integrations_phpredis4 \
 	test_integrations_phpredis5 \
@@ -742,6 +745,7 @@ TEST_INTEGRATIONS_73 :=\
 	test_integrations_guzzle6 \
 	test_integrations_guzzle_latest \
 	test_integrations_pcntl \
+	test_integrations_exec \
 	test_integrations_phpredis3 \
 	test_integrations_phpredis4 \
 	test_integrations_phpredis5 \
@@ -806,6 +810,7 @@ TEST_INTEGRATIONS_74 := \
 	test_integrations_guzzle6 \
 	test_integrations_guzzle_latest \
 	test_integrations_pcntl \
+	test_integrations_exec \
 	test_integrations_phpredis3 \
 	test_integrations_phpredis4 \
 	test_integrations_phpredis5 \
@@ -877,6 +882,7 @@ TEST_INTEGRATIONS_80 := \
 	test_integrations_guzzle6 \
 	test_integrations_guzzle_latest \
 	test_integrations_pcntl \
+	test_integrations_exec \
 	test_integrations_phpredis5 \
 	test_integrations_predis_1 \
 	test_integrations_predis_2 \
@@ -931,6 +937,7 @@ TEST_INTEGRATIONS_81 := \
 	test_integrations_googlespanner_latest \
 	test_integrations_guzzle_latest \
 	test_integrations_pcntl \
+	test_integrations_exec \
 	test_integrations_pdo \
 	test_integrations_elasticsearch7 \
 	test_integrations_elasticsearch8 \
@@ -992,6 +999,7 @@ TEST_INTEGRATIONS_82 := \
 	test_integrations_googlespanner_latest \
 	test_integrations_guzzle_latest \
 	test_integrations_pcntl \
+	test_integrations_exec \
 	test_integrations_pdo \
 	test_integrations_elasticsearch7 \
 	test_integrations_elasticsearch8 \
@@ -1060,6 +1068,7 @@ TEST_INTEGRATIONS_83 := \
 	test_integrations_googlespanner_latest \
 	test_integrations_guzzle_latest \
 	test_integrations_pcntl \
+	test_integrations_exec \
 	test_integrations_pdo \
 	test_integrations_elasticsearch7 \
 	test_integrations_elasticsearch8 \
@@ -1122,6 +1131,7 @@ TEST_INTEGRATIONS_84 := \
 	test_integrations_googlespanner_latest \
 	test_integrations_guzzle_latest \
 	test_integrations_pcntl \
+	test_integrations_exec \
 	test_integrations_pdo \
 	test_integrations_elasticsearch7 \
 	test_integrations_elasticsearch8 \
@@ -1170,6 +1180,7 @@ TEST_INTEGRATIONS_85 := \
 	test_opentelemetry_1 \
 	test_integrations_guzzle_latest \
 	test_integrations_pcntl \
+	test_integrations_exec \
 	test_integrations_pdo \
 	test_integrations_elasticsearch7 \
 	test_integrations_elasticsearch8 \
@@ -1373,6 +1384,8 @@ test_integrations_deferred_loading: global_test_run_dependencies tests/Integrati
 	$(call run_tests_debug,tests/Integrations/DeferredLoading)
 test_integrations_filesystem: global_test_run_dependencies
 	$(call run_tests_debug,tests/Integrations/Filesystem)
+test_integrations_exec: global_test_run_dependencies
+	$(call run_tests_debug,tests/Integrations/Exec)
 test_integrations_curl: global_test_run_dependencies
 	$(call run_tests_debug,tests/Integrations/Curl)
 test_integrations_elasticsearch1: global_test_run_dependencies tests/Integrations/Elasticsearch/V1/composer.lock-php$(PHP_MAJOR_MINOR)

--- a/components-rs/ddtrace.h
+++ b/components-rs/ddtrace.h
@@ -15,6 +15,10 @@ extern ddog_Uuid ddtrace_session_id;
 
 extern uint8_t ddtrace_formatted_session_id[36];
 
+extern uint8_t ddtrace_formatted_root_session_id[36];
+
+extern uint8_t ddtrace_formatted_parent_session_id[36];
+
 extern void (*ddog_log_callback)(ddog_CharSlice);
 
 extern ddog_VecRemoteConfigProduct DDTRACE_REMOTE_CONFIG_PRODUCTS;
@@ -25,7 +29,7 @@ extern const uint8_t *DDOG_PHP_FUNCTION;
 
 /**
  * # Safety
- * Must be called from a single-threaded context, such as MINIT.
+ * Must be called from a single-threaded context, such as MINIT or first rinit.
  */
 void ddtrace_generate_runtime_id(void);
 
@@ -82,6 +86,15 @@ void ddog_apply_agent_info(struct ddog_AgentInfoReader *reader,
                            ddog_CharSlice *container_hash_out);
 
 /**
+ * Serialize the current cached agent info as a JSON string.
+ * Returns NULL if no info has been read yet.
+ * The returned pointer must be freed with `ddog_agent_info_json_free`.
+ */
+char *ddog_agent_info_as_json(struct ddog_AgentInfoReader *reader);
+
+void ddog_agent_info_json_free(char *ptr);
+
+/**
  * Apply concentrator config changes from the agent /info SHM.
  *
  * Cheap no-op when the SHM has not changed (`changed == false`).  Only applies when
@@ -92,9 +105,6 @@ void ddog_apply_agent_info(struct ddog_AgentInfoReader *reader,
  * `reader` must be a valid pointer to an `AgentInfoReader`.
  */
 void ddog_apply_agent_info_concentrator_config(struct ddog_AgentInfoReader *reader);
-
-char *ddog_agent_info_as_json(struct ddog_AgentInfoReader *reader);
-void ddog_agent_info_json_free(char *ptr);
 
 bool ddog_shall_log(enum ddog_Log category);
 
@@ -117,10 +127,18 @@ struct ddog_RemoteConfigState *ddog_init_remote_config_state(const struct ddog_E
 
 const char *ddog_remote_config_get_path(const struct ddog_RemoteConfigState *remote_config);
 
-char *ddog_remote_config_get_loaded_configs(const struct ddog_RemoteConfigState *remote_config);
-void ddog_remote_config_loaded_configs_free(char *ptr);
-
 bool ddog_process_remote_configs(struct ddog_RemoteConfigState *remote_config);
+
+/**
+ * Returns all loaded remote config entries as a JSON object:
+ *   { "config_id": "content_summary", ... }
+ * For live debugger entries the value is the probe ID (or "service_config").
+ * For dynamic config entries the value is "apm_tracing".
+ * The returned pointer must be freed with `ddog_remote_config_loaded_configs_free`.
+ */
+char *ddog_remote_config_get_loaded_configs(const struct ddog_RemoteConfigState *remote_config);
+
+void ddog_remote_config_loaded_configs_free(char *ptr);
 
 bool ddog_type_can_be_instrumented(const struct ddog_RemoteConfigState *remote_config,
                                    ddog_CharSlice typename_);

--- a/components-rs/lib.rs
+++ b/components-rs/lib.rs
@@ -16,7 +16,7 @@ use libdd_common::entity_id::{get_container_id, set_cgroup_file};
 use http::uri::{PathAndQuery, Scheme};
 use http::Uri;
 use std::borrow::Cow;
-use std::ffi::c_char;
+use std::ffi::{c_char, OsStr};
 use std::ptr::null_mut;
 use uuid::Uuid;
 
@@ -40,8 +40,16 @@ pub static mut ddtrace_session_id: Uuid = Uuid::nil();
 #[allow(non_upper_case_globals)]
 pub static mut ddtrace_formatted_session_id: [u8; 36] = [0u8; 36];
 
+#[no_mangle]
+#[allow(non_upper_case_globals)]
+pub static mut ddtrace_formatted_root_session_id: [u8; 36] = [0u8; 36];
+
+#[no_mangle]
+#[allow(non_upper_case_globals)]
+pub static mut ddtrace_formatted_parent_session_id: [u8; 36] = [0u8; 36];
+
 /// # Safety
-/// Must be called from a single-threaded context, such as MINIT.
+/// Must be called from a single-threaded context, such as MINIT or first rinit.
 #[no_mangle]
 pub unsafe extern "C" fn ddtrace_generate_runtime_id() {
     ddtrace_runtime_id = Uuid::new_v4();
@@ -54,6 +62,22 @@ pub unsafe extern "C" fn ddtrace_generate_session_id() {
     ddtrace_session_id = Uuid::new_v4();
     ddtrace_runtime_id = ddtrace_session_id;
     ddtrace_session_id.as_hyphenated().encode_lower(&mut ddtrace_formatted_session_id);
+
+    unsafe fn set(name: &str, value: &mut [u8; 36], force: bool) {
+        if let Ok(str) = std::env::var(name) {
+            let bytes = str.as_bytes();
+            if bytes.len() == 36 {
+                value.copy_from_slice(bytes);
+                if !force {
+                    return;
+                }
+            }
+        }
+        std::env::set_var(name, OsStr::from_encoded_bytes_unchecked(&ddtrace_formatted_session_id));
+    }
+
+    set("_DD_PARENT_PHP_SESSION_ID", &mut ddtrace_formatted_parent_session_id, true);
+    set("_DD_ROOT_PHP_SESSION_ID", &mut ddtrace_formatted_root_session_id, false);
 }
 
 #[no_mangle]

--- a/components-rs/sidecar.h
+++ b/components-rs/sidecar.h
@@ -215,7 +215,9 @@ ddog_MaybeError ddog_sidecar_session_set_config(struct ddog_SidecarTransport **t
                                                 bool is_fork,
                                                 const struct ddog_Vec_Tag *process_tags,
                                                 ddog_CharSlice hostname,
-                                                ddog_CharSlice root_service);
+                                                ddog_CharSlice root_service,
+                                                ddog_CharSlice root_session_id,
+                                                ddog_CharSlice parent_session_id);
 
 /**
  * Updates the process_tags for an existing session.

--- a/ext/hook/uhook.c
+++ b/ext/hook/uhook.c
@@ -985,6 +985,8 @@ ZEND_METHOD(DDTrace_HookData, overrideArguments) {
             ZVAL_NEW_REF(&zv, val);
             Z_DELREF_P(&zv); // we'll copy it right below
             val = &zv;
+        } else if (Z_ISREF_P(val) && !(i < (int)func->common.num_args && func->common.arg_info && (ZEND_ARG_SEND_MODE(&func->common.arg_info[i]) & (ZEND_SEND_BY_REF | ZEND_SEND_PREFER_REF)))) {
+            val = Z_REFVAL_P(val);
         }
 #if PHP_VERSION_ID < 80000
         // While the observer API, triggers immediately after args passing, on PHP 7 the interceptor only triggers after all args have been parsed

--- a/ext/integrations/exec_integration.c
+++ b/ext/integrations/exec_integration.c
@@ -12,6 +12,7 @@
 #include "../compatibility.h"
 #include "../ddtrace.h"
 #include "../span.h"
+#include "../sidecar.h"
 #include "exec_integration_arginfo.h"
 
 #if PHP_VERSION_ID < 80000
@@ -260,6 +261,27 @@ PHP_FUNCTION(DDTrace_Integrations_Exec_proc_get_pid) {
     php_process_handle *proc_h = Z_RES_P(zres)->ptr;
     RETURN_LONG((long)proc_h->child);
 }
+PHP_FUNCTION(DDTrace_Integrations_Exec_proc_inject_session_ids) {
+    zval *env_zv;
+
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+    Z_PARAM_ARRAY_EX(env_zv, 0, 1)
+    ZEND_PARSE_PARAMETERS_END();
+
+    zend_array *env = Z_ARR_P(env_zv);
+
+    zval zv;
+    ZVAL_STRINGL(&zv, (char *)ddtrace_formatted_session_id, sizeof(ddtrace_formatted_session_id));
+    zend_hash_str_update(env, "_DD_PARENT_PHP_SESSION_ID", sizeof("_DD_PARENT_PHP_SESSION_ID") - 1, &zv);
+
+    if (ddtrace_is_empty_session_id(ddtrace_formatted_root_session_id)) {
+        ZVAL_STRINGL(&zv, (char *)ddtrace_formatted_session_id, sizeof(ddtrace_formatted_session_id));
+    } else {
+        ZVAL_STRINGL(&zv, (char *)ddtrace_formatted_root_session_id, sizeof(ddtrace_formatted_root_session_id));
+    }
+    zend_hash_str_update(env, "_DD_ROOT_PHP_SESSION_ID", sizeof("_DD_ROOT_PHP_SESSION_ID") - 1, &zv);
+}
+
 PHP_FUNCTION(DDTrace_Integrations_Exec_test_rshutdown) {
     if (zend_parse_parameters_none() != SUCCESS) {
         return;

--- a/ext/integrations/exec_integration.stub.php
+++ b/ext/integrations/exec_integration.stub.php
@@ -52,6 +52,14 @@ namespace DDTrace\Integrations\Exec {
     function proc_get_pid($proc_h) : ?int {}
 
     /**
+     * Inject _DD_PARENT_PHP_SESSION_ID and _DD_ROOT_PHP_SESSION_ID into an env array for proc_open().
+     *
+     * @internal for use by the exec integration only
+     * @param array $env The environment array passed to proc_open()
+     */
+    function proc_inject_session_ids(array &$env): void {}
+
+    /**
      * Closes the spans associated with live resources opened by popen() and proc_open()
      *
      * @internal for use by the testes of the exec integration only

--- a/ext/integrations/exec_integration_arginfo.h
+++ b/ext/integrations/exec_integration_arginfo.h
@@ -1,5 +1,5 @@
-/* This is a generated file, edit the .stub.php file instead.
- * Stub hash: defedfc462eb97b2649c178fd7b94d880f0d2ea7 */
+/* This is a generated file, edit exec_integration.stub.php instead.
+ * Stub hash: f92693ec69345c95bf956a1fed3b64c5c8981165 */
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_Integrations_Exec_register_stream, 0, 2, _IS_BOOL, 0)
 	ZEND_ARG_INFO(0, stream)
@@ -19,22 +19,26 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_Integrations_Exec_proc_g
 	ZEND_ARG_INFO(0, proc_h)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_Integrations_Exec_test_rshutdown, 0, 0, _IS_BOOL, 0)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_Integrations_Exec_proc_inject_session_ids, 0, 1, IS_VOID, 0)
+	ZEND_ARG_TYPE_INFO(1, env, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_Integrations_Exec_test_rshutdown, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
 
 ZEND_FUNCTION(DDTrace_Integrations_Exec_register_stream);
 ZEND_FUNCTION(DDTrace_Integrations_Exec_proc_assoc_span);
 ZEND_FUNCTION(DDTrace_Integrations_Exec_proc_get_span);
 ZEND_FUNCTION(DDTrace_Integrations_Exec_proc_get_pid);
+ZEND_FUNCTION(DDTrace_Integrations_Exec_proc_inject_session_ids);
 ZEND_FUNCTION(DDTrace_Integrations_Exec_test_rshutdown);
 
-
 static const zend_function_entry ext_functions[] = {
-	ZEND_NS_FALIAS("DDTrace\\Integrations\\Exec", register_stream, DDTrace_Integrations_Exec_register_stream, arginfo_DDTrace_Integrations_Exec_register_stream)
-	ZEND_NS_FALIAS("DDTrace\\Integrations\\Exec", proc_assoc_span, DDTrace_Integrations_Exec_proc_assoc_span, arginfo_DDTrace_Integrations_Exec_proc_assoc_span)
-	ZEND_NS_FALIAS("DDTrace\\Integrations\\Exec", proc_get_span, DDTrace_Integrations_Exec_proc_get_span, arginfo_DDTrace_Integrations_Exec_proc_get_span)
-	ZEND_NS_FALIAS("DDTrace\\Integrations\\Exec", proc_get_pid, DDTrace_Integrations_Exec_proc_get_pid, arginfo_DDTrace_Integrations_Exec_proc_get_pid)
-	ZEND_NS_FALIAS("DDTrace\\Integrations\\Exec", test_rshutdown, DDTrace_Integrations_Exec_test_rshutdown, arginfo_DDTrace_Integrations_Exec_test_rshutdown)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace\\Integrations\\Exec", "register_stream"), zif_DDTrace_Integrations_Exec_register_stream, arginfo_DDTrace_Integrations_Exec_register_stream, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace\\Integrations\\Exec", "proc_assoc_span"), zif_DDTrace_Integrations_Exec_proc_assoc_span, arginfo_DDTrace_Integrations_Exec_proc_assoc_span, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace\\Integrations\\Exec", "proc_get_span"), zif_DDTrace_Integrations_Exec_proc_get_span, arginfo_DDTrace_Integrations_Exec_proc_get_span, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace\\Integrations\\Exec", "proc_get_pid"), zif_DDTrace_Integrations_Exec_proc_get_pid, arginfo_DDTrace_Integrations_Exec_proc_get_pid, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace\\Integrations\\Exec", "proc_inject_session_ids"), zif_DDTrace_Integrations_Exec_proc_inject_session_ids, arginfo_DDTrace_Integrations_Exec_proc_inject_session_ids, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace\\Integrations\\Exec", "test_rshutdown"), zif_DDTrace_Integrations_Exec_test_rshutdown, arginfo_DDTrace_Integrations_Exec_test_rshutdown, 0, NULL, NULL)
 	ZEND_FE_END
 };

--- a/ext/sidecar.c
+++ b/ext/sidecar.c
@@ -78,7 +78,7 @@ static void dd_free_endpoints(void) {
 }
 
 DDTRACE_PUBLIC const uint8_t *ddtrace_get_formatted_session_id(void) {
-    if (memcmp(ddtrace_formatted_session_id, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 36) == 0) {
+    if (ddtrace_is_empty_session_id(ddtrace_formatted_session_id)) {
         return NULL;
     }
     return ddtrace_formatted_session_id;
@@ -102,6 +102,8 @@ DDTRACE_PUBLIC uint64_t ddtrace_get_sidecar_queue_id(void) {
 
 static void dd_sidecar_post_connect(ddog_SidecarTransport **transport, bool is_fork, const char *logpath) {
     ddog_CharSlice session_id = (ddog_CharSlice) {.ptr = (char *) ddtrace_formatted_session_id, .len = sizeof(ddtrace_formatted_session_id)};
+    ddog_CharSlice root_session_id = ddtrace_is_empty_session_id(ddtrace_formatted_root_session_id) ? DDOG_CHARSLICE_C("") : (ddog_CharSlice) {.ptr = (char *) ddtrace_formatted_root_session_id, .len = sizeof(ddtrace_formatted_root_session_id)};
+    ddog_CharSlice parent_session_id = ddtrace_is_empty_session_id(ddtrace_formatted_parent_session_id) ? DDOG_CHARSLICE_C("") : (ddog_CharSlice) {.ptr = (char *) ddtrace_formatted_parent_session_id, .len = sizeof(ddtrace_formatted_parent_session_id)};
     const ddog_Vec_Tag *process_tags = ddtrace_process_tags_get_vec();
     ddog_sidecar_session_set_config(transport, session_id, ddtrace_endpoint, dogstatsd_endpoint,
                                     DDOG_CHARSLICE_C("php"),
@@ -126,7 +128,9 @@ static void dd_sidecar_post_connect(ddog_SidecarTransport **transport, bool is_f
                                     is_fork,
                                     process_tags,
                                     dd_zend_string_to_CharSlice(get_global_DD_HOSTNAME()),
-                                    dd_zend_string_to_CharSlice(get_global_DD_SERVICE())
+                                    dd_zend_string_to_CharSlice(get_global_DD_SERVICE()),
+                                    root_session_id,
+                                    parent_session_id
                                 );
 
     if (get_global_DD_INSTRUMENTATION_TELEMETRY_ENABLED()) {

--- a/ext/sidecar.h
+++ b/ext/sidecar.h
@@ -14,6 +14,10 @@ typedef enum {
     DD_SIDECAR_CONNECTION_THREAD = 2
 } dd_sidecar_active_mode_t;
 
+static inline bool ddtrace_is_empty_session_id(uint8_t id[36]) {
+    return memcmp(id, "\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0", 36) == 0;
+}
+
 // ddtrace_sidecar_instance_id is a process global — one identity per PHP process.
 extern struct ddog_InstanceId *ddtrace_sidecar_instance_id;
 // Best-effort pointer used only by the signal handler (SIGTERM/SIGINT), which cannot call

--- a/src/DDTrace/Integrations/Exec/ExecIntegration.php
+++ b/src/DDTrace/Integrations/Exec/ExecIntegration.php
@@ -51,12 +51,12 @@ class ExecIntegration extends Integration
             'popen',
             self::preHookShell('popen'),
             static function (HookData $hook) {
-                /** @var SpanData $span */
-                $span = $hook->data;
-                if (!$span) {
+                if (!isset($hook->data)) {
                     return;
                 }
 
+                /** @var SpanData $span */
+                $span = $hook->data;
                 if ($hook->exception) {
                     $span->exception = $hook->exception;
                 } elseif (!is_resource($hook->returned)) {
@@ -84,6 +84,11 @@ class ExecIntegration extends Integration
             static function (HookData $hook) {
                 if (count($hook->args) == 0) {
                     return;
+                }
+
+                if (count($hook->args) >= 5 && is_array($hook->args[4])) {
+                    proc_inject_session_ids($hook->args[4]);
+                    $hook->overrideArguments($hook->args);
                 }
 
                 $arg = $hook->args[0];
@@ -205,6 +210,7 @@ class ExecIntegration extends Integration
         'system'     => 1,
         'passthru'   => 1,
         'shell_exec' => null,
+        'popen'      => null,
     ];
 
     private static function preHookShell($variant)
@@ -243,12 +249,12 @@ class ExecIntegration extends Integration
     private static function postHookShell($variant)
     {
         return static function (HookData $hook) use ($variant) {
-            /** @var SpanData $span */
-            $span = $hook->data;
-            if (!$span) {
+            if (!isset($hook->data)) {
                 return;
             }
 
+            /** @var SpanData $span */
+            $span = $hook->data;
             $retCodeArg = self::RET_CODE_ARGNUM[$variant];
 
             if ($hook->exception) {

--- a/tests/Integrations/Exec/ExecIntegrationTest.php
+++ b/tests/Integrations/Exec/ExecIntegrationTest.php
@@ -399,8 +399,10 @@ class ExecIntegrationTest extends IntegrationTestCase
 
             try {
                 $res = self::doShell($sf, $opts);
-            } catch (\PHPUnit\Framework\Error\Warning | \ValueError $w) {
+            } catch (\PHPUnit\Framework\Error\Warning $v) {
                 // ignore warning
+                $res = false;
+            } catch (\ValueError $v) {
                 $res = false;
             }
             $this->assertEquals('', $res);
@@ -423,8 +425,10 @@ class ExecIntegrationTest extends IntegrationTestCase
 
             try {
                 $res = self::doShell($sf, $opts);
-            } catch (\PHPUnit\Framework\Error\Warning | \ValueError $w) {
+            } catch (\PHPUnit\Framework\Error\Warning $v) {
                 // ignore warning
+                $res = false;
+            } catch (\ValueError $v) {
                 $res = false;
             }
             $this->assertEquals('', $res);
@@ -461,8 +465,10 @@ class ExecIntegrationTest extends IntegrationTestCase
 
             try {
                 $res = self::doShell($sf, $opts);
-            } catch (\PHPUnit\Framework\Error\Warning | \ArgumentCountError $w) {
+            } catch (\PHPUnit\Framework\Error\Warning $v) {
                 // ignore warning
+                $res = false;
+            } catch (\ArgumentCountError $v) {
                 $res = false;
             }
             $this->assertEquals('', $res);
@@ -607,7 +613,7 @@ class ExecIntegrationTest extends IntegrationTestCase
         fclose($pipes[1]);
         proc_close($h);
 
-        [$childParent, $childRoot] = explode("\n", $output, 2);
+        list($childParent, $childRoot) = explode("\n", $output, 2);
         $this->assertSame($expectedParent, $childParent);
         $this->assertSame($expectedRoot, $childRoot);
     }
@@ -625,7 +631,7 @@ class ExecIntegrationTest extends IntegrationTestCase
         // without ddtrace overwriting _DD_PARENT_PHP_SESSION_ID with the child's own UUID.
         $output = (string)shell_exec('printf "%s\n%s" "$_DD_PARENT_PHP_SESSION_ID" "$_DD_ROOT_PHP_SESSION_ID"');
 
-        [$childParent, $childRoot] = explode("\n", $output, 2);
+        list($childParent, $childRoot) = explode("\n", $output, 2);
         $this->assertSame($expectedParent, $childParent);
         $this->assertSame($expectedRoot, $childRoot);
     }

--- a/tests/Integrations/Exec/ExecIntegrationTest.php
+++ b/tests/Integrations/Exec/ExecIntegrationTest.php
@@ -580,6 +580,56 @@ class ExecIntegrationTest extends IntegrationTestCase
         );
     }
 
+    public function testProcOpenInjectsSessionIds()
+    {
+        // Verify proc_inject_session_ids directly modifies the env array in place
+        $env = ['EXISTING' => 'preserved'];
+        \DDTrace\Integrations\Exec\proc_inject_session_ids($env);
+        $this->assertArrayHasKey('_DD_PARENT_PHP_SESSION_ID', $env);
+        $this->assertArrayHasKey('_DD_ROOT_PHP_SESSION_ID', $env);
+        $this->assertSame(36, strlen($env['_DD_PARENT_PHP_SESSION_ID']));
+        $this->assertSame(36, strlen($env['_DD_ROOT_PHP_SESSION_ID']));
+        $this->assertSame('preserved', $env['EXISTING']);
+
+        // Values may contain null bytes (zeros for root process); C env vars are
+        // null-terminated, so compute what the child will actually receive.
+        $expectedParent = explode("\0", $env['_DD_PARENT_PHP_SESSION_ID'], 2)[0];
+        $expectedRoot   = explode("\0", $env['_DD_ROOT_PHP_SESSION_ID'], 2)[0];
+
+        // Verify the proc_open hook injects the session IDs into an explicit env array.
+        // Use a plain shell command (no PHP/ddtrace) so env vars are read as-is.
+        $desc = [1 => ['pipe', 'wb']];
+        $h = proc_open(
+            'printf "%s\n%s" "$_DD_PARENT_PHP_SESSION_ID" "$_DD_ROOT_PHP_SESSION_ID"',
+            $desc, $pipes, null, ['PATH' => '/usr/bin:/bin']
+        );
+        $output = stream_get_contents($pipes[1]);
+        fclose($pipes[1]);
+        proc_close($h);
+
+        [$childParent, $childRoot] = explode("\n", $output, 2);
+        $this->assertSame($expectedParent, $childParent);
+        $this->assertSame($expectedRoot, $childRoot);
+    }
+
+    public function testShellExecInheritsSessionIds()
+    {
+        // For shell functions (no explicit env), subprocesses inherit the process
+        // environment. ddtrace_generate_session_id() sets _DD_PARENT_PHP_SESSION_ID
+        // and _DD_ROOT_PHP_SESSION_ID in the process env at startup, so they are
+        // always available to child processes without any extra injection.
+        $expectedParent = (string)getenv('_DD_PARENT_PHP_SESSION_ID');
+        $expectedRoot   = (string)getenv('_DD_ROOT_PHP_SESSION_ID');
+
+        // Use a plain shell command (no PHP/ddtrace) so env vars are read as inherited,
+        // without ddtrace overwriting _DD_PARENT_PHP_SESSION_ID with the child's own UUID.
+        $output = (string)shell_exec('printf "%s\n%s" "$_DD_PARENT_PHP_SESSION_ID" "$_DD_ROOT_PHP_SESSION_ID"');
+
+        [$childParent, $childRoot] = explode("\n", $output, 2);
+        $this->assertSame($expectedParent, $childParent);
+        $this->assertSame($expectedRoot, $childRoot);
+    }
+
     private static function doShell($function, array &$opts = [])
     {
         $cmdVariant = $opts['cmd_variant'] ?? 'normal';


### PR DESCRIPTION
Fix sending reference args to non-by-ref args and actually run exec integration in CI.