### PR TITLE
chore(ci): collect sidecar logs for test jobs

### DIFF
--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -204,6 +204,7 @@ stages:
     DATADOG_HAVE_DEV_ENV: 1
     HTTPBIN_HOSTNAME: httpbin-integration
     HTTPBIN_PORT: 8080
+<?php sidecar_logs(); ?>
   before_script:
 <?php before_script_steps(true) ?>
     - .gitlab/wait-for-service-ready.sh
@@ -213,7 +214,6 @@ stages:
   variables:
     SWITCH_PHP_VERSION: debug-zts-asan
     ASAN_OPTIONS: abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1
-<?php sidecar_logs(); ?>
 
 <?php
 foreach ($asan_minor_major_targets as $major_minor):
@@ -505,7 +505,6 @@ foreach ($all_minor_major_targets as $major_minor):
 <?php if (version_compare($major_minor, "7.2", ">=")): /* too expensive */ ?>
     DD_INSTRUMENTATION_TELEMETRY_ENABLED: 0
 <?php endif; ?>
-<?php sidecar_logs(); ?>
   timeout: 40m
   retry:
     max: 2


### PR DESCRIPTION
## Summary
- Lifts `_DD_DEBUG_SIDECAR_LOG_LEVEL=trace` + `_DD_DEBUG_SIDECAR_LOG_METHOD=file://${CI_PROJECT_DIR}/artifacts/sidecar.log` from `.asan_test` / `PHP Language Tests` up into `.base_test`.
- This extends sidecar log capture to all `.debug_test` jobs (notably **test_extension_ci**, plus Unit, API unit, Disabled test_c, Internal api randomized, Opcache, xDebug) and `.cli_integration_test` jobs (web/integration), where we currently fly blind on failures.
- Existing `artifacts: paths: ["artifacts/"]` with `when: "always"` already uploads the log on every run, so no extra plumbing is required. ASAN jobs and `PHP Language Tests` keep the same behavior via inheritance.

## Test plan
- [ ] Generated YAML diff inspected: `_DD_DEBUG_SIDECAR_LOG_*` appears once under `.base_test.variables`; no duplicates remain in `.asan_test` or `PHP Language Tests`.
- [ ] CI pipeline passes `generate-templates` and downstream tracer-trigger.
- [ ] On a failing `test_extension_ci` run, `artifacts/sidecar.log` is uploaded as a job artifact.