### PR TITLE
fix(ci): retry helper-rust coverage jobs on vault transient failures

### DIFF
--- a/.gitlab/generate-appsec.php
+++ b/.gitlab/generate-appsec.php
@@ -283,7 +283,14 @@ stages:
     - |
       echo "Uploading helper-rust unit test coverage to codecov"
       cd "$CI_PROJECT_DIR"
-      CODECOV_TOKEN=$(vault kv get --format=json kv/k8s/gitlab-runner/dd-trace-php/codecov | jq -r .data.data.token)
+      if ! CODECOV_TOKEN=$(vault kv get --format=json kv/k8s/gitlab-runner/dd-trace-php/codecov 2>&1 | jq -r .data.data.token); then
+        echo "ERROR: vault unreachable while fetching CODECOV_TOKEN; exiting 75 so GitLab auto-retries (see default retry.exit_codes in generate-common.php)"
+        exit 75
+      fi
+      if [ -z "$CODECOV_TOKEN" ] || [ "$CODECOV_TOKEN" = "null" ]; then
+        echo "ERROR: CODECOV_TOKEN empty/null after vault fetch; exiting 75 so GitLab auto-retries"
+        exit 75
+      fi
       codecov -t "$CODECOV_TOKEN" -n helper-rust-unit -F helper-rust-unit -v -f appsec/helper-rust/coverage-unit.lcov
   artifacts:
     paths:
@@ -354,7 +361,14 @@ stages:
     - |
       echo "Uploading helper-rust integration test coverage to codecov"
       cd "$CI_PROJECT_DIR"
-      CODECOV_TOKEN=$(vault kv get --format=json kv/k8s/gitlab-runner/dd-trace-php/codecov | jq -r .data.data.token)
+      if ! CODECOV_TOKEN=$(vault kv get --format=json kv/k8s/gitlab-runner/dd-trace-php/codecov 2>&1 | jq -r .data.data.token); then
+        echo "ERROR: vault unreachable while fetching CODECOV_TOKEN; exiting 75 so GitLab auto-retries (see default retry.exit_codes in generate-common.php)"
+        exit 75
+      fi
+      if [ -z "$CODECOV_TOKEN" ] || [ "$CODECOV_TOKEN" = "null" ]; then
+        echo "ERROR: CODECOV_TOKEN empty/null after vault fetch; exiting 75 so GitLab auto-retries"
+        exit 75
+      fi
       codecov -t "$CODECOV_TOKEN" -n helper-rust-integration -F helper-rust-integration -v -f appsec/helper-rust/coverage-integration.lcov
   after_script:
     - mkdir -p "${CI_PROJECT_DIR}/artifacts"

--- a/.gitlab/generate-appsec.php
+++ b/.gitlab/generate-appsec.php
@@ -283,10 +283,6 @@ stages:
     - |
       echo "Uploading helper-rust unit test coverage to codecov"
       cd "$CI_PROJECT_DIR"
-      # Capture only vault's stdout (the JSON token document) and let stderr
-      # flow to the CI log unchanged -- merging stderr into the pipe would
-      # corrupt jq's input whenever vault prints a non-fatal warning on a
-      # successful call, falsely tripping the exit-75 retry path.
       if ! VAULT_OUTPUT=$(vault kv get --format=json kv/k8s/gitlab-runner/dd-trace-php/codecov); then
         echo "ERROR: vault unreachable while fetching CODECOV_TOKEN; exiting 75 so GitLab auto-retries (see default retry.exit_codes in generate-common.php)"
         exit 75
@@ -366,10 +362,6 @@ stages:
     - |
       echo "Uploading helper-rust integration test coverage to codecov"
       cd "$CI_PROJECT_DIR"
-      # Capture only vault's stdout (the JSON token document) and let stderr
-      # flow to the CI log unchanged -- merging stderr into the pipe would
-      # corrupt jq's input whenever vault prints a non-fatal warning on a
-      # successful call, falsely tripping the exit-75 retry path.
       if ! VAULT_OUTPUT=$(vault kv get --format=json kv/k8s/gitlab-runner/dd-trace-php/codecov); then
         echo "ERROR: vault unreachable while fetching CODECOV_TOKEN; exiting 75 so GitLab auto-retries (see default retry.exit_codes in generate-common.php)"
         exit 75

