### PR TITLE
feat(ffe): add injectable feature flags client

### DIFF
--- a/src/api/FeatureFlags/Client.php
+++ b/src/api/FeatureFlags/Client.php
@@ -1,0 +1,184 @@
+<?php
+
+namespace DDTrace\FeatureFlags;
+
+final class Client
+{
+    private $evaluator;
+    private $warningEmitter;
+    private $warnedAboutNonProductionRuntime = false;
+
+    public function __construct(Evaluator $evaluator, WarningEmitter $warningEmitter)
+    {
+        $this->evaluator = $evaluator;
+        $this->warningEmitter = $warningEmitter;
+    }
+
+    public static function create($evaluator = null, $warningEmitter = null)
+    {
+        if ($evaluator !== null && !$evaluator instanceof Evaluator) {
+            throw new \InvalidArgumentException('Expected an Evaluator instance');
+        }
+
+        if ($warningEmitter !== null && !$warningEmitter instanceof WarningEmitter) {
+            throw new \InvalidArgumentException('Expected a WarningEmitter instance');
+        }
+
+        return new self(
+            $evaluator ?: new UnavailableEvaluator(),
+            $warningEmitter ?: new TriggerErrorWarningEmitter()
+        );
+    }
+
+    public function getBooleanValue($flagKey, $defaultValue, array $context = array())
+    {
+        return $this->getBooleanDetails($flagKey, $defaultValue, $context)->getValue();
+    }
+
+    public function getStringValue($flagKey, $defaultValue, array $context = array())
+    {
+        return $this->getStringDetails($flagKey, $defaultValue, $context)->getValue();
+    }
+
+    public function getIntegerValue($flagKey, $defaultValue, array $context = array())
+    {
+        return $this->getIntegerDetails($flagKey, $defaultValue, $context)->getValue();
+    }
+
+    public function getFloatValue($flagKey, $defaultValue, array $context = array())
+    {
+        return $this->getFloatDetails($flagKey, $defaultValue, $context)->getValue();
+    }
+
+    public function getObjectValue($flagKey, array $defaultValue, array $context = array())
+    {
+        return $this->getObjectDetails($flagKey, $defaultValue, $context)->getValue();
+    }
+
+    public function getBooleanDetails($flagKey, $defaultValue, array $context = array())
+    {
+        return $this->evaluate($flagKey, EvaluationType::BOOLEAN, $this->expectBoolean($defaultValue), $context);
+    }
+
+    public function getStringDetails($flagKey, $defaultValue, array $context = array())
+    {
+        return $this->evaluate($flagKey, EvaluationType::STRING, $this->expectString($defaultValue), $context);
+    }
+
+    public function getIntegerDetails($flagKey, $defaultValue, array $context = array())
+    {
+        return $this->evaluate($flagKey, EvaluationType::INTEGER, $this->expectInteger($defaultValue), $context);
+    }
+
+    public function getFloatDetails($flagKey, $defaultValue, array $context = array())
+    {
+        return $this->evaluate($flagKey, EvaluationType::FLOAT, $this->expectFloat($defaultValue), $context);
+    }
+
+    public function getObjectDetails($flagKey, array $defaultValue, array $context = array())
+    {
+        return $this->evaluate($flagKey, EvaluationType::OBJECT, $defaultValue, $context);
+    }
+
+    private function evaluate($flagKey, $expectedType, $defaultValue, array $context)
+    {
+        $flagKey = $this->expectFlagKey($flagKey);
+        list($targetingKey, $attributes) = $this->normalizeContext($context);
+
+        $details = $this->evaluator->evaluate(
+            $flagKey,
+            $expectedType,
+            $defaultValue,
+            $targetingKey,
+            $attributes
+        );
+
+        $this->warnIfNonProductionRuntime($details);
+
+        return $details;
+    }
+
+    private function normalizeContext(array $context)
+    {
+        $targetingKey = null;
+        if (array_key_exists('targetingKey', $context) && $context['targetingKey'] !== null) {
+            $targetingKey = (string) $context['targetingKey'];
+        }
+
+        $attributes = array();
+        if (isset($context['attributes']) && is_array($context['attributes'])) {
+            foreach ($context['attributes'] as $key => $value) {
+                if (is_bool($value) || is_int($value) || is_float($value) || is_string($value)) {
+                    $attributes[(string) $key] = $value;
+                }
+            }
+        }
+
+        return array($targetingKey, $attributes);
+    }
+
+    private function warnIfNonProductionRuntime(EvaluationDetails $details)
+    {
+        if ($this->warnedAboutNonProductionRuntime) {
+            return;
+        }
+
+        $providerState = $details->getProviderState();
+        if (!array_key_exists('productionRuntime', $providerState) || $providerState['productionRuntime'] !== false) {
+            return;
+        }
+
+        $message = $details->getErrorMessage();
+        if (!is_string($message) || $message === '') {
+            $message = 'Datadog-backed PHP feature flag evaluation is not fully enabled yet.';
+        }
+
+        $this->warningEmitter->warning($message);
+        $this->warnedAboutNonProductionRuntime = true;
+    }
+
+    private function expectFlagKey($flagKey)
+    {
+        if (!is_string($flagKey) || $flagKey === '') {
+            throw new \InvalidArgumentException('Feature flag key must be a non-empty string');
+        }
+
+        return $flagKey;
+    }
+
+    private function expectBoolean($value)
+    {
+        if (!is_bool($value)) {
+            throw new \InvalidArgumentException('Boolean flag default value must be a bool');
+        }
+
+        return $value;
+    }
+
+    private function expectString($value)
+    {
+        if (!is_string($value)) {
+            throw new \InvalidArgumentException('String flag default value must be a string');
+        }
+
+        return $value;
+    }
+
+    private function expectInteger($value)
+    {
+        if (!is_int($value)) {
+            throw new \InvalidArgumentException('Integer flag default value must be an int');
+        }
+
+        return $value;
+    }
+
+    private function expectFloat($value)
+    {
+        if (!is_int($value) && !is_float($value)) {
+            throw new \InvalidArgumentException('Float flag default value must be a number');
+        }
+
+        return (float) $value;
+    }
+}

