### PR TITLE
fix: correct unit mismatch in php.compilation.total_time_ms

### DIFF
--- a/ext/engine_hooks.c
+++ b/ext/engine_hooks.c
@@ -77,7 +77,7 @@ static zend_op_array *_dd_compile_file(zend_file_handle *file_handle, int type) 
     zend_op_array *res;
     uint64_t start = zend_hrtime();
     res = _prev_compile_file(file_handle, type);
-    DDTRACE_G(compile_time_microseconds) += (int64_t)(zend_hrtime() - start);
+    DDTRACE_G(compile_time_microseconds) += (int64_t)((zend_hrtime() - start) / 1000);
     return res;
 }
 


### PR DESCRIPTION
## Description

PR #2230 (v0.98.0) replaced `_get_microseconds()` (which used `clock_gettime` and returned microseconds) with `zend_hrtime()` (which returns nanoseconds) in `ext/engine_hooks.c`, but did not update the accumulator. The serializer in `ext/serializer.c` divides by `1000.` expecting microseconds → milliseconds, so since v0.98.0 the metric `php.compilation.total_time_ms` has been reporting **microseconds labeled as milliseconds** — a 1000x inflation.

The same PR correctly handled this conversion in `circuit_breaker.c` (`return zend_hrtime() / 1000;`). This change applies the same pattern to the compile time accumulator.

### Evidence

A request with a total duration of ~4,350 ms reported `php.compilation.total_time_ms` of ~28,346 — impossible if in milliseconds (exceeds request duration), but consistent with ~28.3 ms when interpreted as microseconds.

Fixes #3914