### PR TITLE
feat(process-tags): signal service name source via svc.user/svc.auto

### DIFF
--- a/components-rs/sidecar.h
+++ b/components-rs/sidecar.h
@@ -228,6 +228,23 @@ ddog_MaybeError ddog_sidecar_session_set_process_tags(struct ddog_SidecarTranspo
                                                       const struct ddog_Vec_Tag *process_tags);
 
 /**
+ * Records the tracer's auto-resolved default service name for the session
+ * (process-bound; sidecar emits `svc.auto:<name>` when `DD_SERVICE` is not
+ * currently set for the active request). Pass an empty `CharSlice` to clear.
+ */
+ddog_MaybeError ddog_sidecar_session_set_default_service_name(struct ddog_SidecarTransport **transport,
+                                                              ddog_CharSlice default_service_name);
+
+/**
+ * Records whether `DD_SERVICE` is currently set for the session (per-request
+ * mutable; refresh on each RINIT). When `true` the sidecar emits
+ * `svc.user:true`; when `false` it falls back to the previously-recorded
+ * `svc.auto:<name>` (if any).
+ */
+ddog_MaybeError ddog_sidecar_session_set_user_service_defined(struct ddog_SidecarTransport **transport,
+                                                              bool is_user_defined);
+
+/**
  * Enqueues a telemetry log action to be processed internally.
  * Non-blocking. Logs might be dropped if the internal queue is full.
  *

--- a/ext/sidecar.c
+++ b/ext/sidecar.c
@@ -157,9 +157,7 @@ void datadog_sidecar_update_process_tags(void) {
     // Session-bound, process-stable: the tracer's auto-resolved default name.
     zend_string *default_svc = datadog_default_service_name();
     if (default_svc) {
-        const char *normalized = ddog_normalize_process_tag_value((ddog_CharSlice){
-            .ptr = ZSTR_VAL(default_svc), .len = ZSTR_LEN(default_svc)
-        });
+        const char *normalized = ddog_normalize_process_tag_value(dd_zend_string_to_CharSlice(default_svc));
         if (normalized) {
             datadog_ffi_try("Failed updating sidecar default service name",
                 ddog_sidecar_session_set_default_service_name(&DATADOG_G(sidecar),

--- a/ext/sidecar.c
+++ b/ext/sidecar.c
@@ -153,6 +153,33 @@ void datadog_sidecar_update_process_tags(void) {
     }
 
     ddog_sidecar_session_set_process_tags(&DATADOG_G(sidecar), process_tags);
+
+    // Session-bound, process-stable: the tracer's auto-resolved default name.
+    zend_string *default_svc = datadog_default_service_name();
+    if (default_svc) {
+        const char *normalized = ddog_normalize_process_tag_value((ddog_CharSlice){
+            .ptr = ZSTR_VAL(default_svc), .len = ZSTR_LEN(default_svc)
+        });
+        if (normalized) {
+            datadog_ffi_try("Failed updating sidecar default service name",
+                ddog_sidecar_session_set_default_service_name(&DATADOG_G(sidecar),
+                    (ddog_CharSlice){ .ptr = normalized, .len = strlen(normalized) }));
+            ddog_free_normalized_tag_value(normalized);
+        }
+        zend_string_release(default_svc);
+    }
+
+    datadog_sidecar_refresh_user_service_defined();
+}
+
+void datadog_sidecar_refresh_user_service_defined(void) {
+    if (!DATADOG_G(sidecar)) {
+        return;
+    }
+    zend_string *dd_service = get_DD_SERVICE();
+    bool is_defined = dd_service && ZSTR_LEN(dd_service) > 0;
+    datadog_ffi_try("Failed updating sidecar user-service-defined flag",
+        ddog_sidecar_session_set_user_service_defined(&DATADOG_G(sidecar), is_defined));
 }
 
 static void datadog_sidecar_setup_thread_mode(void);
@@ -799,6 +826,10 @@ void datadog_sidecar_rinit(void) {
     }
 
     ddtrace_sidecar_submit_span_data_direct_defaults(&DATADOG_G(sidecar), NULL);
+
+    if (get_global_DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED()) {
+        datadog_sidecar_refresh_user_service_defined();
+    }
 }
 
 void datadog_sidecar_rshutdown(void) {

--- a/ext/sidecar.h
+++ b/ext/sidecar.h
@@ -47,6 +47,7 @@ void datadog_sidecar_handle_fork(void);
 bool datadog_sidecar_should_enable(ddog_RemoteConfigFlags *flags);
 void datadog_sidecar_ensure_active(void);
 void datadog_sidecar_update_process_tags(void);
+void datadog_sidecar_refresh_user_service_defined(void);
 void datadog_sidecar_finalize(bool clear_id);
 void datadog_sidecar_shutdown(void);
 void datadog_force_new_instance_id(void);

--- a/tests/Frameworks/Custom/Version_Autoloaded/src/SetServiceController.php
+++ b/tests/Frameworks/Custom/Version_Autoloaded/src/SetServiceController.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace App;
+
+class SetServiceController
+{
+    public function render()
+    {
+        ini_set('datadog.service', 'request-svc');
+        header('Content-type: text/plain; charset=utf-8');
+        echo 'service set';
+    }
+}

--- a/tests/Frameworks/Custom/Version_Autoloaded/src/routes.php
+++ b/tests/Frameworks/Custom/Version_Autoloaded/src/routes.php
@@ -2,6 +2,7 @@
 
 return function(FastRoute\RouteCollector $r) {
     $r->addRoute('GET', '/simple', '\App\SimpleController');
+    $r->addRoute('GET', '/set_service', '\App\SetServiceController');
     $r->addRoute('GET', '/simple_view', '\App\SimpleViewController');
     $r->addRoute('GET', '/error', '\App\ErrorController');
     $r->addRoute('GET', '/telemetry', '\App\TelemetryFlushController');

--- a/tests/Integrations/Custom/Autoloaded/ProcessTagsWebTest.php
+++ b/tests/Integrations/Custom/Autoloaded/ProcessTagsWebTest.php
@@ -65,4 +65,28 @@ class ProcessTagsWebTest extends WebFrameworkTestCase
         );
         $this->assertEquals($tags['entrypoint.type'], 'script');
     }
+
+    /**
+     * Proves the per-span svc.* design has no static-state leak between
+     * requests served by the same FPM worker: request 1 calls
+     * ini_set('datadog.service', ...) and must report svc.user:true; request 2
+     * reuses the same worker but does not override the service, and must
+     * report svc.auto:<default> (not the leaked svc.user from request 1).
+     */
+    public function testSvcTagDoesNotLeakBetweenRequests()
+    {
+        $tracesUser = $this->tracesFromWebRequest(function () {
+            return $this->call(new RequestSpec(__FUNCTION__ . '_user', 'GET', '/set_service', []));
+        });
+        $userTags = $tracesUser[0][0]['meta']['_dd.tags.process'];
+        $this->assertStringContainsString('svc.user:true', $userTags);
+        $this->assertStringNotContainsString('svc.auto:', $userTags);
+
+        $tracesAuto = $this->tracesFromWebRequest(function () {
+            return $this->call(new RequestSpec(__FUNCTION__ . '_auto', 'GET', '/simple', []));
+        });
+        $autoTags = $tracesAuto[0][0]['meta']['_dd.tags.process'];
+        $this->assertStringNotContainsString('svc.user', $autoTags);
+        $this->assertStringContainsString('svc.auto:', $autoTags);
+    }
 }

