### PR TITLE
fix(ci): expand DinD loopback for tracer-release system tests

### DIFF
--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -1229,10 +1229,6 @@ endforeach;
     PIP_CACHE_DIR: $CI_PROJECT_DIR/.cache/pip
     APT_CACHE: $CI_PROJECT_DIR/.cache/apt
     DOCKER_DEFAULT_PLATFORM: linux/amd64
-    # Expand the DinD loopback volume to avoid running out of disk space.
-    # See https://datadoghq.atlassian.net/wiki/spaces/K8S/pages/2874901299/How+to+use+Micro+VMs#DinD-in-CI
-    DOCKER_LOOPBACK_SIZE: 50G
-    DOCKER_LOOPBACK_PATH: /
     # TODO DD_API_KEY; SYSTEM_TESTS_AWS_ACCESS_KEY_ID; SYSTEM_TESTS_AWS_SECRET_ACCESS_KEY
   needs:
     - job: "package extension: [amd64, x86_64-unknown-linux-gnu]"
@@ -1325,6 +1321,10 @@ endforeach;
 "System Tests: [tracer-release]":
   extends: .system_tests
   timeout: 4h
+  variables:
+    # Expand the DinD loopback volume to avoid running out of disk space.
+    # See https://datadoghq.atlassian.net/wiki/spaces/K8S/pages/2874901299/How+to+use+Micro+VMs#DinD-in-CI
+    DOCKER_LOOPBACK_SIZE: 50G
   rules:
     - if: $CI_COMMIT_REF_NAME == "master"
       when: on_success

--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -1229,6 +1229,10 @@ endforeach;
     PIP_CACHE_DIR: $CI_PROJECT_DIR/.cache/pip
     APT_CACHE: $CI_PROJECT_DIR/.cache/apt
     DOCKER_DEFAULT_PLATFORM: linux/amd64
+    # Expand the DinD loopback volume to avoid running out of disk space.
+    # See https://datadoghq.atlassian.net/wiki/spaces/K8S/pages/2874901299/How+to+use+Micro+VMs#DinD-in-CI
+    DOCKER_LOOPBACK_SIZE: 50G
+    DOCKER_LOOPBACK_PATH: /
     # TODO DD_API_KEY; SYSTEM_TESTS_AWS_ACCESS_KEY_ID; SYSTEM_TESTS_AWS_SECRET_ACCESS_KEY
   needs:
     - job: "package extension: [amd64, x86_64-unknown-linux-gnu]"


### PR DESCRIPTION
## Summary
- The `System Tests: [tracer-release]` job has been consistently failing with `no space left on device`, always during the parametric scenario, on the DinD µVM runners (e.g. [this run](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-php/-/jobs/1670865773)). The tracer-release job runs every system-tests scenario in sequence and the parametric one exhausts the default 20G Docker-in-Docker loopback volume on Kata-based runners.
- Bump `DOCKER_LOOPBACK_SIZE` to `50G` **only** on `System Tests: [tracer-release]`. The default `/tmp` path on these runners is real disk (not tmpfs), so a larger loopback there works without changing dockerd startup timing.
- Reference: [How to use Micro VMs — DinD in CI](https://datadoghq.atlassian.net/wiki/spaces/K8S/pages/2874901299/How+to+use+Micro+VMs#DinD-in-CI).