### PR TITLE
fix(ci): skip flaky live-debugger probe tests under valgrind

### DIFF
--- a/tests/ext/live-debugger/debugger_enable_dynamic_config.phpt
+++ b/tests/ext/live-debugger/debugger_enable_dynamic_config.phpt
@@ -2,6 +2,7 @@
 Enabling dynamic instrumentation via dynamic configuration
 --SKIPIF--
 <?php include __DIR__ . '/../includes/skipif_no_dev_env.inc'; ?>
+<?php if (getenv('USE_ZEND_ALLOC') === '0' && !getenv("SKIP_ASAN")) die('skip timing sensitive test - valgrind is too slow'); ?>
 --ENV--
 DD_AGENT_HOST=request-replayer
 DD_TRACE_AGENT_PORT=80

--- a/tests/ext/live-debugger/debugger_log_probe.phpt
+++ b/tests/ext/live-debugger/debugger_log_probe.phpt
@@ -2,6 +2,7 @@
 Installing a live debugger log probe
 --SKIPIF--
 <?php include __DIR__ . '/../includes/skipif_no_dev_env.inc'; ?>
+<?php if (getenv('USE_ZEND_ALLOC') === '0' && !getenv("SKIP_ASAN")) die('skip timing sensitive test - valgrind is too slow'); ?>
 --ENV--
 DD_AGENT_HOST=request-replayer
 DD_TRACE_AGENT_PORT=80

--- a/tests/ext/live-debugger/debugger_log_probe_process_tags.phpt
+++ b/tests/ext/live-debugger/debugger_log_probe_process_tags.phpt
@@ -2,6 +2,7 @@
 Live debugger log probe includes process_tags
 --SKIPIF--
 <?php include __DIR__ . '/../includes/skipif_no_dev_env.inc'; ?>
+<?php if (getenv('USE_ZEND_ALLOC') === '0' && !getenv("SKIP_ASAN")) die('skip timing sensitive test - valgrind is too slow'); ?>
 --ENV--
 DD_AGENT_HOST=request-replayer
 DD_TRACE_AGENT_PORT=80

--- a/tests/ext/live-debugger/debugger_span_decoration_probe.phpt
+++ b/tests/ext/live-debugger/debugger_span_decoration_probe.phpt
@@ -2,6 +2,7 @@
 Installing a live debugger span decoration probe
 --SKIPIF--
 <?php include __DIR__ . '/../includes/skipif_no_dev_env.inc'; ?>
+<?php if (getenv('USE_ZEND_ALLOC') === '0' && !getenv("SKIP_ASAN")) die('skip timing sensitive test - valgrind is too slow'); ?>
 --ENV--
 DD_AGENT_HOST=request-replayer
 DD_TRACE_AGENT_PORT=80

--- a/tests/ext/live-debugger/debugger_span_probe.phpt
+++ b/tests/ext/live-debugger/debugger_span_probe.phpt
@@ -2,6 +2,7 @@
 Installing a live debugger span probe
 --SKIPIF--
 <?php include __DIR__ . '/../includes/skipif_no_dev_env.inc'; ?>
+<?php if (getenv('USE_ZEND_ALLOC') === '0' && !getenv("SKIP_ASAN")) die('skip timing sensitive test - valgrind is too slow'); ?>
 --ENV--
 DD_AGENT_HOST=request-replayer
 DD_TRACE_AGENT_PORT=80


### PR DESCRIPTION
Skip 5 flaky `live-debugger` probe tests under valgrind — they exceed the ~15s remote-config probe wait and report `LEAK&FAIL`. Mirrors the existing skip in `debugger_span_probe_class.phpt`; tests still run in the normal pass.