### PR TITLE
fix(tracing): sandbox should save/restore jit_trace_num

### DIFF
--- a/tests/opcache/jit_trace_num_bailout.phpt
+++ b/tests/opcache/jit_trace_num_bailout.phpt
@@ -1,0 +1,129 @@
+--TEST--
+[Sandbox regression] Bailout in a hot hook closure restores the active JIT trace
+--DESCRIPTION--
+Tracing JIT is enabled with very low hot thresholds so both the caller and the
+hook closure run inside JIT traces. The hook closure deliberately raises a fatal
+error that ddtrace catches through its sandbox, then the caller continues and
+takes JIT side exits. Without restoring EG(jit_trace_num) during the sandbox
+bailout path, the resumed caller can exit through the wrong trace metadata and
+crash in zend_jit_trace_exit().
+--SKIPIF--
+<?php
+if (PHP_VERSION_ID < 80000) die('skip: JIT is only available on PHP 8+');
+if (!extension_loaded('Zend OPcache')) die('skip: Zend OPcache is required');
+?>
+--ENV--
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_TRACE_LOG_LEVEL=off
+DD_APPSEC_ENABLED=0
+--INI--
+opcache.enable=1
+opcache.enable_cli=1
+opcache.jit_buffer_size=128M
+opcache.jit=1255
+opcache.jit_hot_func=1
+opcache.jit_hot_loop=1
+opcache.jit_hot_return=1
+opcache.jit_hot_side_exit=1
+--FILE--
+<?php
+
+$armed = false;
+$bailoutEnabled = false;
+$bailed = false;
+
+DDTrace\hook_function('observed_call', function () use (&$armed, &$bailoutEnabled, &$bailed) {
+    static $calls = 0;
+
+    $calls++;
+    $sum = 0;
+    for ($i = 0; $i < 48; $i++) {
+        $value = $i + $calls;
+        $sum += ($value & 1) ? $value : -$value;
+    }
+
+    if ($armed && $calls > 2048) {
+        $sum += $calls & 7;
+
+        if ($bailoutEnabled && !$bailed) {
+            $bailed = true;
+            trigger_error('force sandbox bailout after entering a JIT trace', E_USER_ERROR);
+        }
+    }
+
+    return $sum;
+});
+
+function observed_call(int $value): int
+{
+    return $value + 1;
+}
+
+function fold_value($value): int
+{
+    if (is_int($value)) {
+        return $value;
+    }
+
+    if (is_string($value)) {
+        return strlen($value);
+    }
+
+    return (int) $value;
+}
+
+function hot_caller(int $round): int
+{
+    global $bailed;
+
+    $sum = 0;
+    $v0 = $round;
+    $v1 = $round + 1;
+    $v2 = $round + 2;
+    $v3 = $round + 3;
+
+    for ($i = 0; $i < 96; $i++) {
+        $sum += observed_call($i);
+
+        if ($bailed && $i === 17) {
+            $v0 = 'trace-exit-a';
+        }
+        if ($bailed && $i === 29) {
+            $v1 = 3.14;
+        }
+        if ($bailed && $i === 41) {
+            $v2 = [];
+        }
+        if ($bailed && $i === 53) {
+            $v3 = null;
+        }
+
+        $sum += fold_value($v0);
+        $sum += fold_value($v1);
+        $sum += fold_value($v2);
+        $sum += fold_value($v3);
+    }
+
+    return $sum;
+}
+
+for ($i = 0; $i < 64; $i++) {
+    hot_caller($i);
+}
+
+$armed = true;
+
+for ($i = 0; $i < 64; $i++) {
+    hot_caller($i);
+}
+
+$bailoutEnabled = true;
+
+for ($i = 0; $i < 64; $i++) {
+    hot_caller($i);
+}
+
+echo "ok\n";
+?>
+--EXPECT--
+ok

--- a/zend_abstract_interface/sandbox/sandbox.h
+++ b/zend_abstract_interface/sandbox/sandbox.h
@@ -126,6 +126,7 @@ typedef struct zai_exception_state_s {
 
 typedef struct zai_engine_state_s {
     zend_execute_data *current_execute_data;
+    uint32_t jit_trace_num;
 } zai_engine_state;
 
 typedef struct zai_sandbox_s {
@@ -189,10 +190,12 @@ inline void zai_sandbox_exception_state_restore(zai_exception_state *es) {
 
 inline void zai_sandbox_engine_state_backup(zai_engine_state *es) {
     es->current_execute_data = EG(current_execute_data);
+    es->jit_trace_num = EG(jit_trace_num);
 }
 
 inline void zai_sandbox_engine_state_restore(zai_engine_state *es) {
     EG(current_execute_data) = es->current_execute_data;
+    EG(jit_trace_num) = es->jit_trace_num;
 }
 
 inline void zai_sandbox_open(zai_sandbox *sandbox) {


### PR DESCRIPTION
### Description

Fixes a PHP 8 tracing-JIT crash after sandboxed hook bailouts.

AppSec/RASP can trigger a `zend_bailout()` when it blocks a request during a hooked call. That bailout skips PHP’s normal `EG(jit_trace_num)` restore in `zend_call_function()`. ddtrace’s sandbox restored `current_execute_data`, but not `jit_trace_num`, leaving the JIT with a stale trace id.

A later JIT side exit could then read exit metadata from the wrong trace and crash.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
