### PR TITLE
ci: replace secrets.GITHUB_TOKEN with dd-octo-sts

### DIFF
--- a/.github/workflows/add-asset-to-gh-release.yml
+++ b/.github/workflows/add-asset-to-gh-release.yml
@@ -4,16 +4,26 @@ on:
   workflow_dispatch:
     inputs:
       packagesUrl:
-        description: 'URL for `packages.tar.gz` to add to release'
+        description: "URL for `packages.tar.gz` to add to release"
         required: true
       releaseVersion:
-        description: 'Version to add the assets to'
+        description: "Version to add the assets to"
         required: true
 
 jobs:
   add-assets-to-release:
     runs-on: ubuntu-8-core-latest
+    permissions:
+      contents: write
+      id-token: write
     steps:
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-php
+          policy: self.add-asset-to-gh-release
+
       - run: |
           curl -L -o packages.tar.gz $PACKAGES_URL
           tar -xvzf packages.tar.gz
@@ -22,4 +32,4 @@ jobs:
         env:
           PACKAGES_URL: ${{ inputs.packagesUrl }}
           RELEASE: ${{ inputs.releaseVersion }}
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.github/workflows/auto_add_pr_to_miletone.yml
+++ b/.github/workflows/auto_add_pr_to_miletone.yml
@@ -15,6 +15,7 @@ jobs:
       contents: read
       pull-requests: write # need to modify existing PR
       issues: write # need to potentially create a new milestone
+      id-token: write
 
     steps:
       - name: Checkout
@@ -22,10 +23,17 @@ jobs:
 
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
-          dotnet-version: '7.0.101'
+          dotnet-version: "7.0.101"
+
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-php
+          policy: self.auto-add-pr-to-milestone
 
       - name: "Assign to vNext Milestone"
         run: ./github-actions-helpers/build.sh AssignPullRequestToMilestone
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
           PullRequestNumber: "${{ github.event.pull_request.number }}"

--- a/.github/workflows/auto_check_snapshots.yml
+++ b/.github/workflows/auto_check_snapshots.yml
@@ -9,6 +9,7 @@ jobs:
     permissions:
       contents: read
       pull-requests: write # need to add a comment to a PR
+      id-token: write
 
     steps:
       - name: Checkout
@@ -18,11 +19,18 @@ jobs:
 
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
-          dotnet-version: '7.0.101'
+          dotnet-version: "7.0.101"
+
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-php
+          policy: self.auto-check-snapshots
 
       - name: "Check Snapshots"
         run: ./github-actions-helpers/build.sh SummaryOfSnapshotChanges
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
           PullRequestNumber: "${{ github.event.pull_request.number }}"
           TargetBranch: "${{ github.base_ref }}"

--- a/.github/workflows/auto_label_prs.yml
+++ b/.github/workflows/auto_label_prs.yml
@@ -1,16 +1,16 @@
 name: Label PRs
 
 on:
-- pull_request
+  - pull_request
 
 jobs:
   add-labels:
-
     runs-on: ubuntu-24.04
     permissions:
       contents: read
       issues: write # Update labels on PRs (might not be necessary, but we call the UpdateIssue API so...)
       pull-requests: write # Update labels on PRs
+      id-token: write
 
     steps:
       - name: Checkout
@@ -18,10 +18,17 @@ jobs:
 
       - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
         with:
-          dotnet-version: '7.0.101'
+          dotnet-version: "7.0.101"
+
+      - name: Get GitHub Token via dd-octo-sts
+        id: generate-token
+        uses: DataDog/dd-octo-sts-action@96a25462dbcb10ebf0bfd6e2ccc917d2ab235b9a # v1.0.4
+        with:
+          scope: DataDog/dd-trace-php
+          policy: self.auto-label-prs
 
       - name: "Add labels"
         run: ./github-actions-helpers/build.sh AssignLabelsToPullRequest
         env:
-          GITHUB_TOKEN: "${{ secrets.GITHUB_TOKEN }}"
+          GITHUB_TOKEN: "${{ steps.generate-token.outputs.token }}"
           PullRequestNumber: "${{ github.event.pull_request.number }}"


### PR DESCRIPTION
> **Stacked on #3878** (chainguard policies — merge first).

### Description

Replace all `secrets.GITHUB_TOKEN` usage across 4 GitHub Actions workflows with OIDC tokens from `DataDog/dd-octo-sts-action`.

- Added 4 Chainguard policy files
- Added `permissions` block to `add-asset-to-gh-release.yml` (previously had none)
- No functional changes

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.

### Jira

- [APMLP-1605](https://datadoghq.atlassian.net/browse/APMLP-1605)


[APMLP-1605]: https://datadoghq.atlassian.net/browse/APMLP-1605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