### PR TITLE
appsec/int: add maven central proxy in ci

### DIFF
--- a/.gitlab/generate-appsec.php
+++ b/.gitlab/generate-appsec.php
@@ -29,6 +29,7 @@ EOT;
 variables:
   FF_ENABLE_BASH_EXIT_CODE_CHECK: "true"
   FF_USE_NEW_BASH_EVAL_STRATEGY: "true"
+  MAVEN_REPOSITORY_PROXY: "https://depot-read-api-java.us1.ddbuild.io/magicmirror/magicmirror/@current/"
   CI_REGISTRY_USER:
     value: ""
     description: "Your docker hub username"

--- a/appsec/tests/integration/build.gradle
+++ b/appsec/tests/integration/build.gradle
@@ -14,7 +14,12 @@ plugins {
 }
 
 repositories {
-    mavenCentral()
+    def proxy = System.getenv('MAVEN_REPOSITORY_PROXY')
+    if (proxy) {
+        maven { url proxy }
+    } else {
+        mavenCentral()
+    }
 }
 
 java {

--- a/appsec/tests/integration/settings.gradle
+++ b/appsec/tests/integration/settings.gradle
@@ -1,1 +1,12 @@
+pluginManagement {
+    repositories {
+        def proxy = System.getenv('MAVEN_REPOSITORY_PROXY')
+        if (proxy) {
+            maven { url proxy }
+        } else {
+            gradlePluginPortal()
+        }
+    }
+}
+
 rootProject.name = 'dd-appsec-php-integration'


### PR DESCRIPTION
### Description

Attempt to fix intermittent 403 errors on maven central through the use of a proxy on CI. 

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
