### PR TITLE
fix(ci): patch run-tests.php getTimer() to return float instead of comma-formatted string

### DIFF
--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -232,7 +232,7 @@ foreach ($asan_minor_major_targets as $major_minor):
       artifacts: true
   retry: 2
   variables:
-    WAIT_FOR: test-agent:9126
+    WAIT_FOR: test-agent:9126 request-replayer:80
     KUBERNETES_CPU_REQUEST: 6
     KUBERNETES_CPU_LIMIT: 6
     KUBERNETES_MEMORY_REQUEST: 4Gi
@@ -305,7 +305,7 @@ foreach ($asan_minor_major_targets as $major_minor):
             ARCH: "amd64"
       artifacts: true
   variables:
-    WAIT_FOR: test-agent:9126
+    WAIT_FOR: test-agent:9126 request-replayer:80
     KUBERNETES_CPU_REQUEST: 12
     MAX_TEST_PARALLELISM: 4
     PHP_MAJOR_MINOR: "<?= $major_minor ?>"
@@ -360,7 +360,7 @@ foreach ($all_minor_major_targets as $major_minor):
             ARCH: "amd64"
       artifacts: true
   variables:
-    WAIT_FOR: test-agent:9126
+    WAIT_FOR: test-agent:9126 request-replayer:80
     KUBERNETES_CPU_REQUEST: 12
     MAX_TEST_PARALLELISM: 4
     PHP_MAJOR_MINOR: "<?= $major_minor ?>"

--- a/.gitlab/wait-for-service-ready.sh
+++ b/.gitlab/wait-for-service-ready.sh
@@ -40,8 +40,9 @@ wait_for_single_service() {
         fi
         ;;
       request-replayer)
-        # /replay is read-only and always returns valid JSON when the PHP server is up
-        if curl -sf "http://${HOST}:${PORT}/replay" > /dev/null 2>&1; then
+        # Any HTTP response (2xx/3xx/4xx/5xx) proves php -S is up and executing index.php.
+        # /replay may return 4xx when no data has been dumped yet, so do not use -f.
+        if curl -s -o /dev/null "http://${HOST}:${PORT}/replay"; then
           echo "request-replayer is ready"
           return 0
         fi

--- a/.gitlab/wait-for-service-ready.sh
+++ b/.gitlab/wait-for-service-ready.sh
@@ -6,6 +6,7 @@ detect_service_type() {
   local host=${1}
   case ${host} in
     test-agent) echo "test-agent" ;;
+    request-replayer) echo "request-replayer" ;;
     mysql-integration) echo "mysql" ;;
     elasticsearch*) echo "elasticsearch" ;;
     zookeeper*) echo "zookeeper" ;;
@@ -35,6 +36,13 @@ wait_for_single_service() {
       test-agent)
         if curl -sf "http://${HOST}:${PORT}/info" > /dev/null 2>&1; then
           echo "Test agent is ready"
+          return 0
+        fi
+        ;;
+      request-replayer)
+        # /replay is read-only and always returns valid JSON when the PHP server is up
+        if curl -sf "http://${HOST}:${PORT}/replay" > /dev/null 2>&1; then
+          echo "request-replayer is ready"
           return 0
         fi
         ;;

--- a/Makefile
+++ b/Makefile
@@ -211,7 +211,8 @@ test_extension_ci: $(SO_FILE) $(TEST_FILES) $(TEST_STUB_FILES) $(BUILD_DIR)/run-
 	\
 	export TEST_PHP_JUNIT=$(JUNIT_RESULTS_DIR)/valgrind-extension-test.xml; \
 	export TEST_PHP_OUTPUT=$(JUNIT_RESULTS_DIR)/valgrind-run-tests.out; \
-	DD_SPAWN_WORKER_STABLE_TRAMPOLINE=1 $(ALL_TEST_ENV_OVERRIDE) $(RUN_TESTS_CMD) -d extension=$(SO_FILE) -m -s $$TEST_PHP_OUTPUT $(BUILD_DIR)/$(TESTS) && ! grep -e '^LEAKED TEST SUMMARY' $$TEST_PHP_OUTPUT; \
+	SHOW_SLOW=$$(php -r 'echo PHP_VERSION_ID >= 70200 ? "--show-slow 10000" : "";'); \
+	DD_SPAWN_WORKER_STABLE_TRAMPOLINE=1 $(ALL_TEST_ENV_OVERRIDE) $(RUN_TESTS_CMD) $$SHOW_SLOW -d extension=$(SO_FILE) -m -s $$TEST_PHP_OUTPUT $(BUILD_DIR)/$(TESTS) && ! grep -e '^LEAKED TEST SUMMARY' $$TEST_PHP_OUTPUT; \
 	)
 
 build_tea: TEA_BUILD_TESTS=ON