--- a/src/api/FeatureFlags/Testing/FakeEvaluator.php
+++ b/src/api/FeatureFlags/Testing/FakeEvaluator.php
@@ -61,7 +61,7 @@ final class FakeEvaluator implements Evaluator
             'variant' => $variant,
             'flag_metadata' => $flagMetadata,
             'exposure_data' => $exposureData,
-            'provider_state' => $providerState,
+            'provider_state' => $this->fakeProviderState($providerState),
         ));
     }
 
@@ -127,6 +127,15 @@ final class FakeEvaluator implements Evaluator
             'reason' => ResultMapper::BRIDGE_REASON_ERROR,
             'error_code' => $bridgeErrorCode,
             'error_message' => $message,
+            'provider_state' => $this->fakeProviderState(),
         ));
+    }
+
+    private function fakeProviderState(array $providerState = array())
+    {
+        return array_merge(array(
+            'evaluator' => 'fake',
+            'productionRuntime' => false,
+        ), $providerState);
     }
 }

--- a/src/api/FeatureFlags/TriggerErrorWarningEmitter.php
+++ b/src/api/FeatureFlags/TriggerErrorWarningEmitter.php
@@ -1,0 +1,11 @@
+<?php
+
+namespace DDTrace\FeatureFlags;
+
+final class TriggerErrorWarningEmitter implements WarningEmitter
+{
+    public function warning($message)
+    {
+        trigger_error($message, E_USER_WARNING);
+    }
+}

