### PR TITLE
style(profiling): fix clippy::useless-nonzero-new-unchecked

### DIFF
--- a/profiling/src/allocation/mod.rs
+++ b/profiling/src/allocation/mod.rs
@@ -72,9 +72,7 @@ pub mod allocation_ge84;
 pub mod allocation_le83;
 
 /// Default sampling interval in bytes (4 MiB).
-// SAFETY: value is > 0.
-pub const DEFAULT_ALLOCATION_SAMPLING_INTERVAL: NonZeroU32 =
-    unsafe { NonZero::new_unchecked(1024 * 4096) };
+pub const DEFAULT_ALLOCATION_SAMPLING_INTERVAL: NonZeroU32 = NonZero::new(1024 * 4096).unwrap();
 
 /// Sampling distance feed into poison sampling algo. This must be > 0.
 pub static ALLOCATION_PROFILING_INTERVAL: AtomicU64 =

--- a/profiling/src/config.rs
+++ b/profiling/src/config.rs
@@ -474,8 +474,7 @@ static DEFAULT_SYSTEM_SETTINGS: SystemSettings = SystemSettings {
     profiling_endpoint_collection_enabled: true,
     profiling_experimental_cpu_time_enabled: true,
     profiling_allocation_enabled: true,
-    // SAFETY: value is > 0.
-    profiling_allocation_sampling_distance: unsafe { NonZeroU32::new_unchecked(1024 * 4096) },
+    profiling_allocation_sampling_distance: NonZeroU32::new(1024 * 4096).unwrap(),
     profiling_timeline_enabled: true,
     profiling_exception_enabled: true,
     profiling_exception_message_enabled: false,


### PR DESCRIPTION
### Description

Fixes the `clippy::useless-nonzero-new-unchecked` lint. [`Option::unwrap` has been stable in a const context since 1.83](https://doc.rust-lang.org/std/option/enum.Option.html#method.unwrap) and [`NonZero::new` has been stable in a const context since 1.47](https://doc.rust-lang.org/std/num/type.NonZeroU32.html#method.new).

This is needed for an upcoming MSRV bump to Rust 1.87.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
