### PR TITLE
test(ffe): specify exposure and metric semantics

### DIFF
--- a/src/api/FeatureFlags/BufferedExposureWriter.php
+++ b/src/api/FeatureFlags/BufferedExposureWriter.php
@@ -1,0 +1,85 @@
+<?php
+
+namespace DDTrace\FeatureFlags;
+
+final class BufferedExposureWriter implements ExposureWriter
+{
+    private $sink;
+    private $maxBatchSize;
+    private $buffer = array();
+    private $dedup = array();
+
+    public function __construct($sink, $maxBatchSize = 100)
+    {
+        if (!is_callable($sink)) {
+            throw new \InvalidArgumentException('Expected an exposure sink callable');
+        }
+
+        if (!is_int($maxBatchSize) || $maxBatchSize < 1) {
+            throw new \InvalidArgumentException('Exposure batch size must be a positive integer');
+        }
+
+        $this->sink = $sink;
+        $this->maxBatchSize = $maxBatchSize;
+    }
+
+    public function write(array $event)
+    {
+        if (array_key_exists('doLog', $event) && $event['doLog'] === false) {
+            return;
+        }
+
+        $dedupKey = $this->dedupKey($event);
+        $stateKey = $this->stateKey($event);
+        if (isset($this->dedup[$dedupKey]) && $this->dedup[$dedupKey] === $stateKey) {
+            return;
+        }
+
+        $this->dedup[$dedupKey] = $stateKey;
+        $this->buffer[] = $event;
+
+        if (count($this->buffer) >= $this->maxBatchSize) {
+            $this->flush();
+        }
+    }
+
+    public function flush()
+    {
+        if (!$this->buffer) {
+            return;
+        }
+
+        $batch = $this->buffer;
+        $this->buffer = array();
+
+        call_user_func($this->sink, $batch);
+    }
+
+    public function getBufferedCount()
+    {
+        return count($this->buffer);
+    }
+
+    private function dedupKey(array $event)
+    {
+        return $this->eventValue($event, 'flagKey') . "\0" . $this->eventValue($event, 'targetingKey');
+    }
+
+    private function stateKey(array $event)
+    {
+        return $this->eventValue($event, 'allocationKey') . "\0" . $this->eventValue($event, 'variant');
+    }
+
+    private function eventValue(array $event, $key)
+    {
+        if (!array_key_exists($key, $event) || $event[$key] === null) {
+            return '';
+        }
+
+        if (is_scalar($event[$key])) {
+            return (string) $event[$key];
+        }
+
+        return json_encode($event[$key]);
+    }
+}

--- a/src/api/FeatureFlags/CallableMetricsRecorder.php
+++ b/src/api/FeatureFlags/CallableMetricsRecorder.php
@@ -1,0 +1,48 @@
+<?php
+
+namespace DDTrace\FeatureFlags;
+
+final class CallableMetricsRecorder implements MetricsRecorder
+{
+    const METRIC_NAME = 'feature_flag.evaluations';
+
+    private $sink;
+    private $enabled;
+
+    public function __construct($sink, $enabled)
+    {
+        if (!is_callable($sink)) {
+            throw new \InvalidArgumentException('Expected a metrics sink callable');
+        }
+
+        $this->sink = $sink;
+        $this->enabled = (bool) $enabled;
+    }
+
+    public static function createFromEnvironment($sink)
+    {
+        return new self($sink, self::isTruthy(getenv('DD_METRICS_OTEL_ENABLED')));
+    }
+
+    public function recordEvaluation($flagKey, $valueType, $reason, $errorCode = null)
+    {
+        if (!$this->enabled) {
+            return;
+        }
+
+        call_user_func($this->sink, array(
+            'name' => self::METRIC_NAME,
+            'attributes' => array(
+                'feature_flag.key' => $flagKey,
+                'feature_flag.result.reason' => $reason,
+                'feature_flag.result.value_type' => $valueType,
+                'feature_flag.error.code' => $errorCode === null ? 'none' : $errorCode,
+            ),
+        ));
+    }
+
+    private static function isTruthy($value)
+    {
+        return in_array(strtolower((string) $value), array('1', 'true', 'yes', 'on'), true);
+    }
+}

