### PR TITLE
feat(ffe): add evaluator contract and fake runtime

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -14,6 +14,10 @@ compile_rust.sh @Datadog/libdatadog-apm
 # APM IDM Team
 /src/ @DataDog/apm-idm-php
 
+# FFE (Feature Flagging & Experimentation) SDK Team
+/src/api/FeatureFlags/ @DataDog/feature-flagging-and-experimentation-sdk
+/tests/api/Unit/FeatureFlags/ @DataDog/feature-flagging-and-experimentation-sdk
+
 # Release files
 Cargo.lock @DataDog/apm-php @DataDog/profiling-php @Datadog/libdatadog-apm
 package.xml @DataDog/apm-php @DataDog/profiling-php @Datadog/asm-php

--- a/src/api/FeatureFlags/EvaluationDetails.php
+++ b/src/api/FeatureFlags/EvaluationDetails.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace DDTrace\FeatureFlags;
+
+final class EvaluationDetails
+{
+    private $value;
+    private $valueType;
+    private $reason;
+    private $variant;
+    private $errorCode;
+    private $errorMessage;
+    private $flagMetadata;
+    private $exposureData;
+    private $providerState;
+
+    /**
+     * @param mixed $value
+     * @param string $valueType One of EvaluationType::*.
+     * @param string $reason One of EvaluationReason::*.
+     * @param string|null $variant
+     * @param string|null $errorCode One of EvaluationErrorCode::* or null on success.
+     * @param string|null $errorMessage
+     * @param array<string, mixed> $flagMetadata
+     * @param array<string, mixed> $exposureData
+     * @param array<string, mixed> $providerState
+     */
+    public function __construct(
+        $value,
+        $valueType,
+        $reason,
+        $variant = null,
+        $errorCode = null,
+        $errorMessage = null,
+        array $flagMetadata = array(),
+        array $exposureData = array(),
+        array $providerState = array()
+    ) {
+        if (!EvaluationType::isValid($valueType)) {
+            throw new \InvalidArgumentException('Unknown feature flag value type: ' . (string) $valueType);
+        }
+
+        if (!EvaluationReason::isValid($reason)) {
+            throw new \InvalidArgumentException('Unknown feature flag evaluation reason: ' . (string) $reason);
+        }
+
+        if (!EvaluationErrorCode::isValid($errorCode)) {
+            throw new \InvalidArgumentException('Unknown feature flag evaluation error code: ' . (string) $errorCode);
+        }
+
+        $this->value = $value;
+        $this->valueType = $valueType;
+        $this->reason = $reason;
+        $this->variant = $variant;
+        $this->errorCode = $errorCode;
+        $this->errorMessage = $errorMessage;
+        $this->flagMetadata = $flagMetadata;
+        $this->exposureData = $exposureData;
+        $this->providerState = $providerState;
+    }
+
+    public function getValue()
+    {
+        return $this->value;
+    }
+
+    public function getValueType()
+    {
+        return $this->valueType;
+    }
+
+    public function getReason()
+    {
+        return $this->reason;
+    }
+
+    public function getVariant()
+    {
+        return $this->variant;
+    }
+
+    public function getErrorCode()
+    {
+        return $this->errorCode;
+    }
+
+    public function getErrorMessage()
+    {
+        return $this->errorMessage;
+    }
+
+    public function getFlagMetadata()
+    {
+        return $this->flagMetadata;
+    }
+
+    public function getExposureData()
+    {
+        return $this->exposureData;
+    }
+
+    public function getProviderState()
+    {
+        return $this->providerState;
+    }
+
+    public function isError()
+    {
+        return $this->errorCode !== null;
+    }
+}

--- a/src/api/FeatureFlags/EvaluationErrorCode.php
+++ b/src/api/FeatureFlags/EvaluationErrorCode.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace DDTrace\FeatureFlags;
+
+final class EvaluationErrorCode
+{
+    const FLAG_NOT_FOUND = 'FLAG_NOT_FOUND';
+    const PARSE_ERROR = 'PARSE_ERROR';
+    const TYPE_MISMATCH = 'TYPE_MISMATCH';
+    const GENERAL = 'GENERAL';
+    const PROVIDER_NOT_READY = 'PROVIDER_NOT_READY';
+
+    private static $valid = array(
+        self::FLAG_NOT_FOUND => true,
+        self::PARSE_ERROR => true,
+        self::TYPE_MISMATCH => true,
+        self::GENERAL => true,
+        self::PROVIDER_NOT_READY => true,
+    );
+
+    private function __construct()
+    {
+    }
+
+    public static function isValid($errorCode)
+    {
+        return $errorCode === null || isset(self::$valid[$errorCode]);
+    }
+}