--- a/src/api/FeatureFlags/UnavailableEvaluator.php
+++ b/src/api/FeatureFlags/UnavailableEvaluator.php
@@ -1,0 +1,28 @@
+<?php
+
+namespace DDTrace\FeatureFlags;
+
+final class UnavailableEvaluator implements Evaluator
+{
+    const WARNING_MESSAGE = 'Datadog-backed PHP feature flag evaluation is not fully enabled yet. '
+        . 'Returning default values until the ddtrace FFE runtime path is available.';
+
+    public function evaluate($flagKey, $expectedType, $defaultValue, $targetingKey = null, array $attributes = array())
+    {
+        return new EvaluationDetails(
+            $defaultValue,
+            $expectedType,
+            EvaluationReason::ERROR,
+            null,
+            EvaluationErrorCode::PROVIDER_NOT_READY,
+            self::WARNING_MESSAGE,
+            array(),
+            array(),
+            array(
+                'ready' => false,
+                'productionRuntime' => false,
+                'reason' => 'runtime_unavailable',
+            )
+        );
+    }
+}

--- a/src/api/FeatureFlags/WarningEmitter.php
+++ b/src/api/FeatureFlags/WarningEmitter.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace DDTrace\FeatureFlags;
+
+interface WarningEmitter
+{
+    /**
+     * @param string $message
+     * @return void
+     */
+    public function warning($message);
+}

