### PR TITLE
feat: turn on reporting all threads for crashtracking

### DIFF
--- a/components-rs/common.h
+++ b/components-rs/common.h
@@ -276,35 +276,6 @@ typedef struct _zend_string _zend_string;
 
 #define ddog_MultiTargetFetcher_DEFAULT_CLIENTS_LIMIT 100
 
-typedef enum ddog_ConfigurationOrigin {
-  DDOG_CONFIGURATION_ORIGIN_ENV_VAR,
-  DDOG_CONFIGURATION_ORIGIN_CODE,
-  DDOG_CONFIGURATION_ORIGIN_DD_CONFIG,
-  DDOG_CONFIGURATION_ORIGIN_REMOTE_CONFIG,
-  DDOG_CONFIGURATION_ORIGIN_DEFAULT,
-  DDOG_CONFIGURATION_ORIGIN_LOCAL_STABLE_CONFIG,
-  DDOG_CONFIGURATION_ORIGIN_FLEET_STABLE_CONFIG,
-  DDOG_CONFIGURATION_ORIGIN_CALCULATED,
-} ddog_ConfigurationOrigin;
-
-typedef enum ddog_DynamicConfigUpdateMode {
-  DDOG_DYNAMIC_CONFIG_UPDATE_MODE_READ,
-  DDOG_DYNAMIC_CONFIG_UPDATE_MODE_READ_WRITE,
-  DDOG_DYNAMIC_CONFIG_UPDATE_MODE_WRITE,
-  DDOG_DYNAMIC_CONFIG_UPDATE_MODE_RESTORE,
-} ddog_DynamicConfigUpdateMode;
-
-typedef enum ddog_EvaluateAt {
-  DDOG_EVALUATE_AT_ENTRY,
-  DDOG_EVALUATE_AT_EXIT,
-} ddog_EvaluateAt;
-
-typedef enum ddog_InBodyLocation {
-  DDOG_IN_BODY_LOCATION_NONE,
-  DDOG_IN_BODY_LOCATION_START,
-  DDOG_IN_BODY_LOCATION_END,
-} ddog_InBodyLocation;
-
 typedef enum ddog_Log {
   DDOG_LOG_ERROR = 1,
   DDOG_LOG_WARN = 2,
@@ -319,6 +290,45 @@ typedef enum ddog_Log {
   DDOG_LOG_HOOK_TRACE = (5 | (4 << 4)),
 } ddog_Log;
 
+typedef enum ddog_DynamicConfigUpdateMode {
+  DDOG_DYNAMIC_CONFIG_UPDATE_MODE_READ,
+  DDOG_DYNAMIC_CONFIG_UPDATE_MODE_READ_WRITE,
+  DDOG_DYNAMIC_CONFIG_UPDATE_MODE_WRITE,
+  DDOG_DYNAMIC_CONFIG_UPDATE_MODE_RESTORE,
+} ddog_DynamicConfigUpdateMode;
+
+typedef enum ddog_InBodyLocation {
+  DDOG_IN_BODY_LOCATION_NONE,
+  DDOG_IN_BODY_LOCATION_START,
+  DDOG_IN_BODY_LOCATION_END,
+} ddog_InBodyLocation;
+
+typedef enum ddog_EvaluateAt {
+  DDOG_EVALUATE_AT_ENTRY,
+  DDOG_EVALUATE_AT_EXIT,
+} ddog_EvaluateAt;
+
+typedef enum ddog_MetricKind {
+  DDOG_METRIC_KIND_COUNT,
+  DDOG_METRIC_KIND_GAUGE,
+  DDOG_METRIC_KIND_HISTOGRAM,
+  DDOG_METRIC_KIND_DISTRIBUTION,
+} ddog_MetricKind;
+
+typedef enum ddog_SpanProbeTarget {
+  DDOG_SPAN_PROBE_TARGET_ACTIVE,
+  DDOG_SPAN_PROBE_TARGET_ROOT,
+} ddog_SpanProbeTarget;
+
+typedef enum ddog_ProbeStatus {
+  DDOG_PROBE_STATUS_RECEIVED,
+  DDOG_PROBE_STATUS_INSTALLED,
+  DDOG_PROBE_STATUS_EMITTING,
+  DDOG_PROBE_STATUS_ERROR,
+  DDOG_PROBE_STATUS_BLOCKED,
+  DDOG_PROBE_STATUS_WARNING,
+} ddog_ProbeStatus;
+
 typedef enum ddog_Method {
   DDOG_METHOD_GET = 0,
   DDOG_METHOD_POST = 1,
@@ -332,12 +342,22 @@ typedef enum ddog_Method {
   DDOG_METHOD_OTHER = 9,
 } ddog_Method;
 
-typedef enum ddog_MetricKind {
-  DDOG_METRIC_KIND_COUNT,
-  DDOG_METRIC_KIND_GAUGE,
-  DDOG_METRIC_KIND_HISTOGRAM,
-  DDOG_METRIC_KIND_DISTRIBUTION,
-} ddog_MetricKind;
+typedef enum ddog_ConfigurationOrigin {
+  DDOG_CONFIGURATION_ORIGIN_ENV_VAR,
+  DDOG_CONFIGURATION_ORIGIN_CODE,
+  DDOG_CONFIGURATION_ORIGIN_DD_CONFIG,
+  DDOG_CONFIGURATION_ORIGIN_REMOTE_CONFIG,
+  DDOG_CONFIGURATION_ORIGIN_DEFAULT,
+  DDOG_CONFIGURATION_ORIGIN_LOCAL_STABLE_CONFIG,
+  DDOG_CONFIGURATION_ORIGIN_FLEET_STABLE_CONFIG,
+  DDOG_CONFIGURATION_ORIGIN_CALCULATED,
+} ddog_ConfigurationOrigin;
+
+typedef enum ddog_MetricType {
+  DDOG_METRIC_TYPE_GAUGE,
+  DDOG_METRIC_TYPE_COUNT,
+  DDOG_METRIC_TYPE_DISTRIBUTION,
+} ddog_MetricType;
 
 typedef enum ddog_MetricNamespace {
   DDOG_METRIC_NAMESPACE_TRACERS,
@@ -353,20 +373,17 @@ typedef enum ddog_MetricNamespace {
   DDOG_METRIC_NAMESPACE_SIDECAR,
 } ddog_MetricNamespace;
 
-typedef enum ddog_MetricType {
-  DDOG_METRIC_TYPE_GAUGE,
-  DDOG_METRIC_TYPE_COUNT,
-  DDOG_METRIC_TYPE_DISTRIBUTION,
-} ddog_MetricType;
-
-typedef enum ddog_ProbeStatus {
-  DDOG_PROBE_STATUS_RECEIVED,
-  DDOG_PROBE_STATUS_INSTALLED,
-  DDOG_PROBE_STATUS_EMITTING,
-  DDOG_PROBE_STATUS_ERROR,
-  DDOG_PROBE_STATUS_BLOCKED,
-  DDOG_PROBE_STATUS_WARNING,
-} ddog_ProbeStatus;
+typedef enum ddog_RemoteConfigProduct {
+  DDOG_REMOTE_CONFIG_PRODUCT_AGENT_CONFIG,
+  DDOG_REMOTE_CONFIG_PRODUCT_AGENT_TASK,
+  DDOG_REMOTE_CONFIG_PRODUCT_APM_TRACING,
+  DDOG_REMOTE_CONFIG_PRODUCT_ASM,
+  DDOG_REMOTE_CONFIG_PRODUCT_ASM_DATA,
+  DDOG_REMOTE_CONFIG_PRODUCT_ASM_DD,
+  DDOG_REMOTE_CONFIG_PRODUCT_ASM_FEATURES,
+  DDOG_REMOTE_CONFIG_PRODUCT_FFE_FLAGS,
+  DDOG_REMOTE_CONFIG_PRODUCT_LIVE_DEBUGGER,
+} ddog_RemoteConfigProduct;
 
 typedef enum ddog_RemoteConfigCapabilities {
   DDOG_REMOTE_CONFIG_CAPABILITIES_ASM_ACTIVATION = 1,
@@ -415,23 +432,6 @@ typedef enum ddog_RemoteConfigCapabilities {
   DDOG_REMOTE_CONFIG_CAPABILITIES_APM_TRACING_MULTICONFIG = 45,
   DDOG_REMOTE_CONFIG_CAPABILITIES_FFE_FLAG_CONFIGURATION_RULES = 46,
 } ddog_RemoteConfigCapabilities;
-
-typedef enum ddog_RemoteConfigProduct {
-  DDOG_REMOTE_CONFIG_PRODUCT_AGENT_CONFIG,
-  DDOG_REMOTE_CONFIG_PRODUCT_AGENT_TASK,
-  DDOG_REMOTE_CONFIG_PRODUCT_APM_TRACING,
-  DDOG_REMOTE_CONFIG_PRODUCT_ASM,
-  DDOG_REMOTE_CONFIG_PRODUCT_ASM_DATA,
-  DDOG_REMOTE_CONFIG_PRODUCT_ASM_DD,
-  DDOG_REMOTE_CONFIG_PRODUCT_ASM_FEATURES,
-  DDOG_REMOTE_CONFIG_PRODUCT_FFE_FLAGS,
-  DDOG_REMOTE_CONFIG_PRODUCT_LIVE_DEBUGGER,
-} ddog_RemoteConfigProduct;
-
-typedef enum ddog_SpanProbeTarget {
-  DDOG_SPAN_PROBE_TARGET_ACTIVE,
-  DDOG_SPAN_PROBE_TARGET_ROOT,
-} ddog_SpanProbeTarget;
 
 typedef struct ddog_AgentInfoReader ddog_AgentInfoReader;
 
@@ -912,17 +912,17 @@ typedef struct ddog_DebuggerValue ddog_DebuggerValue;
 
 #define ddog_EVALUATOR_RESULT_REDACTED (const void*)-2
 
-typedef enum ddog_DebuggerType {
-  DDOG_DEBUGGER_TYPE_DIAGNOSTICS,
-  DDOG_DEBUGGER_TYPE_SNAPSHOTS,
-  DDOG_DEBUGGER_TYPE_LOGS,
-} ddog_DebuggerType;
-
 typedef enum ddog_FieldType {
   DDOG_FIELD_TYPE_STATIC,
   DDOG_FIELD_TYPE_ARG,
   DDOG_FIELD_TYPE_LOCAL,
 } ddog_FieldType;
+
+typedef enum ddog_DebuggerType {
+  DDOG_DEBUGGER_TYPE_DIAGNOSTICS,
+  DDOG_DEBUGGER_TYPE_SNAPSHOTS,
+  DDOG_DEBUGGER_TYPE_LOGS,
+} ddog_DebuggerType;
 
 typedef struct ddog_Entry ddog_Entry;
 
@@ -1052,16 +1052,6 @@ typedef struct ddog_OwnedCharSlice {
   void (*free)(ddog_CharSlice);
 } ddog_OwnedCharSlice;
 
-typedef enum ddog_LogLevel {
-  DDOG_LOG_LEVEL_ERROR,
-  DDOG_LOG_LEVEL_WARN,
-  DDOG_LOG_LEVEL_DEBUG,
-} ddog_LogLevel;
-
-typedef enum ddog_TelemetryWorkerBuilderBoolProperty {
-  DDOG_TELEMETRY_WORKER_BUILDER_BOOL_PROPERTY_CONFIG_TELEMETRY_DEBUG_LOGGING_ENABLED,
-} ddog_TelemetryWorkerBuilderBoolProperty;
-
 typedef enum ddog_TelemetryWorkerBuilderEndpointProperty {
   DDOG_TELEMETRY_WORKER_BUILDER_ENDPOINT_PROPERTY_CONFIG_ENDPOINT,
 } ddog_TelemetryWorkerBuilderEndpointProperty;
@@ -1082,6 +1072,16 @@ typedef enum ddog_TelemetryWorkerBuilderStrProperty {
   DDOG_TELEMETRY_WORKER_BUILDER_STR_PROPERTY_PARENT_SESSION_ID,
   DDOG_TELEMETRY_WORKER_BUILDER_STR_PROPERTY_ROOT_SESSION_ID,
 } ddog_TelemetryWorkerBuilderStrProperty;
+
+typedef enum ddog_TelemetryWorkerBuilderBoolProperty {
+  DDOG_TELEMETRY_WORKER_BUILDER_BOOL_PROPERTY_CONFIG_TELEMETRY_DEBUG_LOGGING_ENABLED,
+} ddog_TelemetryWorkerBuilderBoolProperty;
+
+typedef enum ddog_LogLevel {
+  DDOG_LOG_LEVEL_ERROR,
+  DDOG_LOG_LEVEL_WARN,
+  DDOG_LOG_LEVEL_DEBUG,
+} ddog_LogLevel;
 
 typedef struct ddog_TelemetryWorkerBuilder ddog_TelemetryWorkerBuilder;
 
@@ -1224,37 +1224,25 @@ typedef struct ddog_SenderParameters {
   ddog_CharSlice url;
 } ddog_SenderParameters;
 
-typedef enum ddog_crasht_BuildIdType {
-  DDOG_CRASHT_BUILD_ID_TYPE_GNU,
-  DDOG_CRASHT_BUILD_ID_TYPE_GO,
-  DDOG_CRASHT_BUILD_ID_TYPE_PDB,
-  DDOG_CRASHT_BUILD_ID_TYPE_SHA1,
-} ddog_crasht_BuildIdType;
-
 /**
- * Result type for runtime callback registration
+ * Stacktrace collection occurs in the context of a crashing process.
+ * If the stack is sufficiently corruputed, it is possible (but unlikely),
+ * for stack trace collection itself to crash.
+ * We recommend fully enabling stacktrace collection, but having an environment
+ * variable to allow downgrading the collector.
  */
-typedef enum ddog_crasht_CallbackResult {
-  DDOG_CRASHT_CALLBACK_RESULT_OK,
-  DDOG_CRASHT_CALLBACK_RESULT_ERROR,
-} ddog_crasht_CallbackResult;
-
-typedef enum ddog_crasht_DemangleOptions {
-  DDOG_CRASHT_DEMANGLE_OPTIONS_COMPLETE,
-  DDOG_CRASHT_DEMANGLE_OPTIONS_NAME_ONLY,
-} ddog_crasht_DemangleOptions;
-
-typedef enum ddog_crasht_ErrorKind {
-  DDOG_CRASHT_ERROR_KIND_PANIC,
-  DDOG_CRASHT_ERROR_KIND_UNHANDLED_EXCEPTION,
-  DDOG_CRASHT_ERROR_KIND_UNIX_SIGNAL,
-} ddog_crasht_ErrorKind;
-
-typedef enum ddog_crasht_FileType {
-  DDOG_CRASHT_FILE_TYPE_APK,
-  DDOG_CRASHT_FILE_TYPE_ELF,
-  DDOG_CRASHT_FILE_TYPE_PE,
-} ddog_crasht_FileType;
+typedef enum ddog_crasht_StacktraceCollection {
+  DDOG_CRASHT_STACKTRACE_COLLECTION_DISABLED,
+  DDOG_CRASHT_STACKTRACE_COLLECTION_WITHOUT_SYMBOLS,
+  /**
+   * This option uses `backtrace::resolve_frame_unsynchronized()` to gather symbol information
+   * and also unwind inlined functions. Enabling this feature will not only provide symbolic
+   * details, but may also yield additional or less stack frames compared to other
+   * configurations.
+   */
+  DDOG_CRASHT_STACKTRACE_COLLECTION_ENABLED_WITH_INPROCESS_SYMBOLS,
+  DDOG_CRASHT_STACKTRACE_COLLECTION_ENABLED_WITH_SYMBOLS_IN_RECEIVER,
+} ddog_crasht_StacktraceCollection;
 
 /**
  * This enum represents operations a the tracked library might be engaged in.
@@ -1278,6 +1266,12 @@ typedef enum ddog_crasht_OpTypes {
    */
   DDOG_CRASHT_OP_TYPES_SIZE,
 } ddog_crasht_OpTypes;
+
+typedef enum ddog_crasht_ErrorKind {
+  DDOG_CRASHT_ERROR_KIND_PANIC,
+  DDOG_CRASHT_ERROR_KIND_UNHANDLED_EXCEPTION,
+  DDOG_CRASHT_ERROR_KIND_UNIX_SIGNAL,
+} ddog_crasht_ErrorKind;
 
 /**
  * See https://man7.org/linux/man-pages/man2/sigaction.2.html
@@ -1351,25 +1345,31 @@ typedef enum ddog_crasht_SignalNames {
   DDOG_CRASHT_SIGNAL_NAMES_UNKNOWN,
 } ddog_crasht_SignalNames;
 
+typedef enum ddog_crasht_BuildIdType {
+  DDOG_CRASHT_BUILD_ID_TYPE_GNU,
+  DDOG_CRASHT_BUILD_ID_TYPE_GO,
+  DDOG_CRASHT_BUILD_ID_TYPE_PDB,
+  DDOG_CRASHT_BUILD_ID_TYPE_SHA1,
+} ddog_crasht_BuildIdType;
+
+typedef enum ddog_crasht_FileType {
+  DDOG_CRASHT_FILE_TYPE_APK,
+  DDOG_CRASHT_FILE_TYPE_ELF,
+  DDOG_CRASHT_FILE_TYPE_PE,
+} ddog_crasht_FileType;
+
+typedef enum ddog_crasht_DemangleOptions {
+  DDOG_CRASHT_DEMANGLE_OPTIONS_COMPLETE,
+  DDOG_CRASHT_DEMANGLE_OPTIONS_NAME_ONLY,
+} ddog_crasht_DemangleOptions;
+
 /**
- * Stacktrace collection occurs in the context of a crashing process.
- * If the stack is sufficiently corruputed, it is possible (but unlikely),
- * for stack trace collection itself to crash.
- * We recommend fully enabling stacktrace collection, but having an environment
- * variable to allow downgrading the collector.
+ * Result type for runtime callback registration
  */
-typedef enum ddog_crasht_StacktraceCollection {
-  DDOG_CRASHT_STACKTRACE_COLLECTION_DISABLED,
-  DDOG_CRASHT_STACKTRACE_COLLECTION_WITHOUT_SYMBOLS,
-  /**
-   * This option uses `backtrace::resolve_frame_unsynchronized()` to gather symbol information
-   * and also unwind inlined functions. Enabling this feature will not only provide symbolic
-   * details, but may also yield additional or less stack frames compared to other
-   * configurations.
-   */
-  DDOG_CRASHT_STACKTRACE_COLLECTION_ENABLED_WITH_INPROCESS_SYMBOLS,
-  DDOG_CRASHT_STACKTRACE_COLLECTION_ENABLED_WITH_SYMBOLS_IN_RECEIVER,
-} ddog_crasht_StacktraceCollection;
+typedef enum ddog_crasht_CallbackResult {
+  DDOG_CRASHT_CALLBACK_RESULT_OK,
+  DDOG_CRASHT_CALLBACK_RESULT_ERROR,
+} ddog_crasht_CallbackResult;
 
 typedef struct ddog_crasht_CrashInfo ddog_crasht_CrashInfo;
 
@@ -1435,6 +1435,11 @@ typedef struct ddog_crasht_Slice_I32 {
 
 typedef struct ddog_crasht_Config {
   struct ddog_crasht_Slice_CharSlice additional_files;
+  /**
+   * If true, the receiver will collect stack traces for all threads in the crashing process
+   * (not just the crashing thread) using ptrace-based remote unwinding.
+   */
+  bool collect_all_threads;
   bool create_alt_stack;
   bool demangle_names;
   /**
@@ -1442,6 +1447,11 @@ typedef struct ddog_crasht_Config {
    * If None, the crashtracker will infer the agent host from env variables.
    */
   struct ddog_crasht_EndpointConfig endpoint;
+  /**
+   * Maximum number of non-crashing threads to collect when `collect_all_threads` is true.
+   * If 0, uses the default (`libdd_crashtracker::default_max_threads()`).
+   */
+  uintptr_t max_threads;
   /**
    * Optional filename for a unix domain socket if the receiver is used asynchonously
    */

--- a/ext/signals.c
+++ b/ext/signals.c
@@ -283,6 +283,8 @@ static void dd_init_crashtracker() {
             .resolve_frames = DDOG_CRASHT_STACKTRACE_COLLECTION_ENABLED_WITH_INPROCESS_SYMBOLS,
             .optional_unix_socket_filename = socket_path,
             .additional_files = {0},
+            .collect_all_threads = true,
+            .max_threads = 0, // uses libdatadog default, which is 256
         },
         .metadata = ddtrace_setup_crashtracking_metadata(&tags),
     };

--- a/tests/ext/crashtracker_collect_all_threads.phpt
+++ b/tests/ext/crashtracker_collect_all_threads.phpt
@@ -7,6 +7,8 @@ if (getenv('SKIP_ASAN') || getenv('USE_ZEND_ALLOC') === '0') die("skip: intentio
 if (getenv('PHP_PEAR_RUNTESTS') === '1') die("skip: pecl run-tests does not support %A in EXPECTF");
 if (getenv('DD_TRACE_CLI_ENABLED') === '0') die("skip: tracer is disabled");
 if (PHP_VERSION_ID < 70200) die("skip: TEST_PHP_EXTRA_ARGS is only available on PHP 7.2+");
+if (!extension_loaded('ffi')) die('skip: ffi extension required');
+if (!trim(shell_exec('which cc 2>/dev/null') ?: shell_exec('which gcc 2>/dev/null') ?: '')) die('skip: C compiler not available');
 include __DIR__ . '/includes/skipif_no_dev_env.inc';
 ?>
 --ENV--
@@ -26,10 +28,46 @@ usleep(100000); // Let time to the sidecar to open the crashtracker socket
 
 posix_setrlimit(POSIX_RLIMIT_CORE, 0, 0);
 
+// Build a tiny C shared library that spawns sleeping pthreads.
+// Using pure C avoids PHP ZTS/NTS thread-safety concerns entirely.
+$so_path = sys_get_temp_dir() . '/ct_thread_helper_' . getmypid() . '.so';
+$src_path = $so_path . '.c';
+
+file_put_contents($src_path, '
+#include <pthread.h>
+#include <unistd.h>
+
+static void *sleeper(void *arg) { sleep(3600); return NULL; }
+
+void ct_spawn_threads(int n) {
+    pthread_t t;
+    int i;
+    for (i = 0; i < n; i++) {
+        pthread_create(&t, NULL, sleeper, NULL);
+        pthread_detach(t);
+    }
+    usleep(50000); /* give threads time to be scheduled */
+}
+');
+
+$cc = trim(shell_exec('which cc 2>/dev/null') ?: shell_exec('which gcc 2>/dev/null') ?: '');
+shell_exec("$cc -shared -fPIC -o $so_path $src_path -lpthread 2>/dev/null");
+
+// Write the crashing PHP script to a temp file so we can load the helper .so
+$script_path = sys_get_temp_dir() . '/ct_crash_test_' . getmypid() . '.php';
+$so_path_esc = addslashes($so_path);
+file_put_contents($script_path, '<?php
+try {
+    $ffi = FFI::cdef("void ct_spawn_threads(int n);", "' . $so_path_esc . '");
+    $ffi->ct_spawn_threads(3);
+} catch (Throwable $e) { /* FFI unavailable or compile failed – crash anyway */ }
+spl_autoload_register(function() { posix_kill(posix_getpid(), 11); });
+class_exists(Test::class);
+');
+
 $php = getenv('TEST_PHP_EXECUTABLE');
-$args = getenv('TEST_PHP_ARGS')." ".getenv("TEST_PHP_EXTRA_ARGS");
-$cmd = $php." ".$args." -r 'spl_autoload_register(function() { posix_kill(posix_getpid(), 11); }); class_exists(Test::class);'";
-system($cmd);
+$args = getenv('TEST_PHP_ARGS') . " " . getenv("TEST_PHP_EXTRA_ARGS");
+system("$php $args $script_path");
 
 $rr->waitForRequest(function ($request) {
     if ($request["uri"] != "/telemetry/proxy/api/v2/apmtelemetry") {
@@ -52,13 +90,12 @@ $rr->waitForRequest(function ($request) {
                 continue;
             }
 
-            $error = $payload["message"]["error"] ?? null;
-            $threads = $error["threads"] ?? null;
+            $error   = $payload["message"]["error"] ?? null;
+            $threads = $error["threads"]["threads"] ?? null;
+            $count   = $threads !== null ? count($threads) : 0;
 
-            echo "collect_all_threads enabled: ", ($threads !== null ? "yes" : "no"), PHP_EOL;
-            echo "thread count: ", ($threads !== null ? count($threads) : 0), PHP_EOL;
-            echo "full crash report:", PHP_EOL;
-            echo json_encode($payload, JSON_PRETTY_PRINT), PHP_EOL;
+            echo "collect_all_threads enabled: ", ($count > 0 ? "yes" : "no"), PHP_EOL;
+            echo "thread count: ", $count, PHP_EOL;
 
             return true;
         }
@@ -66,11 +103,12 @@ $rr->waitForRequest(function ($request) {
 
     return false;
 });
+
+// Cleanup temp files
+@unlink($src_path);
+@unlink($so_path);
+@unlink($script_path);
 ?>
 --EXPECTF--
-collect_all_threads enabled: yes
+%Acollect_all_threads enabled: yes
 thread count: %d
-full crash report:
-%A"error": {
-%A"threads": [
-%A]%A

--- a/tests/ext/crashtracker_collect_all_threads.phpt
+++ b/tests/ext/crashtracker_collect_all_threads.phpt
@@ -1,0 +1,76 @@
+--TEST--
+Crashtracker collects all threads when collect_all_threads is enabled
+--SKIPIF--
+<?php
+if (!extension_loaded('posix')) die('skip: posix extension required');
+if (getenv('SKIP_ASAN') || getenv('USE_ZEND_ALLOC') === '0') die("skip: intentionally causes segfaults");
+if (getenv('PHP_PEAR_RUNTESTS') === '1') die("skip: pecl run-tests does not support %A in EXPECTF");
+if (getenv('DD_TRACE_CLI_ENABLED') === '0') die("skip: tracer is disabled");
+if (PHP_VERSION_ID < 70200) die("skip: TEST_PHP_EXTRA_ARGS is only available on PHP 7.2+");
+include __DIR__ . '/includes/skipif_no_dev_env.inc';
+?>
+--ENV--
+DD_TRACE_LOG_LEVEL=0
+DD_AGENT_HOST=request-replayer
+DD_TRACE_AGENT_PORT=80
+--INI--
+datadog.trace.agent_test_session_token=tests/ext/crashtracker_collect_all_threads.phpt
+--FILE--
+<?php
+
+include __DIR__ . '/includes/request_replayer.inc';
+$rr = new RequestReplayer();
+$rr->replayRequest(); // cleanup possible leftover
+
+usleep(100000); // Let time to the sidecar to open the crashtracker socket
+
+posix_setrlimit(POSIX_RLIMIT_CORE, 0, 0);
+
+$php = getenv('TEST_PHP_EXECUTABLE');
+$args = getenv('TEST_PHP_ARGS')." ".getenv("TEST_PHP_EXTRA_ARGS");
+$cmd = $php." ".$args." -r 'spl_autoload_register(function() { posix_kill(posix_getpid(), 11); }); class_exists(Test::class);'";
+system($cmd);
+
+$rr->waitForRequest(function ($request) {
+    if ($request["uri"] != "/telemetry/proxy/api/v2/apmtelemetry") {
+        return false;
+    }
+    $body = json_decode($request["body"], true);
+    $batch = $body["request_type"] == "message-batch" ? $body["payload"] : [$body];
+
+    foreach ($batch as $json) {
+        if ($json["request_type"] != "logs" || !isset($json["payload"]["logs"])) {
+            continue;
+        }
+
+        foreach ($json["payload"]["logs"] as $payload) {
+            $payload["message"] = json_decode($payload["message"], true);
+            if (!isset($payload["message"]["metadata"])) {
+                break;
+            }
+            if (($payload["is_crash"] ?? false) !== true) {
+                continue;
+            }
+
+            $error = $payload["message"]["error"] ?? null;
+            $threads = $error["threads"] ?? null;
+
+            echo "collect_all_threads enabled: ", ($threads !== null ? "yes" : "no"), PHP_EOL;
+            echo "thread count: ", ($threads !== null ? count($threads) : 0), PHP_EOL;
+            echo "full crash report:", PHP_EOL;
+            echo json_encode($payload, JSON_PRETTY_PRINT), PHP_EOL;
+
+            return true;
+        }
+    }
+
+    return false;
+});
+?>
+--EXPECTF--
+collect_all_threads enabled: yes
+thread count: %d
+full crash report:
+%A"error": {
+%A"threads": [
+%A]%A


### PR DESCRIPTION
### Description

Crashtracking now supports collecting all threads at the moment of a crash, with [feat(crashtracking)!: collect all threads](https://github.com/DataDog/libdatadog/pull/1878)

This PR updates the git submodule to 24cbf670001d65ba6c2ee318578f3a690df1ac36 and turns collecting all threads on

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
