### PR TITLE
fix(sidecar): bump libdatadog to silence VecMap defensive-dedup warning

### DIFF
--- a/tests/Integrations/Guzzle/V6/composer.json
+++ b/tests/Integrations/Guzzle/V6/composer.json
@@ -1,5 +1,10 @@
 {
     "require": {
         "guzzlehttp/guzzle": "~6.0"
+    },
+    "config": {
+        "audit": {
+            "block-insecure": false
+        }
     }
 }


### PR DESCRIPTION
## What

Two CI fixes surfaced after the libdatadog bump to `6760faae` (#3944):

1. **Bump libdatadog** to pick up DataDog/libdatadog#2110, which marks a decoded span's `meta`/`metrics`/`meta_struct` maps as deduped. Without it the sidecar re-encodes decoded spans through `VecMap::defensive_dedup()`, logging `VecMap not deduped before encoding...`. That warning lands in the web server error log and fails sidecar-routed integration tests (e.g. `test_integrations_swoole_5` on 8.3/8.4).

2. **Disable composer's insecure-audit block for the Guzzle V6 test install.** `guzzle ~6.0` pins `psr7 ^1.9`, whose only releases (1.9.0/1.9.1) carry advisories, so composer refuses to install them and fails the `Guzzle/V6/composer.lock-php74` target. Set `config.audit.block-insecure: false` in that fixture's `composer.json`, matching the existing CodeIgniter/CakePHP/Drupal/Laravel fixtures. (Pre-existing issue, unrelated to the bump.)

> Depends on DataDog/libdatadog#2110 — re-point the submodule to the merged SHA before merging.