### PR TITLE
pass ddtrace_globals explicitly through sidecar/telemetry GSHUTDOWN

### DIFF
--- a/.gitlab/generate-appsec.php
+++ b/.gitlab/generate-appsec.php
@@ -129,7 +129,7 @@ stages:
         TERM=dumb ./gradlew loadCaches --info
       fi
 
-      TERM=dumb ./gradlew $targets --info -Pbuildscan --scan $HELPER_RUST_FLAG
+      TERM=dumb ./gradlew $targets --info -Pbuildscan --scan -PcheckCoreDumps $HELPER_RUST_FLAG
       TERM=dumb ./gradlew saveCaches --info
   after_script:
     - mkdir -p "${CI_PROJECT_DIR}/artifacts"
@@ -343,7 +343,7 @@ stages:
       # Build helper-rust with coverage instrumentation
       TERM=dumb ./gradlew buildHelperRustWithCoverage --info -Pbuildscan --scan
       # Run integration tests with coverage-instrumented binary
-      TERM=dumb ./gradlew test8.3-debug --info -Pbuildscan --scan -PuseHelperRustCoverage
+      TERM=dumb ./gradlew test8.3-debug --info -Pbuildscan --scan -PcheckCoreDumps -PuseHelperRustCoverage
       # Generate coverage report from profraw files
       TERM=dumb ./gradlew generateHelperRustIntegrationCoverage --info -Pbuildscan --scan
       TERM=dumb ./gradlew saveCaches --info