--- a/src/api/FeatureFlags/EvaluationReason.php
+++ b/src/api/FeatureFlags/EvaluationReason.php
@@ -1,0 +1,31 @@
+<?php
+
+namespace DDTrace\FeatureFlags;
+
+final class EvaluationReason
+{
+    const STATIC_REASON = 'STATIC';
+    const DEFAULT_REASON = 'DEFAULT';
+    const TARGETING_MATCH = 'TARGETING_MATCH';
+    const SPLIT = 'SPLIT';
+    const DISABLED = 'DISABLED';
+    const ERROR = 'ERROR';
+
+    private static $valid = array(
+        self::STATIC_REASON => true,
+        self::DEFAULT_REASON => true,
+        self::TARGETING_MATCH => true,
+        self::SPLIT => true,
+        self::DISABLED => true,
+        self::ERROR => true,
+    );
+
+    private function __construct()
+    {
+    }
+
+    public static function isValid($reason)
+    {
+        return isset(self::$valid[$reason]);
+    }
+}

--- a/src/api/FeatureFlags/EvaluationType.php
+++ b/src/api/FeatureFlags/EvaluationType.php
@@ -1,0 +1,54 @@
+<?php
+
+namespace DDTrace\FeatureFlags;
+
+final class EvaluationType
+{
+    const BOOLEAN = 'boolean';
+    const STRING = 'string';
+    const INTEGER = 'integer';
+    const FLOAT = 'float';
+    const OBJECT = 'object';
+
+    private static $valid = array(
+        self::BOOLEAN => true,
+        self::STRING => true,
+        self::INTEGER => true,
+        self::FLOAT => true,
+        self::OBJECT => true,
+    );
+
+    private function __construct()
+    {
+    }
+
+    public static function isValid($valueType)
+    {
+        return isset(self::$valid[$valueType]);
+    }
+
+    public static function fromDefaultValue($defaultValue)
+    {
+        if (is_bool($defaultValue)) {
+            return self::BOOLEAN;
+        }
+
+        if (is_string($defaultValue)) {
+            return self::STRING;
+        }
+
+        if (is_int($defaultValue)) {
+            return self::INTEGER;
+        }
+
+        if (is_float($defaultValue)) {
+            return self::FLOAT;
+        }
+
+        if (is_array($defaultValue)) {
+            return self::OBJECT;
+        }
+
+        throw new \InvalidArgumentException('Unsupported feature flag default value type');
+    }
+}

--- a/src/api/FeatureFlags/Evaluator.php
+++ b/src/api/FeatureFlags/Evaluator.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace DDTrace\FeatureFlags;
+
+interface Evaluator
+{
+    /**
+     * @param string $flagKey
+     * @param string $expectedType One of EvaluationType::*.
+     * @param mixed $defaultValue
+     * @param string|null $targetingKey
+     * @param array<string, bool|int|float|string> $attributes
+     * @return EvaluationDetails
+     */
+    public function evaluate($flagKey, $expectedType, $defaultValue, $targetingKey = null, array $attributes = array());
+}

