### PR TITLE
Guard JIT blacklist rewrite to tracing JIT metadata

### DIFF
--- a/zend_abstract_interface/jit_utils/jit_blacklist.c
+++ b/zend_abstract_interface/jit_utils/jit_blacklist.c
@@ -94,6 +94,10 @@ typedef union _zend_op_trace_info {
 #define ZEND_FUNC_INFO(op_array) \
 	((zend_func_info*)((op_array)->reserved[zend_func_info_rid]))
 
+#if !defined(ZEND_FUNC_JIT_ON_HOT_TRACE)
+#define ZEND_FUNC_JIT_ON_HOT_TRACE (1u << 16)
+#endif
+
 static void *opcache_handle;
 static void zai_jit_find_opcache_handle(void *ext) {
     zend_extension *extension = (zend_extension *)ext;
@@ -168,7 +172,7 @@ int zai_get_zend_func_rid(zend_op_array *op_array) {
             }
 
             for (int i = 0; i < ZEND_MAX_RESERVED_RESOURCES; ++i) {
-                if (check_pointer_near(op_array->reserved, op_array->arg_info)) {
+                if (check_pointer_near(op_array->reserved[i], op_array->arg_info)) {
                     return (zend_func_info_rid = i);
                 }
             }
@@ -192,7 +196,11 @@ void zai_jit_blacklist_function_inlining(zend_op_array *op_array) {
     // now in PHP < 8.1, zend_func_info_rid is set (on newer versions it's in zend_func_info.h)
 
     zend_jit_op_array_trace_extension *jit_extension = (zend_jit_op_array_trace_extension *)ZEND_FUNC_INFO(op_array);
-    if (!jit_extension) {
+    if (!jit_extension || !zai_is_mapped(jit_extension, sizeof(*jit_extension))) {
+        return;
+    }
+
+    if (!(jit_extension->func_info.flags & ZEND_FUNC_JIT_ON_HOT_TRACE)) {
         return;
     }
 


### PR DESCRIPTION
### Motivation

- A helper used by `HookData::overrideArguments()` attempted to rewrite JIT/tracing opcache metadata without verifying the layout, which can reinterpret non-tracing JIT data as tracing metadata and cause out-of-bounds reads/writes or crash the PHP worker. 
- The PHP 8.0 reserved-slot heuristic also inspected the wrong pointer, which could select an incorrect resource id and further enable unsafe reinterpretation. 
- The change aims to safely gate the tracing-JIT-specific rewriting so only valid tracing-JIT metadata is modified.

### Description

- Fixed the PHP 8.0 reserved-slot heuristic in `zai_get_zend_func_rid()` to inspect `op_array->reserved[i]` instead of `op_array->reserved`, preventing incorrect resource-id selection. 
- Added a defensive `zai_is_mapped()` check before dereferencing the `jit_extension` pointer to avoid reading unmapped or invalid memory. 
- Only perform trace-layout rewrites when the metadata `func_info.flags` indicates hot-trace JIT by testing `ZEND_FUNC_JIT_ON_HOT_TRACE`, and added a compatibility fallback definition for that flag when headers don't provide it. 

### Testing

- Ran `git diff --check` which reported no conflicts or whitespace errors and succeeded. 
- Verified repository status with `git status --short` and committed the change successfully. 
- No automated unit tests were added or run as part of this minimal, targeted native-safety hardening change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1781e769448323b1590a5bf7f0c0f5)