### PR TITLE
feat(ffe): add native evaluation bridge

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -15,8 +15,10 @@ compile_rust.sh @Datadog/libdatadog-apm
 /src/ @DataDog/apm-idm-php
 
 # FFE (Feature Flagging & Experimentation) SDK Team
+/components-rs/ffe.rs @Datadog/libdatadog-apm @DataDog/feature-flagging-and-experimentation-sdk
 /src/api/FeatureFlags/ @DataDog/feature-flagging-and-experimentation-sdk
 /tests/api/Unit/FeatureFlags/ @DataDog/feature-flagging-and-experimentation-sdk
+/tests/ext/ffe/ @DataDog/feature-flagging-and-experimentation-sdk
 
 # Release files
 Cargo.lock @DataDog/apm-php @DataDog/profiling-php @Datadog/libdatadog-apm

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1451,6 +1451,7 @@ dependencies = [
  "bincode",
  "cbindgen 0.27.0",
  "const-str",
+ "datadog-ffe",
  "datadog-ipc",
  "datadog-live-debugger",
  "datadog-live-debugger-ffi",

--- a/components-rs/Cargo.toml
+++ b/components-rs/Cargo.toml
@@ -15,6 +15,7 @@ libdd-telemetry-ffi = { path = "../libdatadog/libdd-telemetry-ffi", default-feat
 datadog-live-debugger = { path = "../libdatadog/datadog-live-debugger" }
 datadog-live-debugger-ffi = { path = "../libdatadog/datadog-live-debugger-ffi", default-features = false }
 datadog-ipc = { path = "../libdatadog/datadog-ipc" }
+datadog-ffe = { path = "../libdatadog/datadog-ffe" }
 datadog-remote-config = { path = "../libdatadog/datadog-remote-config" }
 datadog-sidecar = { path = "../libdatadog/datadog-sidecar" }
 datadog-sidecar-ffi = { path = "../libdatadog/datadog-sidecar-ffi" }

--- a/components-rs/common.h
+++ b/components-rs/common.h
@@ -439,6 +439,8 @@ typedef struct ddog_DebuggerPayload ddog_DebuggerPayload;
 
 typedef struct ddog_DslString ddog_DslString;
 
+typedef struct ddog_FfeResult ddog_FfeResult;
+
 typedef struct ddog_HashMap_ShmCacheKey__ShmCache ddog_HashMap_ShmCacheKey__ShmCache;
 
 /**
@@ -678,6 +680,14 @@ typedef struct ddog_Vec_DebuggerPayload {
  * It contains a single field, `inner`, which is a 64-bit unsigned integer.
  */
 typedef uint64_t ddog_QueueId;
+
+typedef struct ddog_FfeAttribute {
+  const char *key;
+  int32_t value_type;
+  const char *string_value;
+  double number_value;
+  bool bool_value;
+} ddog_FfeAttribute;
 
 /**
  * A (key, value) pair for peer-service tags, borrowed from PHP/concentrator memory.

--- a/components-rs/ddtrace.h
+++ b/components-rs/ddtrace.h
@@ -61,6 +61,32 @@ int posix_spawn_file_actions_addchdir_np(void *file_actions, const char *path);
 
 uint64_t dd_fnv1a_64(const uint8_t *data, uintptr_t len);
 
+bool ddog_ffe_load_config(const char *json);
+
+bool ddog_ffe_has_config(void);
+
+uint64_t ddog_ffe_config_version(void);
+
+struct ddog_FfeResult *ddog_ffe_evaluate(const char *flag_key,
+                                         int32_t expected_type,
+                                         const char *targeting_key,
+                                         const struct ddog_FfeAttribute *attributes,
+                                         uintptr_t attributes_count);
+
+const char *ddog_ffe_result_value(const struct ddog_FfeResult *result);
+
+const char *ddog_ffe_result_variant(const struct ddog_FfeResult *result);
+
+const char *ddog_ffe_result_allocation_key(const struct ddog_FfeResult *result);
+
+int32_t ddog_ffe_result_reason(const struct ddog_FfeResult *result);
+
+int32_t ddog_ffe_result_error_code(const struct ddog_FfeResult *result);
+
+bool ddog_ffe_result_do_log(const struct ddog_FfeResult *result);
+
+void ddog_ffe_free_result(struct ddog_FfeResult *result);
+
 const char *ddog_normalize_process_tag_value(ddog_CharSlice tag_value);
 
 void ddog_free_normalized_tag_value(const char *ptr);

--- a/components-rs/ffe.rs
+++ b/components-rs/ffe.rs
@@ -1,0 +1,333 @@
+use datadog_ffe::rules_based::{
+    self as ffe, AssignmentReason, AssignmentValue, Attribute, Configuration, EvaluationContext,
+    EvaluationError, ExpectedFlagType, Str, UniversalFlagConfig,
+};
+use std::collections::HashMap;
+use std::ffi::{c_char, CStr, CString};
+use std::sync::{Arc, Mutex};
+
+struct FfeState {
+    config: Option<Configuration>,
+    version: u64,
+}
+
+lazy_static::lazy_static! {
+    static ref FFE_STATE: Mutex<FfeState> = Mutex::new(FfeState {
+        config: None,
+        version: 0,
+    });
+}
+
+pub fn store_config(config: Configuration) {
+    if let Ok(mut state) = FFE_STATE.lock() {
+        state.config = Some(config);
+        state.version = state.version.wrapping_add(1);
+    }
+}
+
+pub fn clear_config() {
+    if let Ok(mut state) = FFE_STATE.lock() {
+        state.config = None;
+        state.version = state.version.wrapping_add(1);
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ddog_ffe_load_config(json: *const c_char) -> bool {
+    if json.is_null() {
+        return false;
+    }
+
+    let json = match unsafe { CStr::from_ptr(json) }.to_str() {
+        Ok(json) => json,
+        Err(_) => return false,
+    };
+
+    match UniversalFlagConfig::from_json(json.as_bytes().to_vec()) {
+        Ok(ufc) => {
+            store_config(Configuration::from_server_response(ufc));
+            true
+        }
+        Err(_) => false,
+    }
+}
+
+#[no_mangle]
+pub extern "C" fn ddog_ffe_has_config() -> bool {
+    FFE_STATE
+        .lock()
+        .map(|state| state.config.is_some())
+        .unwrap_or(false)
+}
+
+#[no_mangle]
+pub extern "C" fn ddog_ffe_config_version() -> u64 {
+    FFE_STATE.lock().map(|state| state.version).unwrap_or(0)
+}
+
+const REASON_STATIC: i32 = 0;
+const REASON_DEFAULT: i32 = 1;
+const REASON_TARGETING_MATCH: i32 = 2;
+const REASON_SPLIT: i32 = 3;
+const REASON_DISABLED: i32 = 4;
+const REASON_ERROR: i32 = 5;
+
+const ERROR_NONE: i32 = 0;
+const ERROR_TYPE_MISMATCH: i32 = 1;
+const ERROR_CONFIG_PARSE: i32 = 2;
+const ERROR_FLAG_UNRECOGNIZED: i32 = 3;
+const ERROR_CONFIG_MISSING: i32 = 6;
+const ERROR_GENERAL: i32 = 7;
+
+const ATTR_TYPE_STRING: i32 = 0;
+const ATTR_TYPE_NUMBER: i32 = 1;
+const ATTR_TYPE_BOOL: i32 = 2;
+
+const TYPE_STRING: i32 = 0;
+const TYPE_INTEGER: i32 = 1;
+const TYPE_FLOAT: i32 = 2;
+const TYPE_BOOLEAN: i32 = 3;
+const TYPE_OBJECT: i32 = 4;
+
+pub struct FfeResult {
+    pub value_json: CString,
+    pub variant: Option<CString>,
+    pub allocation_key: Option<CString>,
+    pub reason: i32,
+    pub error_code: i32,
+    pub do_log: bool,
+}
+
+#[repr(C)]
+pub struct FfeAttribute {
+    pub key: *const c_char,
+    pub value_type: i32,
+    pub string_value: *const c_char,
+    pub number_value: f64,
+    pub bool_value: bool,
+}
+
+#[no_mangle]
+pub extern "C" fn ddog_ffe_evaluate(
+    flag_key: *const c_char,
+    expected_type: i32,
+    targeting_key: *const c_char,
+    attributes: *const FfeAttribute,
+    attributes_count: usize,
+) -> *mut FfeResult {
+    if flag_key.is_null() {
+        return std::ptr::null_mut();
+    }
+
+    let flag_key = match unsafe { CStr::from_ptr(flag_key) }.to_str() {
+        Ok(flag_key) => flag_key,
+        Err(_) => return std::ptr::null_mut(),
+    };
+
+    let expected_type = match expected_type {
+        TYPE_STRING => ExpectedFlagType::String,
+        TYPE_INTEGER => ExpectedFlagType::Integer,
+        TYPE_FLOAT => ExpectedFlagType::Float,
+        TYPE_BOOLEAN => ExpectedFlagType::Boolean,
+        TYPE_OBJECT => ExpectedFlagType::Object,
+        _ => return std::ptr::null_mut(),
+    };
+
+    let targeting_key = if targeting_key.is_null() {
+        None
+    } else {
+        match unsafe { CStr::from_ptr(targeting_key) }.to_str() {
+            Ok(targeting_key) if !targeting_key.is_empty() => Some(Str::from(targeting_key)),
+            _ => None,
+        }
+    };
+
+    let attributes = parse_attributes(attributes, attributes_count);
+    let context = EvaluationContext::new(targeting_key, Arc::new(attributes));
+
+    let state = match FFE_STATE.lock() {
+        Ok(state) => state,
+        Err(_) => return std::ptr::null_mut(),
+    };
+
+    let assignment = ffe::get_assignment(
+        state.config.as_ref(),
+        flag_key,
+        &context,
+        expected_type,
+        ffe::now(),
+    );
+
+    Box::into_raw(Box::new(result_from_assignment(assignment)))
+}
+
+#[no_mangle]
+pub extern "C" fn ddog_ffe_result_value(result: *const FfeResult) -> *const c_char {
+    if result.is_null() {
+        return std::ptr::null();
+    }
+
+    unsafe { &*result }.value_json.as_ptr()
+}
+
+#[no_mangle]
+pub extern "C" fn ddog_ffe_result_variant(result: *const FfeResult) -> *const c_char {
+    if result.is_null() {
+        return std::ptr::null();
+    }
+
+    unsafe { &*result }
+        .variant
+        .as_ref()
+        .map(|value| value.as_ptr())
+        .unwrap_or(std::ptr::null())
+}
+
+#[no_mangle]
+pub extern "C" fn ddog_ffe_result_allocation_key(result: *const FfeResult) -> *const c_char {
+    if result.is_null() {
+        return std::ptr::null();
+    }
+
+    unsafe { &*result }
+        .allocation_key
+        .as_ref()
+        .map(|value| value.as_ptr())
+        .unwrap_or(std::ptr::null())
+}
+
+#[no_mangle]
+pub extern "C" fn ddog_ffe_result_reason(result: *const FfeResult) -> i32 {
+    if result.is_null() {
+        return REASON_ERROR;
+    }
+
+    unsafe { &*result }.reason
+}
+
+#[no_mangle]
+pub extern "C" fn ddog_ffe_result_error_code(result: *const FfeResult) -> i32 {
+    if result.is_null() {
+        return ERROR_GENERAL;
+    }
+
+    unsafe { &*result }.error_code
+}
+
+#[no_mangle]
+pub extern "C" fn ddog_ffe_result_do_log(result: *const FfeResult) -> bool {
+    if result.is_null() {
+        return false;
+    }
+
+    unsafe { &*result }.do_log
+}
+
+#[no_mangle]
+pub unsafe extern "C" fn ddog_ffe_free_result(result: *mut FfeResult) {
+    if !result.is_null() {
+        drop(Box::from_raw(result));
+    }
+}
+
+fn parse_attributes(
+    attributes: *const FfeAttribute,
+    attributes_count: usize,
+) -> HashMap<Str, Attribute> {
+    let mut parsed = HashMap::new();
+
+    if attributes.is_null() || attributes_count == 0 {
+        return parsed;
+    }
+
+    let attributes = unsafe { std::slice::from_raw_parts(attributes, attributes_count) };
+    for attribute in attributes {
+        if attribute.key.is_null() {
+            continue;
+        }
+
+        let key = match unsafe { CStr::from_ptr(attribute.key) }.to_str() {
+            Ok(key) => key,
+            Err(_) => continue,
+        };
+
+        let value = match attribute.value_type {
+            ATTR_TYPE_STRING => {
+                if attribute.string_value.is_null() {
+                    continue;
+                }
+
+                match unsafe { CStr::from_ptr(attribute.string_value) }.to_str() {
+                    Ok(value) => Attribute::from(value),
+                    Err(_) => continue,
+                }
+            }
+            ATTR_TYPE_NUMBER => Attribute::from(attribute.number_value),
+            ATTR_TYPE_BOOL => Attribute::from(attribute.bool_value),
+            _ => continue,
+        };
+
+        parsed.insert(Str::from(key), value);
+    }
+
+    parsed
+}
+
+fn result_from_assignment(assignment: Result<ffe::Assignment, EvaluationError>) -> FfeResult {
+    match assignment {
+        Ok(assignment) => FfeResult {
+            value_json: string_to_cstring(assignment_value_to_json(&assignment.value)),
+            variant: Some(string_to_cstring(
+                assignment.variation_key.as_str().to_string(),
+            )),
+            allocation_key: Some(string_to_cstring(
+                assignment.allocation_key.as_str().to_string(),
+            )),
+            reason: match assignment.reason {
+                AssignmentReason::Static => REASON_STATIC,
+                AssignmentReason::TargetingMatch => REASON_TARGETING_MATCH,
+                AssignmentReason::Split => REASON_SPLIT,
+            },
+            error_code: ERROR_NONE,
+            do_log: assignment.do_log,
+        },
+        Err(error) => {
+            let (error_code, reason) = match &error {
+                EvaluationError::TypeMismatch { .. } => (ERROR_TYPE_MISMATCH, REASON_ERROR),
+                EvaluationError::ConfigurationParseError => (ERROR_CONFIG_PARSE, REASON_ERROR),
+                EvaluationError::ConfigurationMissing => (ERROR_CONFIG_MISSING, REASON_ERROR),
+                EvaluationError::FlagUnrecognizedOrDisabled => {
+                    (ERROR_FLAG_UNRECOGNIZED, REASON_DEFAULT)
+                }
+                EvaluationError::FlagDisabled => (ERROR_NONE, REASON_DISABLED),
+                EvaluationError::DefaultAllocationNull => (ERROR_NONE, REASON_DEFAULT),
+                _ => (ERROR_GENERAL, REASON_ERROR),
+            };
+
+            FfeResult {
+                value_json: string_to_cstring("null".to_string()),
+                variant: None,
+                allocation_key: None,
+                reason,
+                error_code,
+                do_log: false,
+            }
+        }
+    }
+}
+
+fn assignment_value_to_json(value: &AssignmentValue) -> String {
+    match value {
+        AssignmentValue::String(value) => serde_json::to_string(value.as_str()).unwrap_or_default(),
+        AssignmentValue::Integer(value) => value.to_string(),
+        AssignmentValue::Float(value) => serde_json::Number::from_f64(*value)
+            .map(|value| value.to_string())
+            .unwrap_or_else(|| value.to_string()),
+        AssignmentValue::Boolean(value) => value.to_string(),
+        AssignmentValue::Json { raw, .. } => raw.get().to_string(),
+    }
+}
+
+fn string_to_cstring(value: String) -> CString {
+    CString::new(value).unwrap_or_default()
+}

--- a/components-rs/lib.rs
+++ b/components-rs/lib.rs
@@ -4,6 +4,7 @@
 #![allow(static_mut_refs)] // remove with move to Rust 2024 edition
 
 pub mod agent_info;
+pub mod ffe;
 pub mod log;
 pub mod remote_config;
 pub mod sidecar;

--- a/ext/ddtrace.c
+++ b/ext/ddtrace.c
@@ -2951,6 +2951,138 @@ PHP_FUNCTION(DDTrace_flush_endpoints) {
         ddog_sidecar_telemetry_filter_flush(&DDTRACE_G(sidecar), ddtrace_sidecar_instance_id, &DDTRACE_G(sidecar_queue_id), ddtrace_telemetry_buffer(), ddtrace_telemetry_cache(), service_name, env_name));
 }
 
+PHP_FUNCTION(DDTrace_ffe_has_config) {
+    ZEND_PARSE_PARAMETERS_NONE();
+
+    RETURN_BOOL(ddog_ffe_has_config());
+}
+
+PHP_FUNCTION(DDTrace_ffe_config_version) {
+    ZEND_PARSE_PARAMETERS_NONE();
+
+    RETURN_LONG((zend_long) ddog_ffe_config_version());
+}
+
+PHP_FUNCTION(DDTrace_ffe_load_config) {
+    char *json;
+    size_t json_len;
+
+    ZEND_PARSE_PARAMETERS_START(1, 1)
+        Z_PARAM_STRING(json, json_len)
+    ZEND_PARSE_PARAMETERS_END();
+
+    UNUSED(json_len);
+    RETURN_BOOL(ddog_ffe_load_config(json));
+}
+
+PHP_FUNCTION(DDTrace_ffe_evaluate) {
+    char *flag_key;
+    size_t flag_key_len;
+    zend_long type_id_zl;
+    char *targeting_key = NULL;
+    size_t targeting_key_len = 0;
+    zval *attrs_zv;
+    int32_t type_id;
+    struct ddog_FfeAttribute *c_attrs = NULL;
+    size_t attrs_count = 0;
+    const char *tk = NULL;
+    HashTable *attributes;
+    size_t idx = 0;
+    zend_string *key;
+    zval *value;
+    struct ddog_FfeResult *result;
+    const char *value_json;
+    const char *variant;
+    const char *allocation_key;
+
+    ZEND_PARSE_PARAMETERS_START(4, 4)
+        Z_PARAM_STRING(flag_key, flag_key_len)
+        Z_PARAM_LONG(type_id_zl)
+        Z_PARAM_STRING_OR_NULL(targeting_key, targeting_key_len)
+        Z_PARAM_ARRAY(attrs_zv)
+    ZEND_PARSE_PARAMETERS_END();
+
+    UNUSED(flag_key_len);
+
+    type_id = (int32_t) type_id_zl;
+    tk = targeting_key_len > 0 ? targeting_key : NULL;
+    attributes = Z_ARRVAL_P(attrs_zv);
+    attrs_count = zend_hash_num_elements(attributes);
+
+    if (attrs_count > 0) {
+        c_attrs = ecalloc(attrs_count, sizeof(struct ddog_FfeAttribute));
+        ZEND_HASH_FOREACH_STR_KEY_VAL(attributes, key, value) {
+            if (!key || idx >= attrs_count) {
+                continue;
+            }
+
+            c_attrs[idx].key = ZSTR_VAL(key);
+            switch (Z_TYPE_P(value)) {
+                case IS_STRING:
+                    c_attrs[idx].value_type = 0;
+                    c_attrs[idx].string_value = Z_STRVAL_P(value);
+                    break;
+                case IS_LONG:
+                    c_attrs[idx].value_type = 1;
+                    c_attrs[idx].number_value = (double) Z_LVAL_P(value);
+                    break;
+                case IS_DOUBLE:
+                    c_attrs[idx].value_type = 1;
+                    c_attrs[idx].number_value = Z_DVAL_P(value);
+                    break;
+                case IS_TRUE:
+                    c_attrs[idx].value_type = 2;
+                    c_attrs[idx].bool_value = true;
+                    break;
+                case IS_FALSE:
+                    c_attrs[idx].value_type = 2;
+                    c_attrs[idx].bool_value = false;
+                    break;
+                default:
+                    continue;
+            }
+
+            idx++;
+        } ZEND_HASH_FOREACH_END();
+        attrs_count = idx;
+    }
+
+    result = ddog_ffe_evaluate(flag_key, type_id, tk, c_attrs, attrs_count);
+    if (c_attrs) {
+        efree(c_attrs);
+    }
+
+    if (!result) {
+        RETURN_NULL();
+    }
+
+    value_json = ddog_ffe_result_value(result);
+    variant = ddog_ffe_result_variant(result);
+    allocation_key = ddog_ffe_result_allocation_key(result);
+
+    array_init(return_value);
+    if (value_json) {
+        add_assoc_string(return_value, "value_json", (char *) value_json);
+    } else {
+        add_assoc_null(return_value, "value_json");
+    }
+    if (variant) {
+        add_assoc_string(return_value, "variant", (char *) variant);
+    } else {
+        add_assoc_null(return_value, "variant");
+    }
+    if (allocation_key) {
+        add_assoc_string(return_value, "allocation_key", (char *) allocation_key);
+    } else {
+        add_assoc_null(return_value, "allocation_key");
+    }
+    add_assoc_long(return_value, "reason", ddog_ffe_result_reason(result));
+    add_assoc_long(return_value, "error_code", ddog_ffe_result_error_code(result));
+    add_assoc_bool(return_value, "do_log", ddog_ffe_result_do_log(result));
+
+    ddog_ffe_free_result(result);
+}
+
 PHP_FUNCTION(dd_trace_send_traces_via_thread) {
     char *payload = NULL;
     ddtrace_zpplong_t num_traces = 0;

--- a/ext/ddtrace.stub.php
+++ b/ext/ddtrace.stub.php
@@ -845,6 +845,48 @@ namespace DDTrace {
      * Call this once after batching all add_endpoint() calls.
      */
     function flush_endpoints(): void {}
+
+    /**
+     * Evaluate a feature flag using the stored UFC configuration.
+     *
+     * @param string $flagKey The flag key to evaluate.
+     * @param int $expectedType The expected flag type (0=string, 1=int, 2=float, 3=bool, 4=object).
+     * @param string|null $targetingKey The targeting key for evaluation context.
+     * @param array $attributes Flat key-value map of evaluation context attributes (string keys, primitive values).
+     * @return array|null Associative array with keys: value_json, variant, allocation_key, reason, error_code, do_log. Null only if evaluation engine is unavailable.
+     *
+     * @internal Used by the Datadog feature flag client.
+     */
+    function ffe_evaluate(string $flagKey, int $expectedType, ?string $targetingKey, array $attributes): ?array {}
+
+    /**
+     * Check if FFE (Feature Flag Evaluation) configuration is loaded.
+     *
+     * @return bool True if a flag configuration has been loaded.
+     *
+     * @internal Used by the Datadog feature flag client.
+     */
+    function ffe_has_config(): bool {}
+
+    /**
+     * Return the current FFE configuration version counter.
+     *
+     * @return int Monotonically-increasing version counter.
+     *
+     * @internal Used by the Datadog feature flag client.
+     */
+    function ffe_config_version(): int {}
+
+    /**
+     * Load a UFC JSON configuration string into the FFE engine.
+     * Used for testing without Remote Config.
+     *
+     * @param string $json UFC JSON configuration string.
+     * @return bool True if the configuration was parsed and loaded successfully.
+     *
+     * @internal Used by tests.
+     */
+    function ffe_load_config(string $json): bool {}
 }
 
 namespace DDTrace\System {
@@ -975,6 +1017,7 @@ namespace DDTrace\Internal {
      * @internal
      */
     function handle_fork(): void {}
+
 }
 
 namespace datadog\appsec\v2 {

--- a/ext/ddtrace_arginfo.h
+++ b/ext/ddtrace_arginfo.h
@@ -176,6 +176,23 @@ ZEND_END_ARG_INFO()
 
 #define arginfo_DDTrace_flush_endpoints arginfo_DDTrace_flush
 
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_ffe_evaluate, 0, 4, IS_ARRAY, 1)
+	ZEND_ARG_TYPE_INFO(0, flagKey, IS_STRING, 0)
+	ZEND_ARG_TYPE_INFO(0, expectedType, IS_LONG, 0)
+	ZEND_ARG_TYPE_INFO(0, targetingKey, IS_STRING, 1)
+	ZEND_ARG_TYPE_INFO(0, attributes, IS_ARRAY, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_ffe_has_config, 0, 0, _IS_BOOL, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_ffe_config_version, 0, 0, IS_LONG, 0)
+ZEND_END_ARG_INFO()
+
+ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_ffe_load_config, 0, 1, _IS_BOOL, 0)
+	ZEND_ARG_TYPE_INFO(0, json, IS_STRING, 0)
+ZEND_END_ARG_INFO()
+
 ZEND_BEGIN_ARG_WITH_RETURN_TYPE_INFO_EX(arginfo_DDTrace_System_container_id, 0, 0, IS_STRING, 1)
 ZEND_END_ARG_INFO()
 
@@ -394,6 +411,10 @@ ZEND_FUNCTION(DDTrace_resource_weak_get);
 ZEND_FUNCTION(DDTrace_are_endpoints_collected);
 ZEND_FUNCTION(DDTrace_add_endpoint);
 ZEND_FUNCTION(DDTrace_flush_endpoints);
+ZEND_FUNCTION(DDTrace_ffe_evaluate);
+ZEND_FUNCTION(DDTrace_ffe_has_config);
+ZEND_FUNCTION(DDTrace_ffe_config_version);
+ZEND_FUNCTION(DDTrace_ffe_load_config);
 ZEND_FUNCTION(DDTrace_System_container_id);
 ZEND_FUNCTION(DDTrace_System_process_tags_base_hash);
 ZEND_FUNCTION(DDTrace_Config_integration_analytics_enabled);
@@ -489,6 +510,10 @@ static const zend_function_entry ext_functions[] = {
 	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "are_endpoints_collected"), zif_DDTrace_are_endpoints_collected, arginfo_DDTrace_are_endpoints_collected, 0, NULL, NULL)
 	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "add_endpoint"), zif_DDTrace_add_endpoint, arginfo_DDTrace_add_endpoint, 0, NULL, NULL)
 	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "flush_endpoints"), zif_DDTrace_flush_endpoints, arginfo_DDTrace_flush_endpoints, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "ffe_evaluate"), zif_DDTrace_ffe_evaluate, arginfo_DDTrace_ffe_evaluate, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "ffe_has_config"), zif_DDTrace_ffe_has_config, arginfo_DDTrace_ffe_has_config, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "ffe_config_version"), zif_DDTrace_ffe_config_version, arginfo_DDTrace_ffe_config_version, 0, NULL, NULL)