--- a/tests/api/Unit/FeatureFlags/ClientTest.php
+++ b/tests/api/Unit/FeatureFlags/ClientTest.php
@@ -1,0 +1,181 @@
+<?php
+
+namespace DDTrace\Tests\Api\Unit\FeatureFlags;
+
+use DDTrace\FeatureFlags\Client;
+use DDTrace\FeatureFlags\EvaluationErrorCode;
+use DDTrace\FeatureFlags\EvaluationReason;
+use DDTrace\FeatureFlags\EvaluationType;
+use DDTrace\FeatureFlags\Testing\FakeEvaluator;
+use DDTrace\FeatureFlags\UnavailableEvaluator;
+use DDTrace\FeatureFlags\WarningEmitter;
+use PHPUnit\Framework\TestCase;
+
+final class ClientTest extends TestCase
+{
+    public function testValueMethodsReturnEvaluatedValues()
+    {
+        $evaluator = new FakeEvaluator();
+        $evaluator
+            ->setSuccess('bool.flag', true)
+            ->setSuccess('string.flag', 'blue')
+            ->setSuccess('integer.flag', 42)
+            ->setSuccess('float.flag', 3.5)
+            ->setSuccess('object.flag', array('enabled' => true));
+
+        $client = Client::create($evaluator, new RecordingWarningEmitter());
+
+        $this->assertTrue($client->getBooleanValue('bool.flag', false));
+        $this->assertSame('blue', $client->getStringValue('string.flag', 'red'));
+        $this->assertSame(42, $client->getIntegerValue('integer.flag', 0));
+        $this->assertSame(3.5, $client->getFloatValue('float.flag', 0.0));
+        $this->assertSame(array('enabled' => true), $client->getObjectValue('object.flag', array()));
+    }
+
+    public function testDetailsMethodsExposeEvaluationDetails()
+    {
+        $evaluator = new FakeEvaluator();
+        $evaluator->setSuccess(
+            'checkout-redesign',
+            true,
+            EvaluationReason::SPLIT,
+            'treatment',
+            array('owner' => 'ffe'),
+            array('allocationKey' => 'alloc-1'),
+            array('hasConfig' => true)
+        );
+
+        $client = Client::create($evaluator, new RecordingWarningEmitter());
+
+        $details = $client->getBooleanDetails('checkout-redesign', false);
+
+        $this->assertTrue($details->getValue());
+        $this->assertSame(EvaluationType::BOOLEAN, $details->getValueType());
+        $this->assertSame(EvaluationReason::SPLIT, $details->getReason());
+        $this->assertSame('treatment', $details->getVariant());
+        $this->assertSame(array('owner' => 'ffe'), $details->getFlagMetadata());
+        $this->assertSame(array('allocationKey' => 'alloc-1'), $details->getExposureData());
+        $this->assertSame(array(
+            'evaluator' => 'fake',
+            'productionRuntime' => false,
+            'hasConfig' => true,
+        ), $details->getProviderState());
+    }
+
+    public function testContextNormalizesTargetingKeyAndPrimitiveAttributes()
+    {
+        $evaluator = new FakeEvaluator();
+        $evaluator->setSuccess('flag.context', 'on');
+
+        $client = Client::create($evaluator, new RecordingWarningEmitter());
+        $client->getStringValue('flag.context', 'off', array(
+            'targetingKey' => 123,
+            'attributes' => array(
+                'plan' => 'pro',
+                'age' => 41,
+                'rate' => 1.5,
+                'beta' => true,
+                'nested' => array('drop'),
+                'null' => null,
+                'object' => new \stdClass(),
+            ),
+        ));
+
+        $calls = $evaluator->getCalls();
+        $this->assertCount(1, $calls);
+        $this->assertSame('123', $calls[0]['targetingKey']);
+        $this->assertSame(array(
+            'plan' => 'pro',
+            'age' => 41,
+            'rate' => 1.5,
+            'beta' => true,
+        ), $calls[0]['attributes']);
+    }
+
+    public function testUnavailableRuntimeReturnsDefaultWithProviderNotReadyDetailsAndWarning()
+    {
+        $warnings = new RecordingWarningEmitter();
+        $client = Client::create(null, $warnings);
+
+        $value = $client->getBooleanValue('checkout-redesign', true);
+        $details = $client->getStringDetails('checkout-copy', 'fallback');
+
+        $this->assertTrue($value);
+        $this->assertSame('fallback', $details->getValue());
+        $this->assertSame(EvaluationReason::ERROR, $details->getReason());
+        $this->assertSame(EvaluationErrorCode::PROVIDER_NOT_READY, $details->getErrorCode());
+        $this->assertSame(UnavailableEvaluator::WARNING_MESSAGE, $details->getErrorMessage());
+        $this->assertSame(array(
+            'ready' => false,
+            'productionRuntime' => false,
+            'reason' => 'runtime_unavailable',
+        ), $details->getProviderState());
+        $this->assertSame(array(UnavailableEvaluator::WARNING_MESSAGE), $warnings->warnings());
+    }
+
+    public function testWarningIsEmittedOncePerClientNotOncePerEvaluation()
+    {
+        $warnings = new RecordingWarningEmitter();
+        $client = Client::create(null, $warnings);
+
+        $client->getBooleanValue('flag-1', false);
+        $client->getBooleanValue('flag-2', false);
+        $client->getStringDetails('flag-3', 'fallback');
+
+        $this->assertCount(1, $warnings->warnings());
+    }
+
+    public function testFakeEvaluatorModeWarnsAndIsIdentifiable()
+    {
+        $warnings = new RecordingWarningEmitter();
+        $evaluator = new FakeEvaluator();
+        $evaluator->setSuccess('flag.fake', true);
+
+        $client = Client::create($evaluator, $warnings);
+        $details = $client->getBooleanDetails('flag.fake', false);
+
+        $this->assertTrue($details->getValue());
+        $this->assertSame(array(
+            'evaluator' => 'fake',
+            'productionRuntime' => false,
+        ), $details->getProviderState());
+        $this->assertCount(1, $warnings->warnings());
+    }
+
+    /**
+     * @dataProvider invalidDefaultProvider
+     */
+    public function testTypedMethodsRejectInvalidDefaults($method, $defaultValue)
+    {
+        $client = Client::create(new FakeEvaluator(), new RecordingWarningEmitter());
+
+        $this->expectException(\InvalidArgumentException::class);
+
+        $client->$method('flag.invalid', $defaultValue);
+    }
+
+    public function invalidDefaultProvider()
+    {
+        return array(
+            'boolean' => array('getBooleanDetails', 'false'),
+            'string' => array('getStringDetails', false),
+            'integer' => array('getIntegerDetails', 1.2),
+            'float' => array('getFloatDetails', '1.2'),
+        );
+    }
+}
+
+final class RecordingWarningEmitter implements WarningEmitter
+{
+    private $warnings = array();
+
+    public function warning($message)
+    {
+        $this->warnings[] = $message;
+    }
+
+    public function warnings()
+    {
+        return $this->warnings;
+    }
+}

