### PR TITLE
Split rinit ordering in "before sidecar init" and "after sidecar init"

### DIFF
--- a/ext/datadog.c
+++ b/ext/datadog.c
@@ -567,9 +567,6 @@ static pthread_once_t dd_rinit_once_control = PTHREAD_ONCE_INIT;
 static PHP_RINIT_FUNCTION(datadog) {
     UNUSED(module_number, type);
 
-    // Do after env check, so that RC data is not updated before RC init
-    DATADOG_G(request_initialized) = true;
-
     if (!DATADOG_G(remote_config_state) && datadog_endpoint) {
         DATADOG_G(remote_config_state) = ddog_init_remote_config_state(datadog_endpoint, ddtrace_dynamic_instrumentation_state() == DDOG_DYNAMIC_INSTRUMENTATION_CONFIG_STATE_ENABLED);
     }
@@ -584,12 +581,19 @@ static PHP_RINIT_FUNCTION(datadog) {
 
     datadog_log_rinit(PG(error_log));
 
-    datadog_sidecar_rinit();
-
     datadog_agent_info_rinit();
 
     // Single combined read: applies env, container-hash, and concentrator config.
     datadog_apply_agent_info();
+
+#ifdef DDTRACE
+    ddtrace_rinit_early();
+#endif
+
+    // Do after env check, so that RC data is not updated before RC init
+    DATADOG_G(request_initialized) = true;
+
+    datadog_sidecar_rinit();
 
 #ifdef DDTRACE
     ddtrace_rinit();

--- a/ext/telemetry.c
+++ b/ext/telemetry.c
@@ -7,7 +7,7 @@
 #else
 #include <components/atomic_win32_polyfill.h>
 #endif
-#include <tracer/configuration.h>
+#include "configuration.h"
 #include <hook/hook.h>
 #include <components-rs/datadog.h>
 #include "telemetry.h"

--- a/tracer/ddtrace.c
+++ b/tracer/ddtrace.c
@@ -442,7 +442,6 @@ static void dd_initialize_request(void) {
     zend_hash_init(&DDTRACE_G(baggage), 8, unused, ZVAL_PTR_DTOR, 0);
 
     ddtrace_asm_event_rinit();
-    ddtrace_live_debugger_rinit();
 
     if (!DDTRACE_G(agent_config_reader) && !get_global_DD_TRACE_IGNORE_AGENT_SAMPLING_RATES()) {
         if (get_global_DD_TRACE_SIDECAR_TRACE_SENDER()) {
@@ -481,12 +480,13 @@ static void dd_initialize_request(void) {
     }
 }
 
-void ddtrace_rinit(void) {
+void ddtrace_rinit_early(void) {
 #if PHP_VERSION_ID < 80000 || (PHP_VERSION_ID >= 80400 && PHP_VERSION_ID < 80500)
     zai_interceptor_rinit();
 #endif
 
     ddtrace_weak_resources_rinit();
+    ddtrace_live_debugger_rinit();
 
     if (!datadog_disable) {
         // With internal functions also being hookable, they must not be hooked before the CG(map_ptr_base) is zeroed
@@ -497,7 +497,9 @@ void ddtrace_rinit(void) {
         ddtrace_autoload_rinit();
 #endif
     }
+}
 
+void ddtrace_rinit(void) {
     if (!DDTRACE_G(agent_config_reader) && !get_global_DD_TRACE_IGNORE_AGENT_SAMPLING_RATES()) {
         if (get_global_DD_TRACE_SIDECAR_TRACE_SENDER()) {
             if (datadog_endpoint) {
@@ -593,8 +595,6 @@ void ddtrace_rshutdown(bool fast_shutdown) {
         dd_force_shutdown_tracing(fast_shutdown);
     }
 
-    ddtrace_live_debugger_rshutdown();
-
     if (!datadog_disable) {
         dd_shutdown_hooks(fast_shutdown);
 
@@ -610,6 +610,7 @@ void ddtrace_rshutdown(bool fast_shutdown) {
 
     ddtrace_clean_git_object();
     ddtrace_weak_resources_rshutdown();
+    ddtrace_live_debugger_rshutdown();
 }
 
 void ddtrace_post_deactivate(void) {

--- a/tracer/tracer_api.h
+++ b/tracer/tracer_api.h
@@ -15,6 +15,7 @@ void ddtrace_minit_early(int module_number);
 void ddtrace_minit_late(void);
 void ddtrace_mshutdown(void);
 void ddtrace_first_rinit(void);
+void ddtrace_rinit_early(void);
 void ddtrace_rinit(void);
 void ddtrace_rshutdown(bool fast_shutdown);
 void ddtrace_post_deactivate(void);
@@ -33,6 +34,8 @@ void ddtrace_telemetry_finalize(void);
 ddtrace_span_data *ddtrace_active_span(void);
 bool ddtrace_update_remote_config_flags(ddog_RemoteConfigFlags *flags);
 extern ddog_LiveDebuggerSetup ddtrace_live_debugger_setup;
+void ddtrace_live_debugger_rinit(void);
+void ddtrace_live_debugger_rshutdown(void);
 #endif
 
 // Miscellaneous stuff with fallback functions


### PR DESCRIPTION
Fix up after splitting, otherwise e.g. debugger structures aren't initialized yet when sidecar is initialized.

This broke in multi-request scenarios.