### PR TITLE
Improvements for automated login events

### DIFF
--- a/.claude/ci/tracer-web-tests.md
+++ b/.claude/ci/tracer-web-tests.md
@@ -167,13 +167,16 @@ to be per-target.
 (Step 2) before Step 3 runs.
 
 Replace `8.3` with your PHP version and `test_web_laravel_latest` with
-your target.
+your target. Pick a `--php <variant>` matching the SAPI being tested
+(bookworm images: `nts`, `debug`, `zts`, `nts-asan`, `debug-zts-asan`).
+For per-target PHP-version compatibility, see the `TEST_WEB_XY` lists in
+the toplevel `Makefile`.
 
 #### Full suite
 
 ```bash
 PROJECT=tracer-web-83-laravel-latest
-.claude/ci/dockerh --cache tracer-web-83 --overlayfs \
+.claude/ci/dockerh --cache tracer-web-83 --overlayfs --php <variant> \
   datadog/dd-trace-ci:php-8.3_bookworm-6 \
   --network ${PROJECT}_default \
   -e COMPOSER_MEMORY_LIMIT=-1 \

--- a/.claude/ci/tracer-web-tests.md
+++ b/.claude/ci/tracer-web-tests.md
@@ -96,6 +96,7 @@ between the compile and test containers:
 .claude/ci/dockerh --cache tracer-web-83 --overlayfs \
   datadog/dd-trace-ci:php-8.3_bookworm-6 \
   -e CI_COMMIT_TAG=local \
+  -e SHARED=1 \
   -- bash -c '
 set -e
 .gitlab/compile_extension.sh

--- a/appsec/src/extension/tags.c
+++ b/appsec/src/extension/tags.c
@@ -973,35 +973,31 @@ static PHP_FUNCTION(datadog_appsec_track_user_signup_event_automated)
         return;
     }
 
+    zend_string *framework = NULL;
     zend_string *user_login = NULL;
     zend_string *user_id = NULL;
-    zend_string *framework = NULL;
     zend_string *anon_user_login = NULL;
     zend_string *anon_user_id = NULL;
     HashTable *metadata = NULL;
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "S!S!|h!S!", &user_login,
-            &user_id, &metadata, &framework) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "SS!S!|h!", &framework,
+            &user_login, &user_id, &metadata) == FAILURE) {
         mlog(dd_log_debug, "Unexpected parameter combination, expected "
-                           "(user_login, user_id, metadata, framework)");
+                           "(framework, user_login, user_id, metadata)");
         return;
     }
-
-    const char *framework_str =
-        framework != NULL ? ZSTR_VAL(framework) : NULL;
-    size_t framework_len = framework != NULL ? ZSTR_LEN(framework) : 0;
 
     bool login_missing = user_login == NULL || ZSTR_LEN(user_login) == 0;
     bool user_id_missing = user_id == NULL || ZSTR_LEN(user_id) == 0;
 
     if (login_missing) {
         dd_telemetry_add_missing_user_login(
-            LSTRARG("signup"), framework_str, framework_len);
+            LSTRARG("signup"), ZSTR_VAL(framework), ZSTR_LEN(framework));
     }
     // Per spec: for signup events, missing_user_id must only fire when
     // user_login is also unavailable.
     if (login_missing && user_id_missing) {
         dd_telemetry_add_missing_user_id(
-            LSTRARG("signup"), framework_str, framework_len);
+            LSTRARG("signup"), ZSTR_VAL(framework), ZSTR_LEN(framework));
     }
 
     if (login_missing) {
@@ -1150,35 +1146,31 @@ static PHP_FUNCTION(datadog_appsec_track_user_login_success_event_automated)
         return;
     }
 
+    zend_string *framework = NULL;
     zend_string *user_login = NULL;
     zend_string *user_id = NULL;
-    zend_string *framework = NULL;
     zend_string *anon_user_login = NULL;
     zend_string *anon_user_id = NULL;
     HashTable *metadata = NULL;
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "S!S!|h!S!", &user_login,
-            &user_id, &metadata, &framework) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "SS!S!|h!", &framework,
+            &user_login, &user_id, &metadata) == FAILURE) {
         mlog(dd_log_debug, "Unexpected parameter combination, expected "
-                           "(user_login, user_id, metadata, framework)");
+                           "(framework, user_login, user_id, metadata)");
         return;
     }
-
-    const char *framework_str =
-        framework != NULL ? ZSTR_VAL(framework) : NULL;
-    size_t framework_len = framework != NULL ? ZSTR_LEN(framework) : 0;
 
     bool login_missing = user_login == NULL || ZSTR_LEN(user_login) == 0;
     bool user_id_missing = user_id == NULL || ZSTR_LEN(user_id) == 0;
 
     if (login_missing) {
-        dd_telemetry_add_missing_user_login(
-            LSTRARG("login_success"), framework_str, framework_len);
+        dd_telemetry_add_missing_user_login(LSTRARG("login_success"),
+            ZSTR_VAL(framework), ZSTR_LEN(framework));
     }
     // Per spec: for login_success events, missing_user_id must only fire
     // when user_login is also unavailable.
     if (login_missing && user_id_missing) {
-        dd_telemetry_add_missing_user_id(
-            LSTRARG("login_success"), framework_str, framework_len);
+        dd_telemetry_add_missing_user_id(LSTRARG("login_success"),
+            ZSTR_VAL(framework), ZSTR_LEN(framework));
     }
 
     if (login_missing) {
@@ -1332,37 +1324,33 @@ static PHP_FUNCTION(datadog_appsec_track_user_login_failure_event_automated)
         return;
     }
 
+    zend_string *framework = NULL;
     zend_string *user_login = NULL;
     zend_string *user_id = NULL;
-    zend_string *framework = NULL;
     zend_string *anon_user_login = NULL;
     zend_string *anon_user_id = NULL;
     zend_bool exists;
     HashTable *metadata = NULL;
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "S!S!b|h!S!", &user_login,
-            &user_id, &exists, &metadata, &framework) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "SS!S!b|h!", &framework,
+            &user_login, &user_id, &exists, &metadata) == FAILURE) {
         mlog(dd_log_debug,
             "Unexpected parameter combination, expected "
-            "(user_login, user_id, exists, metadata, framework)");
+            "(framework, user_login, user_id, exists, metadata)");
         return;
     }
-
-    const char *framework_str =
-        framework != NULL ? ZSTR_VAL(framework) : NULL;
-    size_t framework_len = framework != NULL ? ZSTR_LEN(framework) : 0;
 
     bool login_missing = user_login == NULL || ZSTR_LEN(user_login) == 0;
     bool user_id_missing = user_id == NULL || ZSTR_LEN(user_id) == 0;
 
     if (login_missing) {
-        dd_telemetry_add_missing_user_login(
-            LSTRARG("login_failure"), framework_str, framework_len);
+        dd_telemetry_add_missing_user_login(LSTRARG("login_failure"),
+            ZSTR_VAL(framework), ZSTR_LEN(framework));
     }
     // Per spec: for login_failure events, missing_user_id must only fire
     // when user_login is also unavailable.
     if (login_missing && user_id_missing) {
-        dd_telemetry_add_missing_user_id(
-            LSTRARG("login_failure"), framework_str, framework_len);
+        dd_telemetry_add_missing_user_id(LSTRARG("login_failure"),
+            ZSTR_VAL(framework), ZSTR_LEN(framework));
     }
 
     if (user_login == NULL) {
@@ -1527,23 +1515,19 @@ static PHP_FUNCTION(datadog_appsec_track_authenticated_user_event_automated)
         return;
     }
 
+    zend_string *framework = NULL;
     zend_string *user_id = NULL;
     zend_string *anon_user_id = NULL;
-    zend_string *framework = NULL;
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "S!|S!", &user_id,
-            &framework) == FAILURE) {
-        mlog(
-            dd_log_debug, "Unexpected parameter combination, expected user_id");
+    if (zend_parse_parameters(
+            ZEND_NUM_ARGS(), "SS!", &framework, &user_id) == FAILURE) {
+        mlog(dd_log_debug,
+            "Unexpected parameter combination, expected (framework, user_id)");
         return;
     }
 
-    const char *framework_str =
-        framework != NULL ? ZSTR_VAL(framework) : NULL;
-    size_t framework_len = framework != NULL ? ZSTR_LEN(framework) : 0;
-
     if (user_id == NULL || ZSTR_LEN(user_id) == 0) {
-        dd_telemetry_add_missing_user_id(
-            LSTRARG("authenticated_request"), framework_str, framework_len);
+        dd_telemetry_add_missing_user_id(LSTRARG("authenticated_request"),
+            ZSTR_VAL(framework), ZSTR_LEN(framework));
         mlog(dd_log_debug, "Unexpected empty user id");
         return;
     }
@@ -1740,11 +1724,11 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(add_ancillary_tags, 0, 1, IS_VOID, 0)
     ZEND_ARG_TYPE_INFO(2, "_server", IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(track_user_login_success_event_automated_arginfo, 0, 0, IS_VOID, 4)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(track_user_login_success_event_automated_arginfo, 0, 3, IS_VOID, 4)
+ZEND_ARG_INFO(0, framework)
 ZEND_ARG_INFO(0, user_login)
 ZEND_ARG_INFO(0, user_id)
 ZEND_ARG_INFO(0, metadata)
-ZEND_ARG_INFO(0, framework)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(track_user_login_success_event_arginfo, 0, 0, IS_VOID, 2)
@@ -1752,11 +1736,11 @@ ZEND_ARG_INFO(0, user_id)
 ZEND_ARG_INFO(0, metadata)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(track_user_signup_event_automated_arginfo, 0, 0, IS_VOID, 4)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(track_user_signup_event_automated_arginfo, 0, 3, IS_VOID, 4)
+ZEND_ARG_INFO(0, framework)
 ZEND_ARG_INFO(0, user_login)
 ZEND_ARG_INFO(0, user_id)
 ZEND_ARG_INFO(0, metadata)
-ZEND_ARG_INFO(0, framework)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(track_user_signup_event_arginfo, 0, 0, IS_VOID, 2)
@@ -1764,12 +1748,12 @@ ZEND_ARG_INFO(0, user_id)
 ZEND_ARG_INFO(0, metadata)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(track_user_login_failure_event_automated_arginfo, 0, 0, IS_VOID, 5)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(track_user_login_failure_event_automated_arginfo, 0, 4, IS_VOID, 5)
+ZEND_ARG_INFO(0, framework)
 ZEND_ARG_INFO(0, user_login)
 ZEND_ARG_INFO(0, user_id)
 ZEND_ARG_INFO(0, exists)
 ZEND_ARG_INFO(0, metadata)
-ZEND_ARG_INFO(0, framework)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(track_user_login_failure_event_arginfo, 0, 0, IS_VOID, 3)
@@ -1778,9 +1762,9 @@ ZEND_ARG_INFO(0, exists)
 ZEND_ARG_INFO(0, metadata)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(track_authenticated_user_event_automated_arginfo, 0, 0, IS_VOID, 2)
-ZEND_ARG_INFO(0, user_id)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(track_authenticated_user_event_automated_arginfo, 0, 2, IS_VOID, 2)
 ZEND_ARG_INFO(0, framework)
+ZEND_ARG_INFO(0, user_id)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(track_authenticated_user_event_arginfo, 0, 0, IS_VOID, 2)

--- a/appsec/src/extension/tags.c
+++ b/appsec/src/extension/tags.c
@@ -1778,13 +1778,13 @@ ZEND_ARG_INFO(0, metadata)
 ZEND_END_ARG_INFO()
 
 static const zend_function_entry functions[] = {
-    ZEND_RAW_FENTRY(DD_APPSEC_NS "track_user_signup_event_automated", PHP_FN(datadog_appsec_track_user_signup_event_automated), track_user_signup_event_automated_arginfo, 0, NULL, NULL)
+    ZEND_RAW_FENTRY("datadog\\appsec\\internal\\track_user_signup_event_automated", PHP_FN(datadog_appsec_track_user_signup_event_automated), track_user_signup_event_automated_arginfo, 0, NULL, NULL)
     ZEND_RAW_FENTRY(DD_APPSEC_NS "track_user_signup_event", PHP_FN(datadog_appsec_track_user_signup_event), track_user_signup_event_arginfo, 0, NULL, NULL)
-    ZEND_RAW_FENTRY(DD_APPSEC_NS "track_user_login_success_event_automated", PHP_FN(datadog_appsec_track_user_login_success_event_automated), track_user_login_success_event_automated_arginfo, 0, NULL, NULL)
+    ZEND_RAW_FENTRY("datadog\\appsec\\internal\\track_user_login_success_event_automated", PHP_FN(datadog_appsec_track_user_login_success_event_automated), track_user_login_success_event_automated_arginfo, 0, NULL, NULL)
     ZEND_RAW_FENTRY(DD_APPSEC_NS "track_user_login_success_event", PHP_FN(datadog_appsec_track_user_login_success_event), track_user_login_success_event_arginfo, 0, NULL, NULL)
-    ZEND_RAW_FENTRY(DD_APPSEC_NS "track_user_login_failure_event_automated", PHP_FN(datadog_appsec_track_user_login_failure_event_automated), track_user_login_failure_event_automated_arginfo, 0, NULL, NULL)
+    ZEND_RAW_FENTRY("datadog\\appsec\\internal\\track_user_login_failure_event_automated", PHP_FN(datadog_appsec_track_user_login_failure_event_automated), track_user_login_failure_event_automated_arginfo, 0, NULL, NULL)
     ZEND_RAW_FENTRY(DD_APPSEC_NS "track_user_login_failure_event", PHP_FN(datadog_appsec_track_user_login_failure_event), track_user_login_failure_event_arginfo, 0, NULL, NULL)
-    ZEND_RAW_FENTRY(DD_APPSEC_NS "track_authenticated_user_event_automated", PHP_FN(datadog_appsec_track_authenticated_user_event_automated), track_authenticated_user_event_automated_arginfo, 0, NULL, NULL)
+    ZEND_RAW_FENTRY("datadog\\appsec\\internal\\track_authenticated_user_event_automated", PHP_FN(datadog_appsec_track_authenticated_user_event_automated), track_authenticated_user_event_automated_arginfo, 0, NULL, NULL)
     ZEND_RAW_FENTRY(DD_APPSEC_NS "track_authenticated_user_event", PHP_FN(datadog_appsec_track_authenticated_user_event), track_authenticated_user_event_arginfo, 0, NULL, NULL)
     ZEND_RAW_FENTRY(DD_APPSEC_NS "track_custom_event", PHP_FN(datadog_appsec_track_custom_event), track_custom_event_arginfo, 0, NULL, NULL)
     PHP_FE_END

--- a/appsec/src/extension/tags.c
+++ b/appsec/src/extension/tags.c
@@ -16,6 +16,7 @@
 #include "php_objects.h"
 #include "request_lifecycle.h"
 #include "string_helpers.h"
+#include "telemetry.h"
 #include "user_tracking.h"
 #include <SAPI.h>
 #include <Zend/zend.h>
@@ -972,21 +973,44 @@ static PHP_FUNCTION(datadog_appsec_track_user_signup_event_automated)
         return;
     }
 
-    zend_string *user_login;
-    zend_string *user_id;
+    zend_string *user_login = NULL;
+    zend_string *user_id = NULL;
+    zend_string *framework = NULL;
     zend_string *anon_user_login = NULL;
     zend_string *anon_user_id = NULL;
     HashTable *metadata = NULL;
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "SS|h", &user_login, &user_id,
-            &metadata) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "S!S!|h!S!", &user_login,
+            &user_id, &metadata, &framework) == FAILURE) {
         mlog(dd_log_debug, "Unexpected parameter combination, expected "
-                           "(user_login, user_id, metadata)");
+                           "(user_login, user_id, metadata, framework)");
         return;
     }
 
-    if (ZSTR_LEN(user_login) == 0) {
+    const char *framework_str =
+        framework != NULL ? ZSTR_VAL(framework) : NULL;
+    size_t framework_len = framework != NULL ? ZSTR_LEN(framework) : 0;
+
+    bool login_missing = user_login == NULL || ZSTR_LEN(user_login) == 0;
+    bool user_id_missing = user_id == NULL || ZSTR_LEN(user_id) == 0;
+
+    if (login_missing) {
+        dd_telemetry_add_missing_user_login(
+            LSTRARG("signup"), framework_str, framework_len);
+    }
+    // Per spec: for signup events, missing_user_id must only fire when
+    // user_login is also unavailable.
+    if (login_missing && user_id_missing) {
+        dd_telemetry_add_missing_user_id(
+            LSTRARG("signup"), framework_str, framework_len);
+    }
+
+    if (login_missing) {
         mlog(dd_log_debug, "Unexpected empty user login");
         return;
+    }
+
+    if (user_id == NULL) {
+        user_id = zend_empty_string;
     }
 
     zval *nullable meta = _root_span_get_meta();
@@ -1004,16 +1028,20 @@ static PHP_FUNCTION(datadog_appsec_track_user_signup_event_automated)
     }
 
     if (mode == user_mode_anon) {
-        anon_user_id = dd_user_info_anonymize(user_id);
-        if (!anon_user_id) {
-            mlog(dd_log_debug, "Failed to anonymize user ID");
-            return;
+        if (ZSTR_LEN(user_id) > 0) {
+            anon_user_id = dd_user_info_anonymize(user_id);
+            if (!anon_user_id) {
+                mlog(dd_log_debug, "Failed to anonymize user ID");
+                return;
+            }
         }
 
         anon_user_login = dd_user_info_anonymize(user_login);
         if (!anon_user_login) {
             mlog(dd_log_debug, "Failed to anonymize user login");
-            zend_string_release(anon_user_id);
+            if (anon_user_id) {
+                zend_string_release(anon_user_id);
+            }
             return;
         }
     }
@@ -1122,21 +1150,44 @@ static PHP_FUNCTION(datadog_appsec_track_user_login_success_event_automated)
         return;
     }
 
-    zend_string *user_login;
-    zend_string *user_id;
+    zend_string *user_login = NULL;
+    zend_string *user_id = NULL;
+    zend_string *framework = NULL;
     zend_string *anon_user_login = NULL;
     zend_string *anon_user_id = NULL;
     HashTable *metadata = NULL;
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "SS|h", &user_login, &user_id,
-            &metadata) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "S!S!|h!S!", &user_login,
+            &user_id, &metadata, &framework) == FAILURE) {
         mlog(dd_log_debug, "Unexpected parameter combination, expected "
-                           "(user_login, user_id, metadata)");
+                           "(user_login, user_id, metadata, framework)");
         return;
     }
 
-    if (ZSTR_LEN(user_login) == 0) {
+    const char *framework_str =
+        framework != NULL ? ZSTR_VAL(framework) : NULL;
+    size_t framework_len = framework != NULL ? ZSTR_LEN(framework) : 0;
+
+    bool login_missing = user_login == NULL || ZSTR_LEN(user_login) == 0;
+    bool user_id_missing = user_id == NULL || ZSTR_LEN(user_id) == 0;
+
+    if (login_missing) {
+        dd_telemetry_add_missing_user_login(
+            LSTRARG("login_success"), framework_str, framework_len);
+    }
+    // Per spec: for login_success events, missing_user_id must only fire
+    // when user_login is also unavailable.
+    if (login_missing && user_id_missing) {
+        dd_telemetry_add_missing_user_id(
+            LSTRARG("login_success"), framework_str, framework_len);
+    }
+
+    if (login_missing) {
         mlog(dd_log_debug, "Unexpected empty user login");
         return;
+    }
+
+    if (user_id == NULL) {
+        user_id = zend_empty_string;
     }
 
     zval *nullable meta = _root_span_get_meta();
@@ -1154,16 +1205,20 @@ static PHP_FUNCTION(datadog_appsec_track_user_login_success_event_automated)
     }
 
     if (mode == user_mode_anon) {
-        anon_user_id = dd_user_info_anonymize(user_id);
-        if (!anon_user_id) {
-            mlog(dd_log_debug, "Failed to anonymize user ID");
-            return;
+        if (ZSTR_LEN(user_id) > 0) {
+            anon_user_id = dd_user_info_anonymize(user_id);
+            if (!anon_user_id) {
+                mlog(dd_log_debug, "Failed to anonymize user ID");
+                return;
+            }
         }
 
         anon_user_login = dd_user_info_anonymize(user_login);
         if (!anon_user_login) {
             mlog(dd_log_debug, "Failed to anonymize user login");
-            zend_string_release(anon_user_id);
+            if (anon_user_id) {
+                zend_string_release(anon_user_id);
+            }
             return;
         }
     }
@@ -1277,17 +1332,44 @@ static PHP_FUNCTION(datadog_appsec_track_user_login_failure_event_automated)
         return;
     }
 
-    zend_string *user_login;
-    zend_string *user_id;
+    zend_string *user_login = NULL;
+    zend_string *user_id = NULL;
+    zend_string *framework = NULL;
     zend_string *anon_user_login = NULL;
     zend_string *anon_user_id = NULL;
     zend_bool exists;
     HashTable *metadata = NULL;
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "SSb|h", &user_login, &user_id,
-            &exists, &metadata) == FAILURE) {
-        mlog(dd_log_debug, "Unexpected parameter combination, expected "
-                           "(user_login, user_id, exists, metadata)");
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "S!S!b|h!S!", &user_login,
+            &user_id, &exists, &metadata, &framework) == FAILURE) {
+        mlog(dd_log_debug,
+            "Unexpected parameter combination, expected "
+            "(user_login, user_id, exists, metadata, framework)");
         return;
+    }
+
+    const char *framework_str =
+        framework != NULL ? ZSTR_VAL(framework) : NULL;
+    size_t framework_len = framework != NULL ? ZSTR_LEN(framework) : 0;
+
+    bool login_missing = user_login == NULL || ZSTR_LEN(user_login) == 0;
+    bool user_id_missing = user_id == NULL || ZSTR_LEN(user_id) == 0;
+
+    if (login_missing) {
+        dd_telemetry_add_missing_user_login(
+            LSTRARG("login_failure"), framework_str, framework_len);
+    }
+    // Per spec: for login_failure events, missing_user_id must only fire
+    // when user_login is also unavailable.
+    if (login_missing && user_id_missing) {
+        dd_telemetry_add_missing_user_id(
+            LSTRARG("login_failure"), framework_str, framework_len);
+    }
+
+    if (user_login == NULL) {
+        user_login = zend_empty_string;
+    }
+    if (user_id == NULL) {
+        user_id = zend_empty_string;
     }
 
     zval *nullable meta = _root_span_get_meta();
@@ -1305,17 +1387,23 @@ static PHP_FUNCTION(datadog_appsec_track_user_login_failure_event_automated)
     }
 
     if (mode == user_mode_anon) {
-        anon_user_id = dd_user_info_anonymize(user_id);
-        if (!anon_user_id) {
-            mlog(dd_log_debug, "Failed to anonymize user ID");
-            return;
+        if (ZSTR_LEN(user_id) > 0) {
+            anon_user_id = dd_user_info_anonymize(user_id);
+            if (!anon_user_id) {
+                mlog(dd_log_debug, "Failed to anonymize user ID");
+                return;
+            }
         }
 
-        anon_user_login = dd_user_info_anonymize(user_login);
-        if (!anon_user_login) {
-            mlog(dd_log_debug, "Failed to anonymize user login");
-            zend_string_release(anon_user_id);
-            return;
+        if (ZSTR_LEN(user_login) > 0) {
+            anon_user_login = dd_user_info_anonymize(user_login);
+            if (!anon_user_login) {
+                mlog(dd_log_debug, "Failed to anonymize user login");
+                if (anon_user_id) {
+                    zend_string_release(anon_user_id);
+                }
+                return;
+            }
         }
 
         if (metadata && zend_array_count(metadata) > 0) {
@@ -1439,15 +1527,23 @@ static PHP_FUNCTION(datadog_appsec_track_authenticated_user_event_automated)
         return;
     }
 
-    zend_string *user_id;
+    zend_string *user_id = NULL;
     zend_string *anon_user_id = NULL;
-    if (zend_parse_parameters(ZEND_NUM_ARGS(), "S", &user_id) == FAILURE) {
+    zend_string *framework = NULL;
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "S!|S!", &user_id,
+            &framework) == FAILURE) {
         mlog(
             dd_log_debug, "Unexpected parameter combination, expected user_id");
         return;
     }
 
-    if (ZSTR_LEN(user_id) == 0) {
+    const char *framework_str =
+        framework != NULL ? ZSTR_VAL(framework) : NULL;
+    size_t framework_len = framework != NULL ? ZSTR_LEN(framework) : 0;
+
+    if (user_id == NULL || ZSTR_LEN(user_id) == 0) {
+        dd_telemetry_add_missing_user_id(
+            LSTRARG("authenticated_request"), framework_str, framework_len);
         mlog(dd_log_debug, "Unexpected empty user id");
         return;
     }
@@ -1644,10 +1740,11 @@ ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(add_ancillary_tags, 0, 1, IS_VOID, 0)
     ZEND_ARG_TYPE_INFO(2, "_server", IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(track_user_login_success_event_automated_arginfo, 0, 0, IS_VOID, 3)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(track_user_login_success_event_automated_arginfo, 0, 0, IS_VOID, 4)
 ZEND_ARG_INFO(0, user_login)
 ZEND_ARG_INFO(0, user_id)
 ZEND_ARG_INFO(0, metadata)
+ZEND_ARG_INFO(0, framework)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(track_user_login_success_event_arginfo, 0, 0, IS_VOID, 2)
@@ -1655,10 +1752,11 @@ ZEND_ARG_INFO(0, user_id)
 ZEND_ARG_INFO(0, metadata)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(track_user_signup_event_automated_arginfo, 0, 0, IS_VOID, 3)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(track_user_signup_event_automated_arginfo, 0, 0, IS_VOID, 4)
 ZEND_ARG_INFO(0, user_login)
 ZEND_ARG_INFO(0, user_id)
 ZEND_ARG_INFO(0, metadata)
+ZEND_ARG_INFO(0, framework)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(track_user_signup_event_arginfo, 0, 0, IS_VOID, 2)
@@ -1666,11 +1764,12 @@ ZEND_ARG_INFO(0, user_id)
 ZEND_ARG_INFO(0, metadata)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(track_user_login_failure_event_automated_arginfo, 0, 0, IS_VOID, 4)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(track_user_login_failure_event_automated_arginfo, 0, 0, IS_VOID, 5)
 ZEND_ARG_INFO(0, user_login)
 ZEND_ARG_INFO(0, user_id)
 ZEND_ARG_INFO(0, exists)
 ZEND_ARG_INFO(0, metadata)
+ZEND_ARG_INFO(0, framework)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(track_user_login_failure_event_arginfo, 0, 0, IS_VOID, 3)
@@ -1679,8 +1778,9 @@ ZEND_ARG_INFO(0, exists)
 ZEND_ARG_INFO(0, metadata)
 ZEND_END_ARG_INFO()
 
-ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(track_authenticated_user_event_automated_arginfo, 0, 0, IS_VOID, 1)
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(track_authenticated_user_event_automated_arginfo, 0, 0, IS_VOID, 2)
 ZEND_ARG_INFO(0, user_id)
+ZEND_ARG_INFO(0, framework)
 ZEND_END_ARG_INFO()
 
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(track_authenticated_user_event_arginfo, 0, 0, IS_VOID, 2)

--- a/appsec/src/extension/tags.c
+++ b/appsec/src/extension/tags.c
@@ -1163,14 +1163,14 @@ static PHP_FUNCTION(datadog_appsec_track_user_login_success_event_automated)
     bool user_id_missing = user_id == NULL || ZSTR_LEN(user_id) == 0;
 
     if (login_missing) {
-        dd_telemetry_add_missing_user_login(LSTRARG("login_success"),
-            ZSTR_VAL(framework), ZSTR_LEN(framework));
+        dd_telemetry_add_missing_user_login(
+            LSTRARG("login_success"), ZSTR_VAL(framework), ZSTR_LEN(framework));
     }
     // Per spec: for login_success events, missing_user_id must only fire
     // when user_login is also unavailable.
     if (login_missing && user_id_missing) {
-        dd_telemetry_add_missing_user_id(LSTRARG("login_success"),
-            ZSTR_VAL(framework), ZSTR_LEN(framework));
+        dd_telemetry_add_missing_user_id(
+            LSTRARG("login_success"), ZSTR_VAL(framework), ZSTR_LEN(framework));
     }
 
     if (login_missing) {
@@ -1343,14 +1343,14 @@ static PHP_FUNCTION(datadog_appsec_track_user_login_failure_event_automated)
     bool user_id_missing = user_id == NULL || ZSTR_LEN(user_id) == 0;
 
     if (login_missing) {
-        dd_telemetry_add_missing_user_login(LSTRARG("login_failure"),
-            ZSTR_VAL(framework), ZSTR_LEN(framework));
+        dd_telemetry_add_missing_user_login(
+            LSTRARG("login_failure"), ZSTR_VAL(framework), ZSTR_LEN(framework));
     }
     // Per spec: for login_failure events, missing_user_id must only fire
     // when user_login is also unavailable.
     if (login_missing && user_id_missing) {
-        dd_telemetry_add_missing_user_id(LSTRARG("login_failure"),
-            ZSTR_VAL(framework), ZSTR_LEN(framework));
+        dd_telemetry_add_missing_user_id(
+            LSTRARG("login_failure"), ZSTR_VAL(framework), ZSTR_LEN(framework));
     }
 
     if (user_login == NULL) {
@@ -1518,8 +1518,8 @@ static PHP_FUNCTION(datadog_appsec_track_authenticated_user_event_automated)
     zend_string *framework = NULL;
     zend_string *user_id = NULL;
     zend_string *anon_user_id = NULL;
-    if (zend_parse_parameters(
-            ZEND_NUM_ARGS(), "SS!", &framework, &user_id) == FAILURE) {
+    if (zend_parse_parameters(ZEND_NUM_ARGS(), "SS!", &framework, &user_id) ==
+        FAILURE) {
         mlog(dd_log_debug,
             "Unexpected parameter combination, expected (framework, user_id)");
         return;

--- a/appsec/src/extension/telemetry.c
+++ b/appsec/src/extension/telemetry.c
@@ -45,8 +45,7 @@ void dd_telemetry_add_metric(zend_string *nonnull name_zstr, double value,
         ZSTR_VAL(tags_zstr), value);
 }
 
-void dd_telemetry_add_sdk_event(
-    char *nonnull event_type, size_t event_type_len)
+void dd_telemetry_add_sdk_event(char *nonnull event_type, size_t event_type_len)
 {
     char *tags = NULL;
     size_t tags_len = asprintf(&tags, "event_type:%.*s,sdk_version:v2",
@@ -67,8 +66,7 @@ static void _add_user_auth_metric(zend_string *nonnull name_zstr,
     size_t tags_len = asprintf(&tags, "framework:%.*s,event_type:%.*s",
         (int)framework_len, framework, (int)event_type_len, event_type);
     zend_string *tags_zstr = zend_string_init(tags, tags_len, 1);
-    dd_telemetry_add_metric(
-        name_zstr, 1, tags_zstr, DDTRACE_METRIC_TYPE_COUNT);
+    dd_telemetry_add_metric(name_zstr, 1, tags_zstr, DDTRACE_METRIC_TYPE_COUNT);
     zend_string_release(tags_zstr);
     free(tags);
 }

--- a/appsec/src/extension/telemetry.c
+++ b/appsec/src/extension/telemetry.c
@@ -8,7 +8,11 @@
 #include <stdatomic.h>
 
 #define DD_SDK_EVENT "sdk.event"
+#define DD_MISSING_USER_LOGIN "appsec.instrum.user_auth.missing_user_login"
+#define DD_MISSING_USER_ID "appsec.instrum.user_auth.missing_user_id"
 static zend_string *_dd_sdk_event_zstr;
+static zend_string *_dd_missing_user_login_zstr;
+static zend_string *_dd_missing_user_id_zstr;
 
 static zend_string *_dd_helper_conn_error_zstr;
 static zend_string *_dd_helper_conn_success_zstr;
@@ -17,6 +21,10 @@ static zend_string *_dd_helper_conn_close_zstr;
 void dd_telemetry_startup(void)
 {
     _dd_sdk_event_zstr = zend_string_init_interned(LSTRARG(DD_SDK_EVENT), 1);
+    _dd_missing_user_login_zstr =
+        zend_string_init_interned(LSTRARG(DD_MISSING_USER_LOGIN), 1);
+    _dd_missing_user_id_zstr =
+        zend_string_init_interned(LSTRARG(DD_MISSING_USER_ID), 1);
     _dd_helper_conn_error_zstr =
         zend_string_init_interned(LSTRARG("helper.connection_error"), 1);
     _dd_helper_conn_success_zstr =
@@ -37,17 +45,59 @@ void dd_telemetry_add_metric(zend_string *nonnull name_zstr, double value,
         ZSTR_VAL(tags_zstr), value);
 }
 
-void dd_telemetry_add_sdk_event(char *nonnull event_type, size_t event_type_len)
+void dd_telemetry_add_sdk_event(char *nonnull event_type, size_t event_type_len,
+    const char *nullable framework, size_t framework_len)
 {
     char *tags = NULL;
-    size_t tags_len = asprintf(&tags, "event_type:%.*s,sdk_version:v2",
-        (int)event_type_len, event_type);
+    size_t tags_len;
+    if (framework != NULL && framework_len > 0) {
+        tags_len = asprintf(&tags,
+            "event_type:%.*s,sdk_version:v2,framework:%.*s",
+            (int)event_type_len, event_type, (int)framework_len, framework);
+    } else {
+        tags_len = asprintf(&tags, "event_type:%.*s,sdk_version:v2",
+            (int)event_type_len, event_type);
+    }
     zend_string *tags_zstr = zend_string_init(tags, tags_len, 1);
     dd_telemetry_add_metric(
         _dd_sdk_event_zstr, 1, tags_zstr, DDTRACE_METRIC_TYPE_COUNT);
     zend_string_release(tags_zstr);
 
     free(tags);
+}
+
+static void _add_user_auth_metric(zend_string *nonnull name_zstr,
+    const char *nonnull event_type, size_t event_type_len,
+    const char *nullable framework, size_t framework_len)
+{
+    char *tags = NULL;
+    size_t tags_len;
+    if (framework != NULL && framework_len > 0) {
+        tags_len = asprintf(&tags, "framework:%.*s,event_type:%.*s",
+            (int)framework_len, framework, (int)event_type_len, event_type);
+    } else {
+        tags_len = asprintf(
+            &tags, "event_type:%.*s", (int)event_type_len, event_type);
+    }
+    zend_string *tags_zstr = zend_string_init(tags, tags_len, 1);
+    dd_telemetry_add_metric(
+        name_zstr, 1, tags_zstr, DDTRACE_METRIC_TYPE_COUNT);
+    zend_string_release(tags_zstr);
+    free(tags);
+}
+
+void dd_telemetry_add_missing_user_login(const char *nonnull event_type,
+    size_t event_type_len, const char *nullable framework, size_t framework_len)
+{
+    _add_user_auth_metric(_dd_missing_user_login_zstr, event_type,
+        event_type_len, framework, framework_len);
+}
+
+void dd_telemetry_add_missing_user_id(const char *nonnull event_type,
+    size_t event_type_len, const char *nullable framework, size_t framework_len)
+{
+    _add_user_auth_metric(_dd_missing_user_id_zstr, event_type, event_type_len,
+        framework, framework_len);
 }
 
 static void _add_helper_conn_metric(zend_string *nonnull name_zstr)

--- a/appsec/src/extension/telemetry.c
+++ b/appsec/src/extension/telemetry.c
@@ -45,19 +45,12 @@ void dd_telemetry_add_metric(zend_string *nonnull name_zstr, double value,
         ZSTR_VAL(tags_zstr), value);
 }
 
-void dd_telemetry_add_sdk_event(char *nonnull event_type, size_t event_type_len,
-    const char *nullable framework, size_t framework_len)
+void dd_telemetry_add_sdk_event(
+    char *nonnull event_type, size_t event_type_len)
 {
     char *tags = NULL;
-    size_t tags_len;
-    if (framework != NULL && framework_len > 0) {
-        tags_len = asprintf(&tags,
-            "event_type:%.*s,sdk_version:v2,framework:%.*s",
-            (int)event_type_len, event_type, (int)framework_len, framework);
-    } else {
-        tags_len = asprintf(&tags, "event_type:%.*s,sdk_version:v2",
-            (int)event_type_len, event_type);
-    }
+    size_t tags_len = asprintf(&tags, "event_type:%.*s,sdk_version:v2",
+        (int)event_type_len, event_type);
     zend_string *tags_zstr = zend_string_init(tags, tags_len, 1);
     dd_telemetry_add_metric(
         _dd_sdk_event_zstr, 1, tags_zstr, DDTRACE_METRIC_TYPE_COUNT);
@@ -68,17 +61,11 @@ void dd_telemetry_add_sdk_event(char *nonnull event_type, size_t event_type_len,
 
 static void _add_user_auth_metric(zend_string *nonnull name_zstr,
     const char *nonnull event_type, size_t event_type_len,
-    const char *nullable framework, size_t framework_len)
+    const char *nonnull framework, size_t framework_len)
 {
     char *tags = NULL;
-    size_t tags_len;
-    if (framework != NULL && framework_len > 0) {
-        tags_len = asprintf(&tags, "framework:%.*s,event_type:%.*s",
-            (int)framework_len, framework, (int)event_type_len, event_type);
-    } else {
-        tags_len = asprintf(
-            &tags, "event_type:%.*s", (int)event_type_len, event_type);
-    }
+    size_t tags_len = asprintf(&tags, "framework:%.*s,event_type:%.*s",
+        (int)framework_len, framework, (int)event_type_len, event_type);
     zend_string *tags_zstr = zend_string_init(tags, tags_len, 1);
     dd_telemetry_add_metric(
         name_zstr, 1, tags_zstr, DDTRACE_METRIC_TYPE_COUNT);
@@ -87,14 +74,14 @@ static void _add_user_auth_metric(zend_string *nonnull name_zstr,
 }
 
 void dd_telemetry_add_missing_user_login(const char *nonnull event_type,
-    size_t event_type_len, const char *nullable framework, size_t framework_len)
+    size_t event_type_len, const char *nonnull framework, size_t framework_len)
 {
     _add_user_auth_metric(_dd_missing_user_login_zstr, event_type,
         event_type_len, framework, framework_len);
 }
 
 void dd_telemetry_add_missing_user_id(const char *nonnull event_type,
-    size_t event_type_len, const char *nullable framework, size_t framework_len)
+    size_t event_type_len, const char *nonnull framework, size_t framework_len)
 {
     _add_user_auth_metric(_dd_missing_user_id_zstr, event_type, event_type_len,
         framework, framework_len);

--- a/appsec/src/extension/telemetry.h
+++ b/appsec/src/extension/telemetry.h
@@ -11,13 +11,13 @@
 void dd_telemetry_add_metric(zend_string *nonnull name_zstr, double value,
     zend_string *nonnull tags_zstr, ddtrace_metric_type type);
 
-void dd_telemetry_add_sdk_event(char *nonnull event_type, size_t event_type_len,
-    const char *nullable framework, size_t framework_len);
+void dd_telemetry_add_sdk_event(
+    char *nonnull event_type, size_t event_type_len);
 void dd_telemetry_add_missing_user_login(const char *nonnull event_type,
-    size_t event_type_len, const char *nullable framework,
+    size_t event_type_len, const char *nonnull framework,
     size_t framework_len);
 void dd_telemetry_add_missing_user_id(const char *nonnull event_type,
-    size_t event_type_len, const char *nullable framework,
+    size_t event_type_len, const char *nonnull framework,
     size_t framework_len);
 void dd_telemetry_startup(void);
 

--- a/appsec/src/extension/telemetry.h
+++ b/appsec/src/extension/telemetry.h
@@ -11,7 +11,14 @@
 void dd_telemetry_add_metric(zend_string *nonnull name_zstr, double value,
     zend_string *nonnull tags_zstr, ddtrace_metric_type type);
 
-void dd_telemetry_add_sdk_event(char *nonnull event_type, size_t event_type_len);
+void dd_telemetry_add_sdk_event(char *nonnull event_type, size_t event_type_len,
+    const char *nullable framework, size_t framework_len);
+void dd_telemetry_add_missing_user_login(const char *nonnull event_type,
+    size_t event_type_len, const char *nullable framework,
+    size_t framework_len);
+void dd_telemetry_add_missing_user_id(const char *nonnull event_type,
+    size_t event_type_len, const char *nullable framework,
+    size_t framework_len);
 void dd_telemetry_startup(void);
 
 void dd_telemetry_helper_conn_error(void);

--- a/appsec/src/extension/user_tracking.c
+++ b/appsec/src/extension/user_tracking.c
@@ -81,7 +81,7 @@ static PHP_FUNCTION(v2_track_user_login_success_wrapper)
         return;
     }
     _ddtrace_v2_track_user_login_success(INTERNAL_FUNCTION_PARAM_PASSTHRU);
-    dd_telemetry_add_sdk_event(LSTRARG("login_success"), NULL, 0);
+    dd_telemetry_add_sdk_event(LSTRARG("login_success"));
     if (!DDAPPSEC_G(active) && UNEXPECTED(!get_global_DD_APPSEC_TESTING())) {
         return;
     }
@@ -117,7 +117,7 @@ static PHP_FUNCTION(v2_track_user_login_failure_wrapper)
         return;
     }
     _ddtrace_v2_track_user_login_failure(INTERNAL_FUNCTION_PARAM_PASSTHRU);
-    dd_telemetry_add_sdk_event(LSTRARG("login_failure"), NULL, 0);
+    dd_telemetry_add_sdk_event(LSTRARG("login_failure"));
     if (!DDAPPSEC_G(active) && UNEXPECTED(!get_global_DD_APPSEC_TESTING())) {
         return;
     }

--- a/appsec/src/extension/user_tracking.c
+++ b/appsec/src/extension/user_tracking.c
@@ -81,7 +81,7 @@ static PHP_FUNCTION(v2_track_user_login_success_wrapper)
         return;
     }
     _ddtrace_v2_track_user_login_success(INTERNAL_FUNCTION_PARAM_PASSTHRU);
-    dd_telemetry_add_sdk_event(LSTRARG("login_success"));
+    dd_telemetry_add_sdk_event(LSTRARG("login_success"), NULL, 0);
     if (!DDAPPSEC_G(active) && UNEXPECTED(!get_global_DD_APPSEC_TESTING())) {
         return;
     }
@@ -117,7 +117,7 @@ static PHP_FUNCTION(v2_track_user_login_failure_wrapper)
         return;
     }
     _ddtrace_v2_track_user_login_failure(INTERNAL_FUNCTION_PARAM_PASSTHRU);
-    dd_telemetry_add_sdk_event(LSTRARG("login_failure"));
+    dd_telemetry_add_sdk_event(LSTRARG("login_failure"), NULL, 0);
     if (!DDAPPSEC_G(active) && UNEXPECTED(!get_global_DD_APPSEC_TESTING())) {
         return;
     }

--- a/appsec/tests/extension/track_authenticated_user_event_automated_anon_mode.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_automated_anon_mode.phpt
@@ -16,6 +16,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 ddtrace_version_at_least('0.79.0');
 
 track_authenticated_user_event_automated(
+    'test',
     "automatedID"
 );
 

--- a/appsec/tests/extension/track_authenticated_user_event_automated_anon_mode.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_automated_anon_mode.phpt
@@ -9,7 +9,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=anon
 <?php
 
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_authenticated_user_event_automated;
+use function datadog\appsec\internal\track_authenticated_user_event_automated;
 
 include __DIR__ . '/inc/ddtrace_version.php';
 

--- a/appsec/tests/extension/track_authenticated_user_event_automated_anon_mode_compat.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_automated_anon_mode_compat.phpt
@@ -9,7 +9,7 @@ DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING=safe
 <?php
 
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_authenticated_user_event_automated;
+use function datadog\appsec\internal\track_authenticated_user_event_automated;
 
 include __DIR__ . '/inc/ddtrace_version.php';
 

--- a/appsec/tests/extension/track_authenticated_user_event_automated_anon_mode_compat.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_automated_anon_mode_compat.phpt
@@ -16,6 +16,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 ddtrace_version_at_least('0.79.0');
 
 track_authenticated_user_event_automated(
+    'test',
     "automatedID"
 );
 

--- a/appsec/tests/extension/track_authenticated_user_event_automated_anon_mode_full_name.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_automated_anon_mode_full_name.phpt
@@ -9,7 +9,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=anonymization
 <?php
 
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_authenticated_user_event_automated;
+use function datadog\appsec\internal\track_authenticated_user_event_automated;
 
 include __DIR__ . '/inc/ddtrace_version.php';
 

--- a/appsec/tests/extension/track_authenticated_user_event_automated_anon_mode_full_name.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_automated_anon_mode_full_name.phpt
@@ -16,6 +16,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 ddtrace_version_at_least('0.79.0');
 
 track_authenticated_user_event_automated(
+    'test',
     "automatedID"
 );
 

--- a/appsec/tests/extension/track_authenticated_user_event_automated_anon_mode_no_user.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_automated_anon_mode_no_user.phpt
@@ -17,6 +17,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 ddtrace_version_at_least('0.79.0');
 
 track_authenticated_user_event_automated(
+    'test',
     ""
 );
 

--- a/appsec/tests/extension/track_authenticated_user_event_automated_anon_mode_no_user.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_automated_anon_mode_no_user.phpt
@@ -10,7 +10,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=anon
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_authenticated_user_event_automated;
+use function datadog\appsec\internal\track_authenticated_user_event_automated;
 
 include __DIR__ . '/inc/ddtrace_version.php';
 

--- a/appsec/tests/extension/track_authenticated_user_event_automated_default_mode.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_automated_default_mode.phpt
@@ -15,6 +15,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 ddtrace_version_at_least('0.79.0');
 
 track_authenticated_user_event_automated(
+    'test',
     "automatedID"
 );
 

--- a/appsec/tests/extension/track_authenticated_user_event_automated_default_mode.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_automated_default_mode.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_ENABLED=1
 <?php
 
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_authenticated_user_event_automated;
+use function datadog\appsec\internal\track_authenticated_user_event_automated;
 
 include __DIR__ . '/inc/ddtrace_version.php';
 

--- a/appsec/tests/extension/track_authenticated_user_event_automated_disabled_config.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_automated_disabled_config.phpt
@@ -10,7 +10,7 @@ DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING_ENABLED=0
 <?php
 
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_authenticated_user_event_automated;
+use function datadog\appsec\internal\track_authenticated_user_event_automated;
 
 include __DIR__ . '/inc/ddtrace_version.php';
 

--- a/appsec/tests/extension/track_authenticated_user_event_automated_disabled_config.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_automated_disabled_config.phpt
@@ -17,6 +17,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 ddtrace_version_at_least('0.79.0');
 
 track_authenticated_user_event_automated(
+    'test',
     "automatedID"
 );
 

--- a/appsec/tests/extension/track_authenticated_user_event_automated_disabled_mode.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_automated_disabled_mode.phpt
@@ -16,6 +16,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 ddtrace_version_at_least('0.79.0');
 
 track_authenticated_user_event_automated(
+    'test',
     "automatedID"
 );
 

--- a/appsec/tests/extension/track_authenticated_user_event_automated_disabled_mode.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_automated_disabled_mode.phpt
@@ -9,7 +9,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=disabled
 <?php
 
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_authenticated_user_event_automated;
+use function datadog\appsec\internal\track_authenticated_user_event_automated;
 
 include __DIR__ . '/inc/ddtrace_version.php';
 

--- a/appsec/tests/extension/track_authenticated_user_event_automated_ident_mode.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_automated_ident_mode.phpt
@@ -9,7 +9,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=ident
 <?php
 
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_authenticated_user_event_automated;
+use function datadog\appsec\internal\track_authenticated_user_event_automated;
 
 include __DIR__ . '/inc/ddtrace_version.php';
 

--- a/appsec/tests/extension/track_authenticated_user_event_automated_ident_mode.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_automated_ident_mode.phpt
@@ -16,6 +16,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 ddtrace_version_at_least('0.79.0');
 
 track_authenticated_user_event_automated(
+    'test',
     "automatedID"
 );
 

--- a/appsec/tests/extension/track_authenticated_user_event_automated_ident_mode_compat.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_automated_ident_mode_compat.phpt
@@ -9,7 +9,7 @@ DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING=extended
 <?php
 
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_authenticated_user_event_automated;
+use function datadog\appsec\internal\track_authenticated_user_event_automated;
 
 include __DIR__ . '/inc/ddtrace_version.php';
 

--- a/appsec/tests/extension/track_authenticated_user_event_automated_ident_mode_compat.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_automated_ident_mode_compat.phpt
@@ -16,6 +16,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 ddtrace_version_at_least('0.79.0');
 
 track_authenticated_user_event_automated(
+    'test',
     "automatedID"
 );
 

--- a/appsec/tests/extension/track_authenticated_user_event_automated_ident_mode_full_name.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_automated_ident_mode_full_name.phpt
@@ -9,7 +9,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=identification
 <?php
 
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_authenticated_user_event_automated;
+use function datadog\appsec\internal\track_authenticated_user_event_automated;
 
 include __DIR__ . '/inc/ddtrace_version.php';
 

--- a/appsec/tests/extension/track_authenticated_user_event_automated_ident_mode_full_name.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_automated_ident_mode_full_name.phpt
@@ -16,6 +16,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 ddtrace_version_at_least('0.79.0');
 
 track_authenticated_user_event_automated(
+    'test',
     "automatedID"
 );
 

--- a/appsec/tests/extension/track_authenticated_user_event_automated_ident_mode_no_user.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_automated_ident_mode_no_user.phpt
@@ -17,6 +17,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 ddtrace_version_at_least('0.79.0');
 
 track_authenticated_user_event_automated(
+    'test',
     ""
 );
 

--- a/appsec/tests/extension/track_authenticated_user_event_automated_ident_mode_no_user.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_automated_ident_mode_no_user.phpt
@@ -10,7 +10,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=identification
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_authenticated_user_event_automated;
+use function datadog\appsec\internal\track_authenticated_user_event_automated;
 
 include __DIR__ . '/inc/ddtrace_version.php';
 

--- a/appsec/tests/extension/track_authenticated_user_event_automated_invalid_mode.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_automated_invalid_mode.phpt
@@ -9,7 +9,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=invalid
 <?php
 
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_authenticated_user_event_automated;
+use function datadog\appsec\internal\track_authenticated_user_event_automated;
 
 include __DIR__ . '/inc/ddtrace_version.php';
 

--- a/appsec/tests/extension/track_authenticated_user_event_automated_invalid_mode.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_automated_invalid_mode.phpt
@@ -16,6 +16,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 ddtrace_version_at_least('0.79.0');
 
 track_authenticated_user_event_automated(
+    'test',
     "automatedID"
 );
 

--- a/appsec/tests/extension/track_authenticated_user_event_automated_no_root_span.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_automated_no_root_span.phpt
@@ -10,7 +10,7 @@ DD_TRACE_GENERATE_ROOT_SPAN=0
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_authenticated_user_event_automated;
+use function datadog\appsec\internal\track_authenticated_user_event_automated;
 
 include __DIR__ . '/inc/ddtrace_version.php';
 

--- a/appsec/tests/extension/track_authenticated_user_event_automated_no_root_span.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_automated_no_root_span.phpt
@@ -17,6 +17,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 ddtrace_version_at_least('0.79.0');
 
 track_authenticated_user_event_automated(
+    'test',
     "automatedID"
 );
 

--- a/appsec/tests/extension/track_authenticated_user_event_sdk_takes_priority.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_sdk_takes_priority.phpt
@@ -9,7 +9,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=ident
 <?php
 
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_authenticated_user_event_automated;
+use function datadog\appsec\internal\track_authenticated_user_event_automated;
 use function datadog\appsec\track_authenticated_user_event;
 
 include __DIR__ . '/inc/ddtrace_version.php';

--- a/appsec/tests/extension/track_authenticated_user_event_sdk_takes_priority.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_sdk_takes_priority.phpt
@@ -17,6 +17,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 ddtrace_version_at_least('0.79.0');
 
 track_authenticated_user_event_automated(
+    'test',
     "automatedID"
 );
 track_authenticated_user_event(

--- a/appsec/tests/extension/track_authenticated_user_event_sdk_takes_priority_02.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_sdk_takes_priority_02.phpt
@@ -9,7 +9,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=ident
 <?php
 
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_authenticated_user_event_automated;
+use function datadog\appsec\internal\track_authenticated_user_event_automated;
 use function datadog\appsec\track_authenticated_user_event;
 
 include __DIR__ . '/inc/ddtrace_version.php';

--- a/appsec/tests/extension/track_authenticated_user_event_sdk_takes_priority_02.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_sdk_takes_priority_02.phpt
@@ -21,6 +21,7 @@ track_authenticated_user_event(
     [ "metadata" => "someValue" ]
 );
 track_authenticated_user_event_automated(
+    'test',
     "automatedID"
 );
 

--- a/appsec/tests/extension/track_authenticated_user_event_sdk_takes_priority_03.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_sdk_takes_priority_03.phpt
@@ -9,7 +9,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=ident
 <?php
 
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_authenticated_user_event_automated;
+use function datadog\appsec\internal\track_authenticated_user_event_automated;
 use function datadog\appsec\track_authenticated_user_event;
 
 include __DIR__ . '/inc/ddtrace_version.php';

--- a/appsec/tests/extension/track_authenticated_user_event_sdk_takes_priority_03.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_sdk_takes_priority_03.phpt
@@ -17,6 +17,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 ddtrace_version_at_least('0.79.0');
 
 track_authenticated_user_event_automated(
+    'test',
     "automatedID"
 );
 track_authenticated_user_event(
@@ -28,6 +29,7 @@ track_authenticated_user_event(
     [ "metadata" => "otherValue" ]
 );
 track_authenticated_user_event_automated(
+    'test',
     "otherAutomatedID"
 );
 

--- a/appsec/tests/extension/track_authenticated_user_event_sdk_takes_priority_04.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_sdk_takes_priority_04.phpt
@@ -9,7 +9,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=ident
 <?php
 
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_authenticated_user_event_automated;
+use function datadog\appsec\internal\track_authenticated_user_event_automated;
 use function datadog\appsec\track_authenticated_user_event;
 
 include __DIR__ . '/inc/ddtrace_version.php';

--- a/appsec/tests/extension/track_authenticated_user_event_sdk_takes_priority_04.phpt
+++ b/appsec/tests/extension/track_authenticated_user_event_sdk_takes_priority_04.phpt
@@ -21,9 +21,11 @@ track_authenticated_user_event(
     [ "metadata" => "someValue" ]
 );
 track_authenticated_user_event_automated(
+    'test',
     "automatedID"
 );
 track_authenticated_user_event_automated(
+    'test',
     "otherAutomatedID"
 );
 track_authenticated_user_event(

--- a/appsec/tests/extension/track_user_login_failure_event_automated_anon_mode.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_anon_mode.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=anon
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_login_failure_event_automated;
+use function datadog\appsec\internal\track_user_login_failure_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_failure_event_automated_anon_mode.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_anon_mode.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_failure_event_automated("login", "automatedID",
+track_user_login_failure_event_automated('test', "login", "automatedID",
     true,
     [
         "value" => "something",

--- a/appsec/tests/extension/track_user_login_failure_event_automated_anon_mode_compat.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_anon_mode_compat.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING=safe
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_login_failure_event_automated;
+use function datadog\appsec\internal\track_user_login_failure_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_failure_event_automated_anon_mode_compat.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_anon_mode_compat.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_failure_event_automated("login", "automatedID",
+track_user_login_failure_event_automated('test', "login", "automatedID",
     true,
     [
         "value" => "something",

--- a/appsec/tests/extension/track_user_login_failure_event_automated_anon_mode_full_name.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_anon_mode_full_name.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=anonymization
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_login_failure_event_automated;
+use function datadog\appsec\internal\track_user_login_failure_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_failure_event_automated_anon_mode_full_name.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_anon_mode_full_name.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_failure_event_automated("login", "automatedID",
+track_user_login_failure_event_automated('test', "login", "automatedID",
     true,
     [
         "value" => "something",

--- a/appsec/tests/extension/track_user_login_failure_event_automated_anon_mode_no_login.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_anon_mode_no_login.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=anon
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_login_failure_event_automated;
+use function datadog\appsec\internal\track_user_login_failure_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_failure_event_automated_anon_mode_no_login.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_anon_mode_no_login.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_failure_event_automated("", "automatedID",
+track_user_login_failure_event_automated('test', "", "automatedID",
     true,
     [
         "value" => "something",

--- a/appsec/tests/extension/track_user_login_failure_event_automated_anon_mode_no_user.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_anon_mode_no_user.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=anon
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_login_failure_event_automated;
+use function datadog\appsec\internal\track_user_login_failure_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_failure_event_automated_anon_mode_no_user.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_anon_mode_no_user.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_failure_event_automated("login", "",
+track_user_login_failure_event_automated('test', "login", "",
     true,
     [
         "value" => "something",

--- a/appsec/tests/extension/track_user_login_failure_event_automated_default_mode.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_default_mode.phpt
@@ -7,7 +7,7 @@ DD_APPSEC_ENABLED=1
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_login_failure_event_automated;
+use function datadog\appsec\internal\track_user_login_failure_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_failure_event_automated_default_mode.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_default_mode.phpt
@@ -12,7 +12,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_failure_event_automated("login", "automatedID", true, ['something' => 'discarded']);
+track_user_login_failure_event_automated('test', "login", "automatedID", true, ['something' => 'discarded']);
 
 echo "root_span_get_meta():\n";
 print_r(root_span_get_meta());

--- a/appsec/tests/extension/track_user_login_failure_event_automated_disabled_config.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_disabled_config.phpt
@@ -14,7 +14,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_failure_event_automated("login", "automatedID", true,
+track_user_login_failure_event_automated('test', "login", "automatedID", true,
 [
     "value" => "something",
     "metadata" => "some other metadata",

--- a/appsec/tests/extension/track_user_login_failure_event_automated_disabled_config.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_disabled_config.phpt
@@ -9,7 +9,7 @@ DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING_ENABLED=0
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_login_failure_event_automated;
+use function datadog\appsec\internal\track_user_login_failure_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_failure_event_automated_disabled_mode.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_disabled_mode.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_failure_event_automated("login", "automatedID", true,
+track_user_login_failure_event_automated('test', "login", "automatedID", true,
 [
     "value" => "something",
     "metadata" => "some other metadata",

--- a/appsec/tests/extension/track_user_login_failure_event_automated_disabled_mode.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_disabled_mode.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=disabled
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_login_failure_event_automated;
+use function datadog\appsec\internal\track_user_login_failure_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_failure_event_automated_ident_mode.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_ident_mode.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=ident
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_login_failure_event_automated;
+use function datadog\appsec\internal\track_user_login_failure_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_failure_event_automated_ident_mode.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_ident_mode.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_failure_event_automated("login", "automatedID", true, ['email' => 'some@email.com']);
+track_user_login_failure_event_automated('test', "login", "automatedID", true, ['email' => 'some@email.com']);
 
 echo "root_span_get_meta():\n";
 print_r(root_span_get_meta());

--- a/appsec/tests/extension/track_user_login_failure_event_automated_ident_mode_02.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_ident_mode_02.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=ident
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_login_failure_event_automated;
+use function datadog\appsec\internal\track_user_login_failure_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_failure_event_automated_ident_mode_02.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_ident_mode_02.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_failure_event_automated("login", "automatedID", true, ['email' => 'some@email.com']);
+track_user_login_failure_event_automated('test', "login", "automatedID", true, ['email' => 'some@email.com']);
 
 echo "root_span_get_meta():\n";
 print_r(root_span_get_meta());

--- a/appsec/tests/extension/track_user_login_failure_event_automated_ident_mode_compat.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_ident_mode_compat.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING=extended
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_login_failure_event_automated;
+use function datadog\appsec\internal\track_user_login_failure_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_failure_event_automated_ident_mode_compat.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_ident_mode_compat.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_failure_event_automated("login", "automatedID", true, ['email' => 'some@email.com']);
+track_user_login_failure_event_automated('test', "login", "automatedID", true, ['email' => 'some@email.com']);
 
 echo "root_span_get_meta():\n";
 print_r(root_span_get_meta());

--- a/appsec/tests/extension/track_user_login_failure_event_automated_ident_mode_full_name.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_ident_mode_full_name.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=identification
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_login_failure_event_automated;
+use function datadog\appsec\internal\track_user_login_failure_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_failure_event_automated_ident_mode_full_name.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_ident_mode_full_name.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_failure_event_automated("login", "automatedID", true, ['email' => 'some@email.com']);
+track_user_login_failure_event_automated('test', "login", "automatedID", true, ['email' => 'some@email.com']);
 
 echo "root_span_get_meta():\n";
 print_r(root_span_get_meta());

--- a/appsec/tests/extension/track_user_login_failure_event_automated_invalid_mode.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_invalid_mode.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=invalid
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_login_failure_event_automated;
+use function datadog\appsec\internal\track_user_login_failure_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_failure_event_automated_invalid_mode.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_invalid_mode.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_failure_event_automated("login", "automatedID", true,
+track_user_login_failure_event_automated('test', "login", "automatedID", true,
 [
     "value" => "something",
     "metadata" => "some other metadata",

--- a/appsec/tests/extension/track_user_login_failure_event_automated_no_login.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_no_login.phpt
@@ -7,7 +7,7 @@ DD_APPSEC_ENABLED=1
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_login_failure_event_automated;
+use function datadog\appsec\internal\track_user_login_failure_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_failure_event_automated_no_login.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_no_login.phpt
@@ -12,7 +12,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_failure_event_automated("", "automatedID", false, []);
+track_user_login_failure_event_automated('test', "", "automatedID", false, []);
 
 echo "root_span_get_meta():\n";
 print_r(root_span_get_meta());

--- a/appsec/tests/extension/track_user_login_failure_event_automated_no_root_span.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_no_root_span.phpt
@@ -14,7 +14,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_failure_event_automated("login", "automatedID", false,
+track_user_login_failure_event_automated('test', "login", "automatedID", false,
 [
     "value" => "something",
     "metadata" => "some other metadata",

--- a/appsec/tests/extension/track_user_login_failure_event_automated_no_root_span.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_no_root_span.phpt
@@ -9,7 +9,7 @@ DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_APPSEC_ENABLED=1
 --FILE--
 <?php
-use function datadog\appsec\track_user_login_failure_event_automated;
+use function datadog\appsec\internal\track_user_login_failure_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_failure_event_automated_no_user.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_no_user.phpt
@@ -7,7 +7,7 @@ DD_APPSEC_ENABLED=1
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_login_failure_event_automated;
+use function datadog\appsec\internal\track_user_login_failure_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_failure_event_automated_no_user.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_automated_no_user.phpt
@@ -12,7 +12,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_failure_event_automated("login", "", false, []);
+track_user_login_failure_event_automated('test', "login", "", false, []);
 
 echo "root_span_get_meta():\n";
 print_r(root_span_get_meta());

--- a/appsec/tests/extension/track_user_login_failure_event_sdk_takes_priority.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_sdk_takes_priority.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_ENABLED=1
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
 use function datadog\appsec\track_user_login_failure_event;
-use function datadog\appsec\track_user_login_failure_event_automated;
+use function datadog\appsec\internal\track_user_login_failure_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_failure_event_sdk_takes_priority.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_sdk_takes_priority.phpt
@@ -14,7 +14,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 ddtrace_version_at_least('0.79.0');
 
 track_user_login_failure_event("sdkID", true, ["value" => "something-from-sdk"]);
-track_user_login_failure_event_automated("login", "automatedID", false, ["value" => "something-from-automated"]);
+track_user_login_failure_event_automated('test', "login", "automatedID", false, ["value" => "something-from-automated"]);
 
 echo "root_span_get_meta():\n";
 print_r(root_span_get_meta());

--- a/appsec/tests/extension/track_user_login_failure_event_sdk_takes_priority_02.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_sdk_takes_priority_02.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_ENABLED=1
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
 use function datadog\appsec\track_user_login_failure_event;
-use function datadog\appsec\track_user_login_failure_event_automated;
+use function datadog\appsec\internal\track_user_login_failure_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_failure_event_sdk_takes_priority_02.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_sdk_takes_priority_02.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_failure_event_automated("login", "automatedID", false, ["value" => "something-from-automated"]);
+track_user_login_failure_event_automated('test', "login", "automatedID", false, ["value" => "something-from-automated"]);
 track_user_login_failure_event("sdkID", true, ["value" => "something-from-sdk"]);
 
 echo "root_span_get_meta():\n";

--- a/appsec/tests/extension/track_user_login_failure_event_sdk_takes_priority_03.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_sdk_takes_priority_03.phpt
@@ -13,10 +13,10 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_failure_event_automated("login", "automatedID", false, ["value" => "something-from-automated"]);
+track_user_login_failure_event_automated('test', "login", "automatedID", false, ["value" => "something-from-automated"]);
 track_user_login_failure_event("sdkID", true, ["value" => "something-from-sdk"]);
 track_user_login_failure_event("otherSdkID", true, ["value" => "something-from-sdk-2"]);
-track_user_login_failure_event_automated("otherLogin", "otherAutomatedID", false, ["value" => "something-from-automated-2"]);
+track_user_login_failure_event_automated('test', "otherLogin", "otherAutomatedID", false, ["value" => "something-from-automated-2"]);
 
 echo "root_span_get_meta():\n";
 print_r(root_span_get_meta());

--- a/appsec/tests/extension/track_user_login_failure_event_sdk_takes_priority_03.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_sdk_takes_priority_03.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_ENABLED=1
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
 use function datadog\appsec\track_user_login_failure_event;
-use function datadog\appsec\track_user_login_failure_event_automated;
+use function datadog\appsec\internal\track_user_login_failure_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_failure_event_sdk_takes_priority_04.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_sdk_takes_priority_04.phpt
@@ -9,7 +9,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=ident
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
 use function datadog\appsec\track_user_login_failure_event;
-use function datadog\appsec\track_user_login_failure_event_automated;
+use function datadog\appsec\internal\track_user_login_failure_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_failure_event_sdk_takes_priority_04.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_sdk_takes_priority_04.phpt
@@ -15,7 +15,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 ddtrace_version_at_least('0.79.0');
 
 track_user_login_failure_event("sdkID", true, ["value" => "something-from-sdk"]);
-track_user_login_failure_event_automated("login", "automatedID", false, ["value" => "something-from-automated"]);
+track_user_login_failure_event_automated('test', "login", "automatedID", false, ["value" => "something-from-automated"]);
 
 echo "root_span_get_meta():\n";
 print_r(root_span_get_meta());

--- a/appsec/tests/extension/track_user_login_failure_event_sdk_takes_priority_05.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_sdk_takes_priority_05.phpt
@@ -14,7 +14,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_failure_event_automated("login", "automatedID", false, ["value" => "something-from-automated"]);
+track_user_login_failure_event_automated('test', "login", "automatedID", false, ["value" => "something-from-automated"]);
 track_user_login_failure_event("sdkID", true, ["value" => "something-from-sdk"]);
 
 echo "root_span_get_meta():\n";

--- a/appsec/tests/extension/track_user_login_failure_event_sdk_takes_priority_05.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_sdk_takes_priority_05.phpt
@@ -9,7 +9,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=ident
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
 use function datadog\appsec\track_user_login_failure_event;
-use function datadog\appsec\track_user_login_failure_event_automated;
+use function datadog\appsec\internal\track_user_login_failure_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_failure_event_sdk_takes_priority_06.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_sdk_takes_priority_06.phpt
@@ -14,10 +14,10 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_failure_event_automated("login", "automatedID", false, ["value" => "something-from-automated"]);
+track_user_login_failure_event_automated('test', "login", "automatedID", false, ["value" => "something-from-automated"]);
 track_user_login_failure_event("sdkID", true, ["value" => "something-from-sdk"]);
 track_user_login_failure_event("otherSdkID", true, ["value" => "something-from-sdk-2"]);
-track_user_login_failure_event_automated("otherLogin", "otherAutomatedID", false, ["value" => "something-from-automated-2"]);
+track_user_login_failure_event_automated('test', "otherLogin", "otherAutomatedID", false, ["value" => "something-from-automated-2"]);
 
 echo "root_span_get_meta():\n";
 print_r(root_span_get_meta());

--- a/appsec/tests/extension/track_user_login_failure_event_sdk_takes_priority_06.phpt
+++ b/appsec/tests/extension/track_user_login_failure_event_sdk_takes_priority_06.phpt
@@ -9,7 +9,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=ident
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
 use function datadog\appsec\track_user_login_failure_event;
-use function datadog\appsec\track_user_login_failure_event_automated;
+use function datadog\appsec\internal\track_user_login_failure_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_success_event_automated_anon_mode.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_automated_anon_mode.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=anon
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_login_success_event_automated;
+use function datadog\appsec\internal\track_user_login_success_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_success_event_automated_anon_mode.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_automated_anon_mode.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_success_event_automated("login", "automatedID", ['something' => 'discarded']);
+track_user_login_success_event_automated('test', "login", "automatedID", ['something' => 'discarded']);
 
 echo "root_span_get_meta():\n";
 print_r(root_span_get_meta());

--- a/appsec/tests/extension/track_user_login_success_event_automated_anon_mode_compat.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_automated_anon_mode_compat.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING=safe
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_login_success_event_automated;
+use function datadog\appsec\internal\track_user_login_success_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_success_event_automated_anon_mode_compat.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_automated_anon_mode_compat.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_success_event_automated("login", "automatedID", ['something' => 'discarded']);
+track_user_login_success_event_automated('test', "login", "automatedID", ['something' => 'discarded']);
 
 echo "root_span_get_meta():\n";
 print_r(root_span_get_meta());

--- a/appsec/tests/extension/track_user_login_success_event_automated_anon_mode_full_name.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_automated_anon_mode_full_name.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=anonymization
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_login_success_event_automated;
+use function datadog\appsec\internal\track_user_login_success_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_success_event_automated_anon_mode_full_name.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_automated_anon_mode_full_name.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_success_event_automated("login", "automatedID", ['something' => 'discarded']);
+track_user_login_success_event_automated('test', "login", "automatedID", ['something' => 'discarded']);
 
 echo "root_span_get_meta():\n";
 print_r(root_span_get_meta());

--- a/appsec/tests/extension/track_user_login_success_event_automated_anon_mode_no_user.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_automated_anon_mode_no_user.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=anon
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_login_success_event_automated;
+use function datadog\appsec\internal\track_user_login_success_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_success_event_automated_anon_mode_no_user.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_automated_anon_mode_no_user.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_success_event_automated("login", "", ['something' => 'discarded']);
+track_user_login_success_event_automated('test', "login", "", ['something' => 'discarded']);
 
 echo "root_span_get_meta():\n";
 print_r(root_span_get_meta());

--- a/appsec/tests/extension/track_user_login_success_event_automated_default_mode.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_automated_default_mode.phpt
@@ -7,7 +7,7 @@ DD_APPSEC_ENABLED=1
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_login_success_event_automated;
+use function datadog\appsec\internal\track_user_login_success_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_success_event_automated_default_mode.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_automated_default_mode.phpt
@@ -12,7 +12,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_success_event_automated("login", "automatedID", []);
+track_user_login_success_event_automated('test', "login", "automatedID", []);
 
 echo "root_span_get_meta():\n";
 print_r(root_span_get_meta());

--- a/appsec/tests/extension/track_user_login_success_event_automated_disabled_config.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_automated_disabled_config.phpt
@@ -14,7 +14,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_success_event_automated("login", "automatedID",
+track_user_login_success_event_automated('test', "login", "automatedID",
 [
     "value" => "something",
     "metadata" => "some other metadata",

--- a/appsec/tests/extension/track_user_login_success_event_automated_disabled_config.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_automated_disabled_config.phpt
@@ -9,7 +9,7 @@ DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING_ENABLED=0
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_login_success_event_automated;
+use function datadog\appsec\internal\track_user_login_success_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_success_event_automated_disabled_mode.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_automated_disabled_mode.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=disabled
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_login_success_event_automated;
+use function datadog\appsec\internal\track_user_login_success_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_success_event_automated_disabled_mode.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_automated_disabled_mode.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_success_event_automated("login", "automatedID",
+track_user_login_success_event_automated('test', "login", "automatedID",
 [
     "value" => "something",
     "metadata" => "some other metadata",

--- a/appsec/tests/extension/track_user_login_success_event_automated_empty_login.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_automated_empty_login.phpt
@@ -9,7 +9,7 @@ DD_APPSEC_ENABLED=1
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_login_success_event_automated;
+use function datadog\appsec\internal\track_user_login_success_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_success_event_automated_empty_login.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_automated_empty_login.phpt
@@ -14,7 +14,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_success_event_automated("", "automatedID",
+track_user_login_success_event_automated('test', "", "automatedID",
 [
     "value" => "something",
     "metadata" => "some other metadata",

--- a/appsec/tests/extension/track_user_login_success_event_automated_empty_user.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_automated_empty_user.phpt
@@ -9,7 +9,7 @@ DD_APPSEC_ENABLED=1
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_login_success_event_automated;
+use function datadog\appsec\internal\track_user_login_success_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_success_event_automated_empty_user.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_automated_empty_user.phpt
@@ -14,7 +14,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_success_event_automated("login", "",
+track_user_login_success_event_automated('test', "login", "",
 [
     "value" => "something",
     "metadata" => "some other metadata",

--- a/appsec/tests/extension/track_user_login_success_event_automated_ident_mode.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_automated_ident_mode.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_success_event_automated("login", "automatedID", ['email' => 'some@email.com']);
+track_user_login_success_event_automated('test', "login", "automatedID", ['email' => 'some@email.com']);
 
 echo "root_span_get_meta():\n";
 print_r(root_span_get_meta());

--- a/appsec/tests/extension/track_user_login_success_event_automated_ident_mode.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_automated_ident_mode.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=ident
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_login_success_event_automated;
+use function datadog\appsec\internal\track_user_login_success_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_success_event_automated_ident_mode_02.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_automated_ident_mode_02.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_success_event_automated("login", "automatedID", ['email' => 'some@email.com']);
+track_user_login_success_event_automated('test', "login", "automatedID", ['email' => 'some@email.com']);
 
 echo "root_span_get_meta():\n";
 print_r(root_span_get_meta());

--- a/appsec/tests/extension/track_user_login_success_event_automated_ident_mode_02.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_automated_ident_mode_02.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=ident
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_login_success_event_automated;
+use function datadog\appsec\internal\track_user_login_success_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_success_event_automated_ident_mode_compat.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_automated_ident_mode_compat.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING=extended
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_login_success_event_automated;
+use function datadog\appsec\internal\track_user_login_success_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_success_event_automated_ident_mode_compat.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_automated_ident_mode_compat.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_success_event_automated("login", "automatedID", ['email' => 'some@email.com']);
+track_user_login_success_event_automated('test', "login", "automatedID", ['email' => 'some@email.com']);
 
 echo "root_span_get_meta():\n";
 print_r(root_span_get_meta());

--- a/appsec/tests/extension/track_user_login_success_event_automated_ident_mode_full_name.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_automated_ident_mode_full_name.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=identification
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_login_success_event_automated;
+use function datadog\appsec\internal\track_user_login_success_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_success_event_automated_ident_mode_full_name.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_automated_ident_mode_full_name.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_success_event_automated("login", "automatedID", ['email' => 'some@email.com']);
+track_user_login_success_event_automated('test', "login", "automatedID", ['email' => 'some@email.com']);
 
 echo "root_span_get_meta():\n";
 print_r(root_span_get_meta());

--- a/appsec/tests/extension/track_user_login_success_event_automated_invalid_mode.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_automated_invalid_mode.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=invalid
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_login_success_event_automated;
+use function datadog\appsec\internal\track_user_login_success_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_success_event_automated_invalid_mode.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_automated_invalid_mode.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_success_event_automated("login", "automatedID",
+track_user_login_success_event_automated('test', "login", "automatedID",
 [
     "value" => "something",
     "metadata" => "some other metadata",

--- a/appsec/tests/extension/track_user_login_success_event_automated_no_root_span.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_automated_no_root_span.phpt
@@ -16,7 +16,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_success_event_automated("login", "automatedID",
+track_user_login_success_event_automated('test', "login", "automatedID",
     [
         "value" => "something",
         "metadata" => "some other metadata",

--- a/appsec/tests/extension/track_user_login_success_event_automated_no_root_span.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_automated_no_root_span.phpt
@@ -10,7 +10,7 @@ DD_APPSEC_ENABLED=1
 --FILE--
 <?php
 
-use function datadog\appsec\track_user_login_success_event_automated;
+use function datadog\appsec\internal\track_user_login_success_event_automated;
 
 include __DIR__ . '/inc/ddtrace_version.php';
 

--- a/appsec/tests/extension/track_user_login_success_event_sdk_takes_priority.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_sdk_takes_priority.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_ENABLED=1
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
 use function datadog\appsec\track_user_login_success_event;
-use function datadog\appsec\track_user_login_success_event_automated;
+use function datadog\appsec\internal\track_user_login_success_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_success_event_sdk_takes_priority.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_sdk_takes_priority.phpt
@@ -14,7 +14,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 ddtrace_version_at_least('0.79.0');
 
 track_user_login_success_event("sdkID", ["value" => "something-from-sdk"]);
-track_user_login_success_event_automated("login",  "automatedID", ["value" => "something-from-automated"]);
+track_user_login_success_event_automated('test', "login",  "automatedID", ["value" => "something-from-automated"]);
 
 echo "root_span_get_meta():\n";
 print_r(root_span_get_meta());

--- a/appsec/tests/extension/track_user_login_success_event_sdk_takes_priority_02.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_sdk_takes_priority_02.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_ENABLED=1
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
 use function datadog\appsec\track_user_login_success_event;
-use function datadog\appsec\track_user_login_success_event_automated;
+use function datadog\appsec\internal\track_user_login_success_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_login_success_event_sdk_takes_priority_02.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_sdk_takes_priority_02.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_success_event_automated("login", "automatedID", ["value" => "something-from-automated"]);
+track_user_login_success_event_automated('test', "login", "automatedID", ["value" => "something-from-automated"]);
 track_user_login_success_event("sdkID", ["value" => "something-from-sdk"]);
 
 echo "root_span_get_meta():\n";

--- a/appsec/tests/extension/track_user_login_success_event_sdk_takes_priority_03.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_sdk_takes_priority_03.phpt
@@ -13,10 +13,10 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_login_success_event_automated("login", "automatedID", ["value" => "something-from-automated"]);
+track_user_login_success_event_automated('test', "login", "automatedID", ["value" => "something-from-automated"]);
 track_user_login_success_event("sdkID", ["value" => "something-from-sdk"]);
 track_user_login_success_event("otherSdkID", ["value" => "something-from-sdk-2"]);
-track_user_login_success_event_automated("otherLogin", "otherAutomatedID", ["value" => "something-from-automated-2"]);
+track_user_login_success_event_automated('test', "otherLogin", "otherAutomatedID", ["value" => "something-from-automated-2"]);
 
 echo "root_span_get_meta():\n";
 print_r(root_span_get_meta());

--- a/appsec/tests/extension/track_user_login_success_event_sdk_takes_priority_03.phpt
+++ b/appsec/tests/extension/track_user_login_success_event_sdk_takes_priority_03.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_ENABLED=1
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
 use function datadog\appsec\track_user_login_success_event;
-use function datadog\appsec\track_user_login_success_event_automated;
+use function datadog\appsec\internal\track_user_login_success_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_signup_event_automated_anon_mode.phpt
+++ b/appsec/tests/extension/track_user_signup_event_automated_anon_mode.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=anon
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_signup_event_automated;
+use function datadog\appsec\internal\track_user_signup_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_signup_event_automated_anon_mode.phpt
+++ b/appsec/tests/extension/track_user_signup_event_automated_anon_mode.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_signup_event_automated("login", "automatedID",
+track_user_signup_event_automated('test', "login", "automatedID",
 [
     "value" => "something",
     "metadata" => "some other metadata",

--- a/appsec/tests/extension/track_user_signup_event_automated_anon_mode_compat.phpt
+++ b/appsec/tests/extension/track_user_signup_event_automated_anon_mode_compat.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING=safe
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_signup_event_automated;
+use function datadog\appsec\internal\track_user_signup_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_signup_event_automated_anon_mode_compat.phpt
+++ b/appsec/tests/extension/track_user_signup_event_automated_anon_mode_compat.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_signup_event_automated("login", "automatedID",
+track_user_signup_event_automated('test', "login", "automatedID",
 [
     "value" => "something",
     "metadata" => "some other metadata",

--- a/appsec/tests/extension/track_user_signup_event_automated_anon_mode_full_name.phpt
+++ b/appsec/tests/extension/track_user_signup_event_automated_anon_mode_full_name.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=anonymization
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_signup_event_automated;
+use function datadog\appsec\internal\track_user_signup_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_signup_event_automated_anon_mode_full_name.phpt
+++ b/appsec/tests/extension/track_user_signup_event_automated_anon_mode_full_name.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_signup_event_automated("login", "automatedID",
+track_user_signup_event_automated('test', "login", "automatedID",
 [
     "value" => "something",
     "metadata" => "some other metadata",

--- a/appsec/tests/extension/track_user_signup_event_automated_anon_mode_no_user.phpt
+++ b/appsec/tests/extension/track_user_signup_event_automated_anon_mode_no_user.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=anon
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_signup_event_automated;
+use function datadog\appsec\internal\track_user_signup_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_signup_event_automated_anon_mode_no_user.phpt
+++ b/appsec/tests/extension/track_user_signup_event_automated_anon_mode_no_user.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_signup_event_automated("login", "",
+track_user_signup_event_automated('test', "login", "",
 [
     "value" => "something",
     "metadata" => "some other metadata",

--- a/appsec/tests/extension/track_user_signup_event_automated_default_mode.phpt
+++ b/appsec/tests/extension/track_user_signup_event_automated_default_mode.phpt
@@ -7,7 +7,7 @@ DD_APPSEC_ENABLED=1
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_signup_event_automated;
+use function datadog\appsec\internal\track_user_signup_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_signup_event_automated_default_mode.phpt
+++ b/appsec/tests/extension/track_user_signup_event_automated_default_mode.phpt
@@ -12,7 +12,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_signup_event_automated("login", "automatedID", []);
+track_user_signup_event_automated('test', "login", "automatedID", []);
 
 echo "root_span_get_meta():\n";
 print_r(root_span_get_meta());

--- a/appsec/tests/extension/track_user_signup_event_automated_disabled_config.phpt
+++ b/appsec/tests/extension/track_user_signup_event_automated_disabled_config.phpt
@@ -14,7 +14,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_signup_event_automated("login", "automatedID",
+track_user_signup_event_automated('test', "login", "automatedID",
 [
     "value" => "something",
     "metadata" => "some other metadata",

--- a/appsec/tests/extension/track_user_signup_event_automated_disabled_config.phpt
+++ b/appsec/tests/extension/track_user_signup_event_automated_disabled_config.phpt
@@ -9,7 +9,7 @@ DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING_ENABLED=0
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_signup_event_automated;
+use function datadog\appsec\internal\track_user_signup_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_signup_event_automated_disabled_mode.phpt
+++ b/appsec/tests/extension/track_user_signup_event_automated_disabled_mode.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=disabled
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_signup_event_automated;
+use function datadog\appsec\internal\track_user_signup_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_signup_event_automated_disabled_mode.phpt
+++ b/appsec/tests/extension/track_user_signup_event_automated_disabled_mode.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_signup_event_automated("login", "automatedID",
+track_user_signup_event_automated('test', "login", "automatedID",
 [
     "value" => "something",
     "metadata" => "some other metadata",

--- a/appsec/tests/extension/track_user_signup_event_automated_empty_login.phpt
+++ b/appsec/tests/extension/track_user_signup_event_automated_empty_login.phpt
@@ -8,7 +8,7 @@ datadog.appsec.log_level=debug
 DD_APPSEC_ENABLED=1
 --FILE--
 <?php
-use function datadog\appsec\track_user_signup_event_automated;
+use function datadog\appsec\internal\track_user_signup_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_signup_event_automated_empty_login.phpt
+++ b/appsec/tests/extension/track_user_signup_event_automated_empty_login.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_signup_event_automated("", "automatedID",
+track_user_signup_event_automated('test', "", "automatedID",
 [
     "value" => "something",
     "metadata" => "some other metadata",

--- a/appsec/tests/extension/track_user_signup_event_automated_empty_user.phpt
+++ b/appsec/tests/extension/track_user_signup_event_automated_empty_user.phpt
@@ -14,7 +14,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_signup_event_automated("login", "",
+track_user_signup_event_automated('test', "login", "",
 [
     "value" => "something",
     "metadata" => "some other metadata",

--- a/appsec/tests/extension/track_user_signup_event_automated_empty_user.phpt
+++ b/appsec/tests/extension/track_user_signup_event_automated_empty_user.phpt
@@ -9,7 +9,7 @@ DD_APPSEC_ENABLED=1
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_signup_event_automated;
+use function datadog\appsec\internal\track_user_signup_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_signup_event_automated_ident_mode.phpt
+++ b/appsec/tests/extension/track_user_signup_event_automated_ident_mode.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=ident
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_signup_event_automated;
+use function datadog\appsec\internal\track_user_signup_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_signup_event_automated_ident_mode.phpt
+++ b/appsec/tests/extension/track_user_signup_event_automated_ident_mode.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_signup_event_automated("login", "automatedID", ['email' => 'some@email.com']);
+track_user_signup_event_automated('test', "login", "automatedID", ['email' => 'some@email.com']);
 
 echo "root_span_get_meta():\n";
 print_r(root_span_get_meta());

--- a/appsec/tests/extension/track_user_signup_event_automated_ident_mode_compat.phpt
+++ b/appsec/tests/extension/track_user_signup_event_automated_ident_mode_compat.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_AUTOMATED_USER_EVENTS_TRACKING=extended
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_signup_event_automated;
+use function datadog\appsec\internal\track_user_signup_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_signup_event_automated_ident_mode_compat.phpt
+++ b/appsec/tests/extension/track_user_signup_event_automated_ident_mode_compat.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_signup_event_automated("login", "automatedID", ['email' => 'some@email.com']);
+track_user_signup_event_automated('test', "login", "automatedID", ['email' => 'some@email.com']);
 
 echo "root_span_get_meta():\n";
 print_r(root_span_get_meta());

--- a/appsec/tests/extension/track_user_signup_event_automated_ident_mode_full_name.phpt
+++ b/appsec/tests/extension/track_user_signup_event_automated_ident_mode_full_name.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=identification
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_signup_event_automated;
+use function datadog\appsec\internal\track_user_signup_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_signup_event_automated_ident_mode_full_name.phpt
+++ b/appsec/tests/extension/track_user_signup_event_automated_ident_mode_full_name.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_signup_event_automated("login", "automatedID", ['email' => 'some@email.com']);
+track_user_signup_event_automated('test', "login", "automatedID", ['email' => 'some@email.com']);
 
 echo "root_span_get_meta():\n";
 print_r(root_span_get_meta());

--- a/appsec/tests/extension/track_user_signup_event_automated_invalid_mode.phpt
+++ b/appsec/tests/extension/track_user_signup_event_automated_invalid_mode.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_signup_event_automated("login", "automatedID",
+track_user_signup_event_automated('test', "login", "automatedID",
 [
     "value" => "something",
     "metadata" => "some other metadata",

--- a/appsec/tests/extension/track_user_signup_event_automated_invalid_mode.phpt
+++ b/appsec/tests/extension/track_user_signup_event_automated_invalid_mode.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_AUTO_USER_INSTRUMENTATION_MODE=invalid
 --FILE--
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
-use function datadog\appsec\track_user_signup_event_automated;
+use function datadog\appsec\internal\track_user_signup_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_signup_event_automated_no_root_span.phpt
+++ b/appsec/tests/extension/track_user_signup_event_automated_no_root_span.phpt
@@ -14,7 +14,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_signup_event_automated("login", "automatedID",
+track_user_signup_event_automated('test', "login", "automatedID",
 [
     "value" => "something",
     "metadata" => "some other metadata",

--- a/appsec/tests/extension/track_user_signup_event_automated_no_root_span.phpt
+++ b/appsec/tests/extension/track_user_signup_event_automated_no_root_span.phpt
@@ -9,7 +9,7 @@ DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_APPSEC_ENABLED=1
 --FILE--
 <?php
-use function datadog\appsec\track_user_signup_event_automated;
+use function datadog\appsec\internal\track_user_signup_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_signup_event_sdk_takes_priority.phpt
+++ b/appsec/tests/extension/track_user_signup_event_sdk_takes_priority.phpt
@@ -15,7 +15,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 ddtrace_version_at_least('0.79.0');
 
 track_user_signup_event("sdkID", ["value" => "something-from-sdk"]);
-track_user_signup_event_automated("login", "automatedID", ["value" => "something-from-automated"]);
+track_user_signup_event_automated('test', "login", "automatedID", ["value" => "something-from-automated"]);
 
 echo "root_span_get_meta():\n";
 print_r(root_span_get_meta());

--- a/appsec/tests/extension/track_user_signup_event_sdk_takes_priority.phpt
+++ b/appsec/tests/extension/track_user_signup_event_sdk_takes_priority.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_ENABLED=1
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
 use function datadog\appsec\track_user_signup_event;
-use function datadog\appsec\track_user_signup_event_automated;
+use function datadog\appsec\internal\track_user_signup_event_automated;
 
 include __DIR__ . '/inc/ddtrace_version.php';
 

--- a/appsec/tests/extension/track_user_signup_event_sdk_takes_priority_02.phpt
+++ b/appsec/tests/extension/track_user_signup_event_sdk_takes_priority_02.phpt
@@ -13,7 +13,7 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_signup_event_automated("login", "automatedID", ["value" => "something-from-automated"]);
+track_user_signup_event_automated('test', "login", "automatedID", ["value" => "something-from-automated"]);
 track_user_signup_event("sdkID", ["value" => "something-from-sdk"]);
 
 echo "root_span_get_meta():\n";

--- a/appsec/tests/extension/track_user_signup_event_sdk_takes_priority_02.phpt
+++ b/appsec/tests/extension/track_user_signup_event_sdk_takes_priority_02.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_ENABLED=1
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
 use function datadog\appsec\track_user_signup_event;
-use function datadog\appsec\track_user_signup_event_automated;
+use function datadog\appsec\internal\track_user_signup_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/extension/track_user_signup_event_sdk_takes_priority_03.phpt
+++ b/appsec/tests/extension/track_user_signup_event_sdk_takes_priority_03.phpt
@@ -13,10 +13,10 @@ include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');
 
-track_user_signup_event_automated("login", "automatedID", ["value" => "something-from-automated"]);
+track_user_signup_event_automated('test', "login", "automatedID", ["value" => "something-from-automated"]);
 track_user_signup_event("sdkID", ["value" => "something-from-sdk"]);
 track_user_signup_event("OtherSdkID", ["value" => "something-from-sdk-2"]);
-track_user_signup_event_automated("OtherLogin", "OtherAutomatedID", ["value" => "something-from-automated-2"]);
+track_user_signup_event_automated('test', "OtherLogin", "OtherAutomatedID", ["value" => "something-from-automated-2"]);
 
 echo "root_span_get_meta():\n";
 print_r(root_span_get_meta());

--- a/appsec/tests/extension/track_user_signup_event_sdk_takes_priority_03.phpt
+++ b/appsec/tests/extension/track_user_signup_event_sdk_takes_priority_03.phpt
@@ -8,7 +8,7 @@ DD_APPSEC_ENABLED=1
 <?php
 use function datadog\appsec\testing\root_span_get_meta;
 use function datadog\appsec\track_user_signup_event;
-use function datadog\appsec\track_user_signup_event_automated;
+use function datadog\appsec\internal\track_user_signup_event_automated;
 include __DIR__ . '/inc/ddtrace_version.php';
 
 ddtrace_version_at_least('0.79.0');

--- a/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/Laravel8xTests.groovy
+++ b/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/Laravel8xTests.groovy
@@ -63,6 +63,45 @@ class Laravel8xTests {
 
     @Test
     @Order(5)
+    void 'Login failure automated event - missing login triggers telemetry'() {
+        // Empty email: Auth::attempt(['email' => '']) fails with no user, the
+        // Laravel integration calls track_user_login_failure_event_automated('',
+        // null, false, [], 'laravel'). Per spec both missing_user_login and
+        // missing_user_id must fire, tagged framework:laravel.
+        container.traceFromRequest('/authenticate?email=') {
+            HttpResponse<InputStream> resp ->
+                assert resp.statusCode() == 403
+        }
+
+        TelemetryHelpers.Metric missingUserLogin
+        TelemetryHelpers.Metric missingUserId
+        TelemetryHelpers.waitForMetrics(container, 30) { List<TelemetryHelpers.GenerateMetrics> messages ->
+            def allSeries = messages.collectMany { it.series }
+            missingUserLogin = allSeries.find {
+                it.name == 'appsec.instrum.user_auth.missing_user_login' &&
+                        'event_type:login_failure' in it.tags &&
+                        'framework:laravel' in it.tags
+            }
+            missingUserId = allSeries.find {
+                it.name == 'appsec.instrum.user_auth.missing_user_id' &&
+                        'event_type:login_failure' in it.tags &&
+                        'framework:laravel' in it.tags
+            }
+            missingUserLogin != null && missingUserId != null
+        }
+        assert missingUserLogin != null
+        assert missingUserLogin.namespace == 'appsec'
+        assert missingUserLogin.points[0][1] >= 1.0
+        assert missingUserLogin.type == 'count'
+
+        assert missingUserId != null
+        assert missingUserId.namespace == 'appsec'
+        assert missingUserId.points[0][1] >= 1.0
+        assert missingUserId.type == 'count'
+    }
+
+    @Test
+    @Order(6)
     void 'Login success automated event'() {
         //The user ciuser@example.com is already on the DB
         def trace = container.traceFromRequest('/authenticate?email=ciuser@example.com') {
@@ -79,7 +118,7 @@ class Laravel8xTests {
     }
 
     @Test
-    @Order(6)
+    @Order(7)
     void 'Sign up automated event'() {
         def trace = container.traceFromRequest(
                 '/register?email=test-user-new@email.coms&name=somename&password=somepassword'
@@ -95,7 +134,7 @@ class Laravel8xTests {
     }
 
     @Test
-    @Order(7)
+    @Order(8)
     void 'test path params'() {
         // Set ip which is blocked
         HttpRequest req = container.buildReq('/dynamic-path/someValue').GET().build()

--- a/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/Laravel8xTests.groovy
+++ b/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/Laravel8xTests.groovy
@@ -58,11 +58,32 @@ class Laravel8xTests {
         assert span.meta."appsec.events.users.login.failure.track" == "true"
         assert span.meta."_dd.appsec.events.users.login.failure.auto.mode" == "identification"
         assert span.meta."appsec.events.users.login.failure.usr.exists" == "false"
+        // Failed event hook reads the credentials array; usr.login is the attempted email.
+        assert span.meta."appsec.events.users.login.failure.usr.login" == 'nonExisiting@email.com'
         assert span.metrics._sampling_priority_v1 == 2.0d
     }
 
     @Test
     @Order(5)
+    void 'Login failure automated event - wrong password for existing user'() {
+        // Existing user (id=1) with a wrong password: the Failed event carries the
+        // resolved user object, so usr.id and usr.exists must be populated.
+        Trace trace = container.traceFromRequest('/authenticate?email=ciuser@example.com&password=wrong') {
+            HttpResponse<InputStream> resp ->
+                assert resp.statusCode() == 403
+        }
+
+        Span span = trace.first()
+        assert span.meta."appsec.events.users.login.failure.track" == "true"
+        assert span.meta."_dd.appsec.events.users.login.failure.auto.mode" == "identification"
+        assert span.meta."appsec.events.users.login.failure.usr.exists" == "true"
+        assert span.meta."appsec.events.users.login.failure.usr.id" == "1"
+        assert span.meta."appsec.events.users.login.failure.usr.login" == 'ciuser@example.com'
+        assert span.metrics._sampling_priority_v1 == 2.0d
+    }
+
+    @Test
+    @Order(6)
     void 'Login failure automated event - missing login triggers telemetry'() {
         // Empty email: Auth::attempt(['email' => '']) fails with no user, the
         // Laravel integration calls track_user_login_failure_event_automated('',
@@ -101,7 +122,7 @@ class Laravel8xTests {
     }
 
     @Test
-    @Order(6)
+    @Order(7)
     void 'Login success automated event'() {
         //The user ciuser@example.com is already on the DB
         def trace = container.traceFromRequest('/authenticate?email=ciuser@example.com') {
@@ -118,7 +139,7 @@ class Laravel8xTests {
     }
 
     @Test
-    @Order(7)
+    @Order(8)
     void 'Sign up automated event'() {
         def trace = container.traceFromRequest(
                 '/register?email=test-user-new@email.coms&name=somename&password=somepassword'
@@ -134,7 +155,7 @@ class Laravel8xTests {
     }
 
     @Test
-    @Order(8)
+    @Order(9)
     void 'test path params'() {
         // Set ip which is blocked
         HttpRequest req = container.buildReq('/dynamic-path/someValue').GET().build()

--- a/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/Symfony62Tests.groovy
+++ b/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/Symfony62Tests.groovy
@@ -79,6 +79,35 @@ class Symfony62Tests {
         assert span.meta."_dd.appsec.events.users.login.failure.auto.mode" == 'identification'
         assert span.meta."appsec.events.users.login.failure.usr.exists" == 'false'
         assert span.metrics._sampling_priority_v1 == 2.0d
+
+        // The Symfony integration calls the automated login_failure tracking with
+        // (null, null), so per spec both missing_user_login and missing_user_id
+        // must fire, tagged framework:symfony.
+        TelemetryHelpers.Metric missingUserLogin
+        TelemetryHelpers.Metric missingUserId
+        TelemetryHelpers.waitForMetrics(container, 30) { List<TelemetryHelpers.GenerateMetrics> messages ->
+            def allSeries = messages.collectMany { it.series }
+            missingUserLogin = allSeries.find {
+                it.name == 'appsec.instrum.user_auth.missing_user_login' &&
+                        'event_type:login_failure' in it.tags &&
+                        'framework:symfony' in it.tags
+            }
+            missingUserId = allSeries.find {
+                it.name == 'appsec.instrum.user_auth.missing_user_id' &&
+                        'event_type:login_failure' in it.tags &&
+                        'framework:symfony' in it.tags
+            }
+            missingUserLogin != null && missingUserId != null
+        }
+        assert missingUserLogin != null
+        assert missingUserLogin.namespace == 'appsec'
+        assert missingUserLogin.points[0][1] >= 1.0
+        assert missingUserLogin.type == 'count'
+
+        assert missingUserId != null
+        assert missingUserId.namespace == 'appsec'
+        assert missingUserId.points[0][1] >= 1.0
+        assert missingUserId.type == 'count'
     }
 
     @Test

--- a/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/Symfony62Tests.groovy
+++ b/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/Symfony62Tests.groovy
@@ -79,35 +79,9 @@ class Symfony62Tests {
         assert span.meta."_dd.appsec.events.users.login.failure.auto.mode" == 'identification'
         assert span.meta."appsec.events.users.login.failure.usr.exists" == 'false'
         assert span.metrics._sampling_priority_v1 == 2.0d
-
-        // The Symfony integration calls the automated login_failure tracking with
-        // (null, null), so per spec both missing_user_login and missing_user_id
-        // must fire, tagged framework:symfony.
-        TelemetryHelpers.Metric missingUserLogin
-        TelemetryHelpers.Metric missingUserId
-        TelemetryHelpers.waitForMetrics(container, 30) { List<TelemetryHelpers.GenerateMetrics> messages ->
-            def allSeries = messages.collectMany { it.series }
-            missingUserLogin = allSeries.find {
-                it.name == 'appsec.instrum.user_auth.missing_user_login' &&
-                        'event_type:login_failure' in it.tags &&
-                        'framework:symfony' in it.tags
-            }
-            missingUserId = allSeries.find {
-                it.name == 'appsec.instrum.user_auth.missing_user_id' &&
-                        'event_type:login_failure' in it.tags &&
-                        'framework:symfony' in it.tags
-            }
-            missingUserLogin != null && missingUserId != null
-        }
-        assert missingUserLogin != null
-        assert missingUserLogin.namespace == 'appsec'
-        assert missingUserLogin.points[0][1] >= 1.0
-        assert missingUserLogin.type == 'count'
-
-        assert missingUserId != null
-        assert missingUserId.namespace == 'appsec'
-        assert missingUserId.points[0][1] >= 1.0
-        assert missingUserId.type == 'count'
+        // The Symfony integration extracts the attempted username from the session;
+        // '_username=aa' is stored as _security.last_username before authenticate() is called.
+        assert span.meta."appsec.events.users.login.failure.usr.login" == 'aa'
     }
 
     @Test

--- a/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/TelemetryTests.groovy
+++ b/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/TelemetryTests.groovy
@@ -559,7 +559,6 @@ class TelemetryTests {
 
         TelemetryHelpers.waitForMetrics(CONTAINER, 30) { List<TelemetryHelpers.GenerateMetrics> messages ->
             def allSeries = messages.collectMany { it.series }
-            println allSeries
             loginSuccess = allSeries.find{ it.name == 'sdk.event' && 'event_type:login_success' in it.tags}
             loginFailure = allSeries.find{ it.name == 'sdk.event' && 'event_type:login_failure' in it.tags}
 

--- a/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/WordPressTests.groovy
+++ b/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/WordPressTests.groovy
@@ -1,9 +1,10 @@
 package com.datadog.appsec.php.integration
 
-import com.datadog.appsec.php.TelemetryHelpers
 import com.datadog.appsec.php.docker.AppSecContainer
 import com.datadog.appsec.php.docker.FailOnUnmatchedTraces
 import com.datadog.appsec.php.docker.InspectContainerHelper
+import com.datadog.appsec.php.model.Span
+import com.datadog.appsec.php.model.Trace
 import groovy.util.logging.Slf4j
 import org.junit.jupiter.api.BeforeAll
 import org.junit.jupiter.api.MethodOrderer
@@ -103,37 +104,94 @@ class WordPressTests {
 
     @Test
     @Order(1)
-    void 'Login failure with empty username triggers missing_user_login and missing_user_id telemetry'() {
-        CONTAINER.traceFromRequest('/login_trigger.php?user=&pass=test') {
+    void 'Login success automated event'() {
+        // admin/admin is the user created by `wp core install` in @BeforeAll.
+        Trace trace = CONTAINER.traceFromRequest('/login_trigger.php?user=admin&pass=admin') {
             HttpResponse<InputStream> resp ->
                 assert resp.statusCode() == 200
         }
 
-        TelemetryHelpers.Metric missingUserLogin
-        TelemetryHelpers.Metric missingUserId
-        TelemetryHelpers.waitForMetrics(CONTAINER, 30) { List<TelemetryHelpers.GenerateMetrics> messages ->
-            def allSeries = messages.collectMany { it.series }
-            missingUserLogin = allSeries.find {
-                it.name == 'appsec.instrum.user_auth.missing_user_login' &&
-                        'event_type:login_failure' in it.tags &&
-                        'framework:wordpress' in it.tags
-            }
-            missingUserId = allSeries.find {
-                it.name == 'appsec.instrum.user_auth.missing_user_id' &&
-                        'event_type:login_failure' in it.tags &&
-                        'framework:wordpress' in it.tags
-            }
-            missingUserLogin != null && missingUserId != null
+        Span span = trace.first()
+        assert span.meta."appsec.events.users.login.success.track" == "true"
+        assert span.meta."_dd.appsec.events.users.login.success.auto.mode" == "identification"
+        assert span.meta."usr.id" == "1"
+        assert span.meta."appsec.events.users.login.success.usr.login" == 'admin'
+        assert span.metrics._sampling_priority_v1 == 2.0d
+    }
+
+    @Test
+    @Order(2)
+    void 'Login failure automated event - wrong password for existing user'() {
+        // Real failure path: the user exists, but the password is wrong. The
+        // integration must call track_user_login_failure_event_automated with a
+        // populated usr.login and usr.exists=true. missing_user_login must NOT
+        // fire because the login is present.
+        Trace trace = CONTAINER.traceFromRequest('/login_trigger.php?user=admin&pass=wrong') {
+            HttpResponse<InputStream> resp ->
+                assert resp.statusCode() == 200
         }
 
-        assert missingUserLogin != null
-        assert missingUserLogin.namespace == 'appsec'
-        assert missingUserLogin.points[0][1] >= 1.0
-        assert missingUserLogin.type == 'count'
+        Span span = trace.first()
+        assert span.meta."appsec.events.users.login.failure.track" == "true"
+        assert span.meta."_dd.appsec.events.users.login.failure.auto.mode" == "identification"
+        assert span.meta."appsec.events.users.login.failure.usr.login" == 'admin'
+        assert span.meta."appsec.events.users.login.failure.usr.exists" == "true"
+        assert !span.meta.containsKey("appsec.events.users.login.failure.usr.id")
+        assert span.metrics._sampling_priority_v1 == 2.0d
+    }
 
-        assert missingUserId != null
-        assert missingUserId.namespace == 'appsec'
-        assert missingUserId.points[0][1] >= 1.0
-        assert missingUserId.type == 'count'
+    @Test
+    @Order(3)
+    void 'Login failure automated event - unknown user'() {
+        // Non-empty unknown username: the integration emits a failure event with
+        // usr.exists=false. Login is non-empty, so no missing_user_login metric.
+        Trace trace = CONTAINER.traceFromRequest('/login_trigger.php?user=ghost&pass=whatever') {
+            HttpResponse<InputStream> resp ->
+                assert resp.statusCode() == 200
+        }
+
+        Span span = trace.first()
+        assert span.meta."appsec.events.users.login.failure.track" == "true"
+        assert span.meta."_dd.appsec.events.users.login.failure.auto.mode" == "identification"
+        assert span.meta."appsec.events.users.login.failure.usr.login" == 'ghost'
+        assert span.meta."appsec.events.users.login.failure.usr.exists" == "false"
+        assert !span.meta.containsKey("appsec.events.users.login.failure.usr.id")
+        assert span.metrics._sampling_priority_v1 == 2.0d
+    }
+
+    @Test
+    @Order(4)
+    void 'Sign up automated event'() {
+        // Direct call to register_new_user via signup_trigger.php; this exercises
+        // the integration's hook on the function call, regardless of multisite or
+        // email-related side effects of the standard registration form.
+        Trace trace = CONTAINER.traceFromRequest(
+                '/signup_trigger.php?login=newuser1&email=newuser1@example.com') {
+            HttpResponse<InputStream> resp ->
+                assert resp.statusCode() == 200
+        }
+
+        Span span = trace.first()
+        assert span.meta."appsec.events.users.signup.track" == "true"
+        assert span.meta."_dd.appsec.events.users.signup.auto.mode" == "identification"
+        assert span.meta."appsec.events.users.signup.usr.login" == 'newuser1'
+        assert span.metrics._sampling_priority_v1 == 2.0d
+    }
+
+    @Test
+    @Order(5)
+    void 'Authenticated user automated event'() {
+        // behind_auth_trigger.php sets the current user and exercises
+        // wp_validate_auth_cookie, which the integration hooks to emit
+        // track_authenticated_user_event_automated.
+        Trace trace = CONTAINER.traceFromRequest('/behind_auth_trigger.php') {
+            HttpResponse<InputStream> resp ->
+                assert resp.statusCode() == 200
+        }
+
+        Span span = trace.first()
+        assert span.meta."usr.id" == "1"
+        assert span.meta."_dd.appsec.usr.id" == "1"
+        assert span.meta."_dd.appsec.user.collection_mode" == "identification"
     }
 }

--- a/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/WordPressTests.groovy
+++ b/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/WordPressTests.groovy
@@ -1,0 +1,139 @@
+package com.datadog.appsec.php.integration
+
+import com.datadog.appsec.php.TelemetryHelpers
+import com.datadog.appsec.php.docker.AppSecContainer
+import com.datadog.appsec.php.docker.FailOnUnmatchedTraces
+import com.datadog.appsec.php.docker.InspectContainerHelper
+import groovy.util.logging.Slf4j
+import org.junit.jupiter.api.BeforeAll
+import org.junit.jupiter.api.MethodOrderer
+import org.junit.jupiter.api.Order
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.TestMethodOrder
+import org.junit.jupiter.api.condition.EnabledIf
+import org.testcontainers.containers.MySQLContainer
+import org.testcontainers.containers.Network
+import org.testcontainers.containers.wait.strategy.Wait
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+import org.testcontainers.utility.DockerImageName
+
+import java.net.http.HttpResponse
+
+import static com.datadog.appsec.php.integration.TestParams.getPhpVersion
+import static com.datadog.appsec.php.integration.TestParams.getVariant
+
+@Testcontainers
+@Slf4j
+@TestMethodOrder(MethodOrderer.OrderAnnotation)
+@EnabledIf('isExpectedVersion')
+class WordPressTests {
+    static boolean expectedVersion = phpVersion == '8.3' && !variant.contains('zts')
+
+    private static Network network = Network.newNetwork()
+
+    @Container
+    private static MySQLContainer MYSQL = new MySQLContainer(
+            DockerImageName.parse("${System.getProperty('DOCKER_MIRROR') ?: 'docker.io'}/library/mysql:8.0")
+                    .asCompatibleSubstituteFor('mysql'))
+            .withDatabaseName('wordpress')
+            .withUsername('root')
+            .withPassword('test')
+            .withNetwork(network)
+            .withNetworkAliases('mysql')
+            .waitingFor(Wait.forLogMessage(".*ready for connections.*", 1)) as MySQLContainer
+
+    @Container
+    @FailOnUnmatchedTraces
+    public static final AppSecContainer CONTAINER =
+            new AppSecContainer(
+                    workVolume: this.name,
+                    baseTag: 'apache2-fpm-php',
+                    phpVersion: phpVersion,
+                    phpVariant: variant,
+                    www: 'wordpress',
+            ).withNetwork(network) as AppSecContainer
+
+    static void main(String[] args) {
+        InspectContainerHelper.run(CONTAINER, MYSQL)
+    }
+
+    @BeforeAll
+    static void installWordPress() {
+        def mysqlInfo = MYSQL.containerInfo
+        def mysqlIp = mysqlInfo.networkSettings.networks.values().find {
+            it.aliases?.contains('mysql')
+        }?.ipAddress
+
+        assert mysqlIp != null : "Could not determine MySQL container IP"
+        log.info("MySQL IP: {}", mysqlIp)
+
+        def res = CONTAINER.execInContainer('bash', '-c',
+                "sed -i \"s/'mysql'/'${mysqlIp}'/\" /var/www/public/wp-config.php")
+        assert res.exitCode == 0 : "Failed to update wp-config.php: ${res.stderr}"
+
+        // Run wp-cli with tracing and AppSec disabled so these CLI processes
+        // don't interfere with the FPM workers' sidecar/AppSec helper. FPM
+        // keeps running throughout so the already-started AppSec helper
+        // (launched by the container's initial FPM workers) remains active.
+        res = CONTAINER.execInContainer('bash', '-c',
+                """export DD_TRACE_CLI_ENABLED=false DD_APPSEC_ENABLED=0
+                   wp core install \\
+                       --path=/var/www/public \\
+                       --url=http://localhost \\
+                       --title='Test Site' \\
+                       --admin_user=admin \\
+                       --admin_password=admin \\
+                       --admin_email=admin@test.com \\
+                       --allow-root \\
+                       --skip-email""")
+        log.info("wp core install stdout: {}", res.stdout)
+        log.info("wp core install stderr: {}", res.stderr)
+        assert res.exitCode == 0 : "WordPress install failed: ${res.stderr}"
+
+        def port = CONTAINER.firstMappedPort
+        res = CONTAINER.execInContainer('bash', '-c',
+                """export DD_TRACE_CLI_ENABLED=false DD_APPSEC_ENABLED=0
+                   wp option update siteurl 'http://localhost:${port}' --path=/var/www/public --allow-root
+                   wp option update home 'http://localhost:${port}' --path=/var/www/public --allow-root""")
+        assert res.exitCode == 0 : "Failed to update WordPress URLs: ${res.stderr}"
+
+        CONTAINER.clearTraces()
+    }
+
+    @Test
+    @Order(1)
+    void 'Login failure with empty username triggers missing_user_login and missing_user_id telemetry'() {
+        CONTAINER.traceFromRequest('/login_trigger.php?user=&pass=test') {
+            HttpResponse<InputStream> resp ->
+                assert resp.statusCode() == 200
+        }
+
+        TelemetryHelpers.Metric missingUserLogin
+        TelemetryHelpers.Metric missingUserId
+        TelemetryHelpers.waitForMetrics(CONTAINER, 30) { List<TelemetryHelpers.GenerateMetrics> messages ->
+            def allSeries = messages.collectMany { it.series }
+            missingUserLogin = allSeries.find {
+                it.name == 'appsec.instrum.user_auth.missing_user_login' &&
+                        'event_type:login_failure' in it.tags &&
+                        'framework:wordpress' in it.tags
+            }
+            missingUserId = allSeries.find {
+                it.name == 'appsec.instrum.user_auth.missing_user_id' &&
+                        'event_type:login_failure' in it.tags &&
+                        'framework:wordpress' in it.tags
+            }
+            missingUserLogin != null && missingUserId != null
+        }
+
+        assert missingUserLogin != null
+        assert missingUserLogin.namespace == 'appsec'
+        assert missingUserLogin.points[0][1] >= 1.0
+        assert missingUserLogin.type == 'count'
+
+        assert missingUserId != null
+        assert missingUserId.namespace == 'appsec'
+        assert missingUserId.points[0][1] >= 1.0
+        assert missingUserId.type == 'count'
+    }
+}

--- a/appsec/tests/integration/src/test/www/base/public/behind_auth.php
+++ b/appsec/tests/integration/src/test/www/base/public/behind_auth.php
@@ -1,3 +1,3 @@
 <?php
 
-\datadog\appsec\track_authenticated_user_event_automated('test', $_GET["id"] ?? "userID");
+\datadog\appsec\internal\track_authenticated_user_event_automated('test', $_GET["id"] ?? "userID");

--- a/appsec/tests/integration/src/test/www/base/public/behind_auth.php
+++ b/appsec/tests/integration/src/test/www/base/public/behind_auth.php
@@ -1,3 +1,3 @@
 <?php
 
-\datadog\appsec\track_authenticated_user_event_automated($_GET["id"] ?? "userID");
+\datadog\appsec\track_authenticated_user_event_automated('test', $_GET["id"] ?? "userID");

--- a/appsec/tests/integration/src/test/www/base/public/user_login_failure_automated.php
+++ b/appsec/tests/integration/src/test/www/base/public/user_login_failure_automated.php
@@ -1,6 +1,6 @@
 <?php
 
-\datadog\appsec\track_user_login_failure_event_automated('test', 'Login', 'Admin', false, [
+\datadog\appsec\internal\track_user_login_failure_event_automated('test', 'Login', 'Admin', false, [
     'email' => 'jean.example@example.com',
     'session_id' => '987654321',
     'role' => 'admin'

--- a/appsec/tests/integration/src/test/www/base/public/user_login_failure_automated.php
+++ b/appsec/tests/integration/src/test/www/base/public/user_login_failure_automated.php
@@ -1,6 +1,6 @@
 <?php
 
-\datadog\appsec\track_user_login_failure_event_automated('Login', 'Admin', false, [
+\datadog\appsec\track_user_login_failure_event_automated('test', 'Login', 'Admin', false, [
     'email' => 'jean.example@example.com',
     'session_id' => '987654321',
     'role' => 'admin'

--- a/appsec/tests/integration/src/test/www/base/public/user_login_success_automated.php
+++ b/appsec/tests/integration/src/test/www/base/public/user_login_success_automated.php
@@ -1,6 +1,7 @@
 <?php
 
 \datadog\appsec\track_user_login_success_event_automated(
+    'test',
     $_GET['login'] ?? 'Login',
     $_GET['id'] ?? 'Admin',
     [

--- a/appsec/tests/integration/src/test/www/base/public/user_login_success_automated.php
+++ b/appsec/tests/integration/src/test/www/base/public/user_login_success_automated.php
@@ -1,6 +1,6 @@
 <?php
 
-\datadog\appsec\track_user_login_success_event_automated(
+\datadog\appsec\internal\track_user_login_success_event_automated(
     'test',
     $_GET['login'] ?? 'Login',
     $_GET['id'] ?? 'Admin',

--- a/appsec/tests/integration/src/test/www/base/public/user_signup_automated.php
+++ b/appsec/tests/integration/src/test/www/base/public/user_signup_automated.php
@@ -1,6 +1,6 @@
 <?php
 
-\datadog\appsec\track_user_signup_event_automated('test', "Login", "Admin", ['email' => 'jean.example@example.com',
+\datadog\appsec\internal\track_user_signup_event_automated('test', "Login", "Admin", ['email' => 'jean.example@example.com',
     'session_id' => '987654321',
     'role' => 'admin'
  ]);

--- a/appsec/tests/integration/src/test/www/base/public/user_signup_automated.php
+++ b/appsec/tests/integration/src/test/www/base/public/user_signup_automated.php
@@ -1,6 +1,6 @@
 <?php
 
-\datadog\appsec\track_user_signup_event_automated("Login", "Admin", ['email' => 'jean.example@example.com',
+\datadog\appsec\track_user_signup_event_automated('test', "Login", "Admin", ['email' => 'jean.example@example.com',
     'session_id' => '987654321',
     'role' => 'admin'
  ]);

--- a/appsec/tests/integration/src/test/www/laravel8x/app/Http/Controllers/LoginController.php
+++ b/appsec/tests/integration/src/test/www/laravel8x/app/Http/Controllers/LoginController.php
@@ -20,23 +20,8 @@ class LoginController extends Controller
      */
     public function authenticate(Request $request)
     {
-        // When the `email` query param is present (even if empty), use its
-        // value verbatim; otherwise fall back to the default. Laravel's
-        // ConvertEmptyStringsToNull middleware coerces `?email=` to null on
-        // the parsed request, so we read from the raw query string instead.
-        $rawQuery = $request->getQueryString() ?? '';
-        $hasEmail = false;
-        $rawEmail = '';
-        foreach (explode('&', $rawQuery) as $pair) {
-            $kv = explode('=', $pair, 2);
-            if ($kv[0] === 'email') {
-                $hasEmail = true;
-                $rawEmail = isset($kv[1]) ? urldecode($kv[1]) : '';
-                break;
-            }
-        }
         $credentials = [
-            'email' => $hasEmail ? $rawEmail : 'ciuser@example.com',
+            'email' => $request->get('email'),
             'password' => $request->query('password', 'password'),
         ];
 

--- a/appsec/tests/integration/src/test/www/laravel8x/app/Http/Controllers/LoginController.php
+++ b/appsec/tests/integration/src/test/www/laravel8x/app/Http/Controllers/LoginController.php
@@ -37,7 +37,7 @@ class LoginController extends Controller
         }
         $credentials = [
             'email' => $hasEmail ? $rawEmail : 'ciuser@example.com',
-            'password' => 'password',
+            'password' => $request->query('password', 'password'),
         ];
 
         if (Auth::attempt($credentials)) {

--- a/appsec/tests/integration/src/test/www/laravel8x/app/Http/Controllers/LoginController.php
+++ b/appsec/tests/integration/src/test/www/laravel8x/app/Http/Controllers/LoginController.php
@@ -20,8 +20,23 @@ class LoginController extends Controller
      */
     public function authenticate(Request $request)
     {
+        // When the `email` query param is present (even if empty), use its
+        // value verbatim; otherwise fall back to the default. Laravel's
+        // ConvertEmptyStringsToNull middleware coerces `?email=` to null on
+        // the parsed request, so we read from the raw query string instead.
+        $rawQuery = $request->getQueryString() ?? '';
+        $hasEmail = false;
+        $rawEmail = '';
+        foreach (explode('&', $rawQuery) as $pair) {
+            $kv = explode('=', $pair, 2);
+            if ($kv[0] === 'email') {
+                $hasEmail = true;
+                $rawEmail = isset($kv[1]) ? urldecode($kv[1]) : '';
+                break;
+            }
+        }
         $credentials = [
-            'email' => $request->get('email') ?? 'ciuser@example.com',
+            'email' => $hasEmail ? $rawEmail : 'ciuser@example.com',
             'password' => 'password',
         ];
 

--- a/appsec/tests/integration/src/test/www/wordpress/initialize.sh
+++ b/appsec/tests/integration/src/test/www/wordpress/initialize.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -ex
+
+cd /var/www/public
+
+export DD_TRACE_CLI_ENABLED=false
+
+# Copy WordPress source from the project mount
+cp -a /project/tests/Frameworks/WordPress/Version_6_1/. .
+# Restore our custom files (the cp above overwrites them in the overlay upper dir)
+cp /test-resources/public/wp-config.php wp-config.php
+cp /test-resources/public/index.php index.php
+cp /test-resources/public/login_trigger.php login_trigger.php
+cp /test-resources/public/hello.php hello.php
+
+# Download WP-CLI
+curl -sf https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar -o /usr/local/bin/wp
+chmod +x /usr/local/bin/wp
+
+chown -R www-data:www-data /var/www/public

--- a/appsec/tests/integration/src/test/www/wordpress/public/.htaccess
+++ b/appsec/tests/integration/src/test/www/wordpress/public/.htaccess
@@ -1,0 +1,12 @@
+DirectoryIndex index.php
+
+# BEGIN WordPress
+<IfModule mod_rewrite.c>
+RewriteEngine On
+RewriteBase /
+RewriteRule ^index\.php$ - [L]
+RewriteCond %{REQUEST_FILENAME} !-f
+RewriteCond %{REQUEST_FILENAME} !-d
+RewriteRule . /index.php [L]
+</IfModule>
+# END WordPress

--- a/appsec/tests/integration/src/test/www/wordpress/public/behind_auth_trigger.php
+++ b/appsec/tests/integration/src/test/www/wordpress/public/behind_auth_trigger.php
@@ -1,0 +1,20 @@
+<?php
+ob_start();
+require __DIR__ . '/wp-load.php';
+ob_end_clean();
+
+// Resolve admin user (created in @BeforeAll via `wp core install`).
+$user = get_user_by('login', 'admin');
+if (!$user) {
+    http_response_code(500);
+    echo 'admin user missing';
+    return;
+}
+
+// Set current user, then exercise the wp_validate_auth_cookie hook, which is
+// where the integration emits track_authenticated_user_event_automated.
+wp_set_current_user($user->ID);
+$cookie = wp_generate_auth_cookie($user->ID, time() + 3600, 'logged_in');
+$validated = wp_validate_auth_cookie($cookie, 'logged_in');
+
+echo 'validated: ' . ($validated ? (int) $validated : 'false');

--- a/appsec/tests/integration/src/test/www/wordpress/public/hello.php
+++ b/appsec/tests/integration/src/test/www/wordpress/public/hello.php
@@ -1,0 +1,7 @@
+<?php
+header('Content-Encoding: foobar');
+header('Content-Language: en');
+
+$content = "Hello world!";
+
+echo $content;

--- a/appsec/tests/integration/src/test/www/wordpress/public/index.php
+++ b/appsec/tests/integration/src/test/www/wordpress/public/index.php
@@ -1,0 +1,12 @@
+<?php
+/**
+ * Front to the WordPress application. This file doesn't do anything, but loads
+ * wp-blog-header.php which does and tells WordPress to load the theme.
+ *
+ * @package WordPress
+ */
+
+define( 'WP_USE_THEMES', true );
+
+/** Loads the WordPress Environment and Template */
+require __DIR__ . '/wp-blog-header.php';

--- a/appsec/tests/integration/src/test/www/wordpress/public/login_trigger.php
+++ b/appsec/tests/integration/src/test/www/wordpress/public/login_trigger.php
@@ -1,0 +1,11 @@
+<?php
+ob_start();
+require __DIR__ . '/wp-load.php';
+ob_end_clean();
+
+$user = $_GET['user'] ?? '';
+$pass = $_GET['pass'] ?? 'test';
+
+wp_authenticate($user, $pass);
+
+echo 'Done';

--- a/appsec/tests/integration/src/test/www/wordpress/public/signup_trigger.php
+++ b/appsec/tests/integration/src/test/www/wordpress/public/signup_trigger.php
@@ -1,0 +1,19 @@
+<?php
+ob_start();
+require __DIR__ . '/wp-load.php';
+require_once ABSPATH . 'wp-includes/user.php';
+ob_end_clean();
+
+$login = $_GET['login'] ?? 'newuser';
+$email = $_GET['email'] ?? 'newuser@example.com';
+
+// Direct call to bypass the email/multisite logic of the registration form.
+// This still triggers our hook on `register_new_user` (the function call), so
+// the integration's `track_user_signup_event_automated` is exercised.
+$result = register_new_user($login, $email);
+
+if (is_wp_error($result)) {
+    echo 'Error: ' . $result->get_error_code();
+} else {
+    echo 'Created user id: ' . (int) $result;
+}

--- a/appsec/tests/integration/src/test/www/wordpress/public/wp-config.php
+++ b/appsec/tests/integration/src/test/www/wordpress/public/wp-config.php
@@ -1,0 +1,28 @@
+<?php
+define('DB_NAME', 'wordpress');
+define('DB_USER', 'root');
+define('DB_PASSWORD', 'test');
+define('DB_HOST', 'mysql');
+define('DB_CHARSET', 'utf8mb4');
+define('DB_COLLATE', '');
+
+define('DISABLE_WP_CRON', true);
+
+define('AUTH_KEY',         'test-key-1');
+define('SECURE_AUTH_KEY',  'test-key-2');
+define('LOGGED_IN_KEY',    'test-key-3');
+define('NONCE_KEY',        'test-key-4');
+define('AUTH_SALT',        'test-salt-1');
+define('SECURE_AUTH_SALT', 'test-salt-2');
+define('LOGGED_IN_SALT',   'test-salt-3');
+define('NONCE_SALT',       'test-salt-4');
+
+$table_prefix = 'wp_';
+
+define('WP_DEBUG', false);
+
+if (!defined('ABSPATH')) {
+    define('ABSPATH', __DIR__ . '/');
+}
+
+require_once ABSPATH . 'wp-settings.php';

--- a/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
+++ b/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
@@ -222,7 +222,7 @@ class LaravelIntegration extends Integration
                             $id = $args[1]['id'];
                         }
 
-                        \datadog\appsec\track_user_signup_event_automated(self::getLoginFromArgs($args[1]), $id, []);
+                        \datadog\appsec\track_user_signup_event_automated(self::getLoginFromArgs($args[1]), $id, [], 'laravel');
                     }
                 },
                 'recurse' => true,
@@ -374,7 +374,7 @@ class LaravelIntegration extends Integration
                     return;
                 }
 
-                \datadog\appsec\track_user_login_failure_event_automated(self::getLoginFromArgs($args[0]), null, false, []);
+                \datadog\appsec\track_user_login_failure_event_automated(self::getLoginFromArgs($args[0]), null, false, [], 'laravel');
             }
         );
 
@@ -417,7 +417,8 @@ class LaravelIntegration extends Integration
                 \datadog\appsec\track_user_login_success_event_automated(
                     self::getLoginFromArgs($user),
                     self::getAuthIdentifier($user),
-                    $metadata
+                    $metadata,
+                    'laravel'
                 );
             }
         );
@@ -450,7 +451,8 @@ class LaravelIntegration extends Integration
                 \datadog\appsec\track_user_login_success_event_automated(
                     self::getLoginFromArgs($args[0]),
                     self::getAuthIdentifier($args[0]),
-                    $metadata
+                    $metadata,
+                    'laravel'
                 );
             }
         );
@@ -465,7 +467,7 @@ class LaravelIntegration extends Integration
                     return;
                 }
 
-                \datadog\appsec\track_user_login_failure_event_automated(self::getLoginFromArgs($args[0]), null, false, []);
+                \datadog\appsec\track_user_login_failure_event_automated(self::getLoginFromArgs($args[0]), null, false, [], 'laravel');
             }
         );
 
@@ -489,7 +491,7 @@ class LaravelIntegration extends Integration
                 }
 
                 \datadog\appsec\track_authenticated_user_event_automated(
-                    self::getAuthIdentifier($user)
+                    self::getAuthIdentifier($user), 'laravel'
                 );
             }
         );
@@ -514,7 +516,7 @@ class LaravelIntegration extends Integration
                 }
 
                 \datadog\appsec\track_authenticated_user_event_automated(
-                    self::getAuthIdentifier($args[1])
+                    self::getAuthIdentifier($args[1]), 'laravel'
                 );
             }
         );
@@ -537,7 +539,8 @@ class LaravelIntegration extends Integration
                 \datadog\appsec\track_user_signup_event_automated(
                     self::getLoginFromArgs($args[0]),
                     self::getAuthIdentifier($args[0]),
-                    []
+                    [],
+                    'laravel'
                 );
             }
         );

--- a/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
+++ b/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
@@ -209,7 +209,7 @@ class LaravelIntegration extends Integration
                     if ($span->resource == 'eloquent.created: User') {
                         $authClass = 'User';
                         if (
-                            !function_exists('\datadog\appsec\track_user_signup_event_automated') ||
+                            !function_exists('\datadog\appsec\internal\track_user_signup_event_automated') ||
                             !isset($args[1]) ||
                             !$args[1] ||
                             !($args[1] instanceof $authClass)
@@ -222,7 +222,7 @@ class LaravelIntegration extends Integration
                             $id = $args[1]['id'];
                         }
 
-                        \datadog\appsec\track_user_signup_event_automated('laravel', self::getLoginFromArgs($args[1]), $id, []);
+                        \datadog\appsec\internal\track_user_signup_event_automated('laravel', self::getLoginFromArgs($args[1]), $id, []);
                     }
                 },
                 'recurse' => true,
@@ -373,7 +373,7 @@ class LaravelIntegration extends Integration
             'Illuminate\Auth\Events\Failed',
             '__construct',
             static function ($This, $scope, $args) {
-                if (!function_exists('\datadog\appsec\track_user_login_failure_event_automated')) {
+                if (!function_exists('\datadog\appsec\internal\track_user_login_failure_event_automated')) {
                     return;
                 }
 
@@ -389,7 +389,7 @@ class LaravelIntegration extends Integration
                 $userExists = $user instanceof $authClass;
                 $userId = $userExists ? self::getAuthIdentifier($user) : null;
 
-                \datadog\appsec\track_user_login_failure_event_automated(
+                \datadog\appsec\internal\track_user_login_failure_event_automated(
                     'laravel',
                     self::getLoginFromArgs($credentials),
                     $userId ?: null,
@@ -410,14 +410,14 @@ class LaravelIntegration extends Integration
             'attempt',
             null,
             static function ($This, $scope, $args, $loginSuccess) {
-                if ($loginSuccess || !function_exists('\datadog\appsec\track_user_login_failure_event_automated')) {
+                if ($loginSuccess || !function_exists('\datadog\appsec\internal\track_user_login_failure_event_automated')) {
                     return;
                 }
                 if (\class_exists('Illuminate\Auth\Events\Failed', false)) {
                     return;
                 }
 
-                \datadog\appsec\track_user_login_failure_event_automated('laravel', self::getLoginFromArgs($args[0]), null, false, []);
+                \datadog\appsec\internal\track_user_login_failure_event_automated('laravel', self::getLoginFromArgs($args[0]), null, false, []);
             }
         );
 
@@ -428,7 +428,7 @@ class LaravelIntegration extends Integration
             static function ($This, $scope, $args) {
                 $authClass = 'Illuminate\Contracts\Auth\Authenticatable';
                 if (
-                    !function_exists('datadog\appsec\track_user_login_success_event_automated') ||
+                    !function_exists('\datadog\appsec\internal\track_user_login_success_event_automated') ||
                     !isset($args[1]) ||
                     !$args[1] ||
                     !($args[1] instanceof $authClass)
@@ -457,7 +457,7 @@ class LaravelIntegration extends Integration
                     }
                 }
 
-                \datadog\appsec\track_user_login_success_event_automated(
+                \datadog\appsec\internal\track_user_login_success_event_automated(
                     'laravel',
                     self::getLoginFromArgs($user),
                     self::getAuthIdentifier($user),
@@ -473,7 +473,7 @@ class LaravelIntegration extends Integration
             static function ($This, $scope, $args) {
                 $authClass = 'Illuminate\Auth\UserInterface';
                 if (
-                    !function_exists('\datadog\appsec\track_user_login_success_event_automated') ||
+                    !function_exists('\datadog\appsec\internal\track_user_login_success_event_automated') ||
                     !isset($args[0]) ||
                     !$args[0] ||
                     !($args[0] instanceof $authClass)
@@ -491,7 +491,7 @@ class LaravelIntegration extends Integration
                     $metadata['email'] = $args[0]['email'];
                 }
 
-                \datadog\appsec\track_user_login_success_event_automated(
+                \datadog\appsec\internal\track_user_login_success_event_automated(
                     'laravel',
                     self::getLoginFromArgs($args[0]),
                     self::getAuthIdentifier($args[0]),
@@ -506,11 +506,11 @@ class LaravelIntegration extends Integration
             'attempt',
             null,
             static function ($This, $scope, $args, $loginSuccess) {
-                if ($loginSuccess || !function_exists('\datadog\appsec\track_user_login_failure_event_automated')) {
+                if ($loginSuccess || !function_exists('\datadog\appsec\internal\track_user_login_failure_event_automated')) {
                     return;
                 }
 
-                \datadog\appsec\track_user_login_failure_event_automated('laravel', self::getLoginFromArgs($args[0]), null, false, []);
+                \datadog\appsec\internal\track_user_login_failure_event_automated('laravel', self::getLoginFromArgs($args[0]), null, false, []);
             }
         );
 
@@ -520,7 +520,7 @@ class LaravelIntegration extends Integration
             'user',
             null,
             static function ($This, $scope, $args, $user) {
-                if (!function_exists('\datadog\appsec\track_authenticated_user_event_automated')) {
+                if (!function_exists('\datadog\appsec\internal\track_authenticated_user_event_automated')) {
                     return;
                 }
 
@@ -533,7 +533,7 @@ class LaravelIntegration extends Integration
                     return;
                 }
 
-                \datadog\appsec\track_authenticated_user_event_automated(
+                \datadog\appsec\internal\track_authenticated_user_event_automated(
                     'laravel', self::getAuthIdentifier($user)
                 );
             }
@@ -545,7 +545,7 @@ class LaravelIntegration extends Integration
             '__construct',
             null,
             static function ($This, $scope, $args) {
-                if (!function_exists('\datadog\appsec\track_authenticated_user_event_automated')) {
+                if (!function_exists('\datadog\appsec\internal\track_authenticated_user_event_automated')) {
                     return;
                 }
 
@@ -558,7 +558,7 @@ class LaravelIntegration extends Integration
                     return;
                 }
 
-                \datadog\appsec\track_authenticated_user_event_automated(
+                \datadog\appsec\internal\track_authenticated_user_event_automated(
                     'laravel', self::getAuthIdentifier($args[1])
                 );
             }
@@ -571,7 +571,7 @@ class LaravelIntegration extends Integration
             static function ($This, $scope, $args) {
                 $authClass = 'Illuminate\Contracts\Auth\Authenticatable';
                 if (
-                    !function_exists('\datadog\appsec\track_user_signup_event_automated') ||
+                    !function_exists('\datadog\appsec\internal\track_user_signup_event_automated') ||
                     !isset($args[0]) ||
                     !$args[0] ||
                     !($args[0] instanceof $authClass)
@@ -579,7 +579,7 @@ class LaravelIntegration extends Integration
                     return;
                 }
 
-                \datadog\appsec\track_user_signup_event_automated(
+                \datadog\appsec\internal\track_user_signup_event_automated(
                     'laravel',
                     self::getLoginFromArgs($args[0]),
                     self::getAuthIdentifier($args[0]),

--- a/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
+++ b/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
@@ -222,7 +222,7 @@ class LaravelIntegration extends Integration
                             $id = $args[1]['id'];
                         }
 
-                        \datadog\appsec\track_user_signup_event_automated(self::getLoginFromArgs($args[1]), $id, [], 'laravel');
+                        \datadog\appsec\track_user_signup_event_automated('laravel', self::getLoginFromArgs($args[1]), $id, []);
                     }
                 },
                 'recurse' => true,
@@ -390,11 +390,11 @@ class LaravelIntegration extends Integration
                 $userId = $userExists ? self::getAuthIdentifier($user) : null;
 
                 \datadog\appsec\track_user_login_failure_event_automated(
+                    'laravel',
                     self::getLoginFromArgs($credentials),
                     $userId ?: null,
                     $userExists,
-                    [],
-                    'laravel'
+                    []
                 );
             }
         );
@@ -417,7 +417,7 @@ class LaravelIntegration extends Integration
                     return;
                 }
 
-                \datadog\appsec\track_user_login_failure_event_automated(self::getLoginFromArgs($args[0]), null, false, [], 'laravel');
+                \datadog\appsec\track_user_login_failure_event_automated('laravel', self::getLoginFromArgs($args[0]), null, false, []);
             }
         );
 
@@ -458,10 +458,10 @@ class LaravelIntegration extends Integration
                 }
 
                 \datadog\appsec\track_user_login_success_event_automated(
+                    'laravel',
                     self::getLoginFromArgs($user),
                     self::getAuthIdentifier($user),
-                    $metadata,
-                    'laravel'
+                    $metadata
                 );
             }
         );
@@ -492,10 +492,10 @@ class LaravelIntegration extends Integration
                 }
 
                 \datadog\appsec\track_user_login_success_event_automated(
+                    'laravel',
                     self::getLoginFromArgs($args[0]),
                     self::getAuthIdentifier($args[0]),
-                    $metadata,
-                    'laravel'
+                    $metadata
                 );
             }
         );
@@ -510,7 +510,7 @@ class LaravelIntegration extends Integration
                     return;
                 }
 
-                \datadog\appsec\track_user_login_failure_event_automated(self::getLoginFromArgs($args[0]), null, false, [], 'laravel');
+                \datadog\appsec\track_user_login_failure_event_automated('laravel', self::getLoginFromArgs($args[0]), null, false, []);
             }
         );
 
@@ -534,7 +534,7 @@ class LaravelIntegration extends Integration
                 }
 
                 \datadog\appsec\track_authenticated_user_event_automated(
-                    self::getAuthIdentifier($user), 'laravel'
+                    'laravel', self::getAuthIdentifier($user)
                 );
             }
         );
@@ -559,7 +559,7 @@ class LaravelIntegration extends Integration
                 }
 
                 \datadog\appsec\track_authenticated_user_event_automated(
-                    self::getAuthIdentifier($args[1]), 'laravel'
+                    'laravel', self::getAuthIdentifier($args[1])
                 );
             }
         );
@@ -580,10 +580,10 @@ class LaravelIntegration extends Integration
                 }
 
                 \datadog\appsec\track_user_signup_event_automated(
+                    'laravel',
                     self::getLoginFromArgs($args[0]),
                     self::getAuthIdentifier($args[0]),
-                    [],
-                    'laravel'
+                    []
                 );
             }
         );

--- a/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
+++ b/src/DDTrace/Integrations/Laravel/LaravelIntegration.php
@@ -364,13 +364,56 @@ class LaravelIntegration extends Integration
             ]
         );
 
-        // Used by Laravel >= 5.0
+        // Used by Laravel >= 5.2.35 (SessionGuard started dispatching Failed in
+        // that point release). Carries the resolved user when credentials matched
+        // a known account (wrong-password case) so we can populate usr.id alongside
+        // usr.login. Constructor signature is ($user, $credentials) on 5.2-5.6 and
+        // ($guard, $user, $credentials) on 5.7+.
+        \DDTrace\hook_method(
+            'Illuminate\Auth\Events\Failed',
+            '__construct',
+            static function ($This, $scope, $args) {
+                if (!function_exists('\datadog\appsec\track_user_login_failure_event_automated')) {
+                    return;
+                }
+
+                if (\count($args) >= 3) {
+                    $user = $args[1] ?? null;
+                    $credentials = $args[2] ?? null;
+                } else {
+                    $user = $args[0] ?? null;
+                    $credentials = $args[1] ?? null;
+                }
+
+                $authClass = 'Illuminate\Contracts\Auth\Authenticatable';
+                $userExists = $user instanceof $authClass;
+                $userId = $userExists ? self::getAuthIdentifier($user) : null;
+
+                \datadog\appsec\track_user_login_failure_event_automated(
+                    self::getLoginFromArgs($credentials),
+                    $userId ?: null,
+                    $userExists,
+                    [],
+                    'laravel'
+                );
+            }
+        );
+
+        // Used by Laravel >= 5.2 (SessionGuard exists since 5.2; earlier versions
+        // use Illuminate\Auth\Guard, hooked separately below). Fallback for the
+        // 5.2.0-5.2.34 window where SessionGuard exists but doesn't dispatch the
+        // Failed event yet. When Failed is available it has already fired by the
+        // time this post-hook runs, so we skip to avoid overwriting the user_id
+        // captured there.
         \DDTrace\hook_method(
             'Illuminate\Auth\SessionGuard',
             'attempt',
             null,
             static function ($This, $scope, $args, $loginSuccess) {
                 if ($loginSuccess || !function_exists('\datadog\appsec\track_user_login_failure_event_automated')) {
+                    return;
+                }
+                if (\class_exists('Illuminate\Auth\Events\Failed', false)) {
                     return;
                 }
 

--- a/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
@@ -86,7 +86,7 @@ class SymfonyIntegration extends Integration
             'Doctrine\ORM\UnitOfWork',
             'executeInserts',
             static function($This, $scope, $args) {
-                if (!function_exists('\datadog\appsec\track_user_signup_event_automated')) {
+                if (!function_exists('\datadog\appsec\internal\track_user_signup_event_automated')) {
                     return;
                 }
 
@@ -115,7 +115,7 @@ class SymfonyIntegration extends Integration
                     $user = $userEntity->getUserIdentifier();
                 }
 
-                \datadog\appsec\track_user_signup_event_automated('symfony', $user, $user, []);
+                \datadog\appsec\internal\track_user_signup_event_automated('symfony', $user, $user, []);
             }
         );
 
@@ -124,7 +124,7 @@ class SymfonyIntegration extends Integration
             'Symfony\Component\Security\Guard\Authenticator\AbstractFormLoginAuthenticator',
             'onAuthenticationSuccess',
             static function($This, $scope, $args) {
-                if (!function_exists('\datadog\appsec\track_user_login_success_event_automated')) {
+                if (!function_exists('\datadog\appsec\internal\track_user_login_success_event_automated')) {
                     return;
                 }
                 if (!isset($args[1])) {
@@ -140,7 +140,7 @@ class SymfonyIntegration extends Integration
                 $metadata = [];
                 $user = \method_exists($token, 'getUsername') ? $token->getUsername() : '';
 
-                \datadog\appsec\track_user_login_success_event_automated(
+                \datadog\appsec\internal\track_user_login_success_event_automated(
                     'symfony',
                     $user,
                     $user,
@@ -154,13 +154,13 @@ class SymfonyIntegration extends Integration
             'Symfony\Component\Security\Guard\Authenticator\AbstractFormLoginAuthenticator',
             'onAuthenticationFailure',
             static function($This, $scope, $args) {
-                if (!function_exists('\datadog\appsec\track_user_login_failure_event_automated')) {
+                if (!function_exists('\datadog\appsec\internal\track_user_login_failure_event_automated')) {
                     return;
                 }
                 $login = SymfonyIntegration::extractLoginFromAuthFailure(
                     $args[0] ?? null, $args[1] ?? null
                 );
-                \datadog\appsec\track_user_login_failure_event_automated('symfony', $login, null, false, []);
+                \datadog\appsec\internal\track_user_login_failure_event_automated('symfony', $login, null, false, []);
             }
         );
 
@@ -169,13 +169,13 @@ class SymfonyIntegration extends Integration
             'Symfony\Component\Security\Http\Firewall\AbstractAuthenticationListener',
             'onFailure',
             static function($This, $scope, $args) {
-                if (!function_exists('\datadog\appsec\track_user_login_failure_event_automated')) {
+                if (!function_exists('\datadog\appsec\internal\track_user_login_failure_event_automated')) {
                     return;
                 }
                 $login = SymfonyIntegration::extractLoginFromAuthFailure(
                     $args[0] ?? null, $args[1] ?? null
                 );
-                \datadog\appsec\track_user_login_failure_event_automated('symfony', $login, null, false, []);
+                \datadog\appsec\internal\track_user_login_failure_event_automated('symfony', $login, null, false, []);
             }
         );
 
@@ -184,7 +184,7 @@ class SymfonyIntegration extends Integration
             'Symfony\Component\Security\Http\Firewall\AbstractAuthenticationListener',
             'onSuccess',
             static function($This, $scope, $args) {
-                if (!function_exists('\datadog\appsec\track_user_login_success_event_automated')) {
+                if (!function_exists('\datadog\appsec\internal\track_user_login_success_event_automated')) {
                     return;
                 }
                 if (!isset($args[1])) {
@@ -199,7 +199,7 @@ class SymfonyIntegration extends Integration
                 $metadata = [];
                 $user = \method_exists($token, 'getUsername') ? $token->getUsername() : '';
 
-                \datadog\appsec\track_user_login_success_event_automated(
+                \datadog\appsec\internal\track_user_login_success_event_automated(
                     'symfony',
                     $user,
                     $user,
@@ -213,13 +213,13 @@ class SymfonyIntegration extends Integration
             'Symfony\Component\Security\Http\Authenticator\FormLoginAuthenticator',
             'onAuthenticationFailure',
             static function($This, $scope, $args) {
-                if (!function_exists('\datadog\appsec\track_user_login_failure_event_automated')) {
+                if (!function_exists('\datadog\appsec\internal\track_user_login_failure_event_automated')) {
                     return;
                 }
                 $login = SymfonyIntegration::extractLoginFromAuthFailure(
                     $args[0] ?? null, $args[1] ?? null
                 );
-                \datadog\appsec\track_user_login_failure_event_automated('symfony', $login, null, false, []);
+                \datadog\appsec\internal\track_user_login_failure_event_automated('symfony', $login, null, false, []);
             }
         );
 
@@ -228,7 +228,7 @@ class SymfonyIntegration extends Integration
             'Symfony\Component\Security\Http\Authenticator\FormLoginAuthenticator',
             'onAuthenticationSuccess',
             static function($This, $scope, $args) {
-                if (!function_exists('\datadog\appsec\track_user_login_success_event_automated')) {
+                if (!function_exists('\datadog\appsec\internal\track_user_login_success_event_automated')) {
                     return;
                 }
                 if (!isset($args[1])) {
@@ -251,7 +251,7 @@ class SymfonyIntegration extends Integration
                     ? $user->getUserIdentifier()
                     : (method_exists($user, 'getUsername') ? $user->getUsername() : '');
 
-                \datadog\appsec\track_user_login_success_event_automated(
+                \datadog\appsec\internal\track_user_login_success_event_automated(
                     'symfony',
                     $userIdentifier,
                     $userIdentifier,
@@ -264,7 +264,7 @@ class SymfonyIntegration extends Integration
             'Symfony\Component\Security\Core\Authorization\AccessDecisionManagerInterface',
             'decide',
             static function($This, $scope, $args, $result) {
-                if (!function_exists('\datadog\appsec\track_authenticated_user_event_automated')) {
+                if (!function_exists('\datadog\appsec\internal\track_authenticated_user_event_automated')) {
                     return;
                 }
 
@@ -285,7 +285,7 @@ class SymfonyIntegration extends Integration
                     : (method_exists($user, 'getUsername') ? $user->getUsername() : '');
 
                 // Track the access check
-                \datadog\appsec\track_authenticated_user_event_automated('symfony', $userIdentifier);
+                \datadog\appsec\internal\track_authenticated_user_event_automated('symfony', $userIdentifier);
             }
         );
 

--- a/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
@@ -115,7 +115,7 @@ class SymfonyIntegration extends Integration
                     $user = $userEntity->getUserIdentifier();
                 }
 
-                \datadog\appsec\track_user_signup_event_automated($user, $user, [], 'symfony');
+                \datadog\appsec\track_user_signup_event_automated('symfony', $user, $user, []);
             }
         );
 
@@ -141,10 +141,10 @@ class SymfonyIntegration extends Integration
                 $user = \method_exists($token, 'getUsername') ? $token->getUsername() : '';
 
                 \datadog\appsec\track_user_login_success_event_automated(
+                    'symfony',
                     $user,
                     $user,
-                    $metadata,
-                    'symfony'
+                    $metadata
                 );
             }
         );
@@ -160,7 +160,7 @@ class SymfonyIntegration extends Integration
                 $login = SymfonyIntegration::extractLoginFromAuthFailure(
                     $args[0] ?? null, $args[1] ?? null
                 );
-                \datadog\appsec\track_user_login_failure_event_automated($login, null, false, [], 'symfony');
+                \datadog\appsec\track_user_login_failure_event_automated('symfony', $login, null, false, []);
             }
         );
 
@@ -175,7 +175,7 @@ class SymfonyIntegration extends Integration
                 $login = SymfonyIntegration::extractLoginFromAuthFailure(
                     $args[0] ?? null, $args[1] ?? null
                 );
-                \datadog\appsec\track_user_login_failure_event_automated($login, null, false, [], 'symfony');
+                \datadog\appsec\track_user_login_failure_event_automated('symfony', $login, null, false, []);
             }
         );
 
@@ -200,10 +200,10 @@ class SymfonyIntegration extends Integration
                 $user = \method_exists($token, 'getUsername') ? $token->getUsername() : '';
 
                 \datadog\appsec\track_user_login_success_event_automated(
+                    'symfony',
                     $user,
                     $user,
-                    $metadata,
-                    'symfony'
+                    $metadata
                 );
             }
         );
@@ -219,7 +219,7 @@ class SymfonyIntegration extends Integration
                 $login = SymfonyIntegration::extractLoginFromAuthFailure(
                     $args[0] ?? null, $args[1] ?? null
                 );
-                \datadog\appsec\track_user_login_failure_event_automated($login, null, false, [], 'symfony');
+                \datadog\appsec\track_user_login_failure_event_automated('symfony', $login, null, false, []);
             }
         );
 
@@ -252,10 +252,10 @@ class SymfonyIntegration extends Integration
                     : (method_exists($user, 'getUsername') ? $user->getUsername() : '');
 
                 \datadog\appsec\track_user_login_success_event_automated(
+                    'symfony',
                     $userIdentifier,
                     $userIdentifier,
-                    $metadata,
-                    'symfony'
+                    $metadata
                 );
             }
         );
@@ -285,7 +285,7 @@ class SymfonyIntegration extends Integration
                     : (method_exists($user, 'getUsername') ? $user->getUsername() : '');
 
                 // Track the access check
-                \datadog\appsec\track_authenticated_user_event_automated($userIdentifier, 'symfony');
+                \datadog\appsec\track_authenticated_user_event_automated('symfony', $userIdentifier);
             }
         );
 

--- a/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
@@ -157,7 +157,10 @@ class SymfonyIntegration extends Integration
                 if (!function_exists('\datadog\appsec\track_user_login_failure_event_automated')) {
                     return;
                 }
-                \datadog\appsec\track_user_login_failure_event_automated(null, null, false, [], 'symfony');
+                $login = SymfonyIntegration::extractLoginFromAuthFailure(
+                    $args[0] ?? null, $args[1] ?? null
+                );
+                \datadog\appsec\track_user_login_failure_event_automated($login, null, false, [], 'symfony');
             }
         );
 
@@ -169,7 +172,10 @@ class SymfonyIntegration extends Integration
                 if (!function_exists('\datadog\appsec\track_user_login_failure_event_automated')) {
                     return;
                 }
-                \datadog\appsec\track_user_login_failure_event_automated(null, null, false, [], 'symfony');
+                $login = SymfonyIntegration::extractLoginFromAuthFailure(
+                    $args[0] ?? null, $args[1] ?? null
+                );
+                \datadog\appsec\track_user_login_failure_event_automated($login, null, false, [], 'symfony');
             }
         );
 
@@ -210,7 +216,10 @@ class SymfonyIntegration extends Integration
                 if (!function_exists('\datadog\appsec\track_user_login_failure_event_automated')) {
                     return;
                 }
-                \datadog\appsec\track_user_login_failure_event_automated(null, null, false, [], 'symfony');
+                $login = SymfonyIntegration::extractLoginFromAuthFailure(
+                    $args[0] ?? null, $args[1] ?? null
+                );
+                \datadog\appsec\track_user_login_failure_event_automated($login, null, false, [], 'symfony');
             }
         );
 
@@ -659,6 +668,65 @@ class SymfonyIntegration extends Integration
                 $hook->data = true;
             });
         }
+    }
+
+    /**
+     * Extract the attempted login name from a Symfony authentication failure.
+     *
+     * Three sources in order of preference:
+     *   A) AuthenticationException::getToken() — set by AuthenticationProviderManager (legacy system)
+     *   B) Walk exception chain for UserNotFoundException / UsernameNotFoundException
+     *   C) Session '_security.last_username' — set by form login before calling authenticate
+     */
+    public static function extractLoginFromAuthFailure($request, $exception): ?string
+    {
+        $login = null;
+
+        // Path A: token attached by AuthenticationProviderManager (Symfony 5.x legacy path)
+        if ($exception !== null && \method_exists($exception, 'getToken')) {
+            $token = $exception->getToken();
+            if ($token) {
+                $login = \method_exists($token, 'getUserIdentifier')
+                    ? $token->getUserIdentifier()
+                    : (\method_exists($token, 'getUsername') ? $token->getUsername() : null);
+            }
+        }
+
+        // Path B: UserNotFoundException / UsernameNotFoundException carries the identifier
+        if (!$login && $exception !== null) {
+            $e = $exception;
+            while ($e !== null) {
+                if (\method_exists($e, 'getUserIdentifier')) {
+                    $id = $e->getUserIdentifier();
+                    if ($id) {
+                        $login = $id;
+                        break;
+                    }
+                } elseif (\method_exists($e, 'getUsername')) {
+                    $name = $e->getUsername();
+                    if ($name) {
+                        $login = $name;
+                        break;
+                    }
+                }
+                $e = \method_exists($e, 'getPrevious') ? $e->getPrevious() : null;
+            }
+        }
+
+        // Path C: session '_security.last_username' — most reliable for form-based logins;
+        // set before authenticate() is called so it survives even when exceptions don't carry tokens
+        if (!$login && $request !== null && \method_exists($request, 'hasSession')) {
+            try {
+                if ($request->hasSession()) {
+                    $sessionLogin = $request->getSession()->get('_security.last_username');
+                    if ($sessionLogin) {
+                        $login = $sessionLogin;
+                    }
+                }
+            } catch (\Throwable $ignored) {}
+        }
+
+        return $login ?: null;
     }
 
     /**

--- a/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
@@ -115,7 +115,7 @@ class SymfonyIntegration extends Integration
                     $user = $userEntity->getUserIdentifier();
                 }
 
-                \datadog\appsec\track_user_signup_event_automated($user, $user, []);
+                \datadog\appsec\track_user_signup_event_automated($user, $user, [], 'symfony');
             }
         );
 
@@ -143,7 +143,8 @@ class SymfonyIntegration extends Integration
                 \datadog\appsec\track_user_login_success_event_automated(
                     $user,
                     $user,
-                    $metadata
+                    $metadata,
+                    'symfony'
                 );
             }
         );
@@ -156,7 +157,7 @@ class SymfonyIntegration extends Integration
                 if (!function_exists('\datadog\appsec\track_user_login_failure_event_automated')) {
                     return;
                 }
-                \datadog\appsec\track_user_login_failure_event_automated(null, null, false, []);
+                \datadog\appsec\track_user_login_failure_event_automated(null, null, false, [], 'symfony');
             }
         );
 
@@ -168,7 +169,7 @@ class SymfonyIntegration extends Integration
                 if (!function_exists('\datadog\appsec\track_user_login_failure_event_automated')) {
                     return;
                 }
-                \datadog\appsec\track_user_login_failure_event_automated(null, null, false, []);
+                \datadog\appsec\track_user_login_failure_event_automated(null, null, false, [], 'symfony');
             }
         );
 
@@ -195,7 +196,8 @@ class SymfonyIntegration extends Integration
                 \datadog\appsec\track_user_login_success_event_automated(
                     $user,
                     $user,
-                    $metadata
+                    $metadata,
+                    'symfony'
                 );
             }
         );
@@ -208,7 +210,7 @@ class SymfonyIntegration extends Integration
                 if (!function_exists('\datadog\appsec\track_user_login_failure_event_automated')) {
                     return;
                 }
-                \datadog\appsec\track_user_login_failure_event_automated(null, null, false, []);
+                \datadog\appsec\track_user_login_failure_event_automated(null, null, false, [], 'symfony');
             }
         );
 
@@ -243,7 +245,8 @@ class SymfonyIntegration extends Integration
                 \datadog\appsec\track_user_login_success_event_automated(
                     $userIdentifier,
                     $userIdentifier,
-                    $metadata
+                    $metadata,
+                    'symfony'
                 );
             }
         );
@@ -273,7 +276,7 @@ class SymfonyIntegration extends Integration
                     : (method_exists($user, 'getUsername') ? $user->getUsername() : '');
 
                 // Track the access check
-                \datadog\appsec\track_authenticated_user_event_automated($userIdentifier);
+                \datadog\appsec\track_authenticated_user_event_automated($userIdentifier, 'symfony');
             }
         );
 

--- a/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
+++ b/src/DDTrace/Integrations/Symfony/SymfonyIntegration.php
@@ -678,7 +678,7 @@ class SymfonyIntegration extends Integration
      *   B) Walk exception chain for UserNotFoundException / UsernameNotFoundException
      *   C) Session '_security.last_username' — set by form login before calling authenticate
      */
-    public static function extractLoginFromAuthFailure($request, $exception): ?string
+    public static function extractLoginFromAuthFailure($request, $exception)
     {
         $login = null;
 

--- a/src/DDTrace/Integrations/WordPress/WordPressIntegration.php
+++ b/src/DDTrace/Integrations/WordPress/WordPressIntegration.php
@@ -71,7 +71,7 @@ class WordPressIntegration extends Integration
                         && in_array($retval->get_error_code(), ['empty_username', 'empty_password'], true)) {
                         return;
                     }
-                    if (!function_exists('\datadog\appsec\track_user_login_failure_event_automated')) {
+                    if (!function_exists('\datadog\appsec\internal\track_user_login_failure_event_automated')) {
                         return;
                     }
                     $exists = $retval instanceof $errorClass &&
@@ -79,12 +79,12 @@ class WordPressIntegration extends Integration
                         is_array($retval->errors) &&
                         isset($retval->errors['incorrect_password']);
 
-                    \datadog\appsec\track_user_login_failure_event_automated('wordpress', $username, null, $exists, []);
+                    \datadog\appsec\internal\track_user_login_failure_event_automated('wordpress', $username, null, $exists, []);
                     return;
                 }
 
                 //From this moment on, login is succesful
-                if (!function_exists('\datadog\appsec\track_user_login_success_event_automated')) {
+                if (!function_exists('\datadog\appsec\internal\track_user_login_success_event_automated')) {
                     return;
                 }
 
@@ -100,7 +100,7 @@ class WordPressIntegration extends Integration
                     $metadata['name'] = $data->display_name;
                 }
 
-                \datadog\appsec\track_user_login_success_event_automated(
+                \datadog\appsec\internal\track_user_login_success_event_automated(
                     'wordpress',
                     $username,
                     $id,
@@ -114,7 +114,7 @@ class WordPressIntegration extends Integration
             'register_new_user',
             null,
             static function ($args, $retval) {
-                if (!function_exists('\datadog\appsec\track_user_signup_event_automated')) {
+                if (!function_exists('\datadog\appsec\internal\track_user_signup_event_automated')) {
                     return;
                 }
 
@@ -130,7 +130,7 @@ class WordPressIntegration extends Integration
                     $metadata['email'] = $args[1];
                 }
 
-                \datadog\appsec\track_user_signup_event_automated(
+                \datadog\appsec\internal\track_user_signup_event_automated(
                     'wordpress',
                     $login,
                     $retval,
@@ -143,12 +143,12 @@ class WordPressIntegration extends Integration
             'wp_validate_auth_cookie',
             null,
             static function ($args, $retval) {
-                if (!function_exists('\datadog\appsec\track_authenticated_user_event_automated')) {
+                if (!function_exists('\datadog\appsec\internal\track_authenticated_user_event_automated')) {
                     return;
                 }
 
                 if ($retval !== false) {
-                    \datadog\appsec\track_authenticated_user_event_automated(
+                    \datadog\appsec\internal\track_authenticated_user_event_automated(
                         'wordpress', $retval
                     );
                 }

--- a/src/DDTrace/Integrations/WordPress/WordPressIntegration.php
+++ b/src/DDTrace/Integrations/WordPress/WordPressIntegration.php
@@ -65,16 +65,13 @@ class WordPressIntegration extends Integration
                     if (!function_exists('\datadog\appsec\track_user_login_failure_event_automated')) {
                         return;
                     }
-                    if (empty($username)) {
-                        return;
-                    }
                     $errorClass = '\WP_Error';
                     $exists = $retval instanceof $errorClass &&
                         \property_exists($retval, 'errors') &&
                         is_array($retval->errors) &&
                         isset($retval->errors['incorrect_password']);
 
-                    \datadog\appsec\track_user_login_failure_event_automated($username, $username, $exists, []);
+                    \datadog\appsec\track_user_login_failure_event_automated($username, $username, $exists, [], 'wordpress');
                     return;
                 }
 
@@ -98,7 +95,8 @@ class WordPressIntegration extends Integration
                 \datadog\appsec\track_user_login_success_event_automated(
                     $username,
                     $id,
-                    $metadata
+                    $metadata,
+                    'wordpress'
                 );
             }
         );
@@ -127,7 +125,8 @@ class WordPressIntegration extends Integration
                 \datadog\appsec\track_user_signup_event_automated(
                     $login,
                     $retval,
-                    $metadata
+                    $metadata,
+                    'wordpress'
                 );
             }
         );
@@ -142,7 +141,7 @@ class WordPressIntegration extends Integration
 
                 if ($retval !== false) {
                     \datadog\appsec\track_authenticated_user_event_automated(
-                        $retval
+                        $retval, 'wordpress'
                     );
                 }
             }

--- a/src/DDTrace/Integrations/WordPress/WordPressIntegration.php
+++ b/src/DDTrace/Integrations/WordPress/WordPressIntegration.php
@@ -79,7 +79,7 @@ class WordPressIntegration extends Integration
                         is_array($retval->errors) &&
                         isset($retval->errors['incorrect_password']);
 
-                    \datadog\appsec\track_user_login_failure_event_automated('wordpress', $username, $username, $exists, []);
+                    \datadog\appsec\track_user_login_failure_event_automated('wordpress', $username, null, $exists, []);
                     return;
                 }
 

--- a/src/DDTrace/Integrations/WordPress/WordPressIntegration.php
+++ b/src/DDTrace/Integrations/WordPress/WordPressIntegration.php
@@ -62,16 +62,24 @@ class WordPressIntegration extends Integration
 
                 if (!($retval instanceof $userClass)) {
                     //Login failed
+                    // Mirror WordPress' own $ignore_codes (wp-includes/pluggable.php
+                    // wp_authenticate). When the failure is a missing username or
+                    // password, WP itself does not consider this a real attempt —
+                    // skip emitting an automated event (e.g. plain GET /wp-login.php).
+                    $errorClass = '\WP_Error';
+                    if ($retval instanceof $errorClass
+                        && in_array($retval->get_error_code(), ['empty_username', 'empty_password'], true)) {
+                        return;
+                    }
                     if (!function_exists('\datadog\appsec\track_user_login_failure_event_automated')) {
                         return;
                     }
-                    $errorClass = '\WP_Error';
                     $exists = $retval instanceof $errorClass &&
                         \property_exists($retval, 'errors') &&
                         is_array($retval->errors) &&
                         isset($retval->errors['incorrect_password']);
 
-                    \datadog\appsec\track_user_login_failure_event_automated($username, $username, $exists, [], 'wordpress');
+                    \datadog\appsec\track_user_login_failure_event_automated('wordpress', $username, $username, $exists, []);
                     return;
                 }
 
@@ -93,10 +101,10 @@ class WordPressIntegration extends Integration
                 }
 
                 \datadog\appsec\track_user_login_success_event_automated(
+                    'wordpress',
                     $username,
                     $id,
-                    $metadata,
-                    'wordpress'
+                    $metadata
                 );
             }
         );
@@ -123,10 +131,10 @@ class WordPressIntegration extends Integration
                 }
 
                 \datadog\appsec\track_user_signup_event_automated(
+                    'wordpress',
                     $login,
                     $retval,
-                    $metadata,
-                    'wordpress'
+                    $metadata
                 );
             }
         );
@@ -141,7 +149,7 @@ class WordPressIntegration extends Integration
 
                 if ($retval !== false) {
                     \datadog\appsec\track_authenticated_user_event_automated(
-                        $retval, 'wordpress'
+                        'wordpress', $retval
                     );
                 }
             }

--- a/tests/Appsec/Mock.php
+++ b/tests/Appsec/Mock.php
@@ -247,12 +247,13 @@ if (!function_exists('datadog\appsec\track_user_login_success_event_automated'))
     /**
      * This function is exposed by appsec but here we are mocking it for tests
      */
-    function track_user_login_success_event_automated($userLogin, $userId, $metadata)
+    function track_user_login_success_event_automated(string $framework, $userLogin, $userId, $metadata)
     {
         if (!appsecMockEnabled()) {
             return;
         }
         $event = [
+            'framework' => $framework,
             'userLogin' => $userLogin,
             'userId' => $userId,
             'metadata' => $metadata,
@@ -284,12 +285,13 @@ if (!function_exists('datadog\appsec\track_user_login_failure_event_automated'))
     /**
      * This function is exposed by appsec but here we are mocking it for tests
      */
-    function track_user_login_failure_event_automated($userLogin, $userId, $exists, $metadata)
+    function track_user_login_failure_event_automated(string $framework, $userLogin, $userId, $exists, $metadata)
     {
         if (!appsecMockEnabled()) {
             return;
         }
         $event = [
+            'framework' => $framework,
             'userLogin' => $userLogin,
             'userId' => $userId,
             'exists' => $exists,
@@ -322,12 +324,13 @@ if (!function_exists('datadog\appsec\track_user_signup_event_automated')) {
     /**
      * This function is exposed by appsec but here we are mocking it for tests
      */
-    function track_user_signup_event_automated($userLogin, $userId, $metadata)
+    function track_user_signup_event_automated(string $framework, $userLogin, $userId, $metadata)
     {
         if (!appsecMockEnabled()) {
             return;
         }
         $event = [
+            'framework' => $framework,
             'userLogin' => $userLogin,
             'userId' => $userId,
             'metadata' => $metadata,
@@ -358,12 +361,13 @@ if (!function_exists('datadog\appsec\track_authenticated_user_event_automated'))
     /**
      * This function is exposed by appsec but here we are mocking it for tests
      */
-    function track_authenticated_user_event_automated($userId)
+    function track_authenticated_user_event_automated(string $framework, $userId)
     {
         if (!appsecMockEnabled()) {
             return;
         }
         $event = [
+            'framework' => $framework,
             'userId' => $userId,
         ];
         AppsecStatus::getInstance()->addEvent($event, 'track_authenticated_user_event_automated');

--- a/tests/Appsec/Mock.php
+++ b/tests/Appsec/Mock.php
@@ -243,13 +243,15 @@ if (!function_exists('datadog\appsec\appsecMockEnabled')) {
     }
 }
 
-if (!function_exists('datadog\appsec\track_user_login_success_event_automated')) {
+namespace datadog\appsec\internal;
+
+if (!function_exists('datadog\appsec\internal\track_user_login_success_event_automated')) {
     /**
      * This function is exposed by appsec but here we are mocking it for tests
      */
     function track_user_login_success_event_automated(string $framework, $userLogin, $userId, $metadata)
     {
-        if (!appsecMockEnabled()) {
+        if (!\datadog\appsec\appsecMockEnabled()) {
             return;
         }
         $event = [
@@ -259,9 +261,11 @@ if (!function_exists('datadog\appsec\track_user_login_success_event_automated'))
             'metadata' => $metadata,
 
         ];
-        AppsecStatus::getInstance()->addEvent($event, 'track_user_login_success_event_automated');
+        \datadog\appsec\AppsecStatus::getInstance()->addEvent($event, 'track_user_login_success_event_automated');
     }
 }
+
+namespace datadog\appsec;
 
 if (!function_exists('datadog\appsec\track_user_login_success_event')) {
     /**
@@ -281,13 +285,15 @@ if (!function_exists('datadog\appsec\track_user_login_success_event')) {
     }
 }
 
-if (!function_exists('datadog\appsec\track_user_login_failure_event_automated')) {
+namespace datadog\appsec\internal;
+
+if (!function_exists('datadog\appsec\internal\track_user_login_failure_event_automated')) {
     /**
      * This function is exposed by appsec but here we are mocking it for tests
      */
     function track_user_login_failure_event_automated(string $framework, $userLogin, $userId, $exists, $metadata)
     {
-        if (!appsecMockEnabled()) {
+        if (!\datadog\appsec\appsecMockEnabled()) {
             return;
         }
         $event = [
@@ -298,9 +304,11 @@ if (!function_exists('datadog\appsec\track_user_login_failure_event_automated'))
             'metadata' => $metadata,
 
         ];
-        AppsecStatus::getInstance()->addEvent($event, 'track_user_login_failure_event_automated');
+        \datadog\appsec\AppsecStatus::getInstance()->addEvent($event, 'track_user_login_failure_event_automated');
     }
 }
+
+namespace datadog\appsec;
 
 if (!function_exists('datadog\appsec\track_user_login_failure_event')) {
     /**
@@ -320,13 +328,15 @@ if (!function_exists('datadog\appsec\track_user_login_failure_event')) {
     }
 }
 
-if (!function_exists('datadog\appsec\track_user_signup_event_automated')) {
+namespace datadog\appsec\internal;
+
+if (!function_exists('datadog\appsec\internal\track_user_signup_event_automated')) {
     /**
      * This function is exposed by appsec but here we are mocking it for tests
      */
     function track_user_signup_event_automated(string $framework, $userLogin, $userId, $metadata)
     {
-        if (!appsecMockEnabled()) {
+        if (!\datadog\appsec\appsecMockEnabled()) {
             return;
         }
         $event = [
@@ -336,9 +346,11 @@ if (!function_exists('datadog\appsec\track_user_signup_event_automated')) {
             'metadata' => $metadata,
 
         ];
-        AppsecStatus::getInstance()->addEvent($event, 'track_user_signup_event_automated');
+        \datadog\appsec\AppsecStatus::getInstance()->addEvent($event, 'track_user_signup_event_automated');
     }
 }
+
+namespace datadog\appsec;
 
 if (!function_exists('datadog\appsec\track_user_signup_event')) {
     /**
@@ -357,22 +369,26 @@ if (!function_exists('datadog\appsec\track_user_signup_event')) {
     }
 }
 
-if (!function_exists('datadog\appsec\track_authenticated_user_event_automated')) {
+namespace datadog\appsec\internal;
+
+if (!function_exists('datadog\appsec\internal\track_authenticated_user_event_automated')) {
     /**
      * This function is exposed by appsec but here we are mocking it for tests
      */
     function track_authenticated_user_event_automated(string $framework, $userId)
     {
-        if (!appsecMockEnabled()) {
+        if (!\datadog\appsec\appsecMockEnabled()) {
             return;
         }
         $event = [
             'framework' => $framework,
             'userId' => $userId,
         ];
-        AppsecStatus::getInstance()->addEvent($event, 'track_authenticated_user_event_automated');
+        \datadog\appsec\AppsecStatus::getInstance()->addEvent($event, 'track_authenticated_user_event_automated');
     }
 }
+
+namespace datadog\appsec;
 
 if (!function_exists('datadog\appsec\track_authenticated_user_event')) {
     /**

--- a/tests/Integrations/CLI/Symfony/V6_2/CommonScenariosTest.php
+++ b/tests/Integrations/CLI/Symfony/V6_2/CommonScenariosTest.php
@@ -181,6 +181,7 @@ class CommonScenariosTest extends IntegrationTestCase
             'DD_TRACE_EXEC_ENABLED' => 'false',
         ], [], 'about', false, null, false);
 
+        $this->assertSame([], $traces);
         $this->assertFlameGraph(
             $traces,
             []

--- a/tests/Integrations/Symfony/AutomatedLoginEventsTestSuite.php
+++ b/tests/Integrations/Symfony/AutomatedLoginEventsTestSuite.php
@@ -74,7 +74,7 @@ abstract class AutomatedLoginEventsTestSuite extends AppsecTestCase
         $this->assertEquals(1, count($loginEvents));
         $this->assertEquals(0, count($authEvents));
 
-        $this->assertEmpty($loginEvents[0]['userLogin']);
+        $this->assertEquals($email, $loginEvents[0]['userLogin']);
         $this->assertEmpty($loginEvents[0]['userId']);
         $this->assertEmpty($loginEvents[0]['metadata']);
     }

--- a/tests/Integrations/WordPress/AutomatedLoginEventsTestSuite.php
+++ b/tests/Integrations/WordPress/AutomatedLoginEventsTestSuite.php
@@ -78,7 +78,7 @@ class AutomatedLoginEventsTestSuite extends AppsecTestCase
         $this->assertEquals(1, count($events));
         $this->assertEquals(0, count($authEvents));
 
-        $this->assertEquals($email, $events[0]['userId']);
+        $this->assertNull($events[0]['userId']);
         $this->assertEquals($email, $events[0]['userLogin']);
         $this->assertFalse($events[0]['exists']);
         $this->assertEmpty($events[0]['metadata']);
@@ -100,7 +100,7 @@ class AutomatedLoginEventsTestSuite extends AppsecTestCase
         $this->assertEquals(1, count($events));
         $this->assertEquals(0, count($authEvents));
 
-        $this->assertEquals($email, $events[0]['userId']);
+        $this->assertNull($events[0]['userId']);
         $this->assertEquals($email, $events[0]['userLogin']);
         $this->assertTrue($events[0]['exists']);
         $this->assertEmpty($events[0]['metadata']);


### PR DESCRIPTION
### Description

* Emit `missing_user_login` / `missing_user_id` telemetry metrics tagged with  the framework name when login/id are absent
* WordPress: stop silently swallowing failures with empty username (pass null through so missing_user_login telemetry fires correctly)
*  Add WordPress integration test app and WordPressTests test class
* Improve login failure events on symfony/laravel so that usr.login (and on, laravel, possibly usr.id) are passed

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