--- a/.gitlab/generate-appsec.php
+++ b/.gitlab/generate-appsec.php
@@ -283,10 +283,15 @@ stages:
     - |
       echo "Uploading helper-rust unit test coverage to codecov"
       cd "$CI_PROJECT_DIR"
-      if ! CODECOV_TOKEN=$(vault kv get --format=json kv/k8s/gitlab-runner/dd-trace-php/codecov 2>&1 | jq -r .data.data.token); then
+      # Capture only vault's stdout (the JSON token document) and let stderr
+      # flow to the CI log unchanged -- merging stderr into the pipe would
+      # corrupt jq's input whenever vault prints a non-fatal warning on a
+      # successful call, falsely tripping the exit-75 retry path.
+      if ! VAULT_OUTPUT=$(vault kv get --format=json kv/k8s/gitlab-runner/dd-trace-php/codecov); then
         echo "ERROR: vault unreachable while fetching CODECOV_TOKEN; exiting 75 so GitLab auto-retries (see default retry.exit_codes in generate-common.php)"
         exit 75
       fi
+      CODECOV_TOKEN=$(echo "$VAULT_OUTPUT" | jq -r .data.data.token)
       if [ -z "$CODECOV_TOKEN" ] || [ "$CODECOV_TOKEN" = "null" ]; then
         echo "ERROR: CODECOV_TOKEN empty/null after vault fetch; exiting 75 so GitLab auto-retries"
         exit 75
@@ -361,10 +366,15 @@ stages:
     - |
       echo "Uploading helper-rust integration test coverage to codecov"
       cd "$CI_PROJECT_DIR"
-      if ! CODECOV_TOKEN=$(vault kv get --format=json kv/k8s/gitlab-runner/dd-trace-php/codecov 2>&1 | jq -r .data.data.token); then
+      # Capture only vault's stdout (the JSON token document) and let stderr
+      # flow to the CI log unchanged -- merging stderr into the pipe would
+      # corrupt jq's input whenever vault prints a non-fatal warning on a
+      # successful call, falsely tripping the exit-75 retry path.
+      if ! VAULT_OUTPUT=$(vault kv get --format=json kv/k8s/gitlab-runner/dd-trace-php/codecov); then
         echo "ERROR: vault unreachable while fetching CODECOV_TOKEN; exiting 75 so GitLab auto-retries (see default retry.exit_codes in generate-common.php)"
         exit 75
       fi
+      CODECOV_TOKEN=$(echo "$VAULT_OUTPUT" | jq -r .data.data.token)
       if [ -z "$CODECOV_TOKEN" ] || [ "$CODECOV_TOKEN" = "null" ]; then
         echo "ERROR: CODECOV_TOKEN empty/null after vault fetch; exiting 75 so GitLab auto-retries"
         exit 75


### PR DESCRIPTION
## Summary

- The `helper-rust code coverage` and `helper-rust integration coverage` jobs fetch `CODECOV_TOKEN` from the local Vault agent at the end of the script. When the agent is transiently unhealthy (failed liveness/readiness probes), `vault kv get` errors with `connection refused` and the whole job fails with exit code 2 — even though the build, tests, and coverage report all succeeded.
- Exit `75` instead so GitLab's default retry config (`max: 2`, `exit_codes: [75, 128]` from `.gitlab/generate-common.php:164-177`) auto-retries the job.
- Coverage data has already been generated and uploaded as a GitLab artifact at this point, so retrying re-runs only the codecov publish.

## Observed failure

Example: [job 1697349099](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-php/-/jobs/1697349099) (and 2 more in the last 2 days on master). Trace tail:
```
Uploading helper-rust integration test coverage to codecov
Get "http://127.0.0.1:8658/vault/agent/v1/sys/internal/ui/mounts/kv/k8s/gitlab-runner/dd-trace-php/codecov":
  dial tcp 127.0.0.1:8658: connect: connection refused
WARNING: ... Liveness probe failed: ... context deadline exceeded
ERROR: Job failed: command terminated with exit code 2
```