### PR TITLE
fix(test): update crashtracker test for flattened threads format

### DIFF
--- a/tests/ext/crashtracker_collect_all_threads.phpt
+++ b/tests/ext/crashtracker_collect_all_threads.phpt
@@ -91,8 +91,8 @@ $rr->waitForRequest(function ($request) {
             }
 
             $error   = $payload["message"]["error"] ?? null;
-            $threads = $error["threads"]["threads"] ?? null;
-            $count   = $threads !== null ? count($threads) : 0;
+            $threads = $error["threads"] ?? null;
+            $count   = is_array($threads) ? count($threads) : 0;
 
             echo "collect_all_threads enabled: ", ($count > 0 ? "yes" : "no"), PHP_EOL;
             echo "thread count: ", $count, PHP_EOL;


### PR DESCRIPTION
## Summary

- libdatadog commit [`2a659a6eb`](https://github.com/DataDog/libdatadog/pull/2054) (`fix(crashtracking)!: flatten all threads object into a list of ThreadData`) changed the crash report JSON format
- Before: `error.threads.threads` (nested array under a `threads` object)
- After: `error.threads` (direct array of `ThreadData` objects)
- The PHP test was reading the old nested path, getting `null`, and incorrectly reporting `collect_all_threads enabled: no`
- This caused `crashtracker_collect_all_threads.phpt` to fail across **all PHP versions** (7.4–8.5) since the libdatadog update was included in `558a2895f`

## Test plan

- [ ] `test_extension_ci` passes for all PHP versions with `crashtracker_collect_all_threads.phpt` now green

🤖 Generated with [Claude Code](https://claude.com/claude-code)