### PR TITLE
helper-rust: redact telemetry logs waf data

### DIFF
--- a/appsec/helper-rust/src/telemetry/tel_aware_logger.rs
+++ b/appsec/helper-rust/src/telemetry/tel_aware_logger.rs
@@ -100,7 +100,7 @@ fn submit_error_to_telemetry(record: &Record) {
         tags.add("module", module);
     }
 
-    let message = format!("{}", record.args());
+    let message = redact_waf_strings(&format!("{}", record.args())).into_owned();
 
     let location = if let (Some(module), Some(line)) = (record.module_path(), record.line()) {
         Cow::Owned(format!("{}:{}", module, line))
@@ -152,6 +152,53 @@ impl<'kvs> VisitSource<'kvs> for BacktraceExtractor {
         }
         Ok(())
     }
+}
+
+/// Replace every `WafString("…")` span with `WafString("<REDACTED>")`.
+///
+/// The Debug impl of libddwaf `WafString` escapes `"` as `\"` and `\` as `\\`
+/// inside the delimiters, so the closing `")` can only be an unescaped `"`
+/// followed by `)`. Returns `Cow::Borrowed` when no replacement is needed.
+pub(crate) fn redact_waf_strings(msg: &str) -> Cow<'_, str> {
+    const OPEN: &str = "WafString(\"";
+    const REPLACEMENT: &str = "WafString(\"<REDACTED>\")";
+
+    if !msg.contains(OPEN) {
+        return Cow::Borrowed(msg);
+    }
+
+    let mut out = String::with_capacity(msg.len());
+    let mut rest = msg;
+
+    while let Some(open_at) = rest.find(OPEN) {
+        let content = &rest[open_at + OPEN.len()..];
+        let Some(end) = find_waf_string_end(content) else {
+            break;
+        };
+        out.push_str(&rest[..open_at]);
+        out.push_str(REPLACEMENT);
+        rest = &content[end..];
+    }
+
+    out.push_str(rest);
+    Cow::Owned(out)
+}
+
+/// Given the bytes right after the opening `WafString("`, return the offset
+/// just past the closing `")`, treating `\\` and `\"` as escapes inside the
+/// quoted content. Returns `None` if the string is unterminated.
+fn find_waf_string_end(content: &str) -> Option<usize> {
+    let bytes = content.as_bytes();
+    let mut i = 0;
+    while i < bytes.len() {
+        match bytes[i] {
+            b'\\' if i + 1 < bytes.len() => i += 2, // skip escaped char
+            b'"' if bytes.get(i + 1) == Some(&b')') => return Some(i + 2),
+            b'"' => return None, // bare `"` not followed by `)` — malformed
+            _ => i += 1,
+        }
+    }
+    None
 }
 
 fn extract_anyhow_backtrace(record: &Record) -> Option<String> {
@@ -298,6 +345,61 @@ mod tests {
 
         let extracted = extract_anyhow_backtrace(&record);
         assert!(extracted.is_none());
+    }
+
+    #[test]
+    fn test_redact_waf_strings_no_match_is_borrowed() {
+        let input = "no waf data here, just text";
+        let out = redact_waf_strings(input);
+        assert!(matches!(out, Cow::Borrowed(_)));
+        assert_eq!(out, input);
+    }
+
+    #[test]
+    fn test_redact_waf_strings_single() {
+        let input = r#"error: WafString("Mozilla/5.0 secret")"#;
+        let out = redact_waf_strings(input);
+        assert_eq!(out, r#"error: WafString("<REDACTED>")"#);
+    }
+
+    #[test]
+    fn test_redact_waf_strings_escaped_quote_not_treated_as_close() {
+        let input = r#"WafString("say \"hi\"")"#;
+        let out = redact_waf_strings(input);
+        assert_eq!(out, r#"WafString("<REDACTED>")"#);
+    }
+
+    #[test]
+    fn test_redact_waf_strings_escaped_backslash_before_close() {
+        let input = r#"WafString("trailing backslash\\")"#;
+        let out = redact_waf_strings(input);
+        assert_eq!(out, r#"WafString("<REDACTED>")"#);
+    }
+
+    #[test]
+    fn test_primary_delegate_receives_unredacted_error_message() {
+        let logs = Arc::new(Mutex::new(Vec::new()));
+        let primary = Box::new(TestLogger { logs: logs.clone() });
+        let composite = TelemetryAwareLogger::new(primary);
+
+        let record = log::Record::builder()
+            .args(format_args!(
+                r#"error in request loop: unexpected command WafString("ORIGINAL_SECRET")"#
+            ))
+            .level(Level::Error)
+            .build();
+
+        composite.log(&record);
+
+        let captured = logs.lock().unwrap();
+        assert_eq!(captured.len(), 1);
+        // Delegate must see the original, unredacted message.
+        assert!(
+            captured[0].contains("ORIGINAL_SECRET"),
+            "delegate did not receive the original message, got: {}",
+            captured[0]
+        );
+        assert!(!captured[0].contains("<REDACTED>"));
     }
 
     #[test]

--- a/appsec/src/extension/ddappsec.c
+++ b/appsec/src/extension/ddappsec.c
@@ -621,12 +621,16 @@ ZEND_ARG_TYPE_INFO(0, data, IS_ARRAY, 0)
 ZEND_END_ARG_INFO()
 
 // clang-format off
-static const zend_function_entry testing_functions[] = {
+// Available under either DD_APPSEC_TESTING or DD_APPSEC_TESTING_INVALID_COMMAND
+static const zend_function_entry testing_request_control_functions[] = {
     ZEND_RAW_FENTRY(DD_TESTING_NS "rinit", PHP_FN(datadog_appsec_testing_rinit), void_ret_bool_arginfo, 0, NULL, NULL)
     ZEND_RAW_FENTRY(DD_TESTING_NS "rshutdown", PHP_FN(datadog_appsec_testing_rshutdown), void_ret_bool_arginfo, 0, NULL, NULL)
+    ZEND_RAW_FENTRY(DD_TESTING_NS "request_exec", PHP_FN(datadog_appsec_testing_request_exec), request_exec_arginfo, 0, NULL, NULL)
+    PHP_FE_END
+};
+static const zend_function_entry testing_functions[] = {
     ZEND_RAW_FENTRY(DD_TESTING_NS "helper_mgr_acquire_conn", PHP_FN(datadog_appsec_testing_helper_mgr_acquire_conn), void_ret_bool_arginfo, 0, NULL, NULL)
     ZEND_RAW_FENTRY(DD_TESTING_NS "stop_for_debugger", PHP_FN(datadog_appsec_testing_stop_for_debugger), void_ret_bool_arginfo, 0, NULL, NULL)
-    ZEND_RAW_FENTRY(DD_TESTING_NS "request_exec", PHP_FN(datadog_appsec_testing_request_exec), request_exec_arginfo, 0, NULL, NULL)
     PHP_FE_END
 };
 static const zend_function_entry testing_invalid_command_functions[] = {
@@ -637,13 +641,18 @@ static const zend_function_entry testing_invalid_command_functions[] = {
 
 static void _register_testing_objects(void)
 {
-    if (get_global_DD_APPSEC_TESTING_INVALID_COMMAND()) {
+    bool invalid_command = get_global_DD_APPSEC_TESTING_INVALID_COMMAND();
+    bool full_testing = get_global_DD_APPSEC_TESTING();
+
+    if (invalid_command) {
         dd_phpobj_reg_funcs(testing_invalid_command_functions);
     }
 
-    if (!get_global_DD_APPSEC_TESTING()) {
-        return;
+    if (invalid_command || full_testing) {
+        dd_phpobj_reg_funcs(testing_request_control_functions);
     }
 
-    dd_phpobj_reg_funcs(testing_functions);
+    if (full_testing) {
+        dd_phpobj_reg_funcs(testing_functions);
+    }
 }

--- a/appsec/tests/integration/src/main/groovy/com/datadog/appsec/php/docker/AppSecContainer.groovy
+++ b/appsec/tests/integration/src/main/groovy/com/datadog/appsec/php/docker/AppSecContainer.groovy
@@ -410,6 +410,16 @@ class AppSecContainer<SELF extends AppSecContainer<SELF>> extends GenericContain
         traceFromRequest(req, HttpResponse.BodyHandlers.ofInputStream(), doWithConn, ignoreOtherRequests)
     }
 
+    <T> Trace traceFromRequest(String path,
+                               HttpResponse.BodyHandler<T> bodyHandler,
+                               @ClosureParams(value = FromString,
+                                       options = 'java.net.http.HttpResponse<T>')
+                                       Closure<Void> doWithResp = null,
+                               boolean ignoreOtherRequests = false) {
+        HttpRequest req = buildReq(path).GET().build()
+        traceFromRequest(req, bodyHandler, doWithResp, ignoreOtherRequests)
+    }
+
     @CompileStatic(TypeCheckingMode.SKIP)
     <T> Trace traceFromRequest(HttpRequest req,
                                HttpResponse.BodyHandler<T> bodyHandler,

--- a/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/TelemetryTests.groovy
+++ b/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/TelemetryTests.groovy
@@ -1049,6 +1049,180 @@ class TelemetryTests {
     }
 
     /**
+     * Verifies that WafString(...) contents in helper error messages are redacted before
+     * being submitted to telemetry, while the local helper file log retains the original
+     * unredacted contents.
+     *
+     * The scenario triggers `unexpected command {:?}` in the helper request loop by
+     * sending a request_exec when the helper is waiting for request_init.
+     */
+    @Test
+    @Order(12)
+    void 'telemetry log redacts WafString contents'() {
+        Assumptions.assumeTrue(System.getProperty('USE_HELPER_RUST') != null)
+
+        Supplier<RemoteConfigRequest> requestSup = CONTAINER.applyRemoteConfig(RC_TARGET, [
+                'datadog/2/ASM_FEATURES/asm_features_activation/config': [
+                        asm: [enabled: true]
+                ]
+        ])
+
+        // warm-up request to start helper and apply RC
+        Trace trace = CONTAINER.traceFromRequest('/hello.php') { HttpResponse<InputStream> resp ->
+            assert resp.statusCode() == 200
+        }
+        assert trace.traceId != null
+        assert requestSup.get() != null
+
+        // another covered request to ensure the connection is established
+        trace = CONTAINER.traceFromRequest('/hello.php') { HttpResponse<InputStream> resp ->
+            assert resp.statusCode() == 200
+        }
+        assert trace.traceId != null
+
+        // trigger the error path with a known sentinel value embedded as a WafString
+        CONTAINER.traceFromRequest('/send_request_exec_before_init.php', ofString()) {
+            HttpResponse<String> resp -> assert resp.statusCode() == 200
+        }
+
+        def messages = TelemetryHelpers.waitForLogs(CONTAINER, 30) { List<TelemetryHelpers.Logs> logs ->
+            def relevantLogs = logs.collectMany {
+                it.logs.findAll {
+                    it.tags?.contains('log_type:helper::logged_error') &&
+                            it.message?.contains('error in request loop')
+                }
+            }
+            !relevantLogs.empty
+        }.collectMany { it.logs }
+
+        def errorLog = messages.find {
+            it.tags?.contains('log_type:helper::logged_error') &&
+                    it.message?.contains('error in request loop')
+        }
+        assert errorLog != null : "Expected to find an 'error in request loop' telemetry log. " +
+                "All logs: ${messages.collect { [tags: it.tags, message: it.message] }}"
+
+        // The telemetry log must NOT leak the original WafString payload
+        assert !errorLog.message.contains('APPSEC_REDACT_TEST_SENTINEL_XYZ') :
+                "Telemetry log leaked unredacted WafString contents: ${errorLog.message}"
+
+        // And the WafString(...) span must have been replaced with the redacted marker
+        assert errorLog.message.contains('WafString("<REDACTED>")') :
+                "Telemetry log is missing redacted WafString marker; got: ${errorLog.message}"
+
+        // The local helper file log must still contain the original unredacted contents
+        def helperLog = CONTAINER.execInContainer('bash', '-c', 'cat /tmp/logs/helper.log').stdout
+        assert helperLog.contains('APPSEC_REDACT_TEST_SENTINEL_XYZ') :
+                "Expected helper.log to contain the original (unredacted) WafString contents"
+    }
+
+    /**
+     * Verifies that appsec.rasp.rule.match carries the `block` tag with the correct value:
+     *   - block:irrelevant  → RASP rule matched but `on_match` did not request a block
+     *   - block:success     → RASP rule matched, block was requested and (per PHP semantics)
+     *                         always succeeds; PHP cannot fail to block once it decides to.
+     *
+     * Cross-tracer spec (see dd-trace-go, dd-trace-py): the tag is always emitted on
+     * rasp.rule.match. PHP never emits block:failure because the layer is assumed to
+     * always succeed at terminating the script.
+     *
+     * Only applies to the Rust helper.
+     */
+    @Test
+    @Order(13)
+    void 'rasp rule match has block tag'() {
+        Assumptions.assumeTrue(System.getProperty('USE_HELPER_RUST') != null,
+                'block tag on rasp.rule.match is only implemented on the Rust helper')
+
+        try {
+            // Phase 1: non-blocking RASP rule match (recommended.json lfi/ssrf rules have
+            // on_match: ["stack_trace"], so a match does not block). Expect block:irrelevant.
+            Supplier<RemoteConfigRequest> requestSup = CONTAINER.applyRemoteConfig(RC_TARGET, [
+                    'datadog/2/ASM_FEATURES/asm_features_activation/config': [
+                            asm: [enabled: true]
+                    ]
+            ])
+
+            CONTAINER.traceFromRequest('/hello.php') { HttpResponse<InputStream> resp ->
+                assert resp.statusCode() == 200
+            }
+            assert requestSup.get() != null
+
+            CONTAINER.traceFromRequest(
+                    '/multiple_rasp.php?path=../somefile&other=../otherfile&domain=169.254.169.254') {
+                HttpResponse<InputStream> resp -> assert resp.statusCode() == 200
+            }
+
+            // Phase 2: override the LFI rule on_match to ["block"]. The first @fopen in
+            // multiple_rasp.php hits an LFI match, the WAF returns block_request, and the
+            // PHP layer terminates the request. Expect block:success on the rasp.rule.match
+            // emitted for rule_type:lfi from that request.
+            Supplier<RemoteConfigRequest> overrideSup = CONTAINER.applyRemoteConfig(RC_TARGET, [
+                    'datadog/2/ASM_FEATURES/asm_features_activation/config': [
+                            asm: [enabled: true]
+                    ],
+                    'datadog/2/ASM/rasp_lfi_block_override/config': [
+                            rules_override: [[
+                                                     rules_target: [[rule_id: 'rasp-001-001']],
+                                                     on_match: ['block']
+                                             ]]
+                    ]
+            ])
+            assert overrideSup.get() != null
+
+            // Trigger the blocking LFI; status code is 403 because the rule now blocks.
+            HttpRequest blockingReq = CONTAINER.buildReq(
+                    '/multiple_rasp.php?path=../somefile&other=../otherfile&domain=169.254.169.254')
+                    .GET().build()
+            CONTAINER.traceFromRequest(blockingReq, ofString()) { HttpResponse<String> resp ->
+                assert resp.statusCode() == 403
+            }
+
+            TelemetryHelpers.Metric lfiMatchIrrelevant
+            TelemetryHelpers.Metric lfiMatchSuccess
+
+            TelemetryHelpers.waitForMetrics(CONTAINER, 30) { List<TelemetryHelpers.GenerateMetrics> messages ->
+                def allSeries = messages.collectMany { it.series }
+                lfiMatchIrrelevant = lfiMatchIrrelevant ?: allSeries.find {
+                    it.name == 'rasp.rule.match' &&
+                            'rule_type:lfi' in it.tags &&
+                            'block:irrelevant' in it.tags
+                }
+                lfiMatchSuccess = lfiMatchSuccess ?: allSeries.find {
+                    it.name == 'rasp.rule.match' &&
+                            'rule_type:lfi' in it.tags &&
+                            'block:success' in it.tags
+                }
+                lfiMatchIrrelevant != null && lfiMatchSuccess != null
+            }
+
+            assert lfiMatchIrrelevant != null :
+                    'rasp.rule.match metric with block:irrelevant not found — ' +
+                    'helper must emit block:irrelevant when the matched RASP rule has no block action'
+            assert lfiMatchIrrelevant.namespace == 'appsec'
+            assert lfiMatchIrrelevant.type == 'count'
+            assert lfiMatchIrrelevant.points[0][1] >= 1.0d
+
+            assert lfiMatchSuccess != null :
+                    'rasp.rule.match metric with block:success not found — ' +
+                    'helper must emit block:success when the matched RASP rule triggered a block'
+            assert lfiMatchSuccess.namespace == 'appsec'
+            assert lfiMatchSuccess.type == 'count'
+            assert lfiMatchSuccess.points[0][1] >= 1.0d
+        } finally {
+            // Drop the override so subsequent ordered tests in this class run with the
+            // default (non-blocking) RASP ruleset, even if assertions above failed.
+            CONTAINER.applyRemoteConfig(RC_TARGET, [
+                    'datadog/2/ASM_FEATURES/asm_features_activation/config': [
+                            asm: [enabled: true]
+                    ],
+                    'datadog/2/ASM/rasp_lfi_block_override/config': null
+            ])
+        }
+    }
+
+
+    /**
      * RFC-1012: appsec.waf.requests must include the rate_limited boolean tag.
      * The rate limiter must only be consulted when the WAF triggered (waf_keep=true),
      * matching C++ semantics: `event.keep && limiter_.allow()`. Clean requests must
@@ -1142,111 +1316,6 @@ class TelemetryTests {
         assert wafReqRateLimited.points[0][1] >= 1.0
         assert 'rule_triggered:true' in wafReqRateLimited.tags
         assert 'rate_limited:true' in wafReqRateLimited.tags
-    }
-
-    /**
-     * Verifies that appsec.rasp.rule.match carries the `block` tag with the correct value:
-     *   - block:irrelevant  → RASP rule matched but `on_match` did not request a block
-     *   - block:success     → RASP rule matched, block was requested and (per PHP semantics)
-     *                         always succeeds; PHP cannot fail to block once it decides to.
-     *
-     * Cross-tracer spec (see dd-trace-go, dd-trace-py): the tag is always emitted on
-     * rasp.rule.match. PHP never emits block:failure because the layer is assumed to
-     * always succeed at terminating the script.
-     *
-     * Only applies to the Rust helper.
-     */
-    @Test
-    @Order(12)
-    void 'rasp rule match has block tag'() {
-        Assumptions.assumeTrue(System.getProperty('USE_HELPER_RUST') != null,
-                'block tag on rasp.rule.match is only implemented on the Rust helper')
-
-        try {
-            // Phase 1: non-blocking RASP rule match (recommended.json lfi/ssrf rules have
-            // on_match: ["stack_trace"], so a match does not block). Expect block:irrelevant.
-            Supplier<RemoteConfigRequest> requestSup = CONTAINER.applyRemoteConfig(RC_TARGET, [
-                    'datadog/2/ASM_FEATURES/asm_features_activation/config': [
-                            asm: [enabled: true]
-                    ]
-            ])
-
-            CONTAINER.traceFromRequest('/hello.php') { HttpResponse<InputStream> resp ->
-                assert resp.statusCode() == 200
-            }
-            assert requestSup.get() != null
-
-            CONTAINER.traceFromRequest(
-                    '/multiple_rasp.php?path=../somefile&other=../otherfile&domain=169.254.169.254') {
-                HttpResponse<InputStream> resp -> assert resp.statusCode() == 200
-            }
-
-            // Phase 2: override the LFI rule on_match to ["block"]. The first @fopen in
-            // multiple_rasp.php hits an LFI match, the WAF returns block_request, and the
-            // PHP layer terminates the request. Expect block:success on the rasp.rule.match
-            // emitted for rule_type:lfi from that request.
-            Supplier<RemoteConfigRequest> overrideSup = CONTAINER.applyRemoteConfig(RC_TARGET, [
-                    'datadog/2/ASM_FEATURES/asm_features_activation/config': [
-                            asm: [enabled: true]
-                    ],
-                    'datadog/2/ASM/rasp_lfi_block_override/config': [
-                            rules_override: [[
-                                                     rules_target: [[rule_id: 'rasp-001-001']],
-                                                     on_match: ['block']
-                                             ]]
-                    ]
-            ])
-            assert overrideSup.get() != null
-
-            // Trigger the blocking LFI; status code is 403 because the rule now blocks.
-            HttpRequest blockingReq = CONTAINER.buildReq(
-                    '/multiple_rasp.php?path=../somefile&other=../otherfile&domain=169.254.169.254')
-                    .GET().build()
-            CONTAINER.traceFromRequest(blockingReq, ofString()) { HttpResponse<String> resp ->
-                assert resp.statusCode() == 403
-            }
-
-            TelemetryHelpers.Metric lfiMatchIrrelevant
-            TelemetryHelpers.Metric lfiMatchSuccess
-
-            TelemetryHelpers.waitForMetrics(CONTAINER, 30) { List<TelemetryHelpers.GenerateMetrics> messages ->
-                def allSeries = messages.collectMany { it.series }
-                lfiMatchIrrelevant = lfiMatchIrrelevant ?: allSeries.find {
-                    it.name == 'rasp.rule.match' &&
-                            'rule_type:lfi' in it.tags &&
-                            'block:irrelevant' in it.tags
-                }
-                lfiMatchSuccess = lfiMatchSuccess ?: allSeries.find {
-                    it.name == 'rasp.rule.match' &&
-                            'rule_type:lfi' in it.tags &&
-                            'block:success' in it.tags
-                }
-                lfiMatchIrrelevant != null && lfiMatchSuccess != null
-            }
-
-            assert lfiMatchIrrelevant != null :
-                    'rasp.rule.match metric with block:irrelevant not found — ' +
-                    'helper must emit block:irrelevant when the matched RASP rule has no block action'
-            assert lfiMatchIrrelevant.namespace == 'appsec'
-            assert lfiMatchIrrelevant.type == 'count'
-            assert lfiMatchIrrelevant.points[0][1] >= 1.0d
-
-            assert lfiMatchSuccess != null :
-                    'rasp.rule.match metric with block:success not found — ' +
-                    'helper must emit block:success when the matched RASP rule triggered a block'
-            assert lfiMatchSuccess.namespace == 'appsec'
-            assert lfiMatchSuccess.type == 'count'
-            assert lfiMatchSuccess.points[0][1] >= 1.0d
-        } finally {
-            // Drop the override so subsequent ordered tests in this class run with the
-            // default (non-blocking) RASP ruleset, even if assertions above failed.
-            CONTAINER.applyRemoteConfig(RC_TARGET, [
-                    'datadog/2/ASM_FEATURES/asm_features_activation/config': [
-                            asm: [enabled: true]
-                    ],
-                    'datadog/2/ASM/rasp_lfi_block_override/config': null
-            ])
-        }
     }
 
     @Test

--- a/appsec/tests/integration/src/test/www/base/public/send_request_exec_before_init.php
+++ b/appsec/tests/integration/src/test/www/base/public/send_request_exec_before_init.php
@@ -1,0 +1,22 @@
+<?php
+/**
+ * This file forces the helper into an error path by:
+ *   1. Calling rshutdown so the helper returns to its outer loop awaiting request_init.
+ *   2. Calling request_exec directly: the helper receives request_exec when it expects
+ *      request_init and bails with `unexpected command {:?}`. That error message is
+ *      logged at ERROR level and ends up in telemetry containing WafString(...) entries
+ *      built from the request_exec payload.
+ *
+ * Used by the integration test for telemetry WafString redaction.
+ */
+
+\datadog\appsec\testing\rshutdown();
+
+\datadog\appsec\testing\request_exec([
+    'server.request.headers.no_cookies' => [
+        'x-test' => 'APPSEC_REDACT_TEST_SENTINEL_XYZ',
+    ],
+]);
+
+header('Content-Type: text/plain');
+echo 'done';


### PR DESCRIPTION
### Description

Avoid the possibility of sensitive data going to the backend via WAF strings.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
