### PR TITLE
Fix remote config notifications in forks

### DIFF
--- a/.gitlab/libdatadog-latest-prompt.md
+++ b/.gitlab/libdatadog-latest-prompt.md
@@ -46,7 +46,7 @@ Do not try to work around these — report them in `tmp/REPORT.md` and leave the
 
 - A panic or unexpected behaviour coming from *inside* libdatadog (not from our code calling it incorrectly)
 - A regression where functionality that previously worked no longer does (and there is no obvious new API to call instead)
-- An API change so large it would require significant redesign of our architecture
+- An API change so large it would require significant redesign of our architecture. But first give it a try! Maybe it's not that bad.
 
 ### Ignore (test flakiness or unrelated failures)
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1187,6 +1187,7 @@ name = "datadog-ffe"
 version = "1.0.0"
 dependencies = [
  "chrono",
+ "datadog-remote-config",
  "derive_more",
  "faststr",
  "libdd-common",
@@ -1255,6 +1256,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "constcat",
+ "datadog-remote-config",
  "http",
  "http-body-util",
  "libdd-common",
@@ -1376,8 +1378,6 @@ version = "0.0.1"
 dependencies = [
  "anyhow",
  "base64 0.22.1",
- "datadog-ffe",
- "datadog-live-debugger",
  "datadog-remote-config",
  "futures",
  "futures-util",
@@ -1392,6 +1392,7 @@ dependencies = [
  "serde_json",
  "serde_with",
  "sha2",
+ "thiserror 2.0.12",
  "time",
  "tokio",
  "tokio-util",
@@ -1439,7 +1440,6 @@ dependencies = [
  "nix 0.29.0",
  "prctl",
  "priority-queue",
- "prost",
  "rand 0.8.5",
  "rmp-serde",
  "sendfd",

--- a/components-rs/Cargo.toml
+++ b/components-rs/Cargo.toml
@@ -16,7 +16,7 @@ datadog-live-debugger = { path = "../libdatadog/datadog-live-debugger" }
 datadog-live-debugger-ffi = { path = "../libdatadog/datadog-live-debugger-ffi", default-features = false }
 datadog-ipc = { path = "../libdatadog/datadog-ipc" }
 datadog-ffe = { path = "../libdatadog/datadog-ffe" }
-datadog-remote-config = { path = "../libdatadog/datadog-remote-config", features = ["ffe"] }
+datadog-remote-config = { path = "../libdatadog/datadog-remote-config" }
 datadog-sidecar = { path = "../libdatadog/datadog-sidecar" }
 datadog-sidecar-ffi = { path = "../libdatadog/datadog-sidecar-ffi" }
 libdd-data-pipeline = { path = "../libdatadog/libdd-data-pipeline" }

--- a/components-rs/datadog.h
+++ b/components-rs/datadog.h
@@ -139,6 +139,8 @@ void ddog_init_remote_config(struct ddog_RemoteConfigFlags flags);
 struct ddog_RemoteConfigState *ddog_init_remote_config_state(const struct ddog_Endpoint *endpoint,
                                                              bool di_enabled);
 
+uint64_t ddog_remote_config_current_generation(const struct ddog_RemoteConfigState *remote_config);
+
 const char *ddog_remote_config_get_path(const struct ddog_RemoteConfigState *remote_config);
 
 bool ddog_process_remote_configs(struct ddog_RemoteConfigState *remote_config);

--- a/components-rs/remote_config.rs
+++ b/components-rs/remote_config.rs
@@ -1,5 +1,5 @@
 use crate::sidecar::MaybeShmLimiter;
-use datadog_ffe::rules_based::Configuration;
+use datadog_ffe::rules_based::{Configuration, UniversalFlagConfig};
 use datadog_live_debugger::debugger_defs::{DebuggerData, DebuggerPayload};
 use datadog_live_debugger::{FilterList, LiveDebuggingData, ServiceConfiguration};
 use datadog_live_debugger_ffi::data::Probe;
@@ -7,11 +7,11 @@ use datadog_live_debugger_ffi::evaluator::{ddog_register_expr_evaluator, Evaluat
 use datadog_live_debugger_ffi::send_data::{
     ddog_debugger_diagnostics_create_unboxed, ddog_snapshot_redacted_type,
 };
+use datadog_remote_config::config::dynamic::{Configs, DynamicConfigFile, TracingSamplingRuleProvenance};
 use datadog_remote_config::fetch::ConfigInvariants;
 use datadog_remote_config::{
-    RemoteConfigCapabilities, RemoteConfigData, RemoteConfigProduct, Target,
+    default_registry, RemoteConfigCapabilities, RemoteConfigParsed, RemoteConfigProduct, Target,
 };
-use datadog_remote_config::config::dynamic::{Configs, TracingSamplingRuleProvenance};
 use datadog_sidecar::service::blocking::SidecarTransport;
 use datadog_sidecar::service::{InstanceId, QueueId};
 use datadog_sidecar::shm_remote_config::{RemoteConfigManager, RemoteConfigUpdate};
@@ -110,7 +110,7 @@ pub struct LiveDebuggerCallbacks {
 #[derive(Default)]
 pub struct LiveDebuggerState {
     pub spans_map: HashMap<String, i64>,
-    pub active: HashMap<String, Box<(LiveDebuggingData, MaybeShmLimiter)>>,
+    pub active: HashMap<String, (RemoteConfigParsed, MaybeShmLimiter)>,
     pub config_id: String,
     pub allow_dfa: Option<Regex>,
     pub deny_dfa: Option<Regex>,
@@ -204,12 +204,20 @@ pub unsafe extern "C" fn ddog_init_remote_config_state(
     endpoint: &Endpoint,
     di_enabled: bool,
 ) -> Box<RemoteConfigState> {
+    #[allow(clippy::expect_used)]
+    let registry = Arc::new(
+        default_registry()
+            .with::<LiveDebuggingData>()
+            .expect("LiveDebugger is distinct from default products")
+            .with::<UniversalFlagConfig>()
+            .expect("FFE is distinct from default products"),
+    );
     Box::new(RemoteConfigState {
-        manager: RemoteConfigManager::new(ConfigInvariants {
+        manager: RemoteConfigManager::new_with_registry(ConfigInvariants {
             language: "php".to_string(),
             tracer_version: include_str!("../VERSION").trim().into(),
             endpoint: endpoint.clone(),
-        }),
+        }, registry),
         live_debugger: LiveDebuggerState {
             di_enabled,
             ..Default::default()
@@ -355,6 +363,11 @@ fn insert_new_configs(
 }
 
 #[no_mangle]
+pub extern "C" fn ddog_remote_config_current_generation(remote_config: &RemoteConfigState) -> u64 {
+    remote_config.manager.current_remote_config_generation()
+}
+
+#[no_mangle]
 pub extern "C" fn ddog_remote_config_get_path(remote_config: &RemoteConfigState) -> *const c_char {
     remote_config
         .manager
@@ -373,47 +386,62 @@ pub extern "C" fn ddog_process_remote_configs(remote_config: &mut RemoteConfigSt
             RemoteConfigUpdate::Add {
                 value,
                 limiter_index,
-            } => match value.data {
-                RemoteConfigData::LiveDebugger(debugger) => {
-                    let val = Box::new((debugger, MaybeShmLimiter::open(limiter_index)));
-                    let rc_ref = unsafe { mem::transmute(remote_config as *mut _) }; // sigh, borrow checker
-                    let entry = remote_config.live_debugger.active.entry(value.config_id);
-                    let (debugger, limiter) = &mut **match entry {
-                        Entry::Occupied(mut e) => {
-                            e.insert(val);
-                            e.into_mut()
+            } => {
+                if let Some(data) = value.data {
+                    match value.product {
+                        RemoteConfigProduct::LiveDebugger => {
+                            let val = (data, MaybeShmLimiter::open(limiter_index));
+                            let rc_ref: &mut RemoteConfigState = unsafe { mem::transmute(remote_config as *mut _) }; // sigh, borrow checker
+                            let entry = remote_config.live_debugger.active.entry(value.config_id);
+                            let (parsed, limiter) = match entry {
+                                Entry::Occupied(mut e) => {
+                                    e.insert(val);
+                                    let r = e.into_mut();
+                                    (&r.0, &r.1)
+                                }
+                                Entry::Vacant(e) => {
+                                    let r = e.insert(val);
+                                    (&r.0, &r.1)
+                                }
+                            };
+                            if let Some(debugger) = parsed.downcast::<LiveDebuggingData>() {
+                                apply_config(rc_ref, debugger, limiter);
+                            }
                         }
-                        Entry::Vacant(e) => e.insert(val),
-                    };
-                    apply_config(rc_ref, debugger, limiter);
-                }
-                RemoteConfigData::DynamicConfig(config_data) => {
-                    let priority = config_data.priority();
-                    let configs: Vec<Configs> = config_data.lib_config.into();
-                    if !configs.is_empty() {
-                        remote_config.dynamic_config.active_configs
-                            .insert(value.config_id, ActiveDynamicConfig { priority, configs });
-                        let merged = compute_merged_configs(&remote_config.dynamic_config.active_configs);
-                        insert_new_configs(
-                            &mut remote_config.dynamic_config.old_config_values,
-                            &mut remote_config.dynamic_config.merged_configs,
-                            merged,
-                        );
+                        RemoteConfigProduct::ApmTracing => {
+                            if let Some(config_data) = data.downcast::<DynamicConfigFile>() {
+                                let priority = config_data.priority();
+                                let configs: Vec<Configs> = config_data.lib_config.clone().into();
+                                if !configs.is_empty() {
+                                    remote_config.dynamic_config.active_configs
+                                        .insert(value.config_id, ActiveDynamicConfig { priority, configs });
+                                    let merged = compute_merged_configs(&remote_config.dynamic_config.active_configs);
+                                    insert_new_configs(
+                                        &mut remote_config.dynamic_config.old_config_values,
+                                        &mut remote_config.dynamic_config.merged_configs,
+                                        merged,
+                                    );
+                                }
+                            }
+                        }
+                        RemoteConfigProduct::FfeFlags => {
+                            debug!("Received FFE flags configuration");
+                            if let Some(ufc) = data.downcast::<UniversalFlagConfig>() {
+                                if let Ok(ufc_owned) = UniversalFlagConfig::from_json(ufc.to_json().to_vec()) {
+                                    crate::ffe::store_config(Configuration::from_server_response(ufc_owned));
+                                }
+                            }
+                        }
+                        _ => {}
                     }
                 }
-                RemoteConfigData::FfeFlags(ufc) => {
-                    debug!("Received FFE flags configuration");
-                    crate::ffe::store_config(Configuration::from_server_response(ufc));
-                }
-                RemoteConfigData::Ignored(_) => (),
-                RemoteConfigData::TracerFlareConfig(_) => {}
-                RemoteConfigData::TracerFlareTask(_) => {}
-            },
+            }
             RemoteConfigUpdate::Remove(path) => match path.product {
                 RemoteConfigProduct::LiveDebugger => {
-                    if let Some(boxed) = remote_config.live_debugger.active.remove(&path.config_id)
-                    {
-                        remove_config(remote_config, &boxed.0);
+                    if let Some((parsed, _)) = remote_config.live_debugger.active.remove(&path.config_id) {
+                        if let Some(debugger) = parsed.downcast::<LiveDebuggingData>() {
+                            remove_config(remote_config, debugger);
+                        }
                     }
                 }
                 RemoteConfigProduct::ApmTracing => {
@@ -524,12 +552,14 @@ fn remove_config(remote_config: &mut RemoteConfigState, debugger: &LiveDebugging
 pub extern "C" fn ddog_remote_config_get_loaded_configs(remote_config: &RemoteConfigState) -> *mut c_char {
     let mut entries: Vec<(String, String)> = Vec::new();
 
-    for (config_id, boxed) in &remote_config.live_debugger.active {
-        let value = match &boxed.0 {
-            LiveDebuggingData::Probe(p) => format!(r#"{{"type":"probe","id":"{}"}}"#, p.id),
-            LiveDebuggingData::ServiceConfiguration(sc) => format!(r#"{{"type":"service_config","id":"{}"}}"#, sc.id),
-        };
-        entries.push((config_id.clone(), value));
+    for (config_id, (parsed, _)) in &remote_config.live_debugger.active {
+        if let Some(debugger) = parsed.downcast::<LiveDebuggingData>() {
+            let value = match debugger {
+                LiveDebuggingData::Probe(p) => format!(r#"{{"type":"probe","id":"{}"}}"#, p.id),
+                LiveDebuggingData::ServiceConfiguration(sc) => format!(r#"{{"type":"service_config","id":"{}"}}"#, sc.id),
+            };
+            entries.push((config_id.clone(), value));
+        }
     }
 
     for config_id in remote_config.dynamic_config.active_configs.keys() {
@@ -580,12 +610,12 @@ pub extern "C" fn ddog_type_can_be_instrumented(
 
 #[no_mangle]
 pub extern "C" fn ddog_global_log_probe_limiter_inc(remote_config: &RemoteConfigState) -> bool {
-    if let Some(boxed) = remote_config
+    if let Some((parsed, limiter)) = remote_config
         .live_debugger
         .active
         .get(&remote_config.live_debugger.config_id)
     {
-        if let (LiveDebuggingData::ServiceConfiguration(config), limiter) = &**boxed {
+        if let Some(LiveDebuggingData::ServiceConfiguration(config)) = parsed.downcast::<LiveDebuggingData>() {
             limiter.inc(config.sampling_snapshots_per_second)
         } else {
             true
@@ -690,8 +720,8 @@ pub extern "C" fn ddog_set_dynamic_instrumentation_enabled(
             }
         } else {
             // Reinstall all probes currently stored in `active`.
-            for (probe_id, boxed) in remote_config.live_debugger.active.iter() {
-                if let (LiveDebuggingData::Probe(probe), limiter) = &**boxed {
+            for (probe_id, (parsed, limiter)) in remote_config.live_debugger.active.iter() {
+                if let Some(LiveDebuggingData::Probe(probe)) = parsed.downcast::<LiveDebuggingData>() {
                     let hook_id = (callbacks.set_probe)(probe.into(), limiter);
                     if hook_id >= 0 {
                         remote_config

--- a/components-rs/sidecar.h
+++ b/components-rs/sidecar.h
@@ -343,7 +343,8 @@ ddog_MaybeError ddog_sidecar_set_universal_service_tags(struct ddog_SidecarTrans
                                                         ddog_CharSlice env_name,
                                                         ddog_CharSlice app_version,
                                                         const struct ddog_Vec_Tag *global_tags,
-                                                        enum ddog_DynamicInstrumentationConfigState dynamic_instrumentation_state);
+                                                        enum ddog_DynamicInstrumentationConfigState dynamic_instrumentation_state,
+                                                        uint64_t remote_config_generation);
 
 ddog_MaybeError ddog_sidecar_set_request_config(struct ddog_SidecarTransport **transport,
                                                 const struct ddog_InstanceId *instance_id,

--- a/ext/datadog.c
+++ b/ext/datadog.c
@@ -705,7 +705,6 @@ static PHP_MINFO_FUNCTION(datadog) {
 void datadog_internal_handle_fork(void) {
     // CHILD PROCESS
     datadog_sidecar_handle_fork();
-    datadog_generate_runtime_id();
 
 #ifdef DDTRACE
     ddtrace_internal_handle_fork();

--- a/ext/datadog.c
+++ b/ext/datadog.c
@@ -138,15 +138,17 @@ static int datadog_startup(zend_extension *extension) {
     }
 
 #ifdef DDTRACE
-    ddtrace_startup(extension);
+    ddtrace_startup();
 #endif
 
     return SUCCESS;
 }
 
 static void datadog_shutdown(zend_extension *extension) {
-#ifdef DDTRACE
-    ddtrace_shutdown(extension);
+    UNUSED(extension);
+
+    #ifdef DDTRACE
+    ddtrace_shutdown();
 #endif
 }
 
@@ -703,22 +705,12 @@ static PHP_MINFO_FUNCTION(datadog) {
 void datadog_internal_handle_fork(void) {
     // CHILD PROCESS
     datadog_sidecar_handle_fork();
-    if (DDTRACE_G(agent_config_reader)) {
-        ddog_agent_remote_config_reader_drop(DDTRACE_G(agent_config_reader));
-        DDTRACE_G(agent_config_reader) = NULL;
-    }
-    if (DATADOG_G(remote_config_state)) {
-        ddog_shutdown_remote_config(DATADOG_G(remote_config_state));
-        DATADOG_G(remote_config_state) = NULL;
-    }
-    if (DATADOG_G(agent_info_reader)) {
-        ddog_drop_agent_info_reader(DATADOG_G(agent_info_reader));
-        DATADOG_G(agent_info_reader) = NULL;
-    }
     datadog_generate_runtime_id();
 
 #ifdef DDTRACE
     ddtrace_internal_handle_fork();
+#else
+    ddtrace_sidecar_submit_span_data_direct_defaults(&DATADOG_G(sidecar), NULL);
 #endif
 }
 

--- a/ext/sidecar.c
+++ b/ext/sidecar.c
@@ -175,9 +175,12 @@ static void dd_sidecar_on_reconnect(ddog_SidecarTransport *transport) {
         ddog_CharSlice service_name = dd_zend_string_to_CharSlice(DATADOG_G(last_service_name));
         ddog_CharSlice env_name = dd_zend_string_to_CharSlice(DATADOG_G(last_env_name));
         ddog_CharSlice version = dd_zend_string_to_CharSlice(DATADOG_G(last_version));
+        uint64_t remote_config_generation = DATADOG_G(remote_config_state)
+            ? ddog_remote_config_current_generation(DATADOG_G(remote_config_state))
+            : 0;
         datadog_ffi_try("Failed sending config data",
                         ddog_sidecar_set_universal_service_tags(&transport, datadog_sidecar_instance_id, &DATADOG_G(sidecar_queue_id), service_name,
-                                                                env_name, version, &DATADOG_G(active_global_tags), ddtrace_dynamic_instrumentation_state()));
+                                                                env_name, version, &DATADOG_G(active_global_tags), ddtrace_dynamic_instrumentation_state(), remote_config_generation));
     }
 
     tsrm_mutex_unlock(DATADOG_G(sidecar_universal_service_tags_mutex));
@@ -566,6 +569,7 @@ void datadog_sidecar_shutdown(void) {
 void datadog_force_new_instance_id(void) {
     if (datadog_sidecar_instance_id) {
         ddog_sidecar_instanceId_drop(datadog_sidecar_instance_id);
+        datadog_generate_runtime_id();
         dd_set_resettable_sidecar_globals();
     }
 }
@@ -745,8 +749,11 @@ void ddtrace_sidecar_submit_span_data_direct(ddog_SidecarTransport **transport, 
         tsrm_mutex_unlock(DATADOG_G(sidecar_universal_service_tags_mutex));
 
         // This must not be in mutex, as a reconnect may happen here
+        uint64_t remote_config_generation = DATADOG_G(remote_config_state)
+            ? ddog_remote_config_current_generation(DATADOG_G(remote_config_state))
+            : 0;
         datadog_ffi_try("Failed sending config data",
-                        ddog_sidecar_set_universal_service_tags(transport, datadog_sidecar_instance_id, &DATADOG_G(sidecar_queue_id), service_slice, env_slice, version_slice, &DATADOG_G(active_global_tags), ddtrace_dynamic_instrumentation_state()));
+                        ddog_sidecar_set_universal_service_tags(transport, datadog_sidecar_instance_id, &DATADOG_G(sidecar_queue_id), service_slice, env_slice, version_slice, &DATADOG_G(active_global_tags), ddtrace_dynamic_instrumentation_state(), remote_config_generation));
     } else {
         zend_string_release(service_string);
         zend_string_release(env_string);
@@ -810,8 +817,10 @@ void datadog_sidecar_gshutdown(zend_datadog_globals *datadog_globals) {
 
 bool datadog_alter_test_session_token(zval *old_value, zval *new_value, zend_string *new_str) {
     UNUSED(old_value, new_str);
-    if (DATADOG_G(sidecar)) {
+    if (datadog_endpoint) {
         ddog_endpoint_set_test_token(datadog_endpoint, dd_zend_string_to_CharSlice(Z_STR_P(new_value)));
+    }
+    if (DATADOG_G(sidecar)) {
         datadog_ffi_try("Failed updating test session token",
                         ddog_sidecar_set_test_session_token(&DATADOG_G(sidecar), dd_zend_string_to_CharSlice(Z_STR_P(new_value))));
     }

--- a/tests/ext/http_endpoint_resource_renaming_basic.phpt
+++ b/tests/ext/http_endpoint_resource_renaming_basic.phpt
@@ -7,8 +7,6 @@ DD_TRACE_AUTO_FLUSH_ENABLED=false
 <?php
 use DDTrace\SpanData;
 
-//sleep(10);
-
 function test_endpoint($path) {
     // create a root span manually
     $root_span = DDTrace\start_trace_span();

--- a/tests/ext/remote_config/dynamic_config_auto_update.phpt
+++ b/tests/ext/remote_config/dynamic_config_auto_update.phpt
@@ -32,7 +32,7 @@ $path = put_dynamic_config_file([
     "code_origin_enabled" => false,
 ]);
 
-sleep(20); // signal interrupts interrupt the sleep().
+dd_trace_internal_fn("await_remote_config");
 
 var_dump(ini_get("datadog.logs_injection"));
 var_dump(ini_get("datadog.dynamic_instrumentation.enabled"));
@@ -42,7 +42,7 @@ var_dump(ini_get("datadog.code_origin_for_spans_enabled"));
 del_rc_file($path);
 
 print "After RC:\n";
-sleep(20);
+dd_trace_internal_fn("await_remote_config");
 
 var_dump(ini_get("datadog.logs_injection"));
 var_dump(ini_get("datadog.dynamic_instrumentation.enabled"));

--- a/tests/ext/remote_config/dynamic_config_multiconfig.phpt
+++ b/tests/ext/remote_config/dynamic_config_multiconfig.phpt
@@ -31,7 +31,7 @@ $specific_path = put_dynamic_config_file([
     "tracing_sample_rate" => 0.7,
 ]);
 
-sleep(20); // signal interrupts interrupt the sleep().
+dd_trace_internal_fn("await_remote_config");
 
 // Specific config wins for sample_rate; org-level provides log_injection.
 print "After both configs:\n";
@@ -40,7 +40,7 @@ var_dump(ini_get("datadog.logs_injection"));
 
 del_rc_file($specific_path);
 
-sleep(20); // signal interrupts interrupt the sleep().
+dd_trace_internal_fn("await_remote_config");
 
 // Only org-level remains: sample_rate falls back to 0.3.
 print "After removing specific config:\n";

--- a/tests/ext/remote_config/dynamic_config_update.phpt
+++ b/tests/ext/remote_config/dynamic_config_update.phpt
@@ -51,7 +51,7 @@ put_dynamic_config_file([
 \DDTrace\start_span();
 
 if (ini_get("datadog.trace.sample_rate") != 0.5) {
-    sleep(20); // signal interrupts interrupt the sleep().
+    dd_trace_internal_fn("await_remote_config");
 }
 
 var_dump(ini_get("datadog.trace.sample_rate"));

--- a/tests/ext/remote_config/rc_fork_notify.phpt
+++ b/tests/ext/remote_config/rc_fork_notify.phpt
@@ -3,6 +3,7 @@ RC notifications must appear in forked processes
 --SKIPIF--
 <?php
 include __DIR__ . '/../includes/skipif_no_dev_env.inc';
+if (!extension_loaded('pcntl')) die('skip: pcntl extension required');
 ?>
 --ENV--
 DD_AGENT_HOST=request-replayer

--- a/tests/ext/remote_config/rc_fork_notify.phpt
+++ b/tests/ext/remote_config/rc_fork_notify.phpt
@@ -1,0 +1,35 @@
+--TEST--
+RC notifications must appear in forked processes
+--SKIPIF--
+<?php
+include __DIR__ . '/../includes/skipif_no_dev_env.inc';
+?>
+--ENV--
+DD_AGENT_HOST=request-replayer
+DD_TRACE_AGENT_PORT=80
+DD_TRACE_ENABLED=0
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS=0.1
+DD_TRACE_AGENT_TEST_SESSION_TOKEN=remote-config/rc_fork_notify
+--FILE--
+<?php
+
+if (!pcntl_fork()) {
+    require __DIR__ . "/remote_config.inc";
+    put_dynamic_config_file(["tracing_enabled" => true]);
+}
+
+if (!ini_get("datadog.trace.enabled")) {
+    dd_trace_internal_fn("await_remote_config");
+}
+
+print ini_get("datadog.trace.enabled");
+
+?>
+--CLEAN--
+<?php
+require __DIR__ . "/remote_config.inc";
+reset_request_replayer();
+?>
+--EXPECT--
+11

--- a/tests/ext/remote_config/rc_trace_enabled_rinit.phpt
+++ b/tests/ext/remote_config/rc_trace_enabled_rinit.phpt
@@ -3,6 +3,7 @@ RC tracing_enabled=true during RINIT does not double-init request globals
 --SKIPIF--
 <?php
 include __DIR__ . '/../includes/skipif_no_dev_env.inc';
+if (!extension_loaded('pcntl')) die('skip: pcntl extension required');
 ?>
 --ENV--
 DD_AGENT_HOST=request-replayer

--- a/tests/ext/remote_config/rc_trace_enabled_rinit.phpt
+++ b/tests/ext/remote_config/rc_trace_enabled_rinit.phpt
@@ -1,0 +1,46 @@
+--TEST--
+RC tracing_enabled=true during RINIT does not double-init request globals
+--SKIPIF--
+<?php
+include __DIR__ . '/../includes/skipif_no_dev_env.inc';
+?>
+--ENV--
+DD_AGENT_HOST=request-replayer
+DD_TRACE_AGENT_PORT=80
+DD_TRACE_ENABLED=0
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS=0.1
+DD_TRACE_AGENT_TEST_SESSION_TOKEN=remote-config/rc_trace_enabled_rinit
+--FILE--
+<?php
+
+if ($argc > 1) {
+    var_dump(ini_get("datadog.trace.enabled"));
+    exit();
+}
+
+require __DIR__ . "/remote_config.inc";
+put_dynamic_config_file(["tracing_enabled" => true]);
+
+if (!ini_get("datadog.trace.enabled")) {
+    dd_trace_internal_fn("await_remote_config");
+}
+
+var_dump(ini_get("datadog.trace.enabled"));
+
+$cmdAndArgs = explode("\0", file_get_contents("/proc/" . getmypid() . "/cmdline"));
+if (!pcntl_fork()) {
+    pcntl_exec(array_shift($cmdAndArgs), array_merge($cmdAndArgs, ["initialized"]));
+} else {
+    pcntl_wait($status);
+}
+
+?>
+--CLEAN--
+<?php
+require __DIR__ . "/remote_config.inc";
+reset_request_replayer();
+?>
+--EXPECT--
+string(1) "1"
+string(1) "1"

--- a/tracer/ddtrace.c
+++ b/tracer/ddtrace.c
@@ -76,7 +76,7 @@
 _Atomic(int64_t) ddtrace_warn_legacy_api;
 
 // put this into startup so that other extensions running code as part of rinit do not crash
-int ddtrace_startup(zend_extension *extension) {
+int ddtrace_startup() {
 #if PHP_VERSION_ID < 80000
     zai_interceptor_startup(datadog_module);
 #else
@@ -93,9 +93,7 @@ int ddtrace_startup(zend_extension *extension) {
     return SUCCESS;
 }
 
-void ddtrace_shutdown(zend_extension *extension) {
-    UNUSED(extension);
-
+void ddtrace_shutdown() {
     if (datadog_disable != 1) {
         ddtrace_internal_handlers_shutdown();
     }
@@ -231,6 +229,8 @@ void ddtrace_activate_late(void) {
 void ddtrace_ginit(zend_datadog_globals *ddtrace_globals) {
 #if PHP_VERSION_ID < 70100
     zai_vm_interrupt = &ddtrace_globals->zai_vm_interrupt;
+#else
+    UNUSED(ddtrace_globals);
 #endif
     zai_hook_ginit();
 }
@@ -489,10 +489,10 @@ void ddtrace_rinit_early(void) {
     ddtrace_live_debugger_rinit();
 
     if (!datadog_disable) {
+        DDTRACE_G(active_stack) = NULL; // This should not be necessary, but somehow sometimes it may be a leftover from a previous request.
+
         // With internal functions also being hookable, they must not be hooked before the CG(map_ptr_base) is zeroed
         zai_hook_activate();
-        DDTRACE_G(active_stack) = NULL; // This should not be necessary, but somehow sometimes it may be a leftover from a previous request.
-        DDTRACE_G(active_stack) = ddtrace_init_root_span_stack();
 #if PHP_VERSION_ID < 80000
         ddtrace_autoload_rinit();
 #endif
@@ -510,6 +510,10 @@ void ddtrace_rinit(void) {
             ddog_agent_remote_config_reader_for_anon_shm(ddtrace_coms_agent_config_handle, &DDTRACE_G(agent_config_reader));
 #endif
         }
+    }
+
+    if (!datadog_disable) {
+        DDTRACE_G(active_stack) = ddtrace_init_root_span_stack();
     }
 
     if (get_DD_TRACE_ENABLED()) {
@@ -687,11 +691,18 @@ void ddtrace_internal_handle_postfork() {
 
 void ddtrace_internal_handle_fork() {
     if (DATADOG_G(sidecar)) {
-        ddtrace_sidecar_submit_root_span_data();
+        // Unconditionally send, even if root span is NULL
+        ddtrace_span_data *root = DDTRACE_G(active_stack) && DDTRACE_G(active_stack)->root_span ? &DDTRACE_G(active_stack)->root_span->span : NULL;
+        ddtrace_sidecar_submit_span_data_direct_defaults(&DATADOG_G(sidecar), root);
     }
 
 #ifndef _WIN32
     if (!get_global_DD_TRACE_SIDECAR_TRACE_SENDER()) {
+        if (DDTRACE_G(agent_config_reader)) {
+            ddog_agent_remote_config_reader_drop(DDTRACE_G(agent_config_reader));
+            DDTRACE_G(agent_config_reader) = NULL;
+        }
+
         ddtrace_coms_curl_shutdown();
         ddtrace_coms_clean_background_sender_after_fork();
     }

--- a/tracer/functions.c
+++ b/tracer/functions.c
@@ -2084,9 +2084,13 @@ PHP_FUNCTION(dd_trace_internal_fn) {
             } else {
                 array_init(return_value);
             }
-        } else if (FUNCTION_NAME_MATCHES("get_remote_config_state")) {
-            // Returns a placeholder; actual state is accessed via globals
-            RETVAL_LONG((zend_long)(uintptr_t)DATADOG_G(remote_config_state));
+        } else if (FUNCTION_NAME_MATCHES("await_remote_config")) {
+            uint32_t timeout_sec = 10;
+            if (params_count == 1) {
+                timeout_sec = (uint32_t)Z_LVAL_P(ZVAL_VARARG_PARAM(params, 0));
+            }
+            sleep(timeout_sec);
+            RETURN_BOOL(DATADOG_G(reread_remote_configuration));
         } else if (FUNCTION_NAME_MATCHES("get_agent_info")) {
             // Returns a PHP array decoded from the agent /info JSON payload.
             if (DATADOG_G(agent_info_reader)) {

--- a/tracer/functions.c
+++ b/tracer/functions.c
@@ -1984,7 +1984,6 @@ PHP_FUNCTION(dd_trace_internal_fn) {
                 RETURN_FALSE;
             }
             ddog_sidecar_send_garbage(&DATADOG_G(sidecar));
-            datadog_generate_runtime_id();
             datadog_force_new_instance_id();
             RETURN_TRUE;
         } else if (FUNCTION_NAME_MATCHES("reload_process_tags")) {
@@ -2089,7 +2088,7 @@ PHP_FUNCTION(dd_trace_internal_fn) {
             if (params_count == 1) {
                 timeout_sec = (uint32_t)Z_LVAL_P(ZVAL_VARARG_PARAM(params, 0));
             }
-            sleep(timeout_sec);
+            php_sleep(timeout_sec);
             RETURN_BOOL(DATADOG_G(reread_remote_configuration));
         } else if (FUNCTION_NAME_MATCHES("get_agent_info")) {
             // Returns a PHP array decoded from the agent /info JSON payload.

--- a/tracer/tracer_api.h
+++ b/tracer/tracer_api.h
@@ -3,8 +3,8 @@
 
 #ifdef DDTRACE
 // Primary lifecycle
-int ddtrace_startup(zend_extension *extension);
-void ddtrace_shutdown(zend_extension *extension);
+int ddtrace_startup(void);
+void ddtrace_shutdown(void);
 void ddtrace_activate_once(void);
 void ddtrace_activate_early(void);
 void ddtrace_activate_late(void);


### PR DESCRIPTION
Make sure that universal service tags are always sent after fork, otherwise no remote config for you.

Also incorporates the remote config changes from libdatadog.