### PR TITLE
fix(tracing): SpanStack::$active unset corruption

### DIFF
--- a/ext/compatibility.h
+++ b/ext/compatibility.h
@@ -274,6 +274,7 @@ static inline HashTable *zend_new_array(uint32_t nSize) {
 #define zend_std_read_dimension std_object_handlers.read_dimension
 #define zend_std_get_property_ptr_ptr std_object_handlers.get_property_ptr_ptr
 #define zend_std_read_property std_object_handlers.read_property
+#define zend_std_unset_property std_object_handlers.unset_property
 
 // make ZEND_STRL work
 #undef zend_hash_str_update

--- a/tests/ext/span_stack/span_stack_active_unset_child.phpt
+++ b/tests/ext/span_stack/span_stack_active_unset_child.phpt
@@ -13,9 +13,9 @@ DD_CODE_ORIGIN_FOR_SPANS_ENABLED=0
 
 use DDTrace\SpanData;
 
-function span_stack_active_unset_child(): void {}
+function span_stack_active_unset_child() {}
 
-\DDTrace\trace_function('span_stack_active_unset_child', static function (SpanData $span): void {
+\DDTrace\trace_function('span_stack_active_unset_child', static function (SpanData $span) {
     $span->name = 'span_stack_active_unset_child';
 });
 

--- a/tests/ext/span_stack/span_stack_active_unset_child.phpt
+++ b/tests/ext/span_stack/span_stack_active_unset_child.phpt
@@ -1,0 +1,40 @@
+--TEST--
+SpanStack active unset does not corrupt child span opening
+--DESCRIPTION--
+DDTrace\SpanStack::$active aliases a C raw span pointer. Unsetting it must not
+drop the active span zval while leaving a stale internal parent pointer behind.
+--ENV--
+DD_TRACE_AUTO_FLUSH_ENABLED=0
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_CODE_ORIGIN_FOR_SPANS_ENABLED=0
+--FILE--
+<?php
+
+use DDTrace\SpanData;
+
+function span_stack_active_unset_child(): void {}
+
+\DDTrace\trace_function('span_stack_active_unset_child', static function (SpanData $span): void {
+    $span->name = 'span_stack_active_unset_child';
+});
+
+$root = \DDTrace\start_span();
+$root->service = 'parent-service';
+$stack = \DDTrace\active_stack();
+
+unset($stack->active);
+
+unset($root);
+gc_collect_cycles();
+
+$junk = [];
+for ($i = 0; $i < 10000; $i++) {
+    $junk[] = new stdClass();
+}
+
+span_stack_active_unset_child();
+echo "ok\n";
+
+?>
+--EXPECT--
+ok

--- a/tests/ext/span_stack/span_stack_active_unset_child.phpt
+++ b/tests/ext/span_stack/span_stack_active_unset_child.phpt
@@ -1,8 +1,9 @@
 --TEST--
 SpanStack active unset does not corrupt child span opening
 --DESCRIPTION--
-DDTrace\SpanStack::$active aliases a C raw span pointer. Unsetting it must not
-drop the active span zval while leaving a stale internal parent pointer behind.
+DDTrace\SpanStack::$active aliases a C raw span pointer. Unsetting it must be
+rejected instead of dropping the active span zval while leaving a stale internal
+parent pointer behind.
 --ENV--
 DD_TRACE_AUTO_FLUSH_ENABLED=0
 DD_TRACE_GENERATE_ROOT_SPAN=0
@@ -22,7 +23,11 @@ $root = \DDTrace\start_span();
 $root->service = 'parent-service';
 $stack = \DDTrace\active_stack();
 
-unset($stack->active);
+try {
+    unset($stack->active);
+} catch (Error $e) {
+    echo $e->getMessage(), "\n";
+}
 
 unset($root);
 gc_collect_cycles();
@@ -37,4 +42,5 @@ echo "ok\n";
 
 ?>
 --EXPECT--
+Cannot unset readonly property DDTrace\SpanStack::$active
 ok

--- a/tracer/functions.c
+++ b/tracer/functions.c
@@ -585,6 +585,11 @@ static zval *ddtrace_root_span_data_write(zend_object *object, zend_string *memb
 #endif
 }
 
+static bool ddtrace_span_stack_is_context_property(zend_string *prop_name) {
+    return zend_string_equals_literal(prop_name, "active")
+        || zend_string_equals_literal(prop_name, "parent");
+}
+
 #if PHP_VERSION_ID < 80000
 static zval *ddtrace_span_stack_read_property(zval *object, zval *member, int type, void **cache_slot, zval *rv) {
     zend_string *prop_name = Z_TYPE_P(member) == IS_STRING ? Z_STR_P(member) : ZSTR_EMPTY_ALLOC();
@@ -595,8 +600,12 @@ static zval *ddtrace_span_stack_read_property(zend_object *object, zend_string *
     ddtrace_span_stack *stack = (ddtrace_span_stack *)object;
 #endif
     if ((type == BP_VAR_W || type == BP_VAR_RW || type == BP_VAR_UNSET)
-            && zend_string_equals_literal(prop_name, "active")) {
-        ZVAL_COPY(rv, &stack->property_active);
+            && ddtrace_span_stack_is_context_property(prop_name)) {
+        if (zend_string_equals_literal(prop_name, "active")) {
+            ZVAL_COPY(rv, &stack->property_active);
+        } else {
+            ZVAL_COPY(rv, &stack->property_parent);
+        }
         return rv;
     }
     return zend_std_read_property(object, member, type, cache_slot, rv);
@@ -610,7 +619,7 @@ static zval *ddtrace_span_stack_get_property_ptr_ptr(zend_object *object, zend_s
     zend_string *prop_name = member;
 #endif
     if ((type == BP_VAR_W || type == BP_VAR_RW || type == BP_VAR_UNSET)
-            && zend_string_equals_literal(prop_name, "active")) {
+            && ddtrace_span_stack_is_context_property(prop_name)) {
         return NULL;  // prevent cache fill; read_property handles the copy
     }
     return zend_std_get_property_ptr_ptr(object, member, type, cache_slot);
@@ -618,12 +627,15 @@ static zval *ddtrace_span_stack_get_property_ptr_ptr(zend_object *object, zend_s
 
 #if PHP_VERSION_ID < 80000
 static void ddtrace_span_stack_unset_property(zval *object, zval *member, void **cache_slot) {
+    zend_object *obj = Z_OBJ_P(object);
     zend_string *prop_name = Z_TYPE_P(member) == IS_STRING ? Z_STR_P(member) : ZSTR_EMPTY_ALLOC();
 #else
 static void ddtrace_span_stack_unset_property(zend_object *object, zend_string *member, void **cache_slot) {
+    zend_object *obj = object;
     zend_string *prop_name = member;
 #endif
-    if (zend_string_equals_literal(prop_name, "active")) {
+    if (ddtrace_span_stack_is_context_property(prop_name)) {
+        zend_throw_error(zend_ce_error, "Cannot unset readonly property %s::$%s", ZSTR_VAL(obj->ce->name), ZSTR_VAL(prop_name));
         return;
     }
 
@@ -643,7 +655,7 @@ static zval *ddtrace_span_stack_readonly(zend_object *object, zend_string *membe
     zend_object *obj = object;
     zend_string *prop_name = member;
 #endif
-    if (zend_string_equals_literal(prop_name, "parent")) {
+    if (ddtrace_span_stack_is_context_property(prop_name)) {
         zend_throw_error(zend_ce_error, "Cannot modify readonly property %s::$%s", ZSTR_VAL(obj->ce->name), ZSTR_VAL(prop_name));
 #if PHP_VERSION_ID >= 70400
         return &EG(uninitialized_zval);

--- a/tracer/functions.c
+++ b/tracer/functions.c
@@ -617,6 +617,20 @@ static zval *ddtrace_span_stack_get_property_ptr_ptr(zend_object *object, zend_s
 }
 
 #if PHP_VERSION_ID < 80000
+static void ddtrace_span_stack_unset_property(zval *object, zval *member, void **cache_slot) {
+    zend_string *prop_name = Z_TYPE_P(member) == IS_STRING ? Z_STR_P(member) : ZSTR_EMPTY_ALLOC();
+#else
+static void ddtrace_span_stack_unset_property(zend_object *object, zend_string *member, void **cache_slot) {
+    zend_string *prop_name = member;
+#endif
+    if (zend_string_equals_literal(prop_name, "active")) {
+        return;
+    }
+
+    zend_std_unset_property(object, member, cache_slot);
+}
+
+#if PHP_VERSION_ID < 80000
 #if PHP_VERSION_ID >= 70400
 static zval *ddtrace_span_stack_readonly(zval *object, zval *member, zval *value, void **cache_slot) {
 #else
@@ -722,6 +736,7 @@ static void dd_register_span_data_ce(void) {
     ddtrace_span_stack_handlers.dtor_obj = ddtrace_span_stack_dtor_obj;
     ddtrace_span_stack_handlers.read_property = ddtrace_span_stack_read_property;
     ddtrace_span_stack_handlers.get_property_ptr_ptr = ddtrace_span_stack_get_property_ptr_ptr;
+    ddtrace_span_stack_handlers.unset_property = ddtrace_span_stack_unset_property;
     ddtrace_span_stack_handlers.write_property = ddtrace_span_stack_readonly;
 
 }


### PR DESCRIPTION
### Description

Both `active` and `parent` are supposed to be protected, but the handlers are currently a bit patchy. This adds a .phpt for unset specifically and makes the handlers more consistent with each other.

We're still seeing crashes in `ddtrace_inherit_span_properties`, so I'm continuing to spend time with AI agents to try and diagnose and fix them. The last batch had technical but unlikely fixes. This PR continues in that vein, but it does seem a little bit more likely that it might help.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
