### PR TITLE
fix(ci): skip macrobenchmarks when package extension is not built

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -90,8 +90,14 @@ workflow:
 
 .pre-release-performance-quality-gates-rules: &pre-release-performance-quality-gates-rules
   - <<: *on-master-or-nightly-benchmarks-or-release-on-success-and-not-interruptible
-  # Unlike on "master", on nightly benchmarks, or on release branches there's
-  # no strict requirement to prevent interruption.
+  - interruptible: true
+
+# notify-slo-breaches must use `when: always` so it fires even when
+# check-slo-breaches fails — a failure there means a breach was detected.
+.notify-slo-breaches-rules: &notify-slo-breaches-rules
+  - if: '($CI_COMMIT_REF_NAME == "master" && ($NIGHTLY_BENCHMARKS || $CI_PIPELINE_SOURCE != "schedule")) || $CI_COMMIT_REF_NAME =~ /^ddtrace-/'
+    when: always
+    interruptible: false
   - interruptible: true
 
 .microbenchmarks:
@@ -255,6 +261,6 @@ notify-slo-breaches:
   extends: .notify-slo-breaches
   stage: notify
   needs: ["check-slo-breaches"]
-  rules: *pre-release-performance-quality-gates-rules
+  rules: *notify-slo-breaches-rules
   variables:
     CHANNEL: "guild-dd-php"

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -77,21 +77,21 @@ workflow:
     allow_failure: true
     interruptible: true
 
-.on-master-or-nightly-benchmarks-or-release-always-and-not-interruptible: &on-master-or-nightly-benchmarks-or-release-always-and-not-interruptible
+.on-master-or-nightly-benchmarks-or-release-on-success-and-not-interruptible: &on-master-or-nightly-benchmarks-or-release-on-success-and-not-interruptible
   if: '($CI_COMMIT_REF_NAME == "master" && ($NIGHTLY_BENCHMARKS || $CI_PIPELINE_SOURCE != "schedule")) || $CI_COMMIT_REF_NAME =~ /^ddtrace-/'
-  when: always
+  when: on_success
   interruptible: false
 
 .macrobenchmarks-rules: &macrobenchmarks-rules
-  - <<: *on-master-or-nightly-benchmarks-or-release-always-and-not-interruptible
+  - <<: *on-master-or-nightly-benchmarks-or-release-on-success-and-not-interruptible
   - when: manual
     allow_failure: true
     interruptible: true
 
 .pre-release-performance-quality-gates-rules: &pre-release-performance-quality-gates-rules
-  - <<: *on-master-or-nightly-benchmarks-or-release-always-and-not-interruptible
+  - <<: *on-master-or-nightly-benchmarks-or-release-on-success-and-not-interruptible
   # Unlike on "master", on nightly benchmarks, or on release branches there's
-  # no strict requirement to run the check unconditionally with "when: always".
+  # no strict requirement to prevent interruption.
   - interruptible: true
 
 .microbenchmarks:


### PR DESCRIPTION
## Problem

Macrobenchmark jobs were launching even when `package extension: [amd64, x86_64-unknown-linux-gnu]` was skipped (e.g. due to an upstream compile failure). The missing tarball caused all non-baseline benchmark configurations to fail with:

```
tar: dd-library-php-*-x86_64-linux-gnu.tar.gz: Cannot open: No such file or directory
ERROR: Cannot extract the archive
```

## Root cause

The shared rule anchor used by `.macrobenchmarks-rules` and `.pre-release-performance-quality-gates-rules` had `when: always`. In GitLab CI, `when: always` overrides `needs` dependency checks — the job runs regardless of whether its dependencies were skipped or failed.

## Fix

Change `when: always` to `when: on_success` in the shared rule anchor. With `needs`, `when: on_success` checks only the listed direct dependencies (not the whole pipeline), so macrobenchmarks still run whenever `package extension` and `datadog-setup.php` succeed, and are correctly skipped when they don't.

`check-slo-breaches` and `notify-slo-breaches` are also correctly skipped when macrobenchmarks don't run, since they have no results to evaluate.

## Verification

https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-php/-/pipelines/111994145.
Package extension has been canceled, macrobenchmark can not be ran since it depends on it now 