### PR TITLE
Fix musl posix_spawn addchdir polyfill recursion

### DIFF
--- a/components-rs/lib.rs
+++ b/components-rs/lib.rs
@@ -189,13 +189,13 @@ pub unsafe extern "C" fn posix_spawn_file_actions_addchdir_np(
         *mut libc::c_void,
         std::option::Option<extern "C" fn(*mut libc::c_void, *const libc::c_char) -> libc::c_int>,
     >(libc::dlsym(
-        null_mut(),
+        libc::RTLD_NEXT,
         c"posix_spawn_file_actions_addchdir_np".as_ptr(),
     ));
     if let Some(sym) = sym {
         sym(file_actions, path)
     } else {
-        -libc::ENOSYS
+        libc::ENOSYS
     }
 }
 


### PR DESCRIPTION
### Motivation
- A musl-only polyfill for `posix_spawn_file_actions_addchdir_np` exported the symbol and used `dlsym(NULL, ...)`, which can resolve back to the polyfill itself and cause infinite recursion and worker crashes; the fallback also returned a negative `-ENOSYS` which is not the expected positive errno-style return.

### Description
- In `components-rs/lib.rs` the polyfill now resolves the next symbol with `libc::RTLD_NEXT` instead of `dlsym(NULL, ...)` to avoid self-resolution recursion, and the fallback now returns `libc::ENOSYS` (positive errno-style) instead of `-libc::ENOSYS`.

### Testing
- Attempted `cargo check -p components-rs`, but the workspace check failed due to a missing workspace dependency (`libdatadog/datadog-ipc/Cargo.toml`), so no successful automated build/test could be completed in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a173cca3710832386ea5e1d9267412e)