### PR TITLE
fix(ci): allow insecure twig/twig in slim test framework composer.json

### DIFF
--- a/tests/Frameworks/Slim/Latest/composer.json
+++ b/tests/Frameworks/Slim/Latest/composer.json
@@ -32,7 +32,10 @@
     },
     "config": {
         "process-timeout": 0,
-        "sort-packages": true
+        "sort-packages": true,
+        "audit": {
+            "block-insecure": false
+        }
     },
     "autoload": {
         "psr-4": {

--- a/tests/Frameworks/Slim/Version_3_12/composer.json
+++ b/tests/Frameworks/Slim/Version_3_12/composer.json
@@ -33,7 +33,10 @@
     },
     "config": {
         "process-timeout": 0,
-        "sort-packages": true
+        "sort-packages": true,
+        "audit": {
+            "block-insecure": false
+        }
     },
     "scripts": {
         "start": "php -S localhost:8080 -t public",

--- a/tests/Frameworks/Slim/Version_4_8/composer.json
+++ b/tests/Frameworks/Slim/Version_4_8/composer.json
@@ -32,7 +32,10 @@
     },
     "config": {
         "process-timeout": 0,
-        "sort-packages": true
+        "sort-packages": true,
+        "audit": {
+            "block-insecure": false
+        }
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
## Summary

- `test_web_slim_312: [7.4, cgi-fcgi]` and likely other `test_web_slim_*` jobs fail on master because composer cannot resolve `slim/twig-view ^2.5` for PHP 7.4.
- Recent Packagist security advisories flag all `twig/twig` 1.x and 2.x; the only unflagged version (`v3.26.0`) requires PHP ≥ 8.1.
- Add `"audit": { "block-insecure": false }` to the 3 Slim composer.json files (`Version_3_12`, `Version_4_8`, `Latest`), matching the existing pattern in Drupal/Lumen/Laravel test framework composer.json files. Test fixtures only — no production impact.

## Observed failure
Example: [job 1698263789](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-php/-/jobs/1698263789) (master pipeline 114201465, sha 607d17af).

## Test plan
- [ ] JSON syntax check on each modified file passes
- [ ] After merge, watch next master pipeline: `test_web_slim_312/_48/_latest` jobs should resolve composer and proceed past the dependency-install step.