### PR TITLE
Retry sidecar connect before probe install

### DIFF
--- a/ext/sidecar.c
+++ b/ext/sidecar.c
@@ -851,6 +851,10 @@ void ddtrace_sidecar_activate(void) {
 }
 
 void ddtrace_sidecar_rinit(void) {
+    if (!DDTRACE_G(sidecar) && ddtrace_endpoint) {
+        ddtrace_sidecar_ensure_active();
+    }
+
     if (get_DD_TRACE_GIT_METADATA_ENABLED()) {
         zval git_object;
         ZVAL_UNDEF(&git_object);


### PR DESCRIPTION
<!-- dd-meta {"pullId":"f3314166-0f4e-44e4-9f61-f9a8c5ed23a3","source":"chat","resourceId":"af922a5a-da62-489e-bd2f-91138bbfc6f1","workflowId":"eb1ca0bf-5685-4e19-9a2f-1b38ab9517f7","codeChangeId":"eb1ca0bf-5685-4e19-9a2f-1b38ab9517f7","sourceType":"action_platform_custom_agent"} -->
### Description

Workflow Automation • [View in Workflow Automation](https://app.datadoghq.com/actions/agents/776f101a-4a83-4c3f-a37d-c67419e1da4d)

Motivation (WHY)
- `test_extension_ci` has recurring flakes in live debugger / dynamic instrumentation tests where probes are not installed in time.
- The failures align with a startup race window where the sidecar transport can still be unavailable when request initialization proceeds, which prevents timely RC polling / probe application.
- This has been a major source of master pipeline instability (for example pipeline 113108177).

Changes (WHAT)
- Added a sidecar readiness retry in `ext/sidecar.c` during `ddtrace_sidecar_rinit()`:
  - If `DDTRACE_G(sidecar)` is not yet connected but `ddtrace_endpoint` is available, call `ddtrace_sidecar_ensure_active()` before submitting root span data.
- This keeps the existing startup path intact and only adds a targeted second-chance connection at request init, reducing probe-install race likelihood without broad timeout increases.

Testing (HOW verified)
- Environment limitations prevented full local CI reproduction:
  - podman compose networking is unavailable in this sandbox (missing CNI plugins), so request-replayer/test-agent services could not be started.
  - `libdatadog` submodule fetch is blocked (403 allowlist restriction), so full extension build/test execution is not possible here.
- Validation performed:
  - Confirmed affected probe-install/test helper paths and sidecar/RC initialization flow in source.
  - Verified the patch is minimal and scoped to sidecar reconnect timing in `ddtrace_sidecar_rinit()`.
  - Confirmed final diff only changes `ext/sidecar.c`.

Relevant failing pipeline example:
https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-php/-/pipelines/113108177

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.

---

PR by Bits - [View session in Datadog](https://app.datadoghq.com/code/af922a5a-da62-489e-bd2f-91138bbfc6f1)

Comment @datadog to request changes