### PR TITLE
fix: crashtracker runtime stack infinite loop

### DIFF
--- a/ext/crashtracking_frames.c
+++ b/ext/crashtracking_frames.c
@@ -95,6 +95,7 @@ static void dd_frames_callback(void (*emit_frame)(const ddog_crasht_RuntimeStack
             if (!zai_is_mapped(opline, sizeof(zend_op))) {
                 frame.column = -1;
                 EMIT(&frame);
+                call = call->prev_execute_data;
                 continue;
             }
 

--- a/ext/crashtracking_frames.c
+++ b/ext/crashtracking_frames.c
@@ -93,7 +93,7 @@ static void dd_frames_callback(void (*emit_frame)(const ddog_crasht_RuntimeStack
 
             const zend_op *opline = call->opline;
             if (!zai_is_mapped(opline, sizeof(zend_op))) {
-                frame.column = -1;
+                frame.column = 0;
                 EMIT(&frame);
                 call = call->prev_execute_data;
                 continue;
@@ -105,7 +105,7 @@ static void dd_frames_callback(void (*emit_frame)(const ddog_crasht_RuntimeStack
                     if (zai_is_mapped(op, sizeof(zend_op))) {
                         frame.line = op->lineno;
                     } else {
-                        frame.column = -2;
+                        frame.column = 0;
                     }
                 } else {
                     frame.line = func->op_array.line_end;

--- a/ext/crashtracking_frames.c
+++ b/ext/crashtracking_frames.c
@@ -93,7 +93,7 @@ static void dd_frames_callback(void (*emit_frame)(const ddog_crasht_RuntimeStack
 
             const zend_op *opline = call->opline;
             if (!zai_is_mapped(opline, sizeof(zend_op))) {
-                frame.column = 0;
+                frame.column = -1;
                 EMIT(&frame);
                 call = call->prev_execute_data;
                 continue;
@@ -105,7 +105,7 @@ static void dd_frames_callback(void (*emit_frame)(const ddog_crasht_RuntimeStack
                     if (zai_is_mapped(op, sizeof(zend_op))) {
                         frame.line = op->lineno;
                     } else {
-                        frame.column = 0;
+                        frame.column = -2;
                     }
                 } else {
                     frame.line = func->op_array.line_end;


### PR DESCRIPTION
### Description

There was a crash report with the runtime stack unwinding infinite looping: https://app.datadoghq.com/logs?query=-%40org_id%3A603589%20%40error.is_crash%3Atrue%20%40org_id%3A1000626888&agg_m=count&agg_m_source=base&agg_t=count&clustering_pattern_field_path=message&cols=host%2Cservice%2C%40org_id&event=AwAAAZ3U6zFHIybQJAAAABhBWjNVNnpGSEFBQVF1X283ZzRmcEh3QUEAAAAkMDE5ZGQ0ZWUtNTMzNC00Mzk4LTliNzktOGU5YTQ5NjZhZDhjAANM0A&fromUser=true&index=instrumentation-telemetry-data&link_source=monitor_notif&messageDisplay=inline&refresh_mode=sliding&storage=flex_tier&stream_sort=desc&viz=stream&from_ts=1747059580431&to_ts=1747145980431&live=true

Here is what the raw stack looks like

```
    [
           {
              "column": 4294967295,
              "file": "some-repeated-file-name.php",
              "function": "someRepeatedFunc",
              "line": 157,
              "type_name": "<corrupted scope>"
            },
            {
              "column": 4294967295,
              "file": "some-repeated-file-name.php",
              "function": "someRepeatedFunc",
              "line": 157,
              "type_name": "<corrupted scope>"
            },
            {
              "column": 4294967295,
              "file": "some-repeated-file-name.php",
              "function": "someRepeatedFunc",
              "line": 157,
              "type_name": "<corrupted scope>"
            },
            ....
            {
              "column": 4294967295,
              "file": "some-repeated-file-name.php",
              "function": "someRepeatedFunc",
              "line": 157,
              "type_name": "<corrupted scope>"
            },
            {
              "column": 4294967295,
              "file": "some-repeated-file-name.php",
              "function": "someRepeatedFunc",
              "line": 157,
              "type_name": "<corrupted scope>"
            }
          ]
```
          
          
Couple of things here. 
1. `type_name` is `corrupted scope'
    - this means that this line:
 ```
 frame.type_name = func->common.scope ? zai_is_mapped(&func->common.scope->name, sizeof(zend_string *)) ? dd_validate_zstr(func->common.scope->name) : DDOG_CHARSLICE_C("<corrupted scope>") : DDOG_CHARSLICE_C("");
```
   triggered

2. The column number is 4294967295. This is unrealistic. The reason this is so is because its `-1` in `uint32`.  2^32-1 = 4294967295

Then, this points to this section of code
```
if (!zai_is_mapped(opline, sizeof(zend_op))) {
                frame.column = -1;
                EMIT(&frame);
                continue;
            }
```
being the culprit. `frame.column` is set to -1, and the frame does not proceed, since we don't perform `call = call->prev_execute_data;`

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
