### PR TITLE
test: add block-insecure: false to unblock CI

### DIFF
--- a/appsec/tests/integration/src/test/www/laravel8x/composer.json
+++ b/appsec/tests/integration/src/test/www/laravel8x/composer.json
@@ -55,7 +55,10 @@
     "config": {
         "optimize-autoloader": true,
         "preferred-install": "dist",
-        "sort-packages": true
+        "sort-packages": true,
+        "audit": {
+            "block-insecure": false
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true

--- a/tests/Frameworks/Laravel/Latest/composer.json
+++ b/tests/Frameworks/Laravel/Latest/composer.json
@@ -64,6 +64,9 @@
         "allow-plugins": {
             "pestphp/pest-plugin": true,
             "php-http/discovery": true
+        },
+        "audit": {
+            "block-insecure": false
         }
     },
     "minimum-stability": "stable",

--- a/tests/Frameworks/Laravel/Octane/Latest/composer.json
+++ b/tests/Frameworks/Laravel/Octane/Latest/composer.json
@@ -63,6 +63,9 @@
         "allow-plugins": {
             "pestphp/pest-plugin": true,
             "php-http/discovery": true
+        },
+        "audit": {
+            "block-insecure": false
         }
     },
     "minimum-stability": "stable",

--- a/tests/Frameworks/Laravel/Version_10_x/composer.json
+++ b/tests/Frameworks/Laravel/Version_10_x/composer.json
@@ -62,6 +62,9 @@
         "allow-plugins": {
             "pestphp/pest-plugin": true,
             "php-http/discovery": true
+        },
+        "audit": {
+            "block-insecure": false
         }
     },
     "minimum-stability": "stable",

--- a/tests/Frameworks/Laravel/Version_11_x/composer.json
+++ b/tests/Frameworks/Laravel/Version_11_x/composer.json
@@ -61,6 +61,9 @@
         "allow-plugins": {
             "pestphp/pest-plugin": true,
             "php-http/discovery": true
+        },
+        "audit": {
+            "block-insecure": false
         }
     },
     "minimum-stability": "stable",

--- a/tests/Frameworks/Lumen/Version_10_0/composer.json
+++ b/tests/Frameworks/Lumen/Version_10_0/composer.json
@@ -33,7 +33,10 @@
     "config": {
         "optimize-autoloader": true,
         "preferred-install": "dist",
-        "sort-packages": true
+        "sort-packages": true,
+        "audit": {
+            "block-insecure": false
+        }
     },
     "minimum-stability": "stable",
     "prefer-stable": true

--- a/tests/Frameworks/Lumen/Version_8_1/composer.json
+++ b/tests/Frameworks/Lumen/Version_8_1/composer.json
@@ -28,7 +28,10 @@
     "config": {
         "preferred-install": "dist",
         "sort-packages": true,
-        "optimize-autoloader": true
+        "optimize-autoloader": true,
+        "audit": {
+            "block-insecure": false
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true,


### PR DESCRIPTION
### Description

Composer 2.10 was released and it blocks certain versions we test against. For now, let's allow them to restore a greener CI and we can discuss if something else should be done.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
