### PR TITLE
Check how content-length is reported when zero content-length

### DIFF
--- a/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/CommonTests.groovy
+++ b/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/CommonTests.groovy
@@ -271,7 +271,6 @@ trait CommonTests {
     @Test
     void 'trace without event'() {
         def respContentType = null
-        def respContentLength = null
         def trace = container.traceFromRequest('/hello.php') { HttpResponse<InputStream> resp ->
             assert resp.statusCode() == 200
             def headerContentType = resp.headers().firstValue('Content-Type')
@@ -286,6 +285,28 @@ trait CommonTests {
         assert span.meta."http.response.headers.content-type" == respContentType
         assert span.meta."http.response.headers.content-encoding" == 'foobar'
         assert span.meta."http.response.headers.content-language" == 'en'
+    }
+
+    @Test
+    void 'response with zero content-length'() {
+        def trace = container.traceFromRequest('/zero_content_length.php') { HttpResponse<InputStream> resp ->
+            assert resp.statusCode() == 200
+        }
+
+        def spanContentLength = trace.first().meta."http.response.headers.content-length"
+        assert spanContentLength instanceof String
+        assert spanContentLength == '0'
+    }
+
+    @Test
+    void 'response with non-zero content-length'() {
+        def trace = container.traceFromRequest('/non_zero_content_length.php') { HttpResponse<InputStream> resp ->
+            assert resp.statusCode() == 200
+        }
+
+        def spanContentLength = trace.first().meta."http.response.headers.content-length"
+        assert spanContentLength instanceof String
+        assert spanContentLength == '12'
     }
 
     @Test

--- a/appsec/tests/integration/src/test/www/base/public/non_zero_content_length.php
+++ b/appsec/tests/integration/src/test/www/base/public/non_zero_content_length.php
@@ -1,0 +1,5 @@
+<?php
+$content = 'Hello world!';
+header('Content-Length: ' . strlen($content));
+header('Content-Type: text/plain');
+echo $content;

--- a/appsec/tests/integration/src/test/www/base/public/zero_content_length.php
+++ b/appsec/tests/integration/src/test/www/base/public/zero_content_length.php
@@ -1,0 +1,3 @@
+<?php
+header('Content-Length: 0');
+header('Content-Type: text/plain');


### PR DESCRIPTION
### Description

Adds AppSec integration coverage for http.response.headers.content-length on the root span, for both zero and non-zero values, and confirms the tag is always reported as a string (not a metric/number).

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
