### PR TITLE
Add block tag to rasp.rule.match

### DIFF
--- a/appsec/helper-rust/src/client/metrics.rs
+++ b/appsec/helper-rust/src/client/metrics.rs
@@ -76,8 +76,18 @@ pub struct WafMetrics {
 
 #[derive(Default, Debug, Clone)]
 pub struct RaspRuleMetrics {
+    /// Total number of RASP rule evaluations, whether they matched or not
     pub evals: u32,
-    pub matches: u32,
+
+    /// Matches whose RASP rule did not request a block (on_match had no block action,
+    /// or the rule was monitor-only). Emitted as rasp.rule.match with `block:irrelevant`.
+    pub matches_irrelevant: u32,
+
+    /// Matches whose RASP rule requested a block. PHP cannot fail to block once it
+    /// decides to, so every such match counts as `block:success` (no `block:failure`).
+    pub matches_blocked: u32,
+
+    /// Total number of RASP rule timeouts
     pub timeouts: u32,
 }
 
@@ -144,7 +154,11 @@ impl WafMetrics {
             .or_default();
         entry.evals += 1;
         if run_output.has_events() {
-            entry.matches += 1;
+            if run_output.is_blocking() {
+                entry.matches_blocked += 1;
+            } else {
+                entry.matches_irrelevant += 1;
+            }
         }
         if run_output.timeout() {
             entry.timeouts += 1;
@@ -250,11 +264,23 @@ impl telemetry::TelemetryMetricsGenerator for WafMetrics {
                 );
             }
 
-            if metrics.matches > 0 {
+            if metrics.matches_irrelevant > 0 {
+                let mut match_tags = tags.clone();
+                match_tags.add("block", "irrelevant");
                 submitter.submit_metric(
                     telemetry::RASP_RULE_MATCH,
-                    metrics.matches as f64,
-                    tags.clone(),
+                    metrics.matches_irrelevant as f64,
+                    match_tags,
+                );
+            }
+
+            if metrics.matches_blocked > 0 {
+                let mut match_tags = tags.clone();
+                match_tags.add("block", "success");
+                submitter.submit_metric(
+                    telemetry::RASP_RULE_MATCH,
+                    metrics.matches_blocked as f64,
+                    match_tags,
                 );
             }
 

--- a/appsec/tests/integration/src/main/groovy/com/datadog/appsec/php/docker/AppSecContainer.groovy
+++ b/appsec/tests/integration/src/main/groovy/com/datadog/appsec/php/docker/AppSecContainer.groovy
@@ -56,7 +56,7 @@ class AppSecContainer<SELF extends AppSecContainer<SELF>> extends GenericContain
                     .connectTimeout(Duration.ofSeconds(5))
                     .build()
 
-    private MockDatadogAgent mockDatadogAgent = new MockDatadogAgent()    
+    private MockDatadogAgent mockDatadogAgent = new MockDatadogAgent()
 
     AppSecContainer(Map options) {
         super(imageNameFuture(options))
@@ -191,7 +191,7 @@ class AppSecContainer<SELF extends AppSecContainer<SELF>> extends GenericContain
                             JsonOutput.toJson(it.value).getBytes(StandardCharsets.UTF_8)
                     ]
                 }
-        long newVersion = Instant.now().epochSecond
+        long newVersion = nextRCVersion
         def rcr = new RemoteConfigResponse()
         rcr.clientConfigs = files.keySet() as List
         rcr.targetFiles = encodedFiles.collect {
@@ -244,7 +244,7 @@ class AppSecContainer<SELF extends AppSecContainer<SELF>> extends GenericContain
      */
     Supplier<RemoteConfigRequest> applyRemoteConfigRaw(Target target, Map<String, byte[]> files) {
         Map<String, byte[]> encodedFiles = files.findAll { it.value != null }
-        long newVersion = Instant.now().epochSecond
+        long newVersion = nextRCVersion
         def rcr = new RemoteConfigResponse()
         rcr.clientConfigs = files.keySet() as List
         rcr.targetFiles = encodedFiles.collect {
@@ -285,6 +285,11 @@ class AppSecContainer<SELF extends AppSecContainer<SELF>> extends GenericContain
         long start = System.currentTimeMillis()
         return { -> waitForRCVersion(target, newVersion,
                 5_000 - (Math.max(0, System.currentTimeMillis() - start))) }
+    }
+
+    // The next version number for the new RC. Using the timestamp helpers troubleshooting
+    private static long getNextRCVersion() {
+        Instant.now().toEpochMilli()
     }
 
     void flushProfilingData() {

--- a/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/TelemetryTests.groovy
+++ b/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/TelemetryTests.groovy
@@ -1144,6 +1144,111 @@ class TelemetryTests {
         assert 'rate_limited:true' in wafReqRateLimited.tags
     }
 
+    /**
+     * Verifies that appsec.rasp.rule.match carries the `block` tag with the correct value:
+     *   - block:irrelevant  → RASP rule matched but `on_match` did not request a block
+     *   - block:success     → RASP rule matched, block was requested and (per PHP semantics)
+     *                         always succeeds; PHP cannot fail to block once it decides to.
+     *
+     * Cross-tracer spec (see dd-trace-go, dd-trace-py): the tag is always emitted on
+     * rasp.rule.match. PHP never emits block:failure because the layer is assumed to
+     * always succeed at terminating the script.
+     *
+     * Only applies to the Rust helper.
+     */
+    @Test
+    @Order(12)
+    void 'rasp rule match has block tag'() {
+        Assumptions.assumeTrue(System.getProperty('USE_HELPER_RUST') != null,
+                'block tag on rasp.rule.match is only implemented on the Rust helper')
+
+        try {
+            // Phase 1: non-blocking RASP rule match (recommended.json lfi/ssrf rules have
+            // on_match: ["stack_trace"], so a match does not block). Expect block:irrelevant.
+            Supplier<RemoteConfigRequest> requestSup = CONTAINER.applyRemoteConfig(RC_TARGET, [
+                    'datadog/2/ASM_FEATURES/asm_features_activation/config': [
+                            asm: [enabled: true]
+                    ]
+            ])
+
+            CONTAINER.traceFromRequest('/hello.php') { HttpResponse<InputStream> resp ->
+                assert resp.statusCode() == 200
+            }
+            assert requestSup.get() != null
+
+            CONTAINER.traceFromRequest(
+                    '/multiple_rasp.php?path=../somefile&other=../otherfile&domain=169.254.169.254') {
+                HttpResponse<InputStream> resp -> assert resp.statusCode() == 200
+            }
+
+            // Phase 2: override the LFI rule on_match to ["block"]. The first @fopen in
+            // multiple_rasp.php hits an LFI match, the WAF returns block_request, and the
+            // PHP layer terminates the request. Expect block:success on the rasp.rule.match
+            // emitted for rule_type:lfi from that request.
+            Supplier<RemoteConfigRequest> overrideSup = CONTAINER.applyRemoteConfig(RC_TARGET, [
+                    'datadog/2/ASM_FEATURES/asm_features_activation/config': [
+                            asm: [enabled: true]
+                    ],
+                    'datadog/2/ASM/rasp_lfi_block_override/config': [
+                            rules_override: [[
+                                                     rules_target: [[rule_id: 'rasp-001-001']],
+                                                     on_match: ['block']
+                                             ]]
+                    ]
+            ])
+            assert overrideSup.get() != null
+
+            // Trigger the blocking LFI; status code is 403 because the rule now blocks.
+            HttpRequest blockingReq = CONTAINER.buildReq(
+                    '/multiple_rasp.php?path=../somefile&other=../otherfile&domain=169.254.169.254')
+                    .GET().build()
+            CONTAINER.traceFromRequest(blockingReq, ofString()) { HttpResponse<String> resp ->
+                assert resp.statusCode() == 403
+            }
+
+            TelemetryHelpers.Metric lfiMatchIrrelevant
+            TelemetryHelpers.Metric lfiMatchSuccess
+
+            TelemetryHelpers.waitForMetrics(CONTAINER, 30) { List<TelemetryHelpers.GenerateMetrics> messages ->
+                def allSeries = messages.collectMany { it.series }
+                lfiMatchIrrelevant = lfiMatchIrrelevant ?: allSeries.find {
+                    it.name == 'rasp.rule.match' &&
+                            'rule_type:lfi' in it.tags &&
+                            'block:irrelevant' in it.tags
+                }
+                lfiMatchSuccess = lfiMatchSuccess ?: allSeries.find {
+                    it.name == 'rasp.rule.match' &&
+                            'rule_type:lfi' in it.tags &&
+                            'block:success' in it.tags
+                }
+                lfiMatchIrrelevant != null && lfiMatchSuccess != null
+            }
+
+            assert lfiMatchIrrelevant != null :
+                    'rasp.rule.match metric with block:irrelevant not found — ' +
+                    'helper must emit block:irrelevant when the matched RASP rule has no block action'
+            assert lfiMatchIrrelevant.namespace == 'appsec'
+            assert lfiMatchIrrelevant.type == 'count'
+            assert lfiMatchIrrelevant.points[0][1] >= 1.0d
+
+            assert lfiMatchSuccess != null :
+                    'rasp.rule.match metric with block:success not found — ' +
+                    'helper must emit block:success when the matched RASP rule triggered a block'
+            assert lfiMatchSuccess.namespace == 'appsec'
+            assert lfiMatchSuccess.type == 'count'
+            assert lfiMatchSuccess.points[0][1] >= 1.0d
+        } finally {
+            // Drop the override so subsequent ordered tests in this class run with the
+            // default (non-blocking) RASP ruleset, even if assertions above failed.
+            CONTAINER.applyRemoteConfig(RC_TARGET, [
+                    'datadog/2/ASM_FEATURES/asm_features_activation/config': [
+                            asm: [enabled: true]
+                    ],
+                    'datadog/2/ASM/rasp_lfi_block_override/config': null
+            ])
+        }
+    }
+
     @Test
     @Order(21)
     void 'waf config errors emitted with action init for bad init rules'() {


### PR DESCRIPTION
### Description

Adds the missing `block` to `appsec.rasp.rule.match` metric.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