--- a/tests/ext/process_tags.phpt
+++ b/tests/ext/process_tags.phpt
@@ -47,6 +47,6 @@ if (isset($spans[1]['meta']['_dd.process_tags'])) {
 ?>
 --EXPECTF--
 Process tags present in root span: YES
-Process tags: entrypoint.basedir:ext,entrypoint.name:process_tags,entrypoint.type:script,entrypoint.workdir:%s,runtime.sapi:cli
+Process tags: entrypoint.basedir:ext,entrypoint.name:process_tags,entrypoint.type:script,entrypoint.workdir:%s,runtime.sapi:cli,svc.auto:process_tags.php
 Keys sorted: YES
 Process tags present in child span: NO

--- a/tests/ext/process_tags.phpt
+++ b/tests/ext/process_tags.phpt
@@ -47,6 +47,6 @@ if (isset($spans[1]['meta']['_dd.process_tags'])) {
 ?>
 --EXPECTF--
 Process tags present in root span: YES
-Process tags: entrypoint.basedir:ext,entrypoint.name:process_tags,entrypoint.type:script,entrypoint.workdir:%s,runtime.sapi:cli,svc.auto:process_tags.php
+Process tags: entrypoint.basedir:ext,entrypoint.name:process_tags,entrypoint.type:script,entrypoint.workdir:%s,runtime.sapi:cli
 Keys sorted: YES
 Process tags present in child span: NO

--- a/tests/ext/svc_auto_tag_cli.phpt
+++ b/tests/ext/svc_auto_tag_cli.phpt
@@ -1,0 +1,23 @@
+--TEST--
+Process tags include svc.auto:<default> when DD_SERVICE is unset (CLI)
+--ENV--
+DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED=1
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_TRACE_AUTO_FLUSH_ENABLED=0
+--FILE--
+<?php
+$span = \DDTrace\start_span();
+$span->name = 'op';
+\DDTrace\close_span();
+
+$spans = dd_trace_serialize_closed_spans();
+$processTags = $spans[0]['meta']['_dd.tags.process'];
+
+echo "has svc.user: " . (strpos($processTags, 'svc.user') !== false ? 'YES' : 'NO') . "\n";
+echo "has svc.auto: " . (strpos($processTags, 'svc.auto:') !== false ? 'YES' : 'NO') . "\n";
+echo "auto value matches script: " . (strpos($processTags, 'svc.auto:svc_auto_tag_cli.php') !== false ? 'YES' : 'NO') . "\n";
+?>
+--EXPECT--
+has svc.user: NO
+has svc.auto: YES
+auto value matches script: YES

--- a/tests/ext/svc_auto_tag_otel.phpt
+++ b/tests/ext/svc_auto_tag_otel.phpt
@@ -1,0 +1,24 @@
+--TEST--
+OTEL_SERVICE_NAME counts as user-defined (emits svc.user:true)
+--ENV--
+DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED=1
+OTEL_SERVICE_NAME=otel-app
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_TRACE_AUTO_FLUSH_ENABLED=0
+--FILE--
+<?php
+$span = \DDTrace\start_span();
+$span->name = 'op';
+\DDTrace\close_span();
+
+$spans = dd_trace_serialize_closed_spans();
+$processTags = $spans[0]['meta']['_dd.tags.process'];
+
+echo "DD_SERVICE resolved to: " . ini_get('datadog.service') . "\n";
+echo "has svc.user:true: " . (strpos($processTags, 'svc.user:true') !== false ? 'YES' : 'NO') . "\n";
+echo "has svc.auto:   : " . (strpos($processTags, 'svc.auto:') !== false ? 'YES' : 'NO') . "\n";
+?>
+--EXPECT--
+DD_SERVICE resolved to: otel-app
+has svc.user:true: YES
+has svc.auto:   : NO

--- a/tests/ext/svc_runtime_change.phpt
+++ b/tests/ext/svc_runtime_change.phpt
@@ -1,0 +1,37 @@
+--TEST--
+Changing datadog.service at runtime recomputes svc.user/svc.auto process tags per-span
+--ENV--
+DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED=1
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_TRACE_AUTO_FLUSH_ENABLED=0
+--FILE--
+<?php
+function assert_tags($label) {
+    $spans = dd_trace_serialize_closed_spans();
+    $tags = $spans[0]['meta']['_dd.tags.process'];
+    $hasUser = strpos($tags, 'svc.user:true') !== false;
+    $hasAuto = strpos($tags, 'svc.auto:') !== false;
+    echo "$label svc.user=" . ($hasUser ? 'YES' : 'NO') . " svc.auto=" . ($hasAuto ? 'YES' : 'NO') . "\n";
+}
+
+$span1 = \DDTrace\start_span();
+$span1->name = 'before';
+\DDTrace\close_span();
+assert_tags('BEFORE  ');
+
+ini_set('datadog.service', 'changed-svc');
+$span2 = \DDTrace\start_span();
+$span2->name = 'after_set';
+\DDTrace\close_span();
+assert_tags('AFTER   ');
+
+ini_restore('datadog.service');
+$span3 = \DDTrace\start_span();
+$span3->name = 'after_restore';
+\DDTrace\close_span();
+assert_tags('REVERTED');
+?>
+--EXPECT--
+BEFORE   svc.user=NO svc.auto=YES
+AFTER    svc.user=YES svc.auto=NO
+REVERTED svc.user=NO svc.auto=YES

--- a/tests/ext/svc_user_tag.phpt
+++ b/tests/ext/svc_user_tag.phpt
@@ -1,0 +1,22 @@
+--TEST--
+Process tags include svc.user:true when DD_SERVICE is set
+--ENV--
+DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED=1
+DD_SERVICE=my-app
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_TRACE_AUTO_FLUSH_ENABLED=0
+--FILE--
+<?php
+$span = \DDTrace\start_span();
+$span->name = 'op';
+\DDTrace\close_span();
+
+$spans = dd_trace_serialize_closed_spans();
+$processTags = $spans[0]['meta']['_dd.tags.process'];
+
+echo "has svc.user:true: " . (strpos($processTags, 'svc.user:true') !== false ? 'YES' : 'NO') . "\n";
+echo "has svc.auto:   : " . (strpos($processTags, 'svc.auto:') !== false ? 'YES' : 'NO') . "\n";
+?>
+--EXPECT--
+has svc.user:true: YES
+has svc.auto:   : NO

--- a/tests/ext/telemetry/telemetry_process_tags.phpt
+++ b/tests/ext/telemetry/telemetry_process_tags.phpt
@@ -46,7 +46,7 @@ if ($i == 300) {
 ?>
 --EXPECTF--
 Included
-string(%d) "entrypoint.basedir:telemetry,entrypoint.name:telemetry_process_tags,entrypoint.type:script,entrypoint.workdir:%s,runtime.sapi:cli"
+string(%d) "entrypoint.basedir:telemetry,entrypoint.name:telemetry_process_tags,entrypoint.type:script,entrypoint.workdir:%s,runtime.sapi:cli,svc.auto:telemetry_process_tags.php"
 --CLEAN--
 <?php
 

--- a/tracer/serializer.c
+++ b/tracer/serializer.c
@@ -1584,12 +1584,11 @@ ddog_SpanBytes *ddtrace_serialize_span_to_rust_span(ddtrace_span_data *span, ddo
             } else {
                 zend_array *root_meta = ddtrace_property_array(&span->root->property_meta);
                 if (!zend_hash_str_exists(root_meta, ZEND_STRL("_dd.svc_src"))) {
-                    zval root_svc;
-                    datadog_convert_to_string(&root_svc, &span->root->property_service);
-                    if (Z_TYPE(root_svc) == IS_STRING && Z_STRLEN(root_svc) > 0) {
-                        normalized_default = ddog_normalize_process_tag_value(dd_zend_string_to_CharSlice(Z_STR(root_svc)));
+                    zend_string *root_svc = datadog_convert_to_str(&span->root->property_service);
+                    if (ZSTR_LEN(root_svc)) {
+                        normalized_default = ddog_normalize_process_tag_value(dd_zend_string_to_CharSlice(root_svc));
                     }
-                    zval_ptr_dtor(&root_svc);
+                    zend_string_release(root_svc);
                 }
             }
 

--- a/tracer/serializer.c
+++ b/tracer/serializer.c
@@ -1585,12 +1585,9 @@ ddog_SpanBytes *ddtrace_serialize_span_to_rust_span(ddtrace_span_data *span, ddo
                 zend_array *root_meta = ddtrace_property_array(&span->root->property_meta);
                 if (!zend_hash_str_exists(root_meta, ZEND_STRL("_dd.svc_src"))) {
                     zval root_svc;
-                    ZVAL_UNDEF(&root_svc);
                     datadog_convert_to_string(&root_svc, &span->root->property_service);
                     if (Z_TYPE(root_svc) == IS_STRING && Z_STRLEN(root_svc) > 0) {
-                        normalized_default = ddog_normalize_process_tag_value((ddog_CharSlice){
-                            .ptr = Z_STRVAL(root_svc), .len = Z_STRLEN(root_svc)
-                        });
+                        normalized_default = ddog_normalize_process_tag_value(dd_zend_string_to_CharSlice(Z_STR(root_svc)));
                     }
                     zval_ptr_dtor(&root_svc);
                 }

--- a/tracer/serializer.c
+++ b/tracer/serializer.c
@@ -1575,7 +1575,46 @@ ddog_SpanBytes *ddtrace_serialize_span_to_rust_span(ddtrace_span_data *span, ddo
     if (is_first_span) {
         zend_string *process_tags = datadog_process_tags_get_serialized();
         if (ZSTR_LEN(process_tags)) {
-            ddog_add_str_span_meta_zstr(rust_span, "_dd.tags.process", process_tags);
+            const char *svc_tag_appendix = NULL;
+            const char *normalized_default = NULL;
+            zend_string *dd_service = get_DD_SERVICE();
+
+            if (dd_service && ZSTR_LEN(dd_service)) {
+                svc_tag_appendix = ",svc.user:true";
+            } else {
+                zend_array *root_meta = ddtrace_property_array(&span->root->property_meta);
+                if (!zend_hash_str_exists(root_meta, ZEND_STRL("_dd.svc_src"))) {
+                    zval root_svc;
+                    ZVAL_UNDEF(&root_svc);
+                    datadog_convert_to_string(&root_svc, &span->root->property_service);
+                    if (Z_TYPE(root_svc) == IS_STRING && Z_STRLEN(root_svc) > 0) {
+                        normalized_default = ddog_normalize_process_tag_value((ddog_CharSlice){
+                            .ptr = Z_STRVAL(root_svc), .len = Z_STRLEN(root_svc)
+                        });
+                    }
+                    zval_ptr_dtor(&root_svc);
+                }
+            }
+
+            if (svc_tag_appendix || normalized_default) {
+                smart_str combined = {0};
+                smart_str_append(&combined, process_tags);
+                if (svc_tag_appendix) {
+                    smart_str_appends(&combined, svc_tag_appendix);
+                } else {
+                    smart_str_appends(&combined, ",svc.auto:");
+                    smart_str_appends(&combined, normalized_default);
+                }
+                smart_str_0(&combined);
+                ddog_add_str_span_meta_zstr(rust_span, "_dd.tags.process", combined.s);
+                smart_str_free(&combined);
+            } else {
+                ddog_add_str_span_meta_zstr(rust_span, "_dd.tags.process", process_tags);
+            }
+
+            if (normalized_default) {
+                ddog_free_normalized_tag_value(normalized_default);
+            }
         }
     }
 


### PR DESCRIPTION
## Summary

Implements the PHP-tracer side of RFC [Signal Service Name Source via Process Tags](https://docs.google.com/document/d/1c47iSTWxIOHMHfZTF2nT9xfyQaIBP9KJvI9sRn5SvpM).

Surfaces one of two mutually-exclusive process tags so the Datadog backend can distinguish user-set vs tracer-auto-resolved service names:

- `svc.user:true` — when `DD_SERVICE` is non-empty (env var, INI, OTEL fallback, remote config)
- `svc.auto:<default_service_name>` — when `DD_SERVICE` is empty and the tracer auto-resolved the name (e.g. `web.request`, script basename, `cli.command`)

Per the RFC caveats, no conclusions are drawn from the absence of both tags.

## Architecture

**Process tags are per-process; the active service name in PHP is per-request** (mutable via `ini_set`, OTEL fallbacks, remote-config-driven INI updates). The earlier approach of baking `svc.user`/`svc.auto` into the static process_tags string leaked the latest request's override into subsequent FPM requests served by the same worker — addressed by the senior review.

Two cooperating paths now:

### 1. Per-span emission (traces) — `ext/serializer.c`

In `ddtrace_serialize_span_to_rust_span`, after attaching the static `_dd.tags.process` string, the per-span `svc.user:true` / `svc.auto:<normalized-default>` tag is appended based on the **request-active** state (`get_DD_SERVICE()` at serialization time, normalized via `ddog_normalize_process_tag_value`). Each span sees its own request's state — cross-request leak is impossible by construction.

### 2. Sidecar (telemetry / remote config / runtime info) — `ext/sidecar.c`

`ddtrace_sidecar_update_process_tags` now also calls the new libdatadog FFI `ddog_sidecar_session_set_default_service_name(transport, default_service_name)`:

- Empty `default_service_name` → sidecar treats it as user-defined and injects `svc.user:true`
- Non-empty `default_service_name` (pre-normalized) → sidecar injects `svc.auto:<default>`

The sidecar performs the injection at payload emission time (via the new `SessionInfo::process_tags_with_svc_source()` helper), so all of telemetry / remote config / runtime_info / stats payloads see consistent svc.* tagging without the tracer having to bake it into the static string.

The libdatadog half lives in DataDog/libdatadog#2053; the submodule pointer in this PR is bumped to that branch tip and must be moved to the merged SHA before this PR merges.

## Behavior

| Source of service name | Span `_dd.tags.process` | Sidecar-emitted process_tags |
|---|---|---|
| `DD_SERVICE=...` env var | `svc.user:true` | `svc.user:true` |
| `datadog.service=...` system INI | `svc.user:true` | `svc.user:true` |
| `OTEL_SERVICE_NAME=...` (fallback) | `svc.user:true` | `svc.user:true` |
| `OTEL_RESOURCE_ATTRIBUTES=service.name=...` (fallback) | `svc.user:true` | `svc.user:true` |
| `ini_set('datadog.service', ...)` (per-request) | `svc.user:true` (this span only) | unchanged (process-level) |
| No DD_SERVICE set | `svc.auto:<basename>.php` (CLI) / `svc.auto:web.request` (web) | same |

## Companion PR

[DataDog/libdatadog#2053](https://github.com/DataDog/libdatadog/pull/2053) — exposes `ddog_sidecar_session_set_default_service_name` and the sidecar-side injection logic. This PR's CI will be red on the submodule pointer until #2053 lands.