### PR TITLE
Allow appending SQL comments via DD_DBM_ALWAYS_APPEND_SQL_COMMENT

### DIFF
--- a/metadata/supported-configurations.json
+++ b/metadata/supported-configurations.json
@@ -284,6 +284,13 @@
         "default": "true"
       }
     ],
+    "DD_DBM_ALWAYS_APPEND_SQL_COMMENT": [
+      {
+        "implementation": "A",
+        "type": "boolean",
+        "default": "false"
+      }
+    ],
     "DD_DBM_INJECT_SQL_BASEHASH": [
       {
         "implementation": "A",

--- a/src/DDTrace/Integrations/DatabaseIntegrationHelper.php
+++ b/src/DDTrace/Integrations/DatabaseIntegrationHelper.php
@@ -32,7 +32,7 @@ class DatabaseIntegrationHelper
             "odbc" => true,
         ];
 
-        $propagationMode = dd_trace_env_config("DD_DBM_PROPAGATION_MODE");
+        $propagationMode = \dd_trace_env_config("DD_DBM_PROPAGATION_MODE");
         if ($propagationMode != \DDTrace\DBM_PROPAGATION_DISABLED && isset($allowedBackends[$backend])) {
             $fullPropagationBackends = [
                 "mysql" => true,
@@ -49,12 +49,14 @@ class DatabaseIntegrationHelper
             $peerService = $span->meta['peer.service'] ?? '';
 
             // Inject base hash into span tags if enabled
-            if (dd_trace_env_config("DD_DBM_INJECT_SQL_BASEHASH")) {
+            if (\dd_trace_env_config("DD_DBM_INJECT_SQL_BASEHASH")) {
                 $baseHash = \DDTrace\System\process_tags_base_hash();
                 if ($baseHash !== null) {
                     $span->meta[Tag::PROPAGATED_HASH] = $baseHash;
                 }
             }
+
+            $append = $backend === "sqlsrv" || \dd_trace_env_config("DD_DBM_ALWAYS_APPEND_SQL_COMMENT");
 
             $query = self::propagateViaSqlComments(
                 $hook->args[$argNum],
@@ -62,7 +64,8 @@ class DatabaseIntegrationHelper
                 $propagationMode,
                 $targetHost,
                 $dbName,
-                $peerService
+                $peerService,
+                $append
             );
             $hook->args[$argNum] = $query;
             $hook->overrideArguments($hook->args);
@@ -78,7 +81,8 @@ class DatabaseIntegrationHelper
         $mode = \DDTrace\DBM_PROPAGATION_FULL,
         $targetHost = '',
         $dbName = '',
-        $peerService = ''
+        $peerService = '',
+        $append = false
     ) {
         $rootSpan = \DDTrace\root_span();
 
@@ -136,17 +140,17 @@ class DatabaseIntegrationHelper
         }
 
         // Inject base hash into SQL comment if enabled
-        if (dd_trace_env_config("DD_DBM_INJECT_SQL_BASEHASH")) {
+        if (\dd_trace_env_config("DD_DBM_INJECT_SQL_BASEHASH")) {
             $baseHash = \DDTrace\System\process_tags_base_hash();
             if ($baseHash !== null) {
                 $tags["ddsh"] = $baseHash;
             }
         }
 
-        return self::injectSqlComment($query, $tags);
+        return self::injectSqlComment($query, $tags, $append);
     }
 
-    public static function injectSqlComment($query, array $tags)
+    public static function injectSqlComment($query, array $tags, $append = false)
     {
         if (!$tags) {
             return $query;
@@ -162,6 +166,9 @@ class DatabaseIntegrationHelper
 
         if ($query == "") {
             return $comment;
+        }
+        if ($append) {
+            return "$query $comment";
         }
         return "$comment $query";
     }

--- a/tooling/generate-supported-configurations.sh
+++ b/tooling/generate-supported-configurations.sh
@@ -17,7 +17,7 @@ readonly PROFILING_CONFIG_FILE="profiling/src/config.rs"
 readonly GENERATOR_SCRIPT_FILE="tooling/generate-supported-configurations.sh"
 readonly CONFIG_GENERATION_INPUT_FILES=(
     "${CONFIG_HEADER_FILES[@]}"
-    "${OTEL_CONFIG_FILE[@]}"
+    "${OTEL_CONFIG_FILES[@]}"
     "${PROFILING_CONFIG_FILE}"
     "${GENERATOR_SCRIPT_FILE}"
 )

--- a/tracer/configuration.h
+++ b/tracer/configuration.h
@@ -129,6 +129,7 @@
     CONFIG(BOOL, DD_TRACE_PROPAGATE_USER_ID_DEFAULT, "false")                                                  \
     CONFIG(CUSTOM(INT), DD_DBM_PROPAGATION_MODE, "disabled", .parser = dd_parse_dbm_mode)                      \
     CONFIG(BOOL, DD_DBM_INJECT_SQL_BASEHASH, "false")                                                          \
+    CONFIG(BOOL, DD_DBM_ALWAYS_APPEND_SQL_COMMENT, "false")                                                    \
     CONFIG(SET, DD_TRACE_WORDPRESS_ADDITIONAL_ACTIONS, "")                                                     \
     CONFIG(BOOL, DD_TRACE_WORDPRESS_CALLBACKS, "true")                                                         \
     CONFIG(BOOL, DD_INTEGRATION_METRICS_ENABLED, "true",                                                       \


### PR DESCRIPTION
Modeled after https://github.com/DataDog/dd-trace-java/pull/9798.

Fixes #3951.