### PR TITLE
build(profiling): Allow zend_strdup for profiler macOS release builds

### DIFF
--- a/profiling/build.rs
+++ b/profiling/build.rs
@@ -576,6 +576,7 @@ fn apple_linker_flags() {
     const ALLOWED_UNDEFINED_SYMBOLS: &[&str] = &[
         // Zend memory allocator
         "___zend_malloc",
+        "___zend_strdup",
         "__efree",
         "__emalloc",
         "__emalloc_40",


### PR DESCRIPTION
## Summary

Adds `___zend_strdup` to the profiler's explicit macOS release-build undefined-symbol allowlist.

## Why

PR #3670 (`perf(config): cache sys getenv`) added persistent duplication in ZAI config via `pestrdup`, which can surface as the `zend_strdup` symbol in the profiler link. The profiler release build on macOS uses an explicit allowlist for PHP/Zend symbols resolved by the PHP process at load time, so the missing `___zend_strdup` entry regressed release builds.

We need this allowlist entry to build release versions of the profiler on arm64 macOS.

## Validation

- `cargo build --release` on arm64 macOS