--- a/src/api/FeatureFlags/ResultMapper.php
+++ b/src/api/FeatureFlags/ResultMapper.php
@@ -1,0 +1,278 @@
+<?php
+
+namespace DDTrace\FeatureFlags;
+
+final class ResultMapper
+{
+    const BRIDGE_REASON_STATIC = 0;
+    const BRIDGE_REASON_DEFAULT = 1;
+    const BRIDGE_REASON_TARGETING_MATCH = 2;
+    const BRIDGE_REASON_SPLIT = 3;
+    const BRIDGE_REASON_DISABLED = 4;
+    const BRIDGE_REASON_ERROR = 5;
+
+    const BRIDGE_ERROR_NONE = 0;
+    const BRIDGE_ERROR_TYPE_MISMATCH = 1;
+    const BRIDGE_ERROR_CONFIG_PARSE = 2;
+    const BRIDGE_ERROR_FLAG_UNRECOGNIZED = 3;
+    const BRIDGE_ERROR_CONFIG_MISSING = 6;
+    const BRIDGE_ERROR_GENERAL = 7;
+
+    /**
+     * @param array<string, mixed>|EvaluationDetails|null $rawResult
+     * @param string $expectedType One of EvaluationType::*.
+     * @param mixed $defaultValue
+     * @return EvaluationDetails
+     */
+    public function map($rawResult, $expectedType, $defaultValue)
+    {
+        if (!EvaluationType::isValid($expectedType)) {
+            throw new \InvalidArgumentException('Unknown feature flag value type: ' . (string) $expectedType);
+        }
+
+        if ($rawResult instanceof EvaluationDetails) {
+            return $rawResult;
+        }
+
+        if ($rawResult === null) {
+            return $this->errorDetails(
+                $defaultValue,
+                $expectedType,
+                EvaluationErrorCode::PROVIDER_NOT_READY,
+                'FFE evaluator is not ready',
+                array('ready' => false)
+            );
+        }
+
+        if (!is_array($rawResult)) {
+            return $this->errorDetails(
+                $defaultValue,
+                $expectedType,
+                EvaluationErrorCode::GENERAL,
+                'FFE evaluator returned an invalid result'
+            );
+        }
+
+        $errorCode = $this->mapErrorCode(
+            $this->read($rawResult, array('error_code', 'errorCode'), self::BRIDGE_ERROR_GENERAL)
+        );
+        if ($errorCode !== null) {
+            return $this->errorDetails(
+                $defaultValue,
+                $expectedType,
+                $errorCode,
+                $this->read($rawResult, array('error_message', 'errorMessage'), null),
+                $this->readArray($rawResult, array('provider_state', 'providerState'))
+            );
+        }
+
+        $decoded = null;
+        $decodeError = $this->decodeValue($rawResult, $expectedType, $decoded);
+        if ($decodeError !== null) {
+            return $this->errorDetails(
+                $defaultValue,
+                $expectedType,
+                $decodeError,
+                $decodeError === EvaluationErrorCode::PARSE_ERROR
+                    ? 'FFE evaluator returned invalid JSON'
+                    : 'FFE evaluator returned a value with the wrong type',
+                $this->readArray($rawResult, array('provider_state', 'providerState'))
+            );
+        }
+
+        $reason = $this->mapReason($this->read($rawResult, array('reason'), self::BRIDGE_REASON_DEFAULT));
+
+        return new EvaluationDetails(
+            $decoded,
+            $expectedType,
+            $reason,
+            $this->read($rawResult, array('variant'), null),
+            null,
+            null,
+            $this->readArray($rawResult, array('flag_metadata', 'flagMetadata', 'metadata')),
+            $this->exposureData($rawResult),
+            $this->providerState($rawResult)
+        );
+    }
+
+    private function errorDetails(
+        $defaultValue,
+        $expectedType,
+        $errorCode,
+        $errorMessage = null,
+        array $providerState = array()
+    ) {
+        return new EvaluationDetails(
+            $defaultValue,
+            $expectedType,
+            EvaluationReason::ERROR,
+            null,
+            $errorCode,
+            $errorMessage,
+            array(),
+            array(),
+            $providerState
+        );
+    }
+
+    private function decodeValue(array $rawResult, $expectedType, &$decoded)
+    {
+        if (array_key_exists('value', $rawResult)) {
+            $value = $rawResult['value'];
+        } else {
+            $valueJson = $this->read($rawResult, array('value_json', 'valueJson'), null);
+            if (!is_string($valueJson) || $valueJson === '') {
+                return EvaluationErrorCode::PARSE_ERROR;
+            }
+
+            $value = json_decode($valueJson, true);
+            if (json_last_error() !== JSON_ERROR_NONE) {
+                return EvaluationErrorCode::PARSE_ERROR;
+            }
+        }
+
+        if (!$this->coerceValue($value, $expectedType, $decoded)) {
+            return EvaluationErrorCode::TYPE_MISMATCH;
+        }
+
+        return null;
+    }
+
+    private function coerceValue($value, $expectedType, &$coerced)
+    {
+        switch ($expectedType) {
+            case EvaluationType::BOOLEAN:
+                if (is_bool($value)) {
+                    $coerced = $value;
+                    return true;
+                }
+                return false;
+
+            case EvaluationType::STRING:
+                if (is_string($value)) {
+                    $coerced = $value;
+                    return true;
+                }
+                return false;
+
+            case EvaluationType::INTEGER:
+                if (is_int($value)) {
+                    $coerced = $value;
+                    return true;
+                }
+                return false;
+
+            case EvaluationType::FLOAT:
+                if (is_int($value) || is_float($value)) {
+                    $coerced = (float) $value;
+                    return true;
+                }
+                return false;
+
+            case EvaluationType::OBJECT:
+                if (is_array($value)) {
+                    $coerced = $value;
+                    return true;
+                }
+                return false;
+        }
+
+        return false;
+    }
+
+    private function mapErrorCode($errorCode)
+    {
+        if ($errorCode === null || $errorCode === self::BRIDGE_ERROR_NONE || $errorCode === '0') {
+            return null;
+        }
+
+        if (is_string($errorCode) && EvaluationErrorCode::isValid($errorCode)) {
+            return $errorCode;
+        }
+
+        switch ((int) $errorCode) {
+            case self::BRIDGE_ERROR_TYPE_MISMATCH:
+                return EvaluationErrorCode::TYPE_MISMATCH;
+            case self::BRIDGE_ERROR_CONFIG_PARSE:
+                return EvaluationErrorCode::PARSE_ERROR;
+            case self::BRIDGE_ERROR_FLAG_UNRECOGNIZED:
+                return EvaluationErrorCode::FLAG_NOT_FOUND;
+            case self::BRIDGE_ERROR_CONFIG_MISSING:
+                return EvaluationErrorCode::PROVIDER_NOT_READY;
+            case self::BRIDGE_ERROR_GENERAL:
+            default:
+                return EvaluationErrorCode::GENERAL;
+        }
+    }
+
+    private function mapReason($reason)
+    {
+        if (is_string($reason) && EvaluationReason::isValid($reason)) {
+            return $reason;
+        }
+
+        switch ((int) $reason) {
+            case self::BRIDGE_REASON_STATIC:
+                return EvaluationReason::STATIC_REASON;
+            case self::BRIDGE_REASON_TARGETING_MATCH:
+                return EvaluationReason::TARGETING_MATCH;
+            case self::BRIDGE_REASON_SPLIT:
+                return EvaluationReason::SPLIT;
+            case self::BRIDGE_REASON_DISABLED:
+                return EvaluationReason::DISABLED;
+            case self::BRIDGE_REASON_ERROR:
+                return EvaluationReason::ERROR;
+            case self::BRIDGE_REASON_DEFAULT:
+            default:
+                return EvaluationReason::DEFAULT_REASON;
+        }
+    }
+
+    private function exposureData(array $rawResult)
+    {
+        $exposureData = $this->readArray($rawResult, array('exposure_data', 'exposureData'));
+
+        if (array_key_exists('allocation_key', $rawResult)) {
+            $exposureData['allocationKey'] = $rawResult['allocation_key'];
+        }
+
+        if (array_key_exists('do_log', $rawResult)) {
+            $exposureData['doLog'] = (bool) $rawResult['do_log'];
+        }
+
+        return $exposureData;
+    }
+
+    private function providerState(array $rawResult)
+    {
+        $providerState = $this->readArray($rawResult, array('provider_state', 'providerState'));
+
+        if (array_key_exists('has_config', $rawResult)) {
+            $providerState['hasConfig'] = (bool) $rawResult['has_config'];
+        }
+
+        if (array_key_exists('config_version', $rawResult)) {
+            $providerState['configVersion'] = $rawResult['config_version'];
+        }
+
+        return $providerState;
+    }
+
+    private function readArray(array $rawResult, array $keys)
+    {
+        $value = $this->read($rawResult, $keys, array());
+
+        return is_array($value) ? $value : array();
+    }
+
+    private function read(array $rawResult, array $keys, $default)
+    {
+        foreach ($keys as $key) {
+            if (array_key_exists($key, $rawResult)) {
+                return $rawResult[$key];
+            }
+        }
+
+        return $default;
+    }
+}

