### PR TITLE
Fix catastrophic backtracking in PDO integration

### DIFF
--- a/src/DDTrace/Integrations/PDO/PDOIntegration.php
+++ b/src/DDTrace/Integrations/PDO/PDOIntegration.php
@@ -359,7 +359,13 @@ REGEX;
 
     public static function useQuestionMarkPlaceholders($query)
     {
+        // Avoid 
+        if (\strlen($query) > 10000) {
+            return $query;
+        }
+
         // Regex according to rules from pdo_sql_parser.re
-        return \preg_replace('((?:/\*([^*]++|\*++[^/])*\*/(*COMMIT)|--.*(*SKIP)(*F)|"(?:""|[^"]++)*"(*COMMIT)|\'(?:\'\'|[^\']++)*\'(*COMMIT)|[^/:\'"-]++|.)*?\K:[a-zA-Z0-9_]+)s', "?", $query);
+        // This \Z(*COMMIT) prevents catastrophic backtracking after the last match
+        return \preg_replace('((?:[^/:\'"-]++|/\*(*COMMIT)([^*]++|\*++[^/])*+\*/|--.*+(*SKIP)(*F)|"(*COMMIT)(?:""|[^"]++)*+"|\'(*COMMIT)(?:\'\'|[^\']++)*+\'|.|\Z(*COMMIT))+?\K:[a-zA-Z0-9_]+)s', "?", $query);
     }
 }


### PR DESCRIPTION
And limit query size for normalization processing to avoid unnecessary overhead on our side.

Fixes #3846.