### PR TITLE
fix(ci): avoid jq argv overflow in analyze-and-create-pr aggregator

### DIFF
--- a/.gitlab/libdatadog-latest.yml
+++ b/.gitlab/libdatadog-latest.yml
@@ -65,7 +65,7 @@ stages:
             "${GITLAB_API}/projects/${CI_PROJECT_ID}/pipelines/${child_id}/jobs?per_page=100&page=${page}" \
             || echo "[]")
           page_failed=$(echo "${page_data}" | jq '[.[] | select(.status == "failed")]')
-          failed_jobs=$(jq -n --argjson a "${failed_jobs}" --argjson b "${page_failed}" '$a + $b')
+          failed_jobs=$(jq -n --slurpfile a <(printf '%s' "${failed_jobs}") --slurpfile b <(printf '%s' "${page_failed}") '$a[0] + $b[0]')
           [ "$(echo "${page_data}" | jq 'length')" -lt 100 ] && break
         done
         echo "${failed_jobs}" | jq --arg t "${trigger_name}" '[.[] | . + {trigger: $t}]'
@@ -108,7 +108,7 @@ stages:
         echo "  Failed jobs (${count}):"
         echo "${failures}" | jq -r '.[] | "    - \(.name)"'
         all=$(cat tmp/artifacts/all_failures.json)
-        jq -n --argjson a "${all}" --argjson b "${failures}" '$a + $b' > tmp/artifacts/all_failures.json
+        jq -n --slurpfile a <(printf '%s' "${all}") --slurpfile b <(printf '%s' "${failures}") '$a[0] + $b[0]' > tmp/artifacts/all_failures.json
       done < <(jq -r '.[] | select(.downstream_pipeline != null)
                       | [(.downstream_pipeline.id | tostring),
                         (.downstream_pipeline.status // "unknown"),
@@ -157,7 +157,7 @@ stages:
           if [ "${status}" = "failed" ]; then
             entry=$(echo "${job_data}" | jq --arg t "${trigger}" '. + {trigger: $t}')
             all=$(cat tmp/artifacts/all_failures.json)
-            jq -n --argjson a "${all}" --argjson b "[${entry}]" '$a + $b' > tmp/artifacts/all_failures.json
+            jq -n --slurpfile a <(printf '%s' "${all}") --argjson b "[${entry}]" '$a[0] + $b' > tmp/artifacts/all_failures.json
           fi
         done < tmp/artifacts/retried_jobs.tsv
 


### PR DESCRIPTION
## Summary

- `.gitlab/libdatadog-latest.yml`'s failed-job aggregator passes the entire accumulated JSON to jq via `--argjson a "${big_var}"`. With 100+ failed jobs (compile-cascade + valgrind flakes) the argv length exceeds Bash's `ARG_MAX` and the script silently corrupts `failed_jobs`, then exits 1 on the next jq call.
- Switch all 3 sites (lines 68, 111, 160) to `--slurpfile a <(printf '%s' "$var")`. JSON flows through a file descriptor instead of argv, so there is no size limit.
- Same jq semantics, no behavior change.

## Observed failure

Job [1697154988](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-php/-/jobs/1697154988):
```
/scripts-355-1697154988/step_script: line 258: /usr/bin/jq: Argument list too long
...
jq: invalid JSON text passed to --argjson
ERROR: Job failed: command terminated with exit code 1
```

Failure has repeated on every scheduled `analyze-and-create-pr` run in the last 2 days.

## Test plan
- [ ] YAML syntax check passes
- [ ] Local dry-run of the jq pattern: `a='[1,2]'; b='[3,4]'; jq -n --slurpfile a <(printf '%s' "$a") --slurpfile b <(printf '%s' "$b") '$a[0] + $b[0]'` → `[1, 2, 3, 4]`
- [ ] Next scheduled nightly run (or manual trigger of `SCHEDULED_LIBDATADOG_LATEST=true`) completes the aggregator step instead of dying on "Argument list too long".