--- a/src/api/FeatureFlags/Testing/FakeEvaluator.php
+++ b/src/api/FeatureFlags/Testing/FakeEvaluator.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace DDTrace\FeatureFlags\Testing;
+
+use DDTrace\FeatureFlags\EvaluationDetails;
+use DDTrace\FeatureFlags\EvaluationErrorCode;
+use DDTrace\FeatureFlags\EvaluationReason;
+use DDTrace\FeatureFlags\Evaluator;
+use DDTrace\FeatureFlags\ResultMapper;
+
+/**
+ * @internal Test and local-development evaluator for code that should not wait
+ * for the native ddtrace FFE bridge to exist.
+ */
+final class FakeEvaluator implements Evaluator
+{
+    private $results;
+    private $calls = array();
+    private $mapper;
+
+    /**
+     * @param array<string, array<string, mixed>|EvaluationDetails|null> $results
+     */
+    public function __construct(array $results = array(), $mapper = null)
+    {
+        if ($mapper !== null && !$mapper instanceof ResultMapper) {
+            throw new \InvalidArgumentException('Expected a ResultMapper instance');
+        }
+
+        $this->results = $results;
+        $this->mapper = $mapper ?: new ResultMapper();
+    }
+
+    public function setResult($flagKey, EvaluationDetails $details)
+    {
+        $this->results[$flagKey] = $details;
+
+        return $this;
+    }
+
+    public function setRawResult($flagKey, $rawResult)
+    {
+        $this->results[$flagKey] = $rawResult;
+
+        return $this;
+    }
+
+    public function setSuccess(
+        $flagKey,
+        $value,
+        $reason = EvaluationReason::TARGETING_MATCH,
+        $variant = null,
+        array $flagMetadata = array(),
+        array $exposureData = array(),
+        array $providerState = array()
+    ) {
+        return $this->setRawResult($flagKey, array(
+            'value' => $value,
+            'reason' => $reason,
+            'error_code' => ResultMapper::BRIDGE_ERROR_NONE,
+            'variant' => $variant,
+            'flag_metadata' => $flagMetadata,
+            'exposure_data' => $exposureData,
+            'provider_state' => $providerState,
+        ));
+    }
+
+    public function setDefault($flagKey, $value, $variant = null)
+    {
+        return $this->setSuccess($flagKey, $value, EvaluationReason::DEFAULT_REASON, $variant);
+    }
+
+    public function setDisabled($flagKey, $value, $variant = null)
+    {
+        return $this->setSuccess($flagKey, $value, EvaluationReason::DISABLED, $variant);
+    }
+
+    public function setFlagNotFound($flagKey, $message = 'Flag was not found')
+    {
+        return $this->setBridgeError($flagKey, ResultMapper::BRIDGE_ERROR_FLAG_UNRECOGNIZED, $message);
+    }
+
+    public function setTypeMismatch($flagKey, $message = 'Flag value had the wrong type')
+    {
+        return $this->setBridgeError($flagKey, ResultMapper::BRIDGE_ERROR_TYPE_MISMATCH, $message);
+    }
+
+    public function setParseError($flagKey, $message = 'Flag configuration could not be parsed')
+    {
+        return $this->setBridgeError($flagKey, ResultMapper::BRIDGE_ERROR_CONFIG_PARSE, $message);
+    }
+
+    public function setProviderNotReady($flagKey, $message = 'FFE evaluator is not ready')
+    {
+        return $this->setBridgeError($flagKey, ResultMapper::BRIDGE_ERROR_CONFIG_MISSING, $message);
+    }
+
+    public function setGeneralError($flagKey, $message = 'FFE evaluator failed')
+    {
+        return $this->setBridgeError($flagKey, ResultMapper::BRIDGE_ERROR_GENERAL, $message);
+    }
+
+    public function evaluate($flagKey, $expectedType, $defaultValue, $targetingKey = null, array $attributes = array())
+    {
+        $this->calls[] = array(
+            'flagKey' => $flagKey,
+            'expectedType' => $expectedType,
+            'defaultValue' => $defaultValue,
+            'targetingKey' => $targetingKey,
+            'attributes' => $attributes,
+        );
+
+        $rawResult = array_key_exists($flagKey, $this->results) ? $this->results[$flagKey] : null;
+
+        return $this->mapper->map($rawResult, $expectedType, $defaultValue);
+    }
+
+    public function getCalls()
+    {
+        return $this->calls;
+    }
+
+    private function setBridgeError($flagKey, $bridgeErrorCode, $message)
+    {
+        return $this->setRawResult($flagKey, array(
+            'value_json' => 'null',
+            'reason' => ResultMapper::BRIDGE_REASON_ERROR,
+            'error_code' => $bridgeErrorCode,
+            'error_message' => $message,
+        ));
+    }
+}

