### PR TITLE
Fix bounds checks for autoload path construction

### DIFF
--- a/ext/autoload_php_files.c
+++ b/ext/autoload_php_files.c
@@ -131,6 +131,10 @@ static void dd_load_file(const char *file) {
     zend_string *sources_path = get_global_DD_TRACE_SOURCES_PATH();
     unsigned int class_start = ZSTR_LEN(sources_path) + 1;
     size_t path_len = snprintf(path, sizeof(path), "%s/%s.php", ZSTR_VAL(sources_path), file);
+    if (path_len >= sizeof(path)) {
+        return;
+    }
+
     for (unsigned int i = class_start; i < path_len; ++i) {
         if (path[i] == '\\') {
             path[i] = '/';
@@ -157,6 +161,10 @@ static void dd_load_files(const char *files_file) {
     zend_string *sources_path = get_global_DD_TRACE_SOURCES_PATH();
     int class_start = ZSTR_LEN(sources_path) + 1;
     size_t path_len = snprintf(path, sizeof(path), "%s/%s.php", ZSTR_VAL(sources_path), files_file);
+    if (path_len >= sizeof(path)) {
+        return;
+    }
+
     for (unsigned int i = class_start; i < path_len; ++i) {
         if (path[i] == '\\') {
             path[i] = '/';


### PR DESCRIPTION
### Motivation
- The autoloader constructed `path[MAXPATHLEN]` with `snprintf()` but then used the unchecked `snprintf` return (`path_len`) for iteration and `memmove()`, which allows an out-of-bounds read/write when the formatted path is truncated by the buffer.

### Description
- Add a truncation guard `if (path_len >= sizeof(path)) { return; }` immediately after the `snprintf()` call in both `dd_load_file()` and `dd_load_files()` to prevent iterating or copying past the stack buffer for oversized inputs.
- This is a minimal remediation that preserves existing autoload behavior for in-bounds paths while preventing memory corruption for oversized class/path inputs.

### Testing
- No automated tests were executed as part of this change; the change is a small bounds-check addition and should be validated by the normal CI build/test matrix (including extension builds and ASan runs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a1760873bd48323a48624927b4b826e)