--- a/Makefile
+++ b/Makefile
@@ -112,6 +112,7 @@ $(BUILD_DIR)/configure: $(M4_FILES) $(BUILD_DIR)/datadog.sym $(BUILD_DIR)/VERSIO
 $(BUILD_DIR)/run-tests.php: $(if $(ASSUME_COMPILED),, $(BUILD_DIR)/configure)
 	$(if $(ASSUME_COMPILED), cp $(shell dirname $(shell realpath $(shell which phpize)))/../lib/php/build/run-tests.php $(BUILD_DIR)/run-tests.php)
 	sed -i 's/\bdl(/(bool)(/' $(BUILD_DIR)/run-tests.php # this dl() stuff in run-tests.php is for --EXTENSIONS-- sections, which we don't use; just strip it away (see https://github.com/php/php-src/issues/15367)
+	sed -i 's/return number_format($$this->rootSuite/return round($$this->rootSuite/' $(BUILD_DIR)/run-tests.php # number_format returns a comma-formatted string for elapsed >= 1000s (e.g. "1,500.0000"), which is non-numeric and triggers E_WARNING in PHP 8.0+ when used in += arithmetic inside record()
 
 # ensure list of rust files is up to date
 $(BUILD_DIR)/.rust_files_list: $(RUST_FILES)

--- a/Makefile
+++ b/Makefile
@@ -212,7 +212,7 @@ test_extension_ci: $(SO_FILE) $(TEST_FILES) $(TEST_STUB_FILES) $(BUILD_DIR)/run-
 	\
 	export TEST_PHP_JUNIT=$(JUNIT_RESULTS_DIR)/valgrind-extension-test.xml; \
 	export TEST_PHP_OUTPUT=$(JUNIT_RESULTS_DIR)/valgrind-run-tests.out; \
-	SHOW_SLOW=$$(php -r 'echo PHP_VERSION_ID >= 70200 ? "--show-slow 10000" : "";'); \
+	SHOW_SLOW=$$(php -r 'echo PHP_VERSION_ID >= 70200 ? "--show-slow 30000" : "";'); \
 	DD_SPAWN_WORKER_STABLE_TRAMPOLINE=1 $(ALL_TEST_ENV_OVERRIDE) $(RUN_TESTS_CMD) $$SHOW_SLOW -d extension=$(SO_FILE) -m -s $$TEST_PHP_OUTPUT $(BUILD_DIR)/$(TESTS) && ! grep -e '^LEAKED TEST SUMMARY' $$TEST_PHP_OUTPUT; \
 	)
 

--- a/tests/ext/includes/request_replayer.inc
+++ b/tests/ext/includes/request_replayer.inc
@@ -200,25 +200,60 @@ class RequestReplayer
      * cross-checks against the same endpoint without the token, so we can tell if
      * the data we were waiting for landed in a different session bucket.
      */
