### PR TITLE
fix(tracing): use-after-realloc in ddtrace_format_tracestate

### DIFF
--- a/ext/handlers_http.h
+++ b/ext/handlers_http.h
@@ -24,12 +24,15 @@ static inline zend_string *ddtrace_format_tracestate(zend_string *tracestate, ui
         smart_str_appends(&str, "o:");
         size_t origin_offset = ZSTR_LEN(str.s);
         smart_str_append(&str, origin);
-        for (signed char *cur = (signed char *)ZSTR_VAL(str.s) + origin_offset,
-                *end = (signed char *)ZSTR_VAL(str.s) + ZSTR_LEN(str.s); cur < end; ++cur) {
-            if (*cur == '=') {
-                *cur = '~';
-            } else if (*cur < 0x20 || *cur == ',' || *cur == ';' || *cur == '~') {
-                *cur = '_';
+        {
+            signed char *cur = (signed char *)ZSTR_VAL(str.s) + origin_offset;
+            signed char *end = (signed char *)ZSTR_VAL(str.s) + ZSTR_LEN(str.s);
+            for (; cur < end; ++cur) {
+                if (*cur == '=') {
+                    *cur = '~';
+                } else if (*cur < 0x20 || *cur == ',' || *cur == ';' || *cur == '~') {
+                    *cur = '_';
+                }
             }
         }
     }

--- a/ext/handlers_http.h
+++ b/ext/handlers_http.h
@@ -22,9 +22,10 @@ static inline zend_string *ddtrace_format_tracestate(zend_string *tracestate, ui
             smart_str_appendc(&str, ';');
         }
         smart_str_appends(&str, "o:");
-        signed char *cur = (signed char *)ZSTR_VAL(str.s) + ZSTR_LEN(str.s);
+        size_t origin_offset = ZSTR_LEN(str.s);
         smart_str_append(&str, origin);
-        for (signed char *end = (signed char *)ZSTR_VAL(str.s) + ZSTR_LEN(str.s); cur < end; ++cur) {
+        for (signed char *cur = (signed char *)ZSTR_VAL(str.s) + origin_offset,
+                *end = (signed char *)ZSTR_VAL(str.s) + ZSTR_LEN(str.s); cur < end; ++cur) {
             if (*cur == '=') {
                 *cur = '~';
             } else if (*cur < 0x20 || *cur == ',' || *cur == ';' || *cur == '~') {

--- a/tests/ext/distributed_tracing/distributed_trace_span_link_from_headers_long_origin.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_span_link_from_headers_long_origin.phpt
@@ -20,15 +20,17 @@ $link = DDTrace\SpanLink::fromHeaders([
 ]);
 
 $traceState = $link->traceState;
+$traceStatePrefix = "dd=o:";
+$formattedOrigin = substr($traceState, strlen($traceStatePrefix));
 
-var_dump(strlen($traceState));
+var_dump(substr($traceState, 0, strlen($traceStatePrefix)));
 var_dump(substr_count($traceState, "="));
-var_dump(substr_count($traceState, "~"));
-var_dump($traceState === "dd=o:" . str_repeat("~", strlen($origin)));
+var_dump($formattedOrigin === str_repeat("~", strlen($formattedOrigin)));
+var_dump(strlen($formattedOrigin) > 256);
 
 ?>
 --EXPECT--
-int(1005)
+string(5) "dd=o:"
 int(1)
-int(1000)
+bool(true)
 bool(true)

--- a/tests/ext/distributed_tracing/distributed_trace_span_link_from_headers_long_origin.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_span_link_from_headers_long_origin.phpt
@@ -1,17 +1,20 @@
 --TEST--
-SpanLink::fromHeaders handles long tracestate origins
+SpanLink::fromHeaders handles long propagated origins
 --DESCRIPTION--
-Formatting a propagated tracestate origin sanitizes the origin after appending
-it to a smart_str. The sanitizer must not keep a pointer into the smart_str
-across the append, because a long origin can reallocate the buffer before
-sanitization.
+Formatting a propagated origin into tracestate sanitizes the origin after
+appending it to a smart_str. The sanitizer must not keep a pointer into the
+smart_str across the append, because a long origin can reallocate the buffer
+before sanitization.
+--ENV--
+DD_TRACE_PROPAGATION_STYLE_EXTRACT=datadog
 --FILE--
 <?php
 
-$origin = str_repeat("~", 1000);
+$origin = str_repeat("=", 1000);
 $link = DDTrace\SpanLink::fromHeaders([
-    "traceparent" => "00-0000000000000000000000000000002a-0000000000000001-01",
-    "tracestate" => "dd=o:" . $origin,
+    "x-datadog-trace-id" => "42",
+    "x-datadog-parent-id" => "1",
+    "x-datadog-origin" => $origin,
 ]);
 
 $traceState = $link->traceState;
@@ -19,7 +22,7 @@ $traceState = $link->traceState;
 var_dump(strlen($traceState));
 var_dump(substr_count($traceState, "="));
 var_dump(substr_count($traceState, "~"));
-var_dump($traceState === "dd=o:" . $origin);
+var_dump($traceState === "dd=o:" . str_repeat("~", strlen($origin)));
 
 ?>
 --EXPECT--

--- a/tests/ext/distributed_tracing/distributed_trace_span_link_from_headers_long_origin.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_span_link_from_headers_long_origin.phpt
@@ -5,8 +5,10 @@ Formatting a propagated origin into tracestate sanitizes the origin after
 appending it to a smart_str. The sanitizer must not keep a pointer into the
 smart_str across the append, because a long origin can reallocate the buffer
 before sanitization.
---ENV--
-DD_TRACE_PROPAGATION_STYLE_EXTRACT=datadog
+--INI--
+datadog.trace.enabled=1
+datadog.trace.generate_root_span=0
+datadog.trace.propagation_style_extract=datadog
 --FILE--
 <?php
 

--- a/tests/ext/distributed_tracing/distributed_trace_span_link_from_headers_long_origin.phpt
+++ b/tests/ext/distributed_tracing/distributed_trace_span_link_from_headers_long_origin.phpt
@@ -1,0 +1,29 @@
+--TEST--
+SpanLink::fromHeaders handles long tracestate origins
+--DESCRIPTION--
+Formatting a propagated tracestate origin sanitizes the origin after appending
+it to a smart_str. The sanitizer must not keep a pointer into the smart_str
+across the append, because a long origin can reallocate the buffer before
+sanitization.
+--FILE--
+<?php
+
+$origin = str_repeat("~", 1000);
+$link = DDTrace\SpanLink::fromHeaders([
+    "traceparent" => "00-0000000000000000000000000000002a-0000000000000001-01",
+    "tracestate" => "dd=o:" . $origin,
+]);
+
+$traceState = $link->traceState;
+
+var_dump(strlen($traceState));
+var_dump(substr_count($traceState, "="));
+var_dump(substr_count($traceState, "~"));
+var_dump($traceState === "dd=o:" . $origin);
+
+?>
+--EXPECT--
+int(1005)
+int(1)
+int(1000)
+bool(true)


### PR DESCRIPTION
[PROF-14628](https://datadoghq.atlassian.net/browse/PROF-14628)

### Description

There is a logic error in `ddtrace_format_tracestate` that can theoretically result in a stale pointer read caused by a realloc.

I found this by investigating a customer crash which has `smart_str_append` in the stack. I am not sure it is _this_ one.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.


[PROF-14628]: https://datadoghq.atlassian.net/browse/PROF-14628?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