--- a/src/api/FeatureFlags/Client.php
+++ b/src/api/FeatureFlags/Client.php
@@ -6,16 +6,36 @@ final class Client
 {
     private $evaluator;
     private $warningEmitter;
+    private $exposureWriter;
+    private $metricsRecorder;
     private $warnedAboutNonProductionRuntime = false;
 
-    public function __construct(Evaluator $evaluator, WarningEmitter $warningEmitter)
-    {
+    public function __construct(
+        Evaluator $evaluator,
+        WarningEmitter $warningEmitter,
+        $exposureWriter = null,
+        $metricsRecorder = null
+    ) {
+        if ($exposureWriter !== null && !$exposureWriter instanceof ExposureWriter) {
+            throw new \InvalidArgumentException('Expected an ExposureWriter instance');
+        }
+
+        if ($metricsRecorder !== null && !$metricsRecorder instanceof MetricsRecorder) {
+            throw new \InvalidArgumentException('Expected a MetricsRecorder instance');
+        }
+
         $this->evaluator = $evaluator;
         $this->warningEmitter = $warningEmitter;
+        $this->exposureWriter = $exposureWriter ?: new NoopExposureWriter();
+        $this->metricsRecorder = $metricsRecorder ?: new NoopMetricsRecorder();
     }
 
-    public static function create($evaluator = null, $warningEmitter = null)
-    {
+    public static function create(
+        $evaluator = null,
+        $warningEmitter = null,
+        $exposureWriter = null,
+        $metricsRecorder = null
+    ) {
         if ($evaluator !== null && !$evaluator instanceof Evaluator) {
             throw new \InvalidArgumentException('Expected an Evaluator instance');
         }
@@ -26,7 +46,9 @@ final class Client
 
         return new self(
             $evaluator ?: new UnavailableEvaluator(),
-            $warningEmitter ?: new TriggerErrorWarningEmitter()
+            $warningEmitter ?: new TriggerErrorWarningEmitter(),
+            $exposureWriter,
+            $metricsRecorder
         );
     }
 
@@ -94,8 +116,49 @@ final class Client
         );
 
         $this->warnIfNonProductionRuntime($details);
+        $this->metricsRecorder->recordEvaluation(
+            $flagKey,
+            $details->getValueType(),
+            $details->getReason(),
+            $details->getErrorCode()
+        );
+        $this->writeExposure($flagKey, $targetingKey, $attributes, $details);
 
         return $details;
+    }
+
+    private function writeExposure($flagKey, $targetingKey, array $attributes, EvaluationDetails $details)
+    {
+        if ($details->isError()) {
+            return;
+        }
+
+        $exposureData = $details->getExposureData();
+        if (!$exposureData || (array_key_exists('doLog', $exposureData) && $exposureData['doLog'] === false)) {
+            return;
+        }
+
+        $event = array(
+            'flagKey' => $flagKey,
+            'targetingKey' => $targetingKey,
+            'attributes' => $attributes,
+            'value' => $details->getValue(),
+            'valueType' => $details->getValueType(),
+            'reason' => $details->getReason(),
+            'variant' => $details->getVariant(),
+            'flagMetadata' => $details->getFlagMetadata(),
+            'exposureData' => $exposureData,
+        );
+
+        if (array_key_exists('allocationKey', $exposureData)) {
+            $event['allocationKey'] = $exposureData['allocationKey'];
+        }
+
+        if (array_key_exists('doLog', $exposureData)) {
+            $event['doLog'] = $exposureData['doLog'];
+        }
+
+        $this->exposureWriter->write($event);
     }
 
     private function normalizeContext(array $context)

--- a/src/api/FeatureFlags/ExposureWriter.php
+++ b/src/api/FeatureFlags/ExposureWriter.php
@@ -1,0 +1,17 @@
+<?php
+
+namespace DDTrace\FeatureFlags;
+
+interface ExposureWriter
+{
+    /**
+     * @param array<string, mixed> $event
+     * @return void
+     */
+    public function write(array $event);
+
+    /**
+     * @return void
+     */
+    public function flush();
+}

--- a/src/api/FeatureFlags/MetricsRecorder.php
+++ b/src/api/FeatureFlags/MetricsRecorder.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace DDTrace\FeatureFlags;
+
+interface MetricsRecorder
+{
+    /**
+     * @param string|null $errorCode
+     * @return void
+     */
+    public function recordEvaluation($flagKey, $valueType, $reason, $errorCode = null);
+}

--- a/src/api/FeatureFlags/NoopExposureWriter.php
+++ b/src/api/FeatureFlags/NoopExposureWriter.php
@@ -1,0 +1,14 @@
+<?php
+
+namespace DDTrace\FeatureFlags;
+
+final class NoopExposureWriter implements ExposureWriter
+{
+    public function write(array $event)
+    {
+    }
+
+    public function flush()
+    {
+    }
+}

--- a/src/api/FeatureFlags/NoopMetricsRecorder.php
+++ b/src/api/FeatureFlags/NoopMetricsRecorder.php
@@ -1,0 +1,10 @@
+<?php
+
+namespace DDTrace\FeatureFlags;
+
+final class NoopMetricsRecorder implements MetricsRecorder
+{
+    public function recordEvaluation($flagKey, $valueType, $reason, $errorCode = null)
+    {
+    }
+}

--- a/tests/api/Unit/FeatureFlags/ExposureWriterTest.php
+++ b/tests/api/Unit/FeatureFlags/ExposureWriterTest.php
@@ -1,0 +1,153 @@
+<?php
+
+namespace DDTrace\Tests\Api\Unit\FeatureFlags;
+
+use DDTrace\FeatureFlags\BufferedExposureWriter;
+use DDTrace\FeatureFlags\Client;
+use DDTrace\FeatureFlags\EvaluationReason;
+use DDTrace\FeatureFlags\NoopMetricsRecorder;
+use DDTrace\FeatureFlags\Testing\FakeEvaluator;
+use DDTrace\FeatureFlags\WarningEmitter;
+use PHPUnit\Framework\TestCase;
+
+final class ExposureWriterTest extends TestCase
+{
+    public function testClientWritesExposureEventFromEvaluationDetails()
+    {
+        $batches = array();
+        $writer = new BufferedExposureWriter(function (array $batch) use (&$batches) {
+            $batches[] = $batch;
+        });
+
+        $evaluator = new FakeEvaluator();
+        $evaluator->setSuccess(
+            'checkout-redesign',
+            true,
+            EvaluationReason::SPLIT,
+            'treatment',
+            array('owner' => 'ffe'),
+            array('allocationKey' => 'alloc-1', 'doLog' => true)
+        );
+
+        $client = Client::create(
+            $evaluator,
+            new ExposureTestWarningEmitter(),
+            $writer,
+            new NoopMetricsRecorder()
+        );
+
+        $client->getBooleanValue('checkout-redesign', false, array(
+            'targetingKey' => 'user-123',
+            'attributes' => array('plan' => 'pro'),
+        ));
+        $writer->flush();
+
+        $this->assertCount(1, $batches);
+        $this->assertCount(1, $batches[0]);
+        $this->assertSame(array(
+            'flagKey' => 'checkout-redesign',
+            'targetingKey' => 'user-123',
+            'attributes' => array('plan' => 'pro'),
+            'value' => true,
+            'valueType' => 'boolean',
+            'reason' => EvaluationReason::SPLIT,
+            'variant' => 'treatment',
+            'flagMetadata' => array('owner' => 'ffe'),
+            'exposureData' => array('allocationKey' => 'alloc-1', 'doLog' => true),
+            'allocationKey' => 'alloc-1',
+            'doLog' => true,
+        ), $batches[0][0]);
+    }
+
+    public function testClientSkipsExposureWhenDoLogFalseOrEvaluationErrors()
+    {
+        $batches = array();
+        $writer = new BufferedExposureWriter(function (array $batch) use (&$batches) {
+            $batches[] = $batch;
+        });
+
+        $evaluator = new FakeEvaluator();
+        $evaluator
+            ->setSuccess(
+                'do-not-log',
+                true,
+                EvaluationReason::SPLIT,
+                'control',
+                array(),
+                array('allocationKey' => 'alloc-1', 'doLog' => false)
+            )
+            ->setProviderNotReady('provider-not-ready');
+
+        $client = Client::create(
+            $evaluator,
+            new ExposureTestWarningEmitter(),
+            $writer,
+            new NoopMetricsRecorder()
+        );
+
+        $client->getBooleanValue('do-not-log', false);
+        $client->getBooleanValue('provider-not-ready', false);
+        $writer->flush();
+
+        $this->assertSame(array(), $batches);
+    }
+
+    public function testBufferedWriterSuppressesDuplicatesAndReemitsChangedAssignments()
+    {
+        $batches = array();
+        $writer = new BufferedExposureWriter(function (array $batch) use (&$batches) {
+            $batches[] = $batch;
+        });
+
+        $writer->write($this->event('checkout', 'user-1', 'alloc-1', 'control'));
+        $writer->write($this->event('checkout', 'user-1', 'alloc-1', 'control'));
+        $writer->write($this->event('checkout', 'user-1', 'alloc-1', 'treatment'));
+        $writer->write($this->event('checkout', 'user-1', 'alloc-2', 'treatment'));
+        $writer->flush();
+
+        $this->assertCount(1, $batches);
+        $this->assertSame(array('control', 'treatment', 'treatment'), array(
+            $batches[0][0]['variant'],
+            $batches[0][1]['variant'],
+            $batches[0][2]['variant'],
+        ));
+        $this->assertSame('alloc-2', $batches[0][2]['allocationKey']);
+    }
+
+    public function testBufferedWriterFlushesAtBatchCapAndEmptyFlushIsNoop()
+    {
+        $batches = array();
+        $writer = new BufferedExposureWriter(function (array $batch) use (&$batches) {
+            $batches[] = $batch;
+        }, 2);
+
+        $writer->write($this->event('flag-a', 'user-1', 'alloc-1', 'control'));
+        $this->assertSame(1, $writer->getBufferedCount());
+        $writer->write($this->event('flag-b', 'user-2', 'alloc-1', 'control'));
+
+        $this->assertSame(0, $writer->getBufferedCount());
+        $this->assertCount(1, $batches);
+        $this->assertCount(2, $batches[0]);
+
+        $writer->flush();
+        $this->assertCount(1, $batches);
+    }
+
+    private function event($flagKey, $targetingKey, $allocationKey, $variant)
+    {
+        return array(
+            'flagKey' => $flagKey,
+            'targetingKey' => $targetingKey,
+            'allocationKey' => $allocationKey,
+            'variant' => $variant,
+            'doLog' => true,
+        );
+    }
+}
+
+final class ExposureTestWarningEmitter implements WarningEmitter
+{
+    public function warning($message)
+    {
+    }
+}

--- a/tests/api/Unit/FeatureFlags/MetricsRecorderTest.php
+++ b/tests/api/Unit/FeatureFlags/MetricsRecorderTest.php
@@ -1,0 +1,130 @@
+<?php
+
+namespace DDTrace\Tests\Api\Unit\FeatureFlags;
+
+use DDTrace\FeatureFlags\CallableMetricsRecorder;
+use DDTrace\FeatureFlags\Client;
+use DDTrace\FeatureFlags\EvaluationErrorCode;
+use DDTrace\FeatureFlags\EvaluationReason;
+use DDTrace\FeatureFlags\NoopExposureWriter;
+use DDTrace\FeatureFlags\Testing\FakeEvaluator;
+use DDTrace\FeatureFlags\UnavailableEvaluator;
+use DDTrace\FeatureFlags\WarningEmitter;
+use PHPUnit\Framework\TestCase;
+
+final class MetricsRecorderTest extends TestCase
+{
+    public function testCallableMetricsRecorderUsesFeatureFlagEvaluationAttributes()
+    {
+        $metrics = array();
+        $recorder = new CallableMetricsRecorder(function (array $metric) use (&$metrics) {
+            $metrics[] = $metric;
+        }, true);
+
+        $recorder->recordEvaluation('checkout-redesign', 'BOOLEAN', EvaluationReason::SPLIT);
+
+        $this->assertSame(array(array(
+            'name' => CallableMetricsRecorder::METRIC_NAME,
+            'attributes' => array(
+                'feature_flag.key' => 'checkout-redesign',
+                'feature_flag.result.reason' => EvaluationReason::SPLIT,
+                'feature_flag.result.value_type' => 'BOOLEAN',
+                'feature_flag.error.code' => 'none',
+            ),
+        )), $metrics);
+    }
+
+    public function testMetricsRecorderCanBeGatedByEnvironment()
+    {
+        $previous = getenv('DD_METRICS_OTEL_ENABLED');
+        $metrics = array();
+
+        try {
+            putenv('DD_METRICS_OTEL_ENABLED=false');
+            $disabled = CallableMetricsRecorder::createFromEnvironment(function (array $metric) use (&$metrics) {
+                $metrics[] = $metric;
+            });
+            $disabled->recordEvaluation('checkout-redesign', 'BOOLEAN', EvaluationReason::SPLIT);
+            $this->assertSame(array(), $metrics);
+
+            putenv('DD_METRICS_OTEL_ENABLED=true');
+            $enabled = CallableMetricsRecorder::createFromEnvironment(function (array $metric) use (&$metrics) {
+                $metrics[] = $metric;
+            });
+            $enabled->recordEvaluation('checkout-redesign', 'BOOLEAN', EvaluationReason::SPLIT);
+            $this->assertCount(1, $metrics);
+        } finally {
+            if ($previous === false) {
+                putenv('DD_METRICS_OTEL_ENABLED');
+            } else {
+                putenv('DD_METRICS_OTEL_ENABLED=' . $previous);
+            }
+        }
+    }
+
+    public function testClientRecordsMetricsOncePerEvaluationForSuccessAndErrors()
+    {
+        $metrics = array();
+        $recorder = new CallableMetricsRecorder(function (array $metric) use (&$metrics) {
+            $metrics[] = $metric;
+        }, true);
+
+        $evaluator = new FakeEvaluator();
+        $evaluator
+            ->setSuccess('success.flag', true)
+            ->setTypeMismatch('type-mismatch.flag');
+
+        $client = Client::create(
+            $evaluator,
+            new MetricsTestWarningEmitter(),
+            new NoopExposureWriter(),
+            $recorder
+        );
+
+        $client->getBooleanValue('success.flag', false);
+        $client->getBooleanValue('type-mismatch.flag', false);
+
+        $this->assertCount(2, $metrics);
+        $this->assertSame('none', $metrics[0]['attributes']['feature_flag.error.code']);
+        $this->assertSame(
+            EvaluationErrorCode::TYPE_MISMATCH,
+            $metrics[1]['attributes']['feature_flag.error.code']
+        );
+    }
+
+    public function testProviderNotReadyMetricsUseErrorCode()
+    {
+        $metrics = array();
+        $recorder = new CallableMetricsRecorder(function (array $metric) use (&$metrics) {
+            $metrics[] = $metric;
+        }, true);
+
+        $client = Client::create(
+            new UnavailableEvaluator(),
+            new MetricsTestWarningEmitter(),
+            new NoopExposureWriter(),
+            $recorder
+        );
+
+        $client->getBooleanValue('not-ready.flag', false);
+
+        $this->assertSame(
+            EvaluationErrorCode::PROVIDER_NOT_READY,
+            $metrics[0]['attributes']['feature_flag.error.code']
+        );
+    }
+
+    public function testRootComposerDoesNotRequireOpenTelemetrySdk()
+    {
+        $composer = json_decode((string) file_get_contents(__DIR__ . '/../../../../composer.json'), true);
+
+        $this->assertArrayNotHasKey('open-telemetry/sdk', isset($composer['require']) ? $composer['require'] : array());
+    }
+}
+
+final class MetricsTestWarningEmitter implements WarningEmitter
+{
+    public function warning($message)
+    {
+    }
+}


### PR DESCRIPTION
## Motivation

This is PR E in the PHP OpenFeature compatibility stack. PR B adds the PHP 7-safe Datadog feature flag client; this PR specifies the exposure and `feature_flag.evaluations` metric behavior that the client should drive while native delivery remains gated.

The native exposure buffer, EVP/sidecar flush path, and OpenTelemetry-backed metric exporter are intentionally not implemented here. This PR gives reviewers a small, runnable contract for event shape, deduplication, batch flush, and metric gating without forcing PHP 7 users to install PHP 8-only telemetry packages.

## Changes

- Add injectable `ExposureWriter` and `MetricsRecorder` contracts with no-op defaults.
- Add `BufferedExposureWriter` for contract tests around exposure event batching, duplicate suppression, changed assignment re-emission, and empty flush behavior.
- Add `CallableMetricsRecorder` for contract tests around `feature_flag.evaluations` attributes and `DD_METRICS_OTEL_ENABLED` gating.
- Wire `DDTrace\FeatureFlags\Client` to record one metric per evaluation and write exposure events only for successful evaluations with exposure data and `doLog != false`.
- Add tests for exposure event shape, `doLog=false`, provider-not-ready/error skip behavior, duplicate suppression, changed variant/allocation re-emission, batch cap flush, metric success/error/provider-not-ready paths, and root Composer dependency guardrails.

## Decisions

- Keep native delivery gated; these writer/recorder contracts are test sinks until the runtime bridge and sidecar/EVP flush path exist.
- Keep metrics optional and callable-based here; root `composer.json` still does not require `open-telemetry/sdk`.
- Keep default client behavior no-op for exposures and metrics unless a writer/recorder is injected.
- Stack this PR on PR B so it can use the PHP 7 client and evaluator details contract.

## Reference

- Shared PHP OpenFeature compatibility plan: https://docs.google.com/document/d/1NvMfTpZWLBlFmEFNjdnlMyeVpy5l7KD8qujGFco6w2w/edit?tab=t.0

## Verification

- `find src/api/FeatureFlags tests/api/Unit/FeatureFlags -name '*.php' -print0 | xargs -0 -n1 php -n -l`
- `php -n vendor/bin/phpunit --config=phpunit.xml tests/api/Unit/FeatureFlags`
- `vendor/bin/phpunit --config=phpunit.xml tests/api/Unit/FeatureFlags`
- `vendor/bin/phpcs -s src/api/FeatureFlags tests/api/Unit/FeatureFlags`