### PR TITLE
fix(swoole): gate post body parsing on allowed post params

### DIFF
--- a/src/DDTrace/Integrations/Swoole/SwooleIntegration.php
+++ b/src/DDTrace/Integrations/Swoole/SwooleIntegration.php
@@ -68,16 +68,18 @@ class SwooleIntegration extends Integration
                     $rootSpan->meta["http.useragent"] = $headers["user-agent"];
                 }
 
-                $rawContent = $request->rawContent();
-                if ($rawContent) {
-                    // The raw content will always be populated if the request is a POST request, independent of the
-                    // Content-Type header.
-                    // However, it may not be json-decodable
-                    $postFields = json_decode($rawContent, true);
-                    if (is_null($postFields)) {
-                        // Fallback to the post fields, which is an array
-                        // This array is not always populated, depending on the Content-Type header
-                        $postFields = $request->post;
+                if (!empty(\dd_trace_env_config('DD_TRACE_HTTP_POST_DATA_PARAM_ALLOWED'))) {
+                    $rawContent = $request->rawContent();
+                    if ($rawContent) {
+                        // The raw content will always be populated if the request is a POST request, independent of
+                        // the Content-Type header.
+                        // However, it may not be json-decodable
+                        $postFields = json_decode($rawContent, true);
+                        if (is_null($postFields)) {
+                            // Fallback to the post fields, which is an array
+                            // This array is not always populated, depending on the Content-Type header
+                            $postFields = $request->post;
+                        }
                     }
                 }
                 if (!empty($postFields)) {


### PR DESCRIPTION
### Motivation
- The Swoole request hook unconditionally called `$request->rawContent()` and `json_decode()` then normalized and added every parsed POST parameter name to span metadata even when `DD_TRACE_HTTP_POST_DATA_PARAM_ALLOWED` is empty, allowing unauthenticated clients to force expensive parsing and metadata growth. 
- The change aligns Swoole behavior with the existing guarded serializer path that only processes POST fields when the allowlist has entries.

### Description
- Add a guard in `SwooleIntegration::instrumentRequestStart()` so request body reading and decoding only runs when `DD_TRACE_HTTP_POST_DATA_PARAM_ALLOWED` is non-empty (changed file: `src/DDTrace/Integrations/Swoole/SwooleIntegration.php`).
- Preserve the existing `Normalizer::sanitizePostFields()` and metadata-writing behavior when POST parameter capture is explicitly enabled.

### Testing
- Ran `php -l src/DDTrace/Integrations/Swoole/SwooleIntegration.php` to validate syntax, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a175c9e12cc8323a19a4d125e105876)