### PR TITLE
Fix OOB iteration in PHP <8.1 backtrace HashTable loop

### DIFF
--- a/appsec/src/extension/php_compat.h
+++ b/appsec/src/extension/php_compat.h
@@ -139,7 +139,7 @@ static zend_always_inline void _gc_try_delref(zend_refcounted_h *rc)
 #    define ZEND_HASH_FOREACH_FROM(_ht, indirect, _from)                       \
         do {                                                                   \
             Bucket *_p = (_ht)->arData + _from;                                \
-            Bucket *_end = _p + (_ht)->nNumUsed;                               \
+            Bucket *_end = (_ht)->arData + (_ht)->nNumUsed;                    \
             for (; _p != _end; _p++) {                                         \
                 zval *_z = &_p->val;                                           \
                 if (indirect && Z_TYPE_P(_z) == IS_INDIRECT) {                 \

--- a/appsec/tests/extension/generate_backtrace_08.phpt
+++ b/appsec/tests/extension/generate_backtrace_08.phpt
@@ -1,0 +1,84 @@
+--TEST--
+Regression: ZEND_HASH_FOREACH_FROM end pointer must be arData+nNumUsed, not _p+nNumUsed
+--SKIPIF--
+<?php
+if (version_compare(PHP_VERSION, '8.1.0', '>=')) {
+    die('skip: custom ZEND_HASH_FOREACH_FROM only compiled for PHP < 8.1');
+}
+?>
+--INI--
+extension=ddtrace.so
+--ENV--
+DD_APPSEC_MAX_STACK_TRACE_DEPTH=4
+--FILE--
+<?php
+
+use function datadog\appsec\testing\generate_backtrace;
+
+function recursive_function($limit)
+{
+    if (--$limit == 0) {
+        var_dump(generate_backtrace("some id"));
+        return;
+    }
+
+    recursive_function($limit);
+}
+
+recursive_function(8);
+
+?>
+--EXPECTF--
+array(3) {
+  ["language"]=>
+  string(3) "php"
+  ["id"]=>
+  string(7) "some id"
+  ["frames"]=>
+  array(4) {
+    [0]=>
+    array(4) {
+      ["line"]=>
+      int(12)
+      ["function"]=>
+      string(18) "recursive_function"
+      ["file"]=>
+      string(25) "generate_backtrace_08.php"
+      ["id"]=>
+      int(0)
+    }
+    [1]=>
+    array(4) {
+      ["line"]=>
+      int(12)
+      ["function"]=>
+      string(18) "recursive_function"
+      ["file"]=>
+      string(25) "generate_backtrace_08.php"
+      ["id"]=>
+      int(5)
+    }
+    [2]=>
+    array(4) {
+      ["line"]=>
+      int(12)
+      ["function"]=>
+      string(18) "recursive_function"
+      ["file"]=>
+      string(25) "generate_backtrace_08.php"
+      ["id"]=>
+      int(6)
+    }
+    [3]=>
+    array(4) {
+      ["line"]=>
+      int(15)
+      ["function"]=>
+      string(18) "recursive_function"
+      ["file"]=>
+      string(25) "generate_backtrace_08.php"
+      ["id"]=>
+      int(7)
+    }
+  }
+}


### PR DESCRIPTION
### Motivation
- Fix an out-of-bounds read in the PHP `< 8.1` compatibility macro `ZEND_HASH_FOREACH_FROM` which computed the loop end from the offset `_p`, causing iteration past the allocated `Bucket` array when `_from` is nonzero and risking PHP worker crashes via the AppSec backtrace truncation path.

### Description
- Replace `Bucket *_end = _p + (_ht)->nNumUsed;` with `Bucket *_end = (_ht)->arData + (_ht)->nNumUsed;` in `appsec/src/extension/php_compat.h` so the foreach end pointer is computed from the HashTable base and iteration stays within bounds.

### Testing
- Verified the source change and committed it using `git diff`, `nl -ba appsec/src/extension/php_compat.h | sed -n '134,150p'`, and a commit operation, and all commands completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a17527aefa483239e52ca790a769e1f)