### PR TITLE
fix(ci): add composer audit block-insecure=false to Drupal 10.1 test fixture

### DIFF
--- a/tests/Frameworks/Drupal/Version_10_1/composer.json
+++ b/tests/Frameworks/Drupal/Version_10_1/composer.json
@@ -61,6 +61,9 @@
             "drupal/core-vendor-hardening": true,
             "phpstan/extension-installer": true,
             "dealerdirect/phpcodesniffer-composer-installer": true
+        },
+        "audit": {
+            "block-insecure": false
         }
     },
     "extra": {


### PR DESCRIPTION
## Summary

- The tracer version bump to 1.19.0 collides with `drupal/core 1.19.0` on Packagist, which is flagged by security advisories SA-CORE-2023-004 and SA-CORE-2023-005
- Composer 2.4+ blocks installation by default when a package version matches a security advisory — Drupal never installs, and all span assertions fail with "received 1 span, expected N"
- `Version_8_9` and `Version_9_5` fixtures already have `"audit": {"block-insecure": false}`; `Version_10_1` was missing it
- This broke all 6 × 6 = 36 `test_web_drupal_101` job instances across every master pipeline in the last 24h