--- a/appsec/tests/integration/build.gradle
+++ b/appsec/tests/integration/build.gradle
@@ -620,6 +620,9 @@ def runMainTask = { String phpVersion, String variant ->
         if (project.hasProperty('XDEBUG')) {
             systemProperty 'XDEBUG', '1'
         }
+        if (project.hasProperty('checkCoreDumps')) {
+            systemProperty 'checkCoreDumps', '1'
+        }
         systemProperty 'PHP_VERSION', phpVersion
         systemProperty 'VARIANT', variant
 
@@ -692,6 +695,9 @@ def runMainTask = { String phpVersion, String variant ->
         it.systemProperty 'VARIANT', variant
         if (project.hasProperty('XDEBUG')) {
             it.systemProperty 'XDEBUG', '1'
+        }
+        if (project.hasProperty('checkCoreDumps')) {
+            it.systemProperty 'checkCoreDumps', '1'
         }
         if (project.hasProperty('helperBinary')) {
             it.systemProperty 'USE_HELPER_RUST', '1'
@@ -800,6 +806,9 @@ if (project.hasProperty('testClass')) {
 
         if (project.hasProperty('XDEBUG')) {
             it.systemProperty 'XDEBUG', '1'
+        }
+        if (project.hasProperty('checkCoreDumps')) {
+            it.systemProperty 'checkCoreDumps', '1'
         }
         if (project.hasProperty('helperBinary')) {
             it.systemProperty 'USE_HELPER_RUST', '1'

--- a/appsec/tests/integration/src/main/groovy/com/datadog/appsec/php/docker/AppSecContainer.groovy
+++ b/appsec/tests/integration/src/main/groovy/com/datadog/appsec/php/docker/AppSecContainer.groovy
@@ -10,6 +10,7 @@ import com.github.dockerjava.api.command.CreateContainerCmd
 import com.github.dockerjava.api.command.ExecCreateCmdResponse
 import com.github.dockerjava.api.exception.NotFoundException
 import com.github.dockerjava.api.model.Bind
+import com.github.dockerjava.api.model.Ulimit
 import com.github.dockerjava.api.model.Volume
 import com.google.common.util.concurrent.SettableFuture
 import groovy.json.JsonOutput
@@ -49,8 +50,10 @@ class AppSecContainer<SELF extends AppSecContainer<SELF>> extends GenericContain
     private File logsDir
     // Set to true to include sidecar.log in stdout (very verbose)
     private static final boolean TAIL_SIDECAR_LOG = false
+    private static final boolean CHECK_CORE_DUMPS = System.getProperty('checkCoreDumps') != null
     private String wwwDir
     private String wwwSrcDir
+    private String savedCorePattern = null
     public final HttpClient httpClient = HttpClient.newBuilder()
                     .followRedirects(HttpClient.Redirect.NEVER)
                     .connectTimeout(Duration.ofSeconds(5))
@@ -110,6 +113,7 @@ class AppSecContainer<SELF extends AppSecContainer<SELF>> extends GenericContain
         this.logConsumer = createLogConsumer()
         followOutput(logConsumer)
         overlayWww()
+        enableCoredumps()
         runInitialize()
     }
 
@@ -315,11 +319,69 @@ class AppSecContainer<SELF extends AppSecContainer<SELF>> extends GenericContain
         }
     }
 
+    private void enableCoredumps() {
+        if (!CHECK_CORE_DUMPS) {
+            return
+        }
+        try {
+            ExecResult res = execInContainer('cat', '/proc/sys/kernel/core_pattern')
+            if (res.exitCode == 0) {
+                savedCorePattern = res.stdout.trim()
+            }
+            execInContainer('sh', '-c',
+                    'mkdir -p /tmp/cores && chmod 1777 /tmp/cores' +
+                    ' && echo /tmp/cores/core.%e.%p.%t > /proc/sys/kernel/core_pattern')
+        } catch (Exception e) {
+            log.warn("Could not enable coredumps: {}", e.message)
+        }
+    }
+
+    private List<String> detectCrashes() {
+        if (!CHECK_CORE_DUMPS) {
+            return []
+        }
+        List<String> crashes = []
+        try {
+            ExecResult res = execInContainer('find', '/tmp/cores', '-type', 'f')
+            if (res.exitCode == 0 && res.stdout.trim()) {
+                res.stdout.trim().readLines()*.trim().findAll { it }.each { String f ->
+                    crashes << "Core dump: $f".toString()
+                    log.error("Crash core dump found: {}", f)
+                }
+            }
+        } catch (Exception e) {
+            log.warn("Could not check for core dumps: {}", e.message)
+        }
+        crashes
+    }
+
+    void clearCoreFiles() {
+        execInContainer('sh', '-c', 'rm -f /tmp/cores/core.*')
+    }
+
+    private void restoreCorePattern() {
+        if (savedCorePattern != null) {
+            try {
+                execInContainer('sh', '-c',
+                        "printf '%s' '${savedCorePattern}' > /proc/sys/kernel/core_pattern")
+            } catch (Exception e) {
+                log.warn("Could not restore core pattern: {}", e.message)
+            }
+        }
+    }
+
     void close() {
         flushProfilingData()
         copyLogs()
+        List<String> crashes = detectCrashes()
+        restoreCorePattern()
         mockDatadogAgent.drainTraces()
         super.close()
+        if (crashes) {
+            throw new AssertionError(
+                    ("Process crash(es) detected in container during test run (${crashes.size()} crash(es)):\n" +
+                            crashes.join('\n')).toString())
+        }
     }
 
     private static final Random RAND = new Random()
@@ -439,6 +501,10 @@ class AppSecContainer<SELF extends AppSecContainer<SELF>> extends GenericContain
         }
 
         privilegedMode = true
+
+        withCreateContainerCmdModifier { cmd ->
+            cmd.hostConfig.withUlimits([new Ulimit('core', -1L, -1L)] as Ulimit[])
+        }
 
         this.wwwDir ="src/test/www/${options.get('www', 'base')}"
         if (options['www_src']) {
@@ -628,6 +694,19 @@ class AppSecContainer<SELF extends AppSecContainer<SELF>> extends GenericContain
             it = it.trim()
             if (it) {
                 copyFileFromContainer(it, new File(logsDir, new File(it).name).absolutePath)
+            }
+        }
+
+        if (CHECK_CORE_DUMPS) {
+            ExecResult coresRes = execInContainer('find', '/tmp/cores', '-type', 'f')
+            if (coresRes.exitCode == 0) {
+                coresRes.stdout.eachLine {
+                    it = it.trim()
+                    if (it) {
+                        log.info("Copying core dump: {}", it)
+                        copyFileFromContainer(it, new File(logsDir, new File(it).name).absolutePath)
+                    }
+                }
             }
         }
     }

--- a/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/ZtsGshutdownTests.groovy
+++ b/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/ZtsGshutdownTests.groovy
@@ -22,16 +22,27 @@ import static org.testcontainers.containers.Container.ExecResult
  * every thread's TSRM storage from the main thread and invokes
  * zm_globals_dtor_ddtrace for each per-thread slot.
  *
