### PR TITLE
test(profiling): ASAN test for #3898

### DIFF
--- a/profiling/tests/phpt/preload_ini_zts_asan.phpt
+++ b/profiling/tests/phpt/preload_ini_zts_asan.phpt
@@ -1,0 +1,34 @@
+--TEST--
+[profiling] ASAN regression: ZTS preloading must not duplicate INI values from themselves
+--DESCRIPTION--
+During preloading in ZTS builds, EG(ini_directives) is still the global INI
+table. The ZTS INI synchronization step must be skipped in that state. If it is
+not skipped, it releases zend_ini_entry.value and then duplicates the same
+pointer, which ASAN reports as a use-after-free.
+--ENV--
+USE_ZEND_ALLOC=0
+DD_PROFILING_ENABLED=0
+DD_PROFILING_LOG_LEVEL=error
+--SKIPIF--
+<?php
+if (!getenv('SKIP_ASAN'))
+    echo "skip: test requires ASAN run-tests mode\n";
+if (!PHP_ZTS)
+    echo "skip: test requires PHP ZTS\n";
+if (PHP_VERSION_ID < 70400)
+    echo "skip: need preloading and therefore PHP >= 7.4.0\n";
+if (!extension_loaded('datadog-profiling'))
+    echo "skip: test requires datadog-profiling\n";
+if (!extension_loaded('Zend OPcache'))
+    echo "skip: test requires opcache\n";
+?>
+--INI--
+opcache.enable_cli=1
+opcache.preload={PWD}/preload_ini_zts_asan_preload.php
+opcache.preload_user=root
+--FILE--
+<?php
+echo "main ini ok: ", ini_get('datadog.profiling.log_level') === 'error' ? 'yes' : 'no', PHP_EOL;
+?>
+--EXPECTREGEX--
+^(?:\[TRACE datadog_php_profiling\] MINIT\([0-9]+, [0-9]+\)\n)*preload ini ok: yes\nmain ini ok: yes\n?$

--- a/profiling/tests/phpt/preload_ini_zts_asan_preload.php
+++ b/profiling/tests/phpt/preload_ini_zts_asan_preload.php
@@ -1,0 +1,3 @@
+<?php
+
+echo "preload ini ok: ", ini_get('datadog.profiling.log_level') === 'error' ? 'yes' : 'no', PHP_EOL;


### PR DESCRIPTION
### Description

Adds a test for #3898 / #3896

This does not yet trigger in CI and that is because we do not run profiler tests against ZTS ASAN because the ZTS ASAN images we prebuild only have DEBUG ZTS ASAN and no NDEBUG version, but the profiler does not build against DEBUG PHP builds.

I hacked this a bit locally and not only does this newly added test fail, but also the other preloading test:

```
  Number of tests : 40
  Tests skipped   : 11
  Tests failed    : 2
  Tests passed    : 27

  Failed tests:

  [profiling] Profiling should only be enabled after preloading has happened
  [profiling] ASAN regression: ZTS preloading must not duplicate INI values from themselves

  ASAN caught the expected issue:

  ERROR: AddressSanitizer: heap-use-after-free
  READ of size 4
  #0 zend_string_dup .../Zend/zend_string.h:217
  #1 zai_config_ini_rinit .../zend_abstract_interface/config/config_ini.c:429
  ...
  freed by thread T0 here:
  #1 zend_string_release .../Zend/zend_string.h:339
  #2 zai_config_ini_rinit .../zend_abstract_interface/config/config_ini.c:428
```