### PR TITLE
ci: add dd-octo-sts chainguard policy files

### DIFF
--- a/.github/chainguard/self.add-asset-to-gh-release.sts.yaml
+++ b/.github/chainguard/self.add-asset-to-gh-release.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-php:ref:refs/heads/.+"
+
+claim_pattern:
+  event_name: workflow_dispatch
+  repository: DataDog/dd-trace-php
+  job_workflow_ref: DataDog/dd-trace-php/\.github/workflows/add-asset-to-gh-release\.yml@refs/heads/.+
+
+permissions:
+  contents: write

--- a/.github/chainguard/self.auto-add-pr-to-milestone.sts.yaml
+++ b/.github/chainguard/self.auto-add-pr-to-milestone.sts.yaml
@@ -1,0 +1,12 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-php:pull_request"
+
+claim_pattern:
+  event_name: pull_request
+  repository: DataDog/dd-trace-php
+  job_workflow_ref: DataDog/dd-trace-php/\.github/workflows/auto_add_pr_to_miletone\.yml@refs/(pull/[0-9]+/merge|heads/.+)
+
+permissions:
+  issues: write
+  pull_requests: write

--- a/.github/chainguard/self.auto-check-snapshots.sts.yaml
+++ b/.github/chainguard/self.auto-check-snapshots.sts.yaml
@@ -1,0 +1,11 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-php:pull_request"
+
+claim_pattern:
+  event_name: pull_request
+  repository: DataDog/dd-trace-php
+  job_workflow_ref: DataDog/dd-trace-php/\.github/workflows/auto_check_snapshots\.yml@refs/(pull/[0-9]+/merge|heads/.+)
+
+permissions:
+  pull_requests: write

--- a/.github/chainguard/self.auto-label-prs.sts.yaml
+++ b/.github/chainguard/self.auto-label-prs.sts.yaml
@@ -1,0 +1,13 @@
+issuer: https://token.actions.githubusercontent.com
+
+subject_pattern: "repo:DataDog/dd-trace-php:pull_request"
+
+claim_pattern:
+  event_name: pull_request
+  repository: DataDog/dd-trace-php
+  job_workflow_ref: DataDog/dd-trace-php/\.github/workflows/auto_label_prs\.yml@refs/(pull/[0-9]+/merge|heads/.+)
+
+permissions:
+  contents: read
+  issues: write
+  pull_requests: write


### PR DESCRIPTION
### Description

Add 4 Chainguard policy files under `.github/chainguard/` for the upcoming migration of `secrets.GITHUB_TOKEN` to `DataDog/dd-octo-sts-action`.

These policies must be on the default branch before the corresponding workflow changes can use them. They declare which workflow, event, and ref pattern may request which permissions via the dd-octo-sts OIDC token exchange.

Policy files only — no workflow changes. Stacked with #3875.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.

### Jira

- [APMLP-1605](https://datadoghq.atlassian.net/browse/APMLP-1605)


[APMLP-1605]: https://datadoghq.atlassian.net/browse/APMLP-1605?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