- * Only runs on ZTS variants (MPM event is only used on ZTS) and only when
- * -PcheckCoreDumps is passed.
+ * Only runs on ZTS variants (MPM event is only used on ZTS), PHP >= 7.4, and
+ * only when -PcheckCoreDumps is passed.
+ *
+ * PHP 7.0-7.3 is excluded because of a PHP bug in zend_llist_destroy: it does
+ * not null out the head/tail pointers after freeing elements. When
+ * php_request_shutdown() calls php_shutdown_ticks() -> zend_llist_destroy(),
+ * the tick-functions list elements are freed but head is left dangling. The
+ * subsequent call to php_shutdown_ticks() from core_globals_dtor() (via
+ * ts_free_id) then hits a double-free -> SIGABRT. (There remains the bug that
+ * shutdown_ticks() should not refer to PG() from GSHUTDOWN, but at least
+ * PHP >= 7.4 doesn't crash).
  */
 @Testcontainers
 @Slf4j
 @EnabledIf('isZtsAndCheckCoreDumps')
 class ZtsGshutdownTests {
-    /** Only enabled on ZTS variants and when -PcheckCoreDumps is passed. */
+    /** Only enabled on ZTS variants, PHP >= 7.4, and when -PcheckCoreDumps is passed. */
     static boolean isZtsAndCheckCoreDumps() {
-        variant.contains('zts') && System.getProperty('checkCoreDumps') != null
+        variant.contains('zts') &&
+                System.getProperty('checkCoreDumps') != null &&
+                phpVersion >= '7.4'
     }
 
     @Container
@@ -43,6 +54,8 @@ class ZtsGshutdownTests {
                     phpVariant: variant,
                     www: 'base',
             )
+            .withEnv('DD_CRASHTRACKING_ENABLED', '0')
+            .withEnv('DD_INSTRUMENTATION_TELEMETRY_ENABLED', '0')
 
     static void main(String[] args) {
         InspectContainerHelper.run(CONTAINER)

--- a/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/ZtsGshutdownTests.groovy
+++ b/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/ZtsGshutdownTests.groovy
@@ -1,0 +1,115 @@
+package com.datadog.appsec.php.integration
+
+import com.datadog.appsec.php.docker.AppSecContainer
+import com.datadog.appsec.php.docker.InspectContainerHelper
+import groovy.util.logging.Slf4j
+import org.junit.jupiter.api.Test
+import org.junit.jupiter.api.condition.EnabledIf
+import org.testcontainers.junit.jupiter.Container
+import org.testcontainers.junit.jupiter.Testcontainers
+
+import java.net.http.HttpResponse
+
+import static com.datadog.appsec.php.integration.TestParams.getPhpVersion
+import static com.datadog.appsec.php.integration.TestParams.getVariant
+import static org.testcontainers.containers.Container.ExecResult
+
+/**
+ * Regression test for a ZTS-only crash in PHP_GSHUTDOWN_FUNCTION(ddtrace).
+ *
+ * Under Apache MPM event with MaxConnectionsPerChild 1, worker threads are
+ * cancelled without calling tsrm_thread_exit(). PHP's ts_free_id then iterates
+ * every thread's TSRM storage from the main thread and invokes
+ * zm_globals_dtor_ddtrace for each per-thread slot.
+ *
+ * Only runs on ZTS variants (MPM event is only used on ZTS) and only when
+ * -PcheckCoreDumps is passed.
+ */
+@Testcontainers
+@Slf4j
+@EnabledIf('isZtsAndCheckCoreDumps')
+class ZtsGshutdownTests {
+    /** Only enabled on ZTS variants and when -PcheckCoreDumps is passed. */
+    static boolean isZtsAndCheckCoreDumps() {
+        variant.contains('zts') && System.getProperty('checkCoreDumps') != null
+    }
+
+    @Container
+    public static final AppSecContainer CONTAINER =
+            new AppSecContainer(
+                    workVolume: this.name,
+                    baseTag: 'apache2-mod-php',
+                    phpVersion: phpVersion,
+                    phpVariant: variant,
+                    www: 'base',
+            )
+
+    static void main(String[] args) {
+        InspectContainerHelper.run(CONTAINER)
+    }
+
+    @Test
+    void 'no crash during GSHUTDOWN when MaxConnectionsPerChild 1 triggers ZTS worker lifecycle'() {
+        long errorLogOffset = (CONTAINER.execInContainer('sh', '-c',
+                'stat -c %s /tmp/logs/apache2/error.log 2>/dev/null || echo 0')
+                .stdout.trim() as long)
+
+        ExecResult backupResult = CONTAINER.execInContainer('sh', '-c',
+                'cp /etc/apache2/mods-enabled/mpm_event.conf /etc/apache2/mods-enabled/mpm_event.conf.bak_zts')
+        assert backupResult.exitCode == 0
+
+        try {
+            // Append MaxConnectionsPerChild 1 + KeepAlive Off so each TCP connection
+            // causes Apache to call clean_child_exit(), which destroys the APR child
+            // pool and triggers PHP MSHUTDOWN + GSHUTDOWN.
+            ExecResult cfgResult = CONTAINER.execInContainer('sh', '-c',
+                    'OLD=$(pgrep -P $(pgrep -f /usr/sbin/apache2 | head -1))' +
+                    ' && echo "MaxConnectionsPerChild 1\nKeepAlive Off" >> /etc/apache2/mods-enabled/mpm_event.conf' +
+                    ' && apache2ctl restart' +
+                    ' && for p in $OLD; do while kill -0 $p 2>/dev/null; do sleep 0.05; done; done')
+            assert cfgResult.exitCode == 0: "apache2 config failed: ${cfgResult.stderr}"
+
+            String apacheParent = CONTAINER.execInContainer('sh', '-c',
+                    'pgrep -f /usr/sbin/apache2 | head -1').stdout.trim()
+
+            for (int i = 0; i < 3; i++) {
+                // Snapshot workers before the request — MaxConnectionsPerChild 1
+                // means exactly one worker will call clean_child_exit() after
+                // responding, running PHP MSHUTDOWN/GSHUTDOWN before it exits.
+                Set<String> workersBefore = CONTAINER.execInContainer('sh', '-c',
+                        "pgrep -P $apacheParent").stdout.trim().readLines().toSet()
+
+                CONTAINER.traceFromRequest('/hello.php', { HttpResponse<InputStream> resp ->
+                    assert resp.statusCode() == 200: "request ${i} failed: ${resp.statusCode()}"
+                })
+
+                // Wait until at least one pre-request worker has exited, confirming
+                // its GSHUTDOWN completed before we inspect for crashes.
+                long deadline = System.currentTimeMillis() + 10_000
+                while (System.currentTimeMillis() < deadline) {
+                    Set<String> workersNow = CONTAINER.execInContainer('sh', '-c',
+                            "pgrep -P $apacheParent").stdout.trim().readLines().toSet()
+                    if (!workersNow.containsAll(workersBefore)) break
+                    Thread.sleep(100)
+                }
+            }
+
+            // Core dump detection is handled automatically by AppSecContainer.close().
+            // Additionally check Apache's error.log for crashes that generate SIGABRT
+            // before a core dump can be written (e.g. Rust allocator panics on
+            // poisoned memory).
+            ExecResult logCheck = CONTAINER.execInContainer('sh', '-c',
+                    "tail -c +${errorLogOffset + 1} /tmp/logs/apache2/error.log")
+            String errorLog = logCheck.stdout ?: ''
+            assert !errorLog.contains('exit signal Aborted'):
+                    "Apache worker exited via SIGABRT during GSHUTDOWN:\n" + errorLog
+            assert !errorLog.contains('exit signal Segmentation'):
+                    "Apache worker segfaulted during GSHUTDOWN:\n" + errorLog
+        } finally {
+            CONTAINER.execInContainer('sh', '-c',
+                    'cp /etc/apache2/mods-enabled/mpm_event.conf.bak_zts' +
+                    ' /etc/apache2/mods-enabled/mpm_event.conf' +
+                    ' && apache2ctl restart')
+        }
+    }
+}

--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -706,7 +706,7 @@ static PHP_GSHUTDOWN_FUNCTION(ddtrace) {
     zend_hash_destroy(&ddtrace_globals->git_metadata);
 
     // Drop the per-thread sidecar transport (thread-lifetime, one per thread).
-    ddtrace_sidecar_gshutdown();
+    ddtrace_sidecar_gshutdown(ddtrace_globals);
 
     tsrm_mutex_free(ddtrace_globals->sidecar_universal_service_tags_mutex);
 

--- a/ext/ddtrace.h
+++ b/ext/ddtrace.h
@@ -204,8 +204,10 @@ ZEND_END_MODULE_GLOBALS(ddtrace)
 #  endif
 extern TSRM_TLS void *ATTR_TLS_GLOBAL_DYNAMIC TSRMLS_CACHE;
 #  define DDTRACE_G(v) ZEND_TSRMG(ddtrace_globals_id, zend_ddtrace_globals *, v)
+#  define DDTRACE_GLOBALS_PTR() TSRMG_BULK_STATIC(ddtrace_globals_id, zend_ddtrace_globals *)
 #else
 #  define DDTRACE_G(v) (ddtrace_globals.v)
+#  define DDTRACE_GLOBALS_PTR() (&ddtrace_globals)
 #endif
 
 #define PHP_DDTRACE_EXTNAME "ddtrace"

--- a/ext/sidecar.c
+++ b/ext/sidecar.c
@@ -875,16 +875,18 @@ void ddtrace_sidecar_rshutdown(void) {
     ddog_Vec_Tag_drop(DDTRACE_G(active_global_tags));
 }
 
-void ddtrace_sidecar_gshutdown(void) {
-    if (DDTRACE_G(sidecar)) {
-        if (DDTRACE_G(sidecar) == ddtrace_sidecar_for_signal) {
+void ddtrace_sidecar_gshutdown(zend_ddtrace_globals *ddtrace_globals) {
+    // NOTE: do not use DDTRACE_G() in this function; it may be called from the
+    // main thread via ts_free_id()
+    if (ddtrace_globals->sidecar) {
+        if (ddtrace_globals->sidecar == ddtrace_sidecar_for_signal) {
             ddtrace_sidecar_for_signal = NULL;
         }
 
         // Drain any accumulated background-sender metrics before the transport goes away.
-        ddtrace_telemetry_flush_bgs_metrics_final();
-        ddog_sidecar_transport_drop(DDTRACE_G(sidecar));
-        DDTRACE_G(sidecar) = NULL;
+        ddtrace_telemetry_flush_bgs_metrics_final(ddtrace_globals);
+        ddog_sidecar_transport_drop(ddtrace_globals->sidecar);
+        ddtrace_globals->sidecar = NULL;
     }
 }
 

--- a/ext/sidecar.h
+++ b/ext/sidecar.h
@@ -64,7 +64,7 @@ void ddtrace_sidecar_send_debugger_datum(ddog_DebuggerPayload *payload);
 void ddtrace_sidecar_activate(void);
 void ddtrace_sidecar_rinit(void);
 void ddtrace_sidecar_rshutdown(void);
-void ddtrace_sidecar_gshutdown(void);
+void ddtrace_sidecar_gshutdown(zend_ddtrace_globals *ddtrace_globals);
 
 void ddtrace_sidecar_dogstatsd_count(zend_string *metric, zend_long value, zval *tags);
 void ddtrace_sidecar_dogstatsd_distribution(zend_string *metric, double value, zval *tags);

--- a/ext/telemetry.c
+++ b/ext/telemetry.c
@@ -274,7 +274,7 @@ void ddtrace_telemetry_finalize() {
     ddog_sidecar_telemetry_buffer_drop(buffer);
 
     // Flush any accumulated BGS (background sender) metrics if enough time has passed.
-    ddtrace_telemetry_flush_bgs_metrics_if_due();
+    ddtrace_telemetry_flush_bgs_metrics_if_due(DDTRACE_GLOBALS_PTR());
 }
 
 void ddtrace_telemetry_notify_integration(const char *name, size_t name_len) {
@@ -350,8 +350,8 @@ void ddtrace_telemetry_send_trace_api_metrics(trace_api_metrics metrics) {
     atomic_fetch_add(&bgs_metric_errors_status_code, metrics.errors_status_code);
 }
 
-void ddtrace_telemetry_flush_bgs_metrics_if_due(void) {
-    if (!DDTRACE_G(sidecar) || !get_global_DD_INSTRUMENTATION_TELEMETRY_ENABLED()) {
+void ddtrace_telemetry_flush_bgs_metrics_if_due(zend_ddtrace_globals *ddtrace_globals) {
+    if (!ddtrace_globals->sidecar || !get_global_DD_INSTRUMENTATION_TELEMETRY_ENABLED()) {
         return;
     }
 
@@ -402,18 +402,18 @@ void ddtrace_telemetry_flush_bgs_metrics_if_due(void) {
     }
 
     ddtrace_ffi_try("Failed flushing background sender metrics",
-                    ddog_sidecar_telemetry_buffer_flush(&DDTRACE_G(sidecar), ddtrace_sidecar_instance_id, &dd_bgs_queued_id, buffer));
+                    ddog_sidecar_telemetry_buffer_flush(&ddtrace_globals->sidecar, ddtrace_sidecar_instance_id, &dd_bgs_queued_id, buffer));
 }
 
-void ddtrace_telemetry_flush_bgs_metrics_final(void) {
-    if (!DDTRACE_G(sidecar) || !get_global_DD_INSTRUMENTATION_TELEMETRY_ENABLED()) {
+void ddtrace_telemetry_flush_bgs_metrics_final(zend_ddtrace_globals *ddtrace_globals) {
+    if (!ddtrace_sidecar_instance_id) {
         return;
     }
     // Bypass the time gate so any remaining metrics are sent before the transport
     // is dropped in GSHUTDOWN.  Setting last_flush_ns to 0 makes the time check in
     // _if_due always pass; the CAS inside still prevents a concurrent double-flush.
     atomic_store(&bgs_metrics_last_flush_ns, 0);
-    ddtrace_telemetry_flush_bgs_metrics_if_due();
+    ddtrace_telemetry_flush_bgs_metrics_if_due(ddtrace_globals);
 }
 
 DDTRACE_PUBLIC void ddtrace_metric_register_buffer(zend_string *name, ddog_MetricType type, ddog_MetricNamespace ns) {

--- a/ext/telemetry.h
+++ b/ext/telemetry.h
@@ -39,11 +39,11 @@ void ddtrace_telemetry_inc_spans_created(ddtrace_span_data *span);
 // Never touches the sidecar; the request thread flushes via ddtrace_telemetry_flush_bgs_metrics_if_due().
 void ddtrace_telemetry_send_trace_api_metrics(trace_api_metrics metrics);
 // Called from ddtrace_telemetry_finalize() to flush accumulated BGS metrics through
-// the current thread's sidecar connection, at most once per flush interval.
-void ddtrace_telemetry_flush_bgs_metrics_if_due(void);
+// the given thread's sidecar connection, at most once per flush interval.
+void ddtrace_telemetry_flush_bgs_metrics_if_due(zend_ddtrace_globals *ddtrace_globals);
 // Force-flush accumulated BGS metrics regardless of the time gate.  Call immediately
 // before dropping the per-thread transport in GSHUTDOWN so no data is lost.
-void ddtrace_telemetry_flush_bgs_metrics_final(void);
+void ddtrace_telemetry_flush_bgs_metrics_final(zend_ddtrace_globals *ddtrace_globals);
 
 // public API
 DDTRACE_PUBLIC void ddtrace_metric_register_buffer(zend_string *name, ddog_MetricType type, ddog_MetricNamespace ns);

--- a/zend_abstract_interface/hook/hook.c
+++ b/zend_abstract_interface/hook/hook.c
@@ -1266,7 +1266,10 @@ void zai_hook_rshutdown(void) {
     }
 }
 
-void zai_hook_gshutdown(void) { free(zai_hook_tls); }
+void zai_hook_gshutdown(void) {
+    free(zai_hook_tls);
+    zai_hook_tls = NULL;
+}
 
 void zai_hook_mshutdown(void) {
     zend_hash_destroy(&zai_hook_static);


### PR DESCRIPTION
In ZTS mode, `ts_free_id` iterates all per-thread TSRM storage slots from the main thread, calling `zm_globals_dtor_ddtrace` for each one. The dtor receives the correct `zend_ddtrace_globals*` for the dead worker thread, but `ddtrace_sidecar_gshutdown()` and
`ddtrace_telemetry_flush_bgs_metrics_if_due()` were using `DDTRACE_G()` which reads the thread's TSRM slot. Once `ts_free_id` has processed the main thread's slot and nulled it, subsequent calls to `DDTRACE_G(sidecar)` dereference NULL → SIGSEGV.

Fix: thread `zend_ddtrace_globals*` explicitly through both functions and replace all `DDTRACE_G(field)` with `ddtrace_globals->field`. Add `DDTRACE_GLOBALS_PTR()` macro for the non-GSHUTDOWN call site in `ddtrace_telemetry_finalize()`.

Add `ZtsGshutdownTests` integration test (runs on ZTS + -PcheckCoreDumps) that reproduces the crash via MaxConnectionsPerChild 1 and verifies no core dump is produced. Enable -PcheckCoreDumps in the appsec integration CI jobs. Also wire up core-dump detection infrastructure in AppSecContainer (ulimit, core_pattern, copy cores to test-logs, detect on close).

The test fails around 80% of the time on my machine.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
