### PR TITLE
fix(tracer): use atomic_store for writer->headers assignment

### DIFF
--- a/tracer/coms.c
+++ b/tracer/coms.c
@@ -956,7 +956,7 @@ static void dd_curl_set_headers(struct _writer_loop_data_t *writer, size_t trace
     dd_curl_reset_headers(writer);
 
     curl_easy_setopt(writer->curl, CURLOPT_HTTPHEADER, headers);
-    writer->headers = headers;
+    atomic_store(&writer->headers, headers);
 }
 
 static size_t dd_curl_writefunc(char *ptr, size_t size, size_t nmemb, void *s) {


### PR DESCRIPTION
### Description

`writer->headers` is declared `_Atomic` but was being stored via a plain non-atomic assignment in `dd_curl_set_headers`, while `dd_curl_reset_headers` reads it with `atomic_exchange`. This replaces the plain write with `atomic_store` to match.

Note: the root cause of the crash in #3917 is not fully identified/fixed with this PR

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.