### PR TITLE
test(ffe): disable pcre.jit in evaluation_metrics_unix_agent_endpoint

### DIFF
--- a/tests/ext/ffe/evaluation_metrics_unix_agent_endpoint.phpt
+++ b/tests/ext/ffe/evaluation_metrics_unix_agent_endpoint.phpt
@@ -12,6 +12,7 @@ DD_INSTRUMENTATION_TELEMETRY_ENABLED=0
 DD_REMOTE_CONFIG_ENABLED=0
 --INI--
 datadog.trace.agent_test_session_token=ffe/evaluation_metrics_unix_agent_endpoint
+pcre.jit=0
 --FILE--
 <?php
 include __DIR__ . '/../includes/request_replayer.inc';


### PR DESCRIPTION
## What

- Disable PCRE JIT (`pcre.jit=0`) in `tests/ext/ffe/evaluation_metrics_unix_agent_endpoint.phpt`.

## Why

The leak/memcheck CI job fails with a Valgrind `Invalid read of size 16` originating from the `preg_match()` call in `wait_for_proxy_request()`:

```
==5530== Invalid read of size 16
==5530==    Address 0xe3395ff is 31 bytes inside a block of size 40 alloc'd
==5530==    ... zend_string_truncate / _php_stream_copy_to_mem / zif_file_get_contents ...
```

The proxy log is read via `file_get_contents()` and fed directly into `preg_match()`. PCRE's JIT-compiled matcher reads the subject buffer in 16-byte aligned chunks, which can over-read past the end of the allocated string. This is a harmless, well-known PCRE optimization, but Valgrind reports it as an invalid read and fails the job.

## How

Add `pcre.jit=0` to the test's `--INI--` section so the regex runs through the interpreter instead of the JIT, eliminating the over-read and keeping the leak job green. Behavior of the test is unchanged.