+    /**
+     * Summarise a JSON-decoded /replay response by URI to spot data that's there
+     * but filtered out by the test's logic (e.g. telemetry vs trace).
+     */
+    private static function summariseUris($body)
+    {
+        if (!is_string($body) || $body === '') {
+            return '(empty body)';
+        }
+        $decoded = json_decode($body, true);
+        if (!is_array($decoded)) {
+            return '(non-array body)';
+        }
+        if (count($decoded) === 0) {
+            return '(empty array)';
+        }
+        $counts = [];
+        foreach ($decoded as $entry) {
+            $uri = is_array($entry) && isset($entry['uri']) ? $entry['uri'] : '(no uri)';
+            $counts[$uri] = ($counts[$uri] ?? 0) + 1;
+        }
+        ksort($counts);
+        $parts = [];
+        foreach ($counts as $u => $c) {
+            $parts[] = "$u=$c";
+        }
+        return implode(', ', $parts);
+    }
+
     private function diagnosticDump($path, $caller, $attempts, $elapsed = null)
     {
         $token = ini_get("datadog.trace.agent_test_session_token");
         $url = $this->endpoint . $path;
 
+        $t0 = microtime(true);
         $bodyToken = @file_get_contents($url, false, stream_context_create([
             "http" => ["header" => "X-Datadog-Test-Session-Token: $token"],
         ]));
+        $tTokenMs = (microtime(true) - $t0) * 1000;
         $statusToken = self::parseStatus($http_response_header ?? null);
         $lenToken = is_string($bodyToken) ? strlen($bodyToken) : -1;
+        $urisToken = self::summariseUris($bodyToken);
 
+        $t1 = microtime(true);
         $bodyNoToken = @file_get_contents($url, false, stream_context_create([]));
+        $tNoTokenMs = (microtime(true) - $t1) * 1000;
         $statusNoToken = self::parseStatus($http_response_header ?? null);
         $lenNoToken = is_string($bodyNoToken) ? strlen($bodyNoToken) : -1;
 
         $elapsedStr = $elapsed !== null ? sprintf(" elapsed=%.2fs", $elapsed) : "";
         echo "[RR-DIAG] $caller timeout after $attempts attempts$elapsedStr; token=" . var_export($token, true) . "\n";
-        echo "[RR-DIAG]   $path with token:    status=" . var_export($statusToken, true) . " body_len=$lenToken\n";
-        echo "[RR-DIAG]   $path without token: status=" . var_export($statusNoToken, true) . " body_len=$lenNoToken\n";
+        echo "[RR-DIAG]   $path with token:    status=" . var_export($statusToken, true) . " body_len=$lenToken fetch_ms=" . round($tTokenMs, 1) . "\n";
+        echo "[RR-DIAG]   $path with token uris: $urisToken\n";
+        echo "[RR-DIAG]   $path without token: status=" . var_export($statusNoToken, true) . " body_len=$lenNoToken fetch_ms=" . round($tNoTokenMs, 1) . "\n";
     }
 
     public function clearDumpedData()