--- a/tests/api/Unit/FeatureFlags/FakeEvaluatorTest.php
+++ b/tests/api/Unit/FeatureFlags/FakeEvaluatorTest.php
@@ -1,0 +1,111 @@
+<?php
+
+namespace DDTrace\Tests\Api\Unit\FeatureFlags;
+
+use DDTrace\FeatureFlags\EvaluationErrorCode;
+use DDTrace\FeatureFlags\EvaluationReason;
+use DDTrace\FeatureFlags\EvaluationType;
+use DDTrace\FeatureFlags\Testing\FakeEvaluator;
+use PHPUnit\Framework\TestCase;
+
+final class FakeEvaluatorTest extends TestCase
+{
+    public function testFakeEvaluatorReturnsConfiguredSuccessAndCapturesCall()
+    {
+        $evaluator = new FakeEvaluator();
+        $evaluator->setSuccess(
+            'checkout-redesign',
+            true,
+            EvaluationReason::TARGETING_MATCH,
+            'on',
+            array('source' => 'fixture'),
+            array('allocationKey' => 'alloc-1'),
+            array('hasConfig' => true)
+        );
+
+        $details = $evaluator->evaluate(
+            'checkout-redesign',
+            EvaluationType::BOOLEAN,
+            false,
+            'user-123',
+            array('plan' => 'pro')
+        );
+
+        $this->assertTrue($details->getValue());
+        $this->assertSame(EvaluationType::BOOLEAN, $details->getValueType());
+        $this->assertSame(EvaluationReason::TARGETING_MATCH, $details->getReason());
+        $this->assertSame('on', $details->getVariant());
+        $this->assertNull($details->getErrorCode());
+        $this->assertSame(array('source' => 'fixture'), $details->getFlagMetadata());
+        $this->assertSame(array('allocationKey' => 'alloc-1'), $details->getExposureData());
+        $this->assertSame(array('hasConfig' => true), $details->getProviderState());
+
+        $this->assertSame(array(
+            array(
+                'flagKey' => 'checkout-redesign',
+                'expectedType' => EvaluationType::BOOLEAN,
+                'defaultValue' => false,
+                'targetingKey' => 'user-123',
+                'attributes' => array('plan' => 'pro'),
+            ),
+        ), $evaluator->getCalls());
+    }
+
+    /**
+     * @dataProvider errorFixtureProvider
+     */
+    public function testFakeEvaluatorErrorFixturesReturnDefaultAndErrorReason($method, $expectedErrorCode)
+    {
+        $evaluator = new FakeEvaluator();
+        $evaluator->$method('flag.error');
+
+        $details = $evaluator->evaluate('flag.error', EvaluationType::STRING, 'fallback');
+
+        $this->assertSame('fallback', $details->getValue());
+        $this->assertSame(EvaluationReason::ERROR, $details->getReason());
+        $this->assertSame($expectedErrorCode, $details->getErrorCode());
+        $this->assertTrue($details->isError());
+    }
+
+    public function errorFixtureProvider()
+    {
+        return array(
+            'flag not found' => array('setFlagNotFound', EvaluationErrorCode::FLAG_NOT_FOUND),
+            'type mismatch' => array('setTypeMismatch', EvaluationErrorCode::TYPE_MISMATCH),
+            'parse error' => array('setParseError', EvaluationErrorCode::PARSE_ERROR),
+            'provider not ready' => array('setProviderNotReady', EvaluationErrorCode::PROVIDER_NOT_READY),
+            'general error' => array('setGeneralError', EvaluationErrorCode::GENERAL),
+        );
+    }
+
+    public function testFakeEvaluatorCanReturnDefaultAndDisabledReasons()
+    {
+        $evaluator = new FakeEvaluator();
+        $evaluator
+            ->setDefault('flag.default', 'control', 'control-variant')
+            ->setDisabled('flag.disabled', false, 'off');
+
+        $default = $evaluator->evaluate('flag.default', EvaluationType::STRING, 'fallback');
+        $disabled = $evaluator->evaluate('flag.disabled', EvaluationType::BOOLEAN, true);
+
+        $this->assertSame('control', $default->getValue());
+        $this->assertSame(EvaluationReason::DEFAULT_REASON, $default->getReason());
+        $this->assertSame('control-variant', $default->getVariant());
+
+        $this->assertFalse($disabled->getValue());
+        $this->assertSame(EvaluationReason::DISABLED, $disabled->getReason());
+        $this->assertSame('off', $disabled->getVariant());
+    }
+
+    public function testUnconfiguredFlagMapsToProviderNotReady()
+    {
+        $evaluator = new FakeEvaluator();
+
+        $details = $evaluator->evaluate('unconfigured', EvaluationType::BOOLEAN, true);
+
+        $this->assertTrue($details->getValue());
+        $this->assertSame(EvaluationReason::ERROR, $details->getReason());
+        $this->assertSame(EvaluationErrorCode::PROVIDER_NOT_READY, $details->getErrorCode());
+        $this->assertSame(array('ready' => false), $details->getProviderState());
+    }
+}

