### PR TITLE
Ensure remote config processing happens strictly after request initialization

### DIFF
--- a/components-rs/remote_config.rs
+++ b/components-rs/remote_config.rs
@@ -592,7 +592,8 @@ pub extern "C" fn ddog_remote_configs_service_env_change(
     }
 
     remote_config.manager.track_target(&Arc::new(new_target));
-    ddog_process_remote_configs(remote_config);
+    // Caller must call ddog_process_remote_configs if true.
+    // We don't call it here to allow the caller delaying the call as necessary.
 
     true
 }

--- a/ext/sidecar.c
+++ b/ext/sidecar.c
@@ -813,9 +813,8 @@ void ddtrace_sidecar_submit_root_span_data_direct(ddog_SidecarTransport **transp
             ddog_sidecar_telemetry_filter_flush(transport, ddtrace_sidecar_instance_id, &DDTRACE_G(sidecar_queue_id), ddtrace_telemetry_buffer(), ddtrace_telemetry_cache(), service_slice, env_slice));
     }
 
-    if (!changed && DDTRACE_G(remote_config_state)) {
-        // ddog_remote_configs_service_env_change() generally only processes configs if they changed. However, upon request initialization it may be identical to the previous request.
-        // However, at request shutdown some configs are unloaded. Explicitly forcing a processing step ensures these are re-loaded.
+    if (DDTRACE_G(remote_config_state)) {
+        // Must happen after ddog_sidecar_set_universal_service_tags (session state fully initialized)
         ddog_process_remote_configs(DDTRACE_G(remote_config_state));
     }
 }


### PR DESCRIPTION
Otherwise it could happen as a side effect of ddog_remote_configs_service_env_change, which could send values to the sidecar and then break, if sent before ddog_sidecar_set_universal_service_tags.