--- a/tests/ext/includes/request_replayer.inc
+++ b/tests/ext/includes/request_replayer.inc
@@ -57,6 +57,7 @@ class RequestReplayer
         $i = 0;
         do {
             if ($i++ == $this->maxIteration) {
+                $this->diagnosticDump('/replay', 'waitForRequest', $i - 1);
                 throw new Exception("wait for replay timeout");
             }
             usleep($this->flushInterval);
@@ -77,6 +78,7 @@ class RequestReplayer
         $i = 0;
         do {
             if ($i++ == $this->maxIteration) {
+                $this->diagnosticDump('/replay-rc-requests', 'waitForRcRequest', $i - 1);
                 throw new Exception("wait for replay timeout");
             }
             usleep($this->flushInterval);
@@ -97,6 +99,7 @@ class RequestReplayer
         $i = 0;
         do {
             if ($i++ == $this->maxIteration) {
+                $this->diagnosticDump('/replay', 'waitForDataAndReplay', $i - 1);
                 throw new Exception("wait for replay timeout");
             }
             usleep($this->flushInterval);
@@ -117,7 +120,7 @@ class RequestReplayer
 
     public function replayAllRequests()
     {
-        return json_decode(file_get_contents($this->endpoint . '/replay', false, stream_context_create([
+        return json_decode(@file_get_contents($this->endpoint . '/replay', false, stream_context_create([
             "http" => [
                 "header" => "X-Datadog-Test-Session-Token: " . ini_get("datadog.trace.agent_test_session_token"),
             ],
@@ -126,7 +129,7 @@ class RequestReplayer
 
     public function replayAllStats()
     {
-        return json_decode(file_get_contents($this->endpoint . '/replay-stats', false, stream_context_create([
+        return json_decode(@file_get_contents($this->endpoint . '/replay-stats', false, stream_context_create([
             "http" => [
                 "header" => "X-Datadog-Test-Session-Token: " . ini_get("datadog.trace.agent_test_session_token"),
             ],
@@ -138,6 +141,7 @@ class RequestReplayer
         $i = 0;
         do {
             if ($i++ == $this->maxIteration) {
+                $this->diagnosticDump('/replay-stats', 'waitForStats', $i - 1);
                 throw new Exception("wait for stats timeout");
             }
             usleep($this->flushInterval);
@@ -154,11 +158,49 @@ class RequestReplayer
 
     public function replayAllRcRequests()
     {
-        return json_decode(file_get_contents($this->endpoint . '/replay-rc-requests', false, stream_context_create([
+        return json_decode(@file_get_contents($this->endpoint . '/replay-rc-requests', false, stream_context_create([
             "http" => [
                 "header" => "X-Datadog-Test-Session-Token: " . ini_get("datadog.trace.agent_test_session_token"),
             ],
         ])), true);
+    }
+
+    /**
+     * Parse the HTTP status code from the magic $http_response_header array.
+     * Returns null if the array is empty (e.g. connection refused / timeout / DNS fail).
+     */
+    private static function parseStatus($headers)
+    {
+        if (is_array($headers) && !empty($headers) && preg_match('#HTTP/\S+\s+(\d+)#', $headers[0], $m)) {
+            return (int)$m[1];
+        }
+        return null;
+    }
+
+    /**
+     * Emit a diagnostic dump to stdout when a wait-loop times out. Captures the
+     * HTTP status code returned by the replayer for the test's session token, then
+     * cross-checks against the same endpoint without the token, so we can tell if
+     * the data we were waiting for landed in a different session bucket.
+     */
+    private function diagnosticDump($path, $caller, $attempts)
+    {
+        $token = ini_get("datadog.trace.agent_test_session_token");
+        $url = $this->endpoint . $path;
+
+        $bodyToken = @file_get_contents($url, false, stream_context_create([
+            "http" => ["header" => "X-Datadog-Test-Session-Token: $token"],
+        ]));
+        $statusToken = self::parseStatus($http_response_header ?? null);
+        $lenToken = is_string($bodyToken) ? strlen($bodyToken) : -1;
+
+        $bodyNoToken = @file_get_contents($url, false, stream_context_create([]));
+        $statusNoToken = self::parseStatus($http_response_header ?? null);
+        $lenNoToken = is_string($bodyNoToken) ? strlen($bodyNoToken) : -1;
+
+        echo "[RR-DIAG] $caller timeout after $attempts attempts; token=" . var_export($token, true) . "\n";
+        echo "[RR-DIAG]   $path with token:    status=" . var_export($statusToken, true) . " body_len=$lenToken\n";
+        echo "[RR-DIAG]   $path without token: status=" . var_export($statusNoToken, true) . " body_len=$lenNoToken\n";
     }
 
     public function clearDumpedData()

--- a/tests/ext/includes/request_replayer.inc
+++ b/tests/ext/includes/request_replayer.inc
@@ -66,9 +66,7 @@ class RequestReplayer
         $i = 0;
         $start = microtime(true);
         do {
-            $elapsed = microtime(true) - $start;
-            if ($i++ == $this->maxIteration || $elapsed > $this->maxWallTimeSeconds) {
-                $this->diagnosticDump('/replay', 'waitForRequest', $i - 1, $elapsed);
+            if ($i++ == $this->maxIteration || microtime(true) - $start > $this->maxWallTimeSeconds) {
                 throw new Exception("wait for replay timeout");
             }
             usleep($this->flushInterval);
@@ -89,9 +87,7 @@ class RequestReplayer
         $i = 0;
         $start = microtime(true);
         do {
-            $elapsed = microtime(true) - $start;
-            if ($i++ == $this->maxIteration || $elapsed > $this->maxWallTimeSeconds) {
-                $this->diagnosticDump('/replay-rc-requests', 'waitForRcRequest', $i - 1, $elapsed);
+            if ($i++ == $this->maxIteration || microtime(true) - $start > $this->maxWallTimeSeconds) {
                 throw new Exception("wait for replay timeout");
             }
             usleep($this->flushInterval);
@@ -112,9 +108,7 @@ class RequestReplayer
         $i = 0;
         $start = microtime(true);
         do {
-            $elapsed = microtime(true) - $start;
-            if ($i++ == $this->maxIteration || $elapsed > $this->maxWallTimeSeconds) {
-                $this->diagnosticDump('/replay', 'waitForDataAndReplay', $i - 1, $elapsed);
+            if ($i++ == $this->maxIteration || microtime(true) - $start > $this->maxWallTimeSeconds) {
                 throw new Exception("wait for replay timeout");
             }
             usleep($this->flushInterval);
@@ -156,9 +150,7 @@ class RequestReplayer
         $i = 0;
         $start = microtime(true);
         do {
-            $elapsed = microtime(true) - $start;
-            if ($i++ == $this->maxIteration || $elapsed > $this->maxWallTimeSeconds) {
-                $this->diagnosticDump('/replay-stats', 'waitForStats', $i - 1, $elapsed);
+            if ($i++ == $this->maxIteration || microtime(true) - $start > $this->maxWallTimeSeconds) {
                 throw new Exception("wait for stats timeout");
             }
             usleep($this->flushInterval);
@@ -180,80 +172,6 @@ class RequestReplayer
                 "header" => "X-Datadog-Test-Session-Token: " . ini_get("datadog.trace.agent_test_session_token"),
             ],
         ])), true);
-    }
-
-    /**
-     * Parse the HTTP status code from the magic $http_response_header array.
-     * Returns null if the array is empty (e.g. connection refused / timeout / DNS fail).
-     */
-    private static function parseStatus($headers)
-    {
-        if (is_array($headers) && !empty($headers) && preg_match('#HTTP/\S+\s+(\d+)#', $headers[0], $m)) {
-            return (int)$m[1];
-        }
-        return null;
-    }
-
-    /**
-     * Emit a diagnostic dump to stdout when a wait-loop times out. Captures the
-     * HTTP status code returned by the replayer for the test's session token, then
-     * cross-checks against the same endpoint without the token, so we can tell if
-     * the data we were waiting for landed in a different session bucket.
-     */
-    /**
-     * Summarise a JSON-decoded /replay response by URI to spot data that's there
-     * but filtered out by the test's logic (e.g. telemetry vs trace).
-     */
-    private static function summariseUris($body)
-    {
-        if (!is_string($body) || $body === '') {
-            return '(empty body)';
-        }
-        $decoded = json_decode($body, true);
-        if (!is_array($decoded)) {
-            return '(non-array body)';
-        }
-        if (count($decoded) === 0) {
-            return '(empty array)';
-        }
-        $counts = [];
-        foreach ($decoded as $entry) {
-            $uri = is_array($entry) && isset($entry['uri']) ? $entry['uri'] : '(no uri)';
-            $counts[$uri] = ($counts[$uri] ?? 0) + 1;
-        }
-        ksort($counts);
-        $parts = [];
-        foreach ($counts as $u => $c) {
-            $parts[] = "$u=$c";
-        }
-        return implode(', ', $parts);
-    }
-
-    private function diagnosticDump($path, $caller, $attempts, $elapsed = null)
-    {
-        $token = ini_get("datadog.trace.agent_test_session_token");
-        $url = $this->endpoint . $path;
-
-        $t0 = microtime(true);
-        $bodyToken = @file_get_contents($url, false, stream_context_create([
-            "http" => ["header" => "X-Datadog-Test-Session-Token: $token"],
-        ]));
-        $tTokenMs = (microtime(true) - $t0) * 1000;
-        $statusToken = self::parseStatus($http_response_header ?? null);
-        $lenToken = is_string($bodyToken) ? strlen($bodyToken) : -1;
-        $urisToken = self::summariseUris($bodyToken);
-
-        $t1 = microtime(true);
-        $bodyNoToken = @file_get_contents($url, false, stream_context_create([]));
-        $tNoTokenMs = (microtime(true) - $t1) * 1000;
-        $statusNoToken = self::parseStatus($http_response_header ?? null);
-        $lenNoToken = is_string($bodyNoToken) ? strlen($bodyNoToken) : -1;
-
-        $elapsedStr = $elapsed !== null ? sprintf(" elapsed=%.2fs", $elapsed) : "";
-        echo "[RR-DIAG] $caller timeout after $attempts attempts$elapsedStr; token=" . var_export($token, true) . "\n";
-        echo "[RR-DIAG]   $path with token:    status=" . var_export($statusToken, true) . " body_len=$lenToken fetch_ms=" . round($tTokenMs, 1) . "\n";
-        echo "[RR-DIAG]   $path with token uris: $urisToken\n";
-        echo "[RR-DIAG]   $path without token: status=" . var_export($statusNoToken, true) . " body_len=$lenNoToken fetch_ms=" . round($tNoTokenMs, 1) . "\n";
     }
 
     public function clearDumpedData()

--- a/tests/ext/includes/request_replayer.inc
+++ b/tests/ext/includes/request_replayer.inc
@@ -32,6 +32,14 @@ class RequestReplayer
      */
     public $maxIteration;
 
+    /**
+     * @var float Wall-clock seconds before a wait loop gives up and emits diagnostic.
+     * Iteration-count alone is unreliable under valgrind where each iteration takes
+     * 10-20x longer than nominal; without a wall-clock cap the process is killed by
+     * run-tests.php's external per-test timeout before our diagnostic can fire.
+     */
+    public $maxWallTimeSeconds;
+
     public function __construct()
     {
         $this->endpoint = sprintf(
@@ -45,6 +53,7 @@ class RequestReplayer
             : 50000;
 
         $this->maxIteration = 500;
+        $this->maxWallTimeSeconds = 60.0;
     }
 
     public function waitForFlush()
@@ -55,9 +64,11 @@ class RequestReplayer
     public function waitForRequest($matcher)
     {
         $i = 0;
+        $start = microtime(true);
         do {
-            if ($i++ == $this->maxIteration) {
-                $this->diagnosticDump('/replay', 'waitForRequest', $i - 1);
+            $elapsed = microtime(true) - $start;
+            if ($i++ == $this->maxIteration || $elapsed > $this->maxWallTimeSeconds) {
+                $this->diagnosticDump('/replay', 'waitForRequest', $i - 1, $elapsed);
                 throw new Exception("wait for replay timeout");
             }
             usleep($this->flushInterval);
@@ -76,9 +87,11 @@ class RequestReplayer
     public function waitForRcRequest($matcher)
     {
         $i = 0;
+        $start = microtime(true);
         do {
-            if ($i++ == $this->maxIteration) {
-                $this->diagnosticDump('/replay-rc-requests', 'waitForRcRequest', $i - 1);
+            $elapsed = microtime(true) - $start;
+            if ($i++ == $this->maxIteration || $elapsed > $this->maxWallTimeSeconds) {
+                $this->diagnosticDump('/replay-rc-requests', 'waitForRcRequest', $i - 1, $elapsed);
                 throw new Exception("wait for replay timeout");
             }
             usleep($this->flushInterval);
@@ -97,9 +110,11 @@ class RequestReplayer
     public function waitForDataAndReplay($ignoreTelemetry = true)
     {
         $i = 0;
+        $start = microtime(true);
         do {
-            if ($i++ == $this->maxIteration) {
-                $this->diagnosticDump('/replay', 'waitForDataAndReplay', $i - 1);
+            $elapsed = microtime(true) - $start;
+            if ($i++ == $this->maxIteration || $elapsed > $this->maxWallTimeSeconds) {
+                $this->diagnosticDump('/replay', 'waitForDataAndReplay', $i - 1, $elapsed);
                 throw new Exception("wait for replay timeout");
             }
             usleep($this->flushInterval);
@@ -139,9 +154,11 @@ class RequestReplayer
     public function waitForStats($matcher = null)
     {
         $i = 0;
+        $start = microtime(true);
         do {
-            if ($i++ == $this->maxIteration) {
-                $this->diagnosticDump('/replay-stats', 'waitForStats', $i - 1);
+            $elapsed = microtime(true) - $start;
+            if ($i++ == $this->maxIteration || $elapsed > $this->maxWallTimeSeconds) {
+                $this->diagnosticDump('/replay-stats', 'waitForStats', $i - 1, $elapsed);
                 throw new Exception("wait for stats timeout");
             }
             usleep($this->flushInterval);
@@ -183,7 +200,7 @@ class RequestReplayer
      * cross-checks against the same endpoint without the token, so we can tell if
      * the data we were waiting for landed in a different session bucket.
      */
-    private function diagnosticDump($path, $caller, $attempts)
+    private function diagnosticDump($path, $caller, $attempts, $elapsed = null)
     {
         $token = ini_get("datadog.trace.agent_test_session_token");
         $url = $this->endpoint . $path;
@@ -198,7 +215,8 @@ class RequestReplayer
         $statusNoToken = self::parseStatus($http_response_header ?? null);
         $lenNoToken = is_string($bodyNoToken) ? strlen($bodyNoToken) : -1;
 
-        echo "[RR-DIAG] $caller timeout after $attempts attempts; token=" . var_export($token, true) . "\n";
+        $elapsedStr = $elapsed !== null ? sprintf(" elapsed=%.2fs", $elapsed) : "";
+        echo "[RR-DIAG] $caller timeout after $attempts attempts$elapsedStr; token=" . var_export($token, true) . "\n";
         echo "[RR-DIAG]   $path with token:    status=" . var_export($statusToken, true) . " body_len=$lenToken\n";
         echo "[RR-DIAG]   $path without token: status=" . var_export($statusNoToken, true) . " body_len=$lenNoToken\n";
     }

--- a/tests/ext/live-debugger/live_debugger.inc
+++ b/tests/ext/live-debugger/live_debugger.inc
@@ -125,7 +125,6 @@ function await_probe_installation($trigger, $num = 1) {
 
     $last_id = \DDtrace\install_hook("_dummy", function () {});
     $ret = $trigger();
-    $expected = $num;
     $start = microtime(true);
     // Wall-clock cap alongside iteration cap so this fires before run-tests.php's
     // external per-test timeout under valgrind-stretched iterations.
@@ -146,18 +145,6 @@ function await_probe_installation($trigger, $num = 1) {
         }
         $last_id = $id;
     }
-
-    // Probe install incomplete after the budget. Emit a diagnostic dump showing
-    // which RC configs (if any) are loaded extension-side and how long we waited.
-    $elapsed = microtime(true) - $start;
-    $loaded = null;
-    try {
-        $loaded = dd_trace_internal_fn('get_loaded_remote_configs');
-    } catch (\Throwable $e) {
-        $loaded = "(get_loaded_remote_configs threw: " . $e->getMessage() . ")";
-    }
-    echo "[PROBE-DIAG] await_probe_installation incomplete: iters=$i elapsed=" . round($elapsed, 2) . "s expected_num=$expected remaining_num=$num\n";
-    echo "[PROBE-DIAG]   loaded_remote_configs=" . (is_array($loaded) ? json_encode($loaded) : var_export($loaded, true)) . "\n";
 
     return $ret;
 }

--- a/tests/ext/live-debugger/live_debugger.inc
+++ b/tests/ext/live-debugger/live_debugger.inc
@@ -125,8 +125,16 @@ function await_probe_installation($trigger, $num = 1) {
 
     $last_id = \DDtrace\install_hook("_dummy", function () {});
     $ret = $trigger();
+    $expected = $num;
+    $start = microtime(true);
+    // Wall-clock cap alongside iteration cap so this fires before run-tests.php's
+    // external per-test timeout under valgrind-stretched iterations.
+    $maxWallSeconds = 30.0;
 
     for ($i = 0; $i < 15000; ++$i) {
+        if (microtime(true) - $start > $maxWallSeconds) {
+            break;
+        }
         usleep(1000);
 
         $id = \DDtrace\install_hook("_dummy", function () {});
@@ -138,6 +146,18 @@ function await_probe_installation($trigger, $num = 1) {
         }
         $last_id = $id;
     }
+
+    // Probe install incomplete after the budget. Emit a diagnostic dump showing
+    // which RC configs (if any) are loaded extension-side and how long we waited.
+    $elapsed = microtime(true) - $start;
+    $loaded = null;
+    try {
+        $loaded = dd_trace_internal_fn('get_loaded_remote_configs');
+    } catch (\Throwable $e) {
+        $loaded = "(get_loaded_remote_configs threw: " . $e->getMessage() . ")";
+    }
+    echo "[PROBE-DIAG] await_probe_installation incomplete: iters=$i elapsed=" . round($elapsed, 2) . "s expected_num=$expected remaining_num=$num\n";
+    echo "[PROBE-DIAG]   loaded_remote_configs=" . (is_array($loaded) ? json_encode($loaded) : var_export($loaded, true)) . "\n";
 
     return $ret;
 }

--- a/tests/ext/request-replayer/client_side_stats_trace_filters.phpt
+++ b/tests/ext/request-replayer/client_side_stats_trace_filters.phpt
@@ -157,6 +157,22 @@ foreach ($secondFlushTraces as $req) {
         }
     }
 }
+// Diagnostic dump: snapshot the agent_info as seen extension-side. If the filter
+// rules aren't present here, the sidecar never propagated them to the extension
+// (regardless of what the agent_info /info endpoint returned).
+try {
+    $ai = dd_trace_internal_fn('get_agent_info');
+    $aiSnap = is_array($ai) ? [
+        'filter_tags'       => $ai['filter_tags']       ?? null,
+        'filter_tags_regex' => $ai['filter_tags_regex'] ?? null,
+        'ignore_resources'  => $ai['ignore_resources']  ?? null,
+        'client_drop_p0s'   => $ai['client_drop_p0s']   ?? null,
+    ] : $ai;
+    echo "[FILTER-DIAG] agent_info_view: " . json_encode($aiSnap) . "\n";
+} catch (\Throwable $e) {
+    echo "[FILTER-DIAG] agent_info_view: (threw: " . $e->getMessage() . ")\n";
+}
+
 ksort($namesInTraces);
 foreach (array_keys($namesInTraces) as $n) {
     echo "in traces: $n\n";
@@ -200,6 +216,7 @@ if (empty($ops)) {
     }
 }
 ?>
---EXPECT--
+--EXPECTF--
+[FILTER-DIAG] agent_info_view: %s
 in traces: op.pass
 in stats: op.pass

--- a/tests/ext/request-replayer/client_side_stats_trace_filters.phpt
+++ b/tests/ext/request-replayer/client_side_stats_trace_filters.phpt
@@ -157,22 +157,6 @@ foreach ($secondFlushTraces as $req) {
         }
     }
 }
-// Diagnostic dump: snapshot the agent_info as seen extension-side. If the filter
-// rules aren't present here, the sidecar never propagated them to the extension
-// (regardless of what the agent_info /info endpoint returned).
-try {
-    $ai = dd_trace_internal_fn('get_agent_info');
-    $aiSnap = is_array($ai) ? [
-        'filter_tags'       => $ai['filter_tags']       ?? null,
-        'filter_tags_regex' => $ai['filter_tags_regex'] ?? null,
-        'ignore_resources'  => $ai['ignore_resources']  ?? null,
-        'client_drop_p0s'   => $ai['client_drop_p0s']   ?? null,
-    ] : $ai;
-    echo "[FILTER-DIAG] agent_info_view: " . json_encode($aiSnap) . "\n";
-} catch (\Throwable $e) {
-    echo "[FILTER-DIAG] agent_info_view: (threw: " . $e->getMessage() . ")\n";
-}
-
 ksort($namesInTraces);
 foreach (array_keys($namesInTraces) as $n) {
     echo "in traces: $n\n";
@@ -216,7 +200,6 @@ if (empty($ops)) {
     }
 }
 ?>
---EXPECTF--
-[FILTER-DIAG] agent_info_view: %s
+--EXPECT--
 in traces: op.pass
 in stats: op.pass

--- a/tests/ext/request-replayer/dd_trace_agent_env.phpt
+++ b/tests/ext/request-replayer/dd_trace_agent_env.phpt
@@ -30,19 +30,10 @@ datadog.trace.agent_test_session_token=dd_trace_agent_env
 --FILE--
 <?php
 
-include __DIR__ . '/../includes/request_replayer.inc';
-
-$rr = new RequestReplayer();
+// Block until the sidecar has fetched /info from the agent so env is propagated
+dd_trace_internal_fn('await_agent_info');
 
 $span = \DDTrace\start_span();
-
-// make sure sidecar keeps up with us
-$start = microtime(true);
-\DDTrace\start_trace_span();
-\DDTrace\close_span();
-$rr->waitForDataAndReplay();
-usleep(floor(microtime(true) - $start) * 100000);
-
 \DDTrace\close_span();
 var_dump($span->env);
 

--- a/tests/ext/telemetry/integration.phpt
+++ b/tests/ext/telemetry/integration.phpt
@@ -60,6 +60,13 @@ namespace
                             var_dump($json["payload"]);
                             break 3;
                         }
+                        // The integrations may also be bundled into the app-started payload
+                        // depending on registration timing (see libdd-telemetry build_app_started).
+                        if ($json["request_type"] == "app-started"
+                            && !empty($json["payload"]["integrations"])) {
+                            var_dump(["integrations" => $json["payload"]["integrations"]]);
+                            break 3;
+                        }
                     }
                 }
             }


### PR DESCRIPTION
## What

- Add a second `sed` patch to `$(BUILD_DIR)/run-tests.php` at build time, replacing `number_format(` with `round(` inside `getTimer()`

## Why

PHP's `run-tests.php` `getTimer()` returns `number_format($elapsed, 4)`, which produces a comma-formatted string (e.g. `"1,500.0000"`) when a test takes ≥1000 seconds. PHP 8.0+ raises `E_WARNING: A non-numeric value encountered` when that string is used in `+=` arithmetic inside `record()`. The main test runner process treats this as a fatal worker error and exits with code 2.

This started surfacing ~1 week ago because commit fdbad2952 moved `DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED=0` from `ALL_TEST_ENV_OVERRIDE` (covers all test targets, including valgrind) into `ENV_OVERRIDE` (covers only the non-valgrind run). The valgrind run now executes with process tags enabled, making live-debugger and sidecar-related tests 5–20× slower under valgrind's instrumentation, pushing some past the 1000s threshold.

## How

We already patch `run-tests.php` at build time for an unrelated `dl()` issue. This adds a second patch in the same `$(BUILD_DIR)/run-tests.php` Makefile target:

```makefile
sed -i 's/return number_format($$this->rootSuite/return round($$this->rootSuite/' $(BUILD_DIR)/run-tests.php
```

`round($elapsed, 4)` returns a `float` (e.g. `1999.5678`) instead of a comma-formatted string, which is safe for `+=` arithmetic. The JUnit XML `time='...'` attribute also benefits — `1999.5678` is more spec-compliant than `1,999.5678`.

Verified the sed pattern matches both PHP 8.4.19 (line 3441) and PHP 8.5.0 (line 3433).

## Testing

- [ ] CI: `test_extension_ci: [8.4]` and `test_extension_ci: [8.5]` valgrind runs no longer abort with `E_WARNING: A non-numeric value encountered in run-tests.php`