### PR TITLE
ci(fix) secure runners - APMSP-3298

### DIFF
--- a/.github/workflows/prof_asan.yml
+++ b/.github/workflows/prof_asan.yml
@@ -3,6 +3,9 @@ name: Profiling ASAN Tests
 on:
   pull_request:
 
+permissions:
+  contents: read
+
 jobs:
   prof-asan:
     name: PHP ${{ matrix.php-version }} ${{ matrix.php-build }} (${{ matrix.runner }})
@@ -20,7 +23,7 @@ jobs:
     container:
       image: datadog/dd-trace-ci:php-${{matrix.php-version}}_bookworm-7
       # https://docs.github.com/en/actions/creating-actions/dockerfile-support-for-github-actions#user
-      options: --user root --privileged
+      options: --user root
 
     steps:
       - name: Checkout

--- a/.github/workflows/prof_correctness.yml
+++ b/.github/workflows/prof_correctness.yml
@@ -5,6 +5,9 @@ on:
   schedule:
     - cron: '0 0 * * *'
 
+permissions:
+  contents: read
+
 jobs:
   prof-correctness:
     runs-on: ubuntu-24.04


### PR DESCRIPTION
### Description

Codex found a potential security issue with the prof asan runs being run on custom runners in a privileged container, this PR fixes it by:
- setting permissions for tokens to read only
- removing the `--privileged` as it is not needed anymore (that was needed on LLVM 17)

We still need to run as `root` due to GitHub mounting a temp directory (`/home/runner/work/_temp` → `/__w/_temp`) into that container and the `circleci` (default in those containers) user's UID is not `1001` which it would need to be in order to access those 

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.

https://datadoghq.atlassian.net/browse/APMSP-3298