--- a/tests/api/Unit/FeatureFlags/ResultMapperTest.php
+++ b/tests/api/Unit/FeatureFlags/ResultMapperTest.php
@@ -1,0 +1,162 @@
+<?php
+
+namespace DDTrace\Tests\Api\Unit\FeatureFlags;
+
+use DDTrace\FeatureFlags\EvaluationDetails;
+use DDTrace\FeatureFlags\EvaluationErrorCode;
+use DDTrace\FeatureFlags\EvaluationReason;
+use DDTrace\FeatureFlags\EvaluationType;
+use DDTrace\FeatureFlags\ResultMapper;
+use PHPUnit\Framework\TestCase;
+
+final class ResultMapperTest extends TestCase
+{
+    public function testMapsSuccessfulBridgeResultToEvaluationDetails()
+    {
+        $details = (new ResultMapper())->map(array(
+            'value_json' => '"blue"',
+            'variant' => 'variant-a',
+            'allocation_key' => 'alloc-1',
+            'reason' => ResultMapper::BRIDGE_REASON_TARGETING_MATCH,
+            'error_code' => ResultMapper::BRIDGE_ERROR_NONE,
+            'do_log' => true,
+            'flag_metadata' => array('owner' => 'ffe'),
+            'provider_state' => array('ready' => true),
+            'has_config' => true,
+            'config_version' => 42,
+        ), EvaluationType::STRING, 'red');
+
+        $this->assertSame('blue', $details->getValue());
+        $this->assertSame(EvaluationType::STRING, $details->getValueType());
+        $this->assertSame(EvaluationReason::TARGETING_MATCH, $details->getReason());
+        $this->assertSame('variant-a', $details->getVariant());
+        $this->assertNull($details->getErrorCode());
+        $this->assertFalse($details->isError());
+        $this->assertSame(array('owner' => 'ffe'), $details->getFlagMetadata());
+        $this->assertSame(array('allocationKey' => 'alloc-1', 'doLog' => true), $details->getExposureData());
+        $this->assertSame(
+            array('ready' => true, 'hasConfig' => true, 'configVersion' => 42),
+            $details->getProviderState()
+        );
+    }
+
+    public function testNonZeroErrorReturnsDefaultAndForcesErrorReason()
+    {
+        $details = (new ResultMapper())->map(array(
+            'value_json' => '"ignored"',
+            'variant' => 'ignored-variant',
+            'reason' => ResultMapper::BRIDGE_REASON_TARGETING_MATCH,
+            'error_code' => ResultMapper::BRIDGE_ERROR_FLAG_UNRECOGNIZED,
+            'error_message' => 'Unknown flag',
+        ), EvaluationType::STRING, 'fallback');
+
+        $this->assertSame('fallback', $details->getValue());
+        $this->assertSame(EvaluationReason::ERROR, $details->getReason());
+        $this->assertNull($details->getVariant());
+        $this->assertSame(EvaluationErrorCode::FLAG_NOT_FOUND, $details->getErrorCode());
+        $this->assertSame('Unknown flag', $details->getErrorMessage());
+        $this->assertTrue($details->isError());
+    }
+
+    public function testNullResultMapsToProviderNotReady()
+    {
+        $details = (new ResultMapper())->map(null, EvaluationType::BOOLEAN, true);
+
+        $this->assertTrue($details->getValue());
+        $this->assertSame(EvaluationReason::ERROR, $details->getReason());
+        $this->assertSame(EvaluationErrorCode::PROVIDER_NOT_READY, $details->getErrorCode());
+        $this->assertSame('FFE evaluator is not ready', $details->getErrorMessage());
+        $this->assertSame(array('ready' => false), $details->getProviderState());
+    }
+
+    public function testConfigMissingErrorMapsToProviderNotReady()
+    {
+        $details = (new ResultMapper())->map(array(
+            'value_json' => 'null',
+            'reason' => ResultMapper::BRIDGE_REASON_ERROR,
+            'error_code' => ResultMapper::BRIDGE_ERROR_CONFIG_MISSING,
+            'provider_state' => array('hasConfig' => false),
+        ), EvaluationType::BOOLEAN, false);
+
+        $this->assertFalse($details->getValue());
+        $this->assertSame(EvaluationErrorCode::PROVIDER_NOT_READY, $details->getErrorCode());
+        $this->assertSame(array('hasConfig' => false), $details->getProviderState());
+    }
+
+    public function testInvalidJsonMapsToParseError()
+    {
+        $details = (new ResultMapper())->map(array(
+            'value_json' => '{bad-json',
+            'reason' => ResultMapper::BRIDGE_REASON_TARGETING_MATCH,
+            'error_code' => ResultMapper::BRIDGE_ERROR_NONE,
+        ), EvaluationType::OBJECT, array('fallback' => true));
+
+        $this->assertSame(array('fallback' => true), $details->getValue());
+        $this->assertSame(EvaluationReason::ERROR, $details->getReason());
+        $this->assertSame(EvaluationErrorCode::PARSE_ERROR, $details->getErrorCode());
+    }
+
+    public function testDecodedTypeMismatchMapsToTypeMismatch()
+    {
+        $details = (new ResultMapper())->map(array(
+            'value_json' => '"not-a-bool"',
+            'reason' => ResultMapper::BRIDGE_REASON_TARGETING_MATCH,
+            'error_code' => ResultMapper::BRIDGE_ERROR_NONE,
+        ), EvaluationType::BOOLEAN, false);
+
+        $this->assertFalse($details->getValue());
+        $this->assertSame(EvaluationReason::ERROR, $details->getReason());
+        $this->assertSame(EvaluationErrorCode::TYPE_MISMATCH, $details->getErrorCode());
+    }
+
+    public function testIntegerJsonCanMapToFloat()
+    {
+        $details = (new ResultMapper())->map(array(
+            'value_json' => '10',
+            'reason' => ResultMapper::BRIDGE_REASON_SPLIT,
+            'error_code' => ResultMapper::BRIDGE_ERROR_NONE,
+        ), EvaluationType::FLOAT, 0.0);
+
+        $this->assertSame(10.0, $details->getValue());
+        $this->assertSame(EvaluationReason::SPLIT, $details->getReason());
+    }
+
+    /**
+     * @dataProvider reasonProvider
+     */
+    public function testReasonMapping($bridgeReason, $expectedReason)
+    {
+        $details = (new ResultMapper())->map(array(
+            'value_json' => 'true',
+            'reason' => $bridgeReason,
+            'error_code' => ResultMapper::BRIDGE_ERROR_NONE,
+        ), EvaluationType::BOOLEAN, false);
+
+        $this->assertSame($expectedReason, $details->getReason());
+    }
+
+    public function reasonProvider()
+    {
+        return array(
+            'static' => array(ResultMapper::BRIDGE_REASON_STATIC, EvaluationReason::STATIC_REASON),
+            'default' => array(ResultMapper::BRIDGE_REASON_DEFAULT, EvaluationReason::DEFAULT_REASON),
+            'targeting match' => array(ResultMapper::BRIDGE_REASON_TARGETING_MATCH, EvaluationReason::TARGETING_MATCH),
+            'split' => array(ResultMapper::BRIDGE_REASON_SPLIT, EvaluationReason::SPLIT),
+            'disabled' => array(ResultMapper::BRIDGE_REASON_DISABLED, EvaluationReason::DISABLED),
+            'error' => array(ResultMapper::BRIDGE_REASON_ERROR, EvaluationReason::ERROR),
+        );
+    }
+
+    public function testExistingEvaluationDetailsPassThrough()
+    {
+        $existing = new EvaluationDetails(
+            'kept',
+            EvaluationType::STRING,
+            EvaluationReason::DEFAULT_REASON
+        );
+
+        $details = (new ResultMapper())->map($existing, EvaluationType::STRING, 'fallback');
+
+        $this->assertSame($existing, $details);
+    }
+}


### PR DESCRIPTION
## Motivation
The PHP OpenFeature compatibility split needs a small PHP 7-safe evaluator boundary before native FFE runtime work. This lets the Datadog API and PHP 8 OpenFeature shim share result semantics and test against a fake runtime.

## Changes
- Add `DDTrace\FeatureFlags\Evaluator`, `EvaluationDetails`, value/reason/error constants, and `ResultMapper`.
- Add `DDTrace\FeatureFlags\Testing\FakeEvaluator` for test and local runtime fixtures.
- Add API unit tests for success, default/disabled, provider-not-ready, flag-not-found, type mismatch, parse error, reason mapping, metadata, exposure data, and provider state.
- Add CODEOWNERS for the new FeatureFlags source and test paths.

## Decisions
- Keep the root package PHP 7-compatible and do not add `open-feature/sdk` or `open-telemetry/sdk`.
- Treat null evaluator results and missing config as `PROVIDER_NOT_READY`.
- Force `ERROR` reason for non-zero bridge error codes and return caller defaults on error.

## Reference
- PHP OpenFeature compatibility plan: https://docs.google.com/document/d/1NvMfTpZWLBlFmEFNjdnlMyeVpy5l7KD8qujGFco6w2w/edit?tab=t.0