--- a/tests/api/Unit/FeatureFlags/FakeEvaluatorTest.php
+++ b/tests/api/Unit/FeatureFlags/FakeEvaluatorTest.php
@@ -38,7 +38,11 @@ final class FakeEvaluatorTest extends TestCase
         $this->assertNull($details->getErrorCode());
         $this->assertSame(array('source' => 'fixture'), $details->getFlagMetadata());
         $this->assertSame(array('allocationKey' => 'alloc-1'), $details->getExposureData());
-        $this->assertSame(array('hasConfig' => true), $details->getProviderState());
+        $this->assertSame(array(
+            'evaluator' => 'fake',
+            'productionRuntime' => false,
+            'hasConfig' => true,
+        ), $details->getProviderState());
 
         $this->assertSame(array(
             array(
@@ -107,5 +111,19 @@ final class FakeEvaluatorTest extends TestCase
         $this->assertSame(EvaluationReason::ERROR, $details->getReason());
         $this->assertSame(EvaluationErrorCode::PROVIDER_NOT_READY, $details->getErrorCode());
         $this->assertSame(array('ready' => false), $details->getProviderState());
+    }
+
+    public function testFakeEvaluatorErrorsAreIdentifiableAsFakeRuntime()
+    {
+        $evaluator = new FakeEvaluator();
+        $evaluator->setProviderNotReady('flag.error');
+
+        $details = $evaluator->evaluate('flag.error', EvaluationType::BOOLEAN, false);
+
+        $this->assertSame(EvaluationErrorCode::PROVIDER_NOT_READY, $details->getErrorCode());
+        $this->assertSame(array(
+            'evaluator' => 'fake',
+            'productionRuntime' => false,
+        ), $details->getProviderState());
     }
 }


### PR DESCRIPTION
## Motivation

This is PR B in the PHP OpenFeature compatibility stack. PR A introduces the evaluator contract and fake evaluator; this PR adds the PHP 7-safe Datadog client surface that can use that evaluator without depending on the upstream PHP 8-only OpenFeature SDK.

The stack is landing in slices, so the public client must make incomplete runtime behavior explicit. Until native Datadog-backed evaluation is wired, default/fake/local paths return typed details and emit a one-time warning instead of silently looking production-ready.

## Changes

- Add `DDTrace\FeatureFlags\Client` with typed value and details helpers for boolean, string, integer, float, and object flags.
- Add an injectable `WarningEmitter` plus the default `TriggerErrorWarningEmitter` implementation.
- Add `UnavailableEvaluator`, which returns defaults with `PROVIDER_NOT_READY` details when no production evaluator is available.
- Normalize targeting context before evaluation, keeping primitive attributes and casting non-null targeting keys to strings.
- Mark `Testing\FakeEvaluator` results as non-production fake runtime state so tests and early client usage can identify fake evaluation.
- Cover typed methods, details mapping, unavailable-runtime warnings, fake-runtime warnings, context normalization, and invalid defaults in unit tests.

## Decisions

- Stack this PR on PR A so it can reuse the evaluator contract before native runtime integration exists.
- Keep the root tracer PHP 7-compatible and do not add `open-feature/sdk` or OpenTelemetry SDK dependencies here.
- Emit transitional warnings only once per client when provider state reports `productionRuntime=false`; tests inject a recording emitter so warning behavior is explicit without leaking real PHP warnings.
- Continue returning defaults with `PROVIDER_NOT_READY` until the native ddtrace FFE runtime path is available.

## Reference

- Shared PHP OpenFeature compatibility plan: https://docs.google.com/document/d/1NvMfTpZWLBlFmEFNjdnlMyeVpy5l7KD8qujGFco6w2w/edit?tab=t.0

## Verification

- `find src/api/FeatureFlags tests/api/Unit/FeatureFlags -name '*.php' -print0 | xargs -0 -n1 php -n -l`
- `php -n vendor/bin/phpunit --config=phpunit.xml tests/api/Unit/FeatureFlags`
- `vendor/bin/phpunit --config=phpunit.xml tests/api/Unit/FeatureFlags`
- `vendor/bin/phpcs -s src/api/FeatureFlags tests/api/Unit/FeatureFlags`