### PR TITLE
ci: auto-retry jobs that fail with exit code 128 (git fatal)

### DIFF
--- a/.gitlab/generate-common.php
+++ b/.gitlab/generate-common.php
@@ -117,6 +117,7 @@ default:
       - job_execution_timeout
     exit_codes:
       - 75
+      - 128
 
 .all_targets: &all_minor_major_targets
 <?php


### PR DESCRIPTION
## Summary

Adds exit code **128** to the global GitLab CI retry list in `.gitlab/generate-common.php`.

GitLab's runner runs `get_sources` (gitretriever / `git clone` / submodule fetch) *before* the user `script:` block, but classifies any non-zero exit from that phase as `failure_reason: script_failure`. Our existing `when:` list (`runner_system_failure`, `stuck_or_timeout_failure`, etc.) therefore does **not** catch these, and the recently added `exit_codes: [75]` mechanism doesn't help either since our scripts never get a chance to run and emit 75.

Concrete example: [job 1679611981](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-php/-/jobs/1679611981) spent ~20 min in `get_sources` retrying gitretriever and direct GitLab clones, all timing out with `Failed to connect to gitlab.ddbuild.io port 443`, then died with `command terminated with exit code 128`. Currently this requires a manual retry.

Git uses 128 as its universal "fatal" exit code, so in our CI it's almost always one of:
- gitretriever / get_sources network flake (the trigger for this PR)
- `git submodule update --init --recursive` network flake
- `composer install` failing at a git step
- Windows job `git clone` / `git checkout` failing

All of these are infra/network failures worth retrying. The rare false positive (a genuinely broken submodule SHA) fails fast and only costs ~2 extra retries.

## Test plan

- [ ] Pipeline runs `generate-templates` and the resulting `*-gen.yml` artifacts contain `- 128` under `default.retry.exit_codes`
- [ ] No unintended retry behavior in jobs that currently fail with non-128 exit codes