### PR TITLE
fix(test): drop ctype dependency in secure_random tests

### DIFF
--- a/tests/ext/secure_random_generates_nonzero_ids.phpt
+++ b/tests/ext/secure_random_generates_nonzero_ids.phpt
@@ -16,8 +16,8 @@ $id2 = DDTrace\active_span()->id;
 DDTrace\close_span();
 
 // Both IDs must be non-empty numeric strings representing non-zero values.
-var_dump(ctype_digit($id1) && $id1 !== '0');
-var_dump(ctype_digit($id2) && $id2 !== '0');
+var_dump(preg_match('/^\d+$/', $id1) === 1 && $id1 !== '0');
+var_dump(preg_match('/^\d+$/', $id2) === 1 && $id2 !== '0');
 
 // Two consecutive IDs drawn from a CSPRNG must differ.
 var_dump($id1 !== $id2);

--- a/tests/ext/secure_random_ignores_prng_seed.phpt
+++ b/tests/ext/secure_random_ignores_prng_seed.phpt
@@ -24,8 +24,8 @@ $id2 = DDTrace\active_span()->id;
 DDTrace\close_span();
 
 // IDs must be valid non-zero numeric strings.
-var_dump(ctype_digit($id1) && $id1 !== '0');
-var_dump(ctype_digit($id2) && $id2 !== '0');
+var_dump(preg_match('/^\d+$/', $id1) === 1 && $id1 !== '0');
+var_dump(preg_match('/^\d+$/', $id2) === 1 && $id2 !== '0');
 
 // CSPRNG output must not be equal across calls; this fails deterministically
 // under the MT because seed 42 would produce the same first two values every run.


### PR DESCRIPTION
## Summary
- Two .phpt tests added in #3873 call `ctype_digit()`, which is **not auto-loaded** on the `php-X.Y-shared-ext` CI images (ctype is built as a shared module there). This causes a fatal `Call to undefined function ctype_digit()` and breaks the shared-ext PHP 8.0 (and 7.4) lanes on master.
- Replaces `ctype_digit($id)` with `preg_match('/^\d+$/', $id) === 1` in both tests. Same semantics for these inputs (non-empty digit-only strings, including 20-digit span IDs > PHP_INT_MAX), no extension dependency — pcre is statically linked into PHP since 5.3.

## Affected tests
- `tests/ext/secure_random_generates_nonzero_ids.phpt`
- `tests/ext/secure_random_ignores_prng_seed.phpt`