+	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace", "ffe_load_config"), zif_DDTrace_ffe_load_config, arginfo_DDTrace_ffe_load_config, 0, NULL, NULL)
 	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace\\System", "container_id"), zif_DDTrace_System_container_id, arginfo_DDTrace_System_container_id, 0, NULL, NULL)
 	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace\\System", "process_tags_base_hash"), zif_DDTrace_System_process_tags_base_hash, arginfo_DDTrace_System_process_tags_base_hash, 0, NULL, NULL)
 	ZEND_RAW_FENTRY(ZEND_NS_NAME("DDTrace\\Config", "integration_analytics_enabled"), zif_DDTrace_Config_integration_analytics_enabled, arginfo_DDTrace_Config_integration_analytics_enabled, 0, NULL, NULL)

--- a/src/api/FeatureFlags/Client.php
+++ b/src/api/FeatureFlags/Client.php
@@ -45,7 +45,7 @@ final class Client
         }
 
         return new self(
-            $evaluator ?: new UnavailableEvaluator(),
+            $evaluator ?: NativeEvaluator::createOrUnavailable(),
             $warningEmitter ?: new TriggerErrorWarningEmitter(),
             $exposureWriter,
             $metricsRecorder

--- a/src/api/FeatureFlags/NativeEvaluator.php
+++ b/src/api/FeatureFlags/NativeEvaluator.php
@@ -1,0 +1,127 @@
+<?php
+
+namespace DDTrace\FeatureFlags;
+
+final class NativeEvaluator implements Evaluator
+{
+    const WARNING_MESSAGE = 'Datadog-backed PHP feature flag evaluation is using the native bridge before Remote Config and exposure delivery are fully enabled.';
+
+    private $mapper;
+    private $unavailableEvaluator;
+
+    public function __construct($mapper = null, $unavailableEvaluator = null)
+    {
+        if ($mapper !== null && !$mapper instanceof ResultMapper) {
+            throw new \InvalidArgumentException('Expected a ResultMapper instance');
+        }
+
+        if ($unavailableEvaluator !== null && !$unavailableEvaluator instanceof Evaluator) {
+            throw new \InvalidArgumentException('Expected an Evaluator instance');
+        }
+
+        $this->mapper = $mapper ?: new ResultMapper();
+        $this->unavailableEvaluator = $unavailableEvaluator ?: new UnavailableEvaluator();
+    }
+
+    public static function isAvailable()
+    {
+        return function_exists('DDTrace\\ffe_evaluate')
+            && function_exists('DDTrace\\ffe_has_config')
+            && function_exists('DDTrace\\ffe_config_version');
+    }
+
+    public static function createOrUnavailable()
+    {
+        return self::isAvailable() ? new self() : new UnavailableEvaluator();
+    }
+
+    public function evaluate(
+        $flagKey,
+        $expectedType,
+        $defaultValue,
+        $targetingKey = null,
+        array $attributes = array()
+    ) {
+        if (!self::isAvailable()) {
+            return $this->unavailableEvaluator->evaluate(
+                $flagKey,
+                $expectedType,
+                $defaultValue,
+                $targetingKey,
+                $attributes
+            );
+        }
+
+        $rawResult = \DDTrace\ffe_evaluate(
+            $flagKey,
+            $this->typeId($expectedType),
+            $targetingKey,
+            $this->normalizeAttributes($attributes)
+        );
+
+        if (is_array($rawResult)) {
+            $rawResult = $this->withProviderState($rawResult);
+        }
+
+        return $this->mapper->map($rawResult, $expectedType, $defaultValue);
+    }
+
+    private function typeId($expectedType)
+    {
+        switch ($expectedType) {
+            case EvaluationType::STRING:
+                return 0;
+            case EvaluationType::INTEGER:
+                return 1;
+            case EvaluationType::FLOAT:
+                return 2;
+            case EvaluationType::BOOLEAN:
+                return 3;
+            case EvaluationType::OBJECT:
+                return 4;
+        }
+
+        throw new \InvalidArgumentException('Unknown feature flag value type: ' . (string) $expectedType);
+    }
+
+    private function normalizeAttributes(array $attributes)
+    {
+        $normalized = array();
+        foreach ($attributes as $key => $value) {
+            if (is_bool($value) || is_int($value) || is_float($value) || is_string($value)) {
+                $normalized[(string) $key] = $value;
+            }
+        }
+
+        return $normalized;
+    }
+
+    private function withProviderState(array $rawResult)
+    {
+        $hasConfig = \DDTrace\ffe_has_config();
+        $configVersion = \DDTrace\ffe_config_version();
+
+        $providerState = array(
+            'ready' => $hasConfig,
+            'hasConfig' => $hasConfig,
+            'configVersion' => $configVersion,
+            'productionRuntime' => false,
+            'mode' => 'manual_native_bridge',
+            'reason' => $hasConfig ? 'remote_config_lifecycle_pending' : 'configuration_missing',
+        );
+
+        if (isset($rawResult['provider_state']) && is_array($rawResult['provider_state'])) {
+            $providerState = array_merge($providerState, $rawResult['provider_state']);
+        }
+
+        if (!$hasConfig) {
+            $rawResult['error_message'] = self::WARNING_MESSAGE;
+        }
+
+        $rawResult['provider_state'] = $providerState;
+        $rawResult['has_config'] = $hasConfig;
+        $rawResult['config_version'] = $configVersion;
+
+        return $rawResult;
+    }
+}

--- a/tests/ext/ffe/native_bridge_evaluate.phpt
+++ b/tests/ext/ffe/native_bridge_evaluate.phpt
@@ -1,0 +1,67 @@
+--TEST--
+FFE native bridge evaluates through libdatadog
+--FILE--
+<?php
+function show($label, $value) {
+    echo $label . '=' . json_encode($value, JSON_UNESCAPED_SLASHES) . "\n";
+}
+
+show('has_config_before', \DDTrace\ffe_has_config());
+show('provider_not_ready', \DDTrace\ffe_evaluate('string.flag', 0, 'user-1', array()));
+
+$config = <<<'JSON'
+{
+  "createdAt": "2024-01-01T00:00:00Z",
+  "environment": {"name": "test"},
+  "flags": {
+    "string.flag": {
+      "key": "string.flag",
+      "enabled": true,
+      "variationType": "STRING",
+      "variations": {
+        "blue": {"key": "blue", "value": "blue"}
+      },
+      "allocations": [{
+        "key": "alloc-string",
+        "rules": [],
+        "splits": [{"variationKey": "blue", "serialId": 7, "shards": []}],
+        "doLog": true
+      }]
+    },
+    "bad.flag": {
+      "key": "bad.flag",
+      "enabled": true,
+      "variationType": "STRING",
+      "variations": {
+        "bad": {"key": "bad", "value": 1}
+      },
+      "allocations": [{
+        "key": "alloc-bad",
+        "rules": [],
+        "splits": [{"variationKey": "bad", "shards": []}]
+      }]
+    }
+  }
+}
+JSON;
+
+show('load', \DDTrace\ffe_load_config($config));
+show('has_config_after', \DDTrace\ffe_has_config());
+show('success', \DDTrace\ffe_evaluate('string.flag', 0, 'user-1', array(
+    'country' => 'US',
+    'age' => 42,
+    'ignored' => array('drop'),
+)));
+show('missing', \DDTrace\ffe_evaluate('missing.flag', 0, 'user-1', array()));
+show('type_mismatch', \DDTrace\ffe_evaluate('string.flag', 3, 'user-1', array()));
+show('parse_error', \DDTrace\ffe_evaluate('bad.flag', 0, 'user-1', array()));
+?>
+--EXPECT--
+has_config_before=false
+provider_not_ready={"value_json":"null","variant":null,"allocation_key":null,"reason":5,"error_code":6,"do_log":false}
+load=true
+has_config_after=true
+success={"value_json":"\"blue\"","variant":"blue","allocation_key":"alloc-string","reason":0,"error_code":0,"do_log":true}
+missing={"value_json":"null","variant":null,"allocation_key":null,"reason":1,"error_code":3,"do_log":false}
+type_mismatch={"value_json":"null","variant":null,"allocation_key":null,"reason":5,"error_code":1,"do_log":false}
+parse_error={"value_json":"null","variant":null,"allocation_key":null,"reason":5,"error_code":2,"do_log":false}


### PR DESCRIPTION
## Motivation

This is PR H in the PHP OpenFeature compatibility stack. It starts the tracer native runtime path by importing `libdatadog/datadog-ffe` into `dd-trace-php` and exposing a small bridge for the PHP feature flag client.

Shared planning/reference doc: https://docs.google.com/document/d/1NvMfTpZWLBlFmEFNjdnlMyeVpy5l7KD8qujGFco6w2w/edit?tab=t.0

Stack context: this PR is stacked on #3902. The native bridge shape follows the `DDTrace\ffe_*` approach from #3630 while keeping Remote Config lifecycle and exposure delivery in later stack slices.

## Changes

- Adds `datadog-ffe` as a direct `components-rs` dependency and registers `components-rs/ffe.rs`.
- Adds a Rust bridge that stores UFC config, evaluates through `datadog_ffe::rules_based`, and maps value/reason/error fields into a C/PHP result object.
- Exposes internal `DDTrace\ffe_evaluate`, `DDTrace\ffe_has_config`, `DDTrace\ffe_config_version`, and `DDTrace\ffe_load_config` functions.
- Adds `DDTrace\FeatureFlags\NativeEvaluator` and makes `Client::create()` prefer it when the extension bridge is available.
- Keeps the transitional user warning/provider state when the native bridge exists before Remote Config and exposure delivery are complete.
- Adds native bridge PHPT coverage and CODEOWNERS entries for the Rust bridge and extension tests.

## Decisions

- Import `libdatadog/datadog-ffe`; do not reimplement the evaluator locally in PHP or C.
- Keep this PR limited to the minimal evaluation bridge. Remote Config lifecycle wiring remains PR I.
- Keep native exposure flush/dedup/fork/ZTS integration out of this slice; that remains PR J.
- Keep OpenFeature SDK dependencies out of the root tracer package so PHP 7 installability remains intact.

## Verification

- `php -n -l src/api/FeatureFlags/NativeEvaluator.php`
- `php -n -l src/api/FeatureFlags/Client.php`
- `php -n -l tests/ext/ffe/native_bridge_evaluate.phpt`
- `git diff --check`
- `RUSTC_BOOTSTRAP=1 cargo check -p ddtrace-php`
- `EXTRA_CFLAGS="-I$(brew --prefix pcre2)/include" EXTRA_LDFLAGS="-L$(brew --prefix pcre2)/lib" make -j"$(sysctl -n hw.ncpu)"`
- `php -n -d extension=tmp/build_extension/modules/ddtrace.so -m | rg -i "^ddtrace$"`
- `make test_c TESTS=tests/ext/ffe/native_bridge_evaluate.phpt`
- Direct client smoke with built `ddtrace.so` confirming fallback value, `PROVIDER_NOT_READY`, native transitional warning, and provider state when no FFE config is loaded.