### PR TITLE
chore: use libdatadog's trace filter implementation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2919,6 +2919,7 @@ dependencies = [
  "libdd-shared-runtime",
  "libdd-telemetry",
  "libdd-tinybytes",
+ "libdd-trace-normalization",
  "libdd-trace-obfuscation",
  "libdd-trace-protobuf",
  "libdd-trace-stats",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2941,9 +2941,12 @@ dependencies = [
 name = "libdd-ddsketch"
 version = "1.0.1"
 dependencies = [
+ "criterion",
  "prost",
  "prost-build",
  "protoc-bin-vendored",
+ "rand 0.8.5",
+ "rand_chacha 0.3.1",
 ]
 
 [[package]]
@@ -3274,6 +3277,7 @@ dependencies = [
  "serde",
  "serde_json",
  "tempfile",
+ "thin-vec",
  "tokio",
  "tracing",
  "urlencoding",
@@ -5628,6 +5632,12 @@ dependencies = [
  "quote",
  "syn 1.0.109",
 ]
+
+[[package]]
+name = "thin-vec"
+version = "0.2.18"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b0f7e269b48f0a7dd0146680fa24b50cc67fc0373f086a5b2f99bd084639b482"
 
 [[package]]
 name = "thiserror"

--- a/components-rs/agent_info.rs
+++ b/components-rs/agent_info.rs
@@ -18,12 +18,15 @@ use std::ffi::CString;
 fn info_to_concentrator_config(info: &AgentInfoStruct) {
     apply_concentrator_config(
         info.peer_tags.as_deref().unwrap_or(&[]).to_owned(),
-        info.span_kinds_stats_computed.as_deref().unwrap_or(&[]).to_owned(),
-        info.filter_tags.as_ref().and_then(|f| f.require.as_deref()).unwrap_or(&[]).to_owned(),
-        info.filter_tags.as_ref().and_then(|f| f.reject.as_deref()).unwrap_or(&[]).to_owned(),
-        info.filter_tags_regex.as_ref().and_then(|f| f.require.as_deref()).unwrap_or(&[]).to_owned(),
-        info.filter_tags_regex.as_ref().and_then(|f| f.reject.as_deref()).unwrap_or(&[]).to_owned(),
-        info.ignore_resources.as_deref().unwrap_or(&[]).to_owned(),
+        info.span_kinds_stats_computed
+            .as_deref()
+            .unwrap_or(&[])
+            .to_owned(),
+        info.filter_tags.require.to_owned(),
+        info.filter_tags.reject.to_owned(),
+        info.filter_tags_regex.require.to_owned(),
+        info.filter_tags_regex.reject.to_owned(),
+        info.ignore_resources.to_owned(),
         info.client_drop_p0s.unwrap_or(false),
         info.version.as_deref(),
     );

--- a/components-rs/common.h
+++ b/components-rs/common.h
@@ -786,21 +786,6 @@ typedef const char *(*ddog_RootTagLookupFn)(const void *ctx,
                                             uintptr_t *out_len);
 
 /**
- * Per-entry callback passed to `RootMetaIterFn`.  Return `false` to stop iteration early.
- */
-typedef bool (*ddog_MetaEntryCb)(void *iter_ctx,
-                                 const char *key,
-                                 uintptr_t key_len,
-                                 const char *val,
-                                 uintptr_t val_len);
-
-/**
- * Slow-path meta iterator.  `NULL` when no regex-key filter entries are present.
- * Iterates all string meta entries, calling `cb` for each; stops when `cb` returns `false`.
- */
-typedef void (*ddog_RootMetaIterFn)(const void *ctx, void *iter_ctx, ddog_MetaEntryCb cb);
-
-/**
  * A 128-bit (16 byte) buffer containing the UUID.
  *
  * # ABI

--- a/components-rs/datadog.h
+++ b/components-rs/datadog.h
@@ -407,16 +407,13 @@ bool ddog_sidecar_telemetry_are_endpoints_collected(ddog_ShmCacheMap *cache,
  * no stats).  Filters are evaluated against the root span — the decision applies uniformly
  * to all spans of the trace.
  *
- * * **Common case**: `filter_tags` and literal-key `filter_tags_regex` entries — one O(1)
+ * * **When configured**: `filter_tags` and `filter_tags_regex` entries — one
  *   `lookup_fn` call per filter entry.
- * * **Rare case**: `filter_tags_regex` entries with regex key patterns — `iter_fn` is invoked
- *   to scan all meta entries for those filters.  Pass `NULL` when not needed.
  * * **Fast path**: returns `true` immediately when no filters are configured.
  */
 bool ddog_check_stats_trace_filter(ddog_CharSlice resource,
                                    const void *root_span,
-                                   ddog_RootTagLookupFn lookup_fn,
-                                   ddog_RootMetaIterFn iter_fn);
+                                   ddog_RootTagLookupFn lookup_fn);
 
 void ddog_init_span_func(void (*free_func)(ddog_OwnedZendString),
                          void (*addref_func)(struct _zend_string*),

--- a/components-rs/trace_filter.rs
+++ b/components-rs/trace_filter.rs
@@ -14,121 +14,49 @@
 //! case).  `ddog_check_stats_trace_filter` returns `true` immediately in that case.
 
 use libdd_common_ffi::slice::{AsBytes, CharSlice};
-use regex::Regex;
+use libdd_trace_utils::trace_filter::{Span as TraceFilterSpan, TraceFilterer};
 use std::ffi::{c_char, c_void};
 use std::sync::{LazyLock, RwLock};
-use tracing::info;
-
-/// An exact-match tag filter: `"key"` (key-presence only) or `"key:value"`.
-struct TagFilter {
-    key: String,
-    value: Option<String>,
-}
-
-/// A `filter_tags_regex` entry whose key is a plain literal — direct O(1) lookup.
-struct TagRegexFilter {
-    key: String,
-    value: Option<Regex>,
-}
-
-/// A `filter_tags_regex` entry whose key is itself a regex pattern — requires meta iteration.
-struct TagRegexKeyFilter {
-    key_re: Regex,
-    value: Option<Regex>,
-}
-
-/// Compiled trace filter rules, ready for fast evaluation.
-pub(crate) struct TraceFilterConfig {
-    filter_tags_require: Vec<TagFilter>,
-    filter_tags_reject: Vec<TagFilter>,
-    /// Literal-key regex filters: O(1) lookup per entry via the C lookup callback.
-    filter_tags_regex_require: Vec<TagRegexFilter>,
-    filter_tags_regex_reject: Vec<TagRegexFilter>,
-    /// Regex-key filters (rare): require meta iteration via the C iterator callback.
-    filter_tags_regex_key_require: Vec<TagRegexKeyFilter>,
-    filter_tags_regex_key_reject: Vec<TagRegexKeyFilter>,
-    ignore_resources: Vec<Regex>,
-}
-
-fn parse_tag_filter(s: &str) -> TagFilter {
-    match s.find(':') {
-        Some(i) => TagFilter { key: s[..i].to_owned(), value: Some(s[i + 1..].to_owned()) },
-        None => TagFilter { key: s.to_owned(), value: None },
-    }
-}
-
-/// Compile a regex anchored to the full string.
-fn compile_anchored(pattern: &str) -> Option<Regex> {
-    Regex::new(&format!("^(?:{pattern})$")).ok()
-}
-
-/// Returns `true` when `key` contains no regex metacharacters and can be used for a direct
-/// O(1) lookup.  `.` is intentionally treated as a literal (not a wildcard) in key patterns.
-fn is_literal_key(key: &str) -> bool {
-    !key.contains(|c: char| matches!(c, '*' | '+' | '?' | '[' | ']' | '(' | ')' | '{' | '}' | '^' | '$' | '|' | '\\'))
-}
-
-/// Compile all `filter_tags_regex` entries, splitting into literal-key (fast) and
-/// regex-key (slow) lists based on whether the key portion contains metacharacters.
-fn compile_regex_filters(entries: &[String]) -> (Vec<TagRegexFilter>, Vec<TagRegexKeyFilter>) {
-    let mut literal = Vec::new();
-    let mut regex_key = Vec::new();
-    for s in entries {
-        let (key_str, value_str) = match s.find(':') {
-            Some(i) => (&s[..i], Some(&s[i + 1..])),
-            None => (s.as_str(), None),
-        };
-        let value = value_str.and_then(|v| compile_anchored(v));
-        if is_literal_key(key_str) {
-            literal.push(TagRegexFilter { key: key_str.to_owned(), value });
-        } else if let Some(key_re) = compile_anchored(key_str) {
-            regex_key.push(TagRegexKeyFilter { key_re, value });
-        } else {
-            info!("'{key_str}' regex tag filter is not a valid regex");
-        }
-    }
-    (literal, regex_key)
-}
 
 /// Compile all filter arguments into a `TraceFilterConfig`, or return `None` when all lists
 /// are empty (no filtering needed).
 pub(crate) fn compile_trace_filter(
-    tags_require: &[String],
-    tags_reject: &[String],
-    regex_require: &[String],
-    regex_reject: &[String],
+    filter_tags_require: &[String],
+    filter_tags_reject: &[String],
+    filter_tags_regex_require: &[String],
+    filter_tags_regex_reject: &[String],
     ignore_resources: &[String],
-) -> Option<TraceFilterConfig> {
-    if tags_require.is_empty()
-        && tags_reject.is_empty()
-        && regex_require.is_empty()
-        && regex_reject.is_empty()
-        && ignore_resources.is_empty()
+) -> Option<TraceFilterer> {
+    if [
+        filter_tags_require,
+        filter_tags_reject,
+        filter_tags_regex_require,
+        filter_tags_regex_reject,
+        ignore_resources,
+    ]
+    .iter()
+    .all(|v| v.is_empty())
     {
-        return None;
+        None
+    } else {
+        Some(TraceFilterer::new(
+            filter_tags_require,
+            filter_tags_reject,
+            filter_tags_regex_require,
+            filter_tags_regex_reject,
+            ignore_resources,
+        ))
     }
-    let (regex_require_literal, regex_require_key) = compile_regex_filters(regex_require);
-    let (regex_reject_literal, regex_reject_key) = compile_regex_filters(regex_reject);
-    Some(TraceFilterConfig {
-        filter_tags_require: tags_require.iter().map(|s| parse_tag_filter(s)).collect(),
-        filter_tags_reject: tags_reject.iter().map(|s| parse_tag_filter(s)).collect(),
-        filter_tags_regex_require: regex_require_literal,
-        filter_tags_regex_reject: regex_reject_literal,
-        filter_tags_regex_key_require: regex_require_key,
-        filter_tags_regex_key_reject: regex_reject_key,
-        ignore_resources: ignore_resources.iter().filter_map(|s| compile_anchored(s)).collect(),
-    })
 }
 
 /// Currently active compiled trace filter.  `None` when no filters are configured.
-static TRACE_FILTER: LazyLock<RwLock<Option<TraceFilterConfig>>> =
-    LazyLock::new(|| RwLock::new(None));
+static TRACE_FILTER: LazyLock<RwLock<Option<TraceFilterer>>> = LazyLock::new(|| RwLock::new(None));
 
 /// Replace the active trace filter with a freshly compiled one.
 ///
 /// Called from `apply_concentrator_config` in `stats.rs` whenever the agent /info SHM
 /// is updated.
-pub(crate) fn set_trace_filter(compiled: Option<TraceFilterConfig>) {
+pub(crate) fn set_trace_filter(compiled: Option<TraceFilterer>) {
     *TRACE_FILTER.write().unwrap() = compiled;
 }
 
@@ -140,76 +68,37 @@ pub type RootTagLookupFn = unsafe extern "C" fn(
     out_len: *mut usize,
 ) -> *const c_char;
 
-/// Per-entry callback passed to `RootMetaIterFn`.  Return `false` to stop iteration early.
-pub type MetaEntryCb = unsafe extern "C" fn(
-    iter_ctx: *mut c_void,
-    key: *const c_char,
-    key_len: usize,
-    val: *const c_char,
-    val_len: usize,
-) -> bool;
+struct Span<'a> {
+    resource_str: &'a str,
+    root_span: *const c_void,
+    lookup_fn: RootTagLookupFn,
+}
 
-/// Slow-path meta iterator.  `NULL` when no regex-key filter entries are present.
-/// Iterates all string meta entries, calling `cb` for each; stops when `cb` returns `false`.
-pub type RootMetaIterFn = Option<
-    unsafe extern "C" fn(ctx: *const c_void, iter_ctx: *mut c_void, cb: MetaEntryCb),
->;
-
-#[inline]
-unsafe fn lookup_tag<'a>(
-    lookup: RootTagLookupFn,
-    ctx: *const c_void,
-    key: &str,
-) -> Option<&'a str> {
-    let mut vlen: usize = 0;
-    let vptr = lookup(ctx, key.as_ptr() as *const c_char, key.len(), &mut vlen);
-    if vptr.is_null() {
-        None
-    } else {
-        Some(std::str::from_utf8_unchecked(std::slice::from_raw_parts(
-            vptr as *const u8,
-            vlen,
-        )))
+impl<'a> TraceFilterSpan<'a> for Span<'a> {
+    fn resource_normalized(&'a self) -> &'a str {
+        // FIXME: normalization: if resource is empty, name should be used instead
+        self.resource_str
     }
-}
 
-/// State threaded through the opaque `iter_ctx` pointer during regex-key meta scans.
-struct IterState<'a> {
-    key_re: &'a Regex,
-    value: &'a Option<Regex>,
-    found: bool,
-}
-
-/// Trampoline called by C for each meta entry.  Sets `found = true` and stops on a match.
-unsafe extern "C" fn meta_entry_cb(
-    iter_ctx: *mut c_void,
-    key: *const c_char,
-    klen: usize,
-    val: *const c_char,
-    vlen: usize,
-) -> bool {
-    let state = &mut *(iter_ctx as *mut IterState);
-    let k = std::str::from_utf8_unchecked(std::slice::from_raw_parts(key as *const u8, klen));
-    if state.key_re.is_match(k) {
-        let v = std::str::from_utf8_unchecked(std::slice::from_raw_parts(val as *const u8, vlen));
-        if state.value.as_ref().map_or(true, |re| re.is_match(v)) {
-            state.found = true;
-            return false; // stop iteration
+    fn get_meta(&'a self, key: &str) -> Option<&'a str> {
+        unsafe {
+            let mut vlen: usize = 0;
+            let vptr = (self.lookup_fn)(
+                self.root_span,
+                key.as_ptr() as *const c_char,
+                key.len(),
+                &mut vlen,
+            );
+            if vptr.is_null() {
+                None
+            } else {
+                Some(std::str::from_utf8_unchecked(std::slice::from_raw_parts(
+                    vptr as *const u8,
+                    vlen,
+                )))
+            }
         }
     }
-    true // continue
-}
-
-/// Use the iterator to check whether any meta entry matches a `TagRegexKeyFilter`.
-#[inline]
-unsafe fn regex_key_matches(
-    iter: unsafe extern "C" fn(*const c_void, *mut c_void, MetaEntryCb),
-    ctx: *const c_void,
-    filter: &TagRegexKeyFilter,
-) -> bool {
-    let mut state = IterState { key_re: &filter.key_re, value: &filter.value, found: false };
-    iter(ctx, &mut state as *mut IterState as *mut c_void, meta_entry_cb);
-    state.found
 }
 
 /// Check whether the trace rooted at `resource` / `root_span` passes all configured trace
@@ -219,17 +108,14 @@ unsafe fn regex_key_matches(
 /// no stats).  Filters are evaluated against the root span — the decision applies uniformly
 /// to all spans of the trace.
 ///
-/// * **Common case**: `filter_tags` and literal-key `filter_tags_regex` entries — one O(1)
+/// * **When configured**: `filter_tags` and `filter_tags_regex` entries — one
 ///   `lookup_fn` call per filter entry.
-/// * **Rare case**: `filter_tags_regex` entries with regex key patterns — `iter_fn` is invoked
-///   to scan all meta entries for those filters.  Pass `NULL` when not needed.
 /// * **Fast path**: returns `true` immediately when no filters are configured.
 #[no_mangle]
 pub unsafe extern "C" fn ddog_check_stats_trace_filter(
     resource: CharSlice<'_>,
     root_span: *const c_void,
     lookup_fn: RootTagLookupFn,
-    iter_fn: RootMetaIterFn,
 ) -> bool {
     let guard = TRACE_FILTER.read().unwrap();
     // Fast path: None means no filters configured (overwhelmingly common).
@@ -237,68 +123,9 @@ pub unsafe extern "C" fn ddog_check_stats_trace_filter(
         return true;
     };
 
-    let resource_str = resource.try_to_utf8().unwrap_or("");
-
-    // 1. ignore_resources: reject if root resource matches any pattern.
-    for re in &f.ignore_resources {
-        if re.is_match(resource_str) {
-            return false;
-        }
-    }
-    // 2. filter_tags.reject: reject if the root span has a matching tag.
-    for filter in &f.filter_tags_reject {
-        if let Some(val) = lookup_tag(lookup_fn, root_span, &filter.key) {
-            if filter.value.as_deref().map_or(true, |v| v == val) {
-                return false;
-            }
-        }
-    }
-    // 3a. filter_tags_regex.reject (literal key): reject if value matches.
-    for filter in &f.filter_tags_regex_reject {
-        if let Some(val) = lookup_tag(lookup_fn, root_span, &filter.key) {
-            if filter.value.as_ref().map_or(true, |re| re.is_match(val)) {
-                return false;
-            }
-        }
-    }
-    // 3b. filter_tags_regex.reject (regex key): slow path — iterate all meta.
-    if let Some(iter) = iter_fn {
-        for filter in &f.filter_tags_regex_key_reject {
-            if regex_key_matches(iter, root_span, filter) {
-                return false;
-            }
-        }
-    }
-    // 4. filter_tags.require: reject unless every required tag is present and matches.
-    for filter in &f.filter_tags_require {
-        match lookup_tag(lookup_fn, root_span, &filter.key) {
-            None => return false,
-            Some(val) => {
-                if filter.value.as_deref().is_some_and(|v| v != val) {
-                    return false;
-                }
-            }
-        }
-    }
-    // 5a. filter_tags_regex.require (literal key): reject unless matched.
-    for filter in &f.filter_tags_regex_require {
-        match lookup_tag(lookup_fn, root_span, &filter.key) {
-            None => return false,
-            Some(val) => {
-                if filter.value.as_ref().is_some_and(|re| !re.is_match(val)) {
-                    return false;
-                }
-            }
-        }
-    }
-    // 5b. filter_tags_regex.require (regex key): slow path — every required pattern must match.
-    if let Some(iter) = iter_fn {
-        for filter in &f.filter_tags_regex_key_require {
-            if !regex_key_matches(iter, root_span, filter) {
-                return false;
-            }
-        }
-    }
-
-    true
+    !f.should_drop(&Span {
+        resource_str: resource.try_to_utf8().unwrap_or(""),
+        root_span,
+        lookup_fn,
+    })
 }

--- a/components-rs/trace_filter.rs
+++ b/components-rs/trace_filter.rs
@@ -18,7 +18,7 @@ use libdd_trace_utils::trace_filter::{Span as TraceFilterSpan, TraceFilterer};
 use std::ffi::{c_char, c_void};
 use std::sync::{LazyLock, RwLock};
 
-/// Compile all filter arguments into a `TraceFilterConfig`, or return `None` when all lists
+/// Compile all filter arguments into a `TraceFilterer`, or return `None` when all lists
 /// are empty (no filtering needed).
 pub(crate) fn compile_trace_filter(
     filter_tags_require: &[String],

--- a/components-rs/trace_filter.rs
+++ b/components-rs/trace_filter.rs
@@ -76,7 +76,7 @@ struct Span<'a> {
 
 impl<'a> TraceFilterSpan<'a> for Span<'a> {
     fn resource_normalized(&'a self) -> &'a str {
-        // FIXME: normalization: if resource is empty, name should be used instead
+        // Resource has been normalized on the C side before calling ddog_check_stats_trace_filter
         self.resource_str
     }
 

--- a/tests/ext/crashtracker_segfault.phpt
+++ b/tests/ext/crashtracker_segfault.phpt
@@ -99,8 +99,7 @@ $rr->waitForRequest(function ($request) {
                         "line": 1
                     }
                 ]
-            },
-            "frame_count": %d
+            }
         },
 %A
         "incomplete": false,

--- a/tests/ext/remote_config/rc_process_tags.phpt
+++ b/tests/ext/remote_config/rc_process_tags.phpt
@@ -62,7 +62,7 @@ reset_request_replayer();
 ?>
 --EXPECTF--
 entrypoint.basedir:remote_config
-entrypoint.name:rc_process_tags
+entrypoint.name:rc_process_tags.skip
 entrypoint.type:script
 entrypoint.workdir:%s
 runtime.sapi:cli

--- a/tests/ext/remote_config/rc_process_tags.phpt
+++ b/tests/ext/remote_config/rc_process_tags.phpt
@@ -62,7 +62,7 @@ reset_request_replayer();
 ?>
 --EXPECTF--
 entrypoint.basedir:remote_config
-entrypoint.name:rc_process_tags.skip
+entrypoint.name:rc_process_tags
 entrypoint.type:script
 entrypoint.workdir:%s
 runtime.sapi:cli

--- a/tests/ext/request-replayer/client_side_stats_trace_filters.phpt
+++ b/tests/ext/request-replayer/client_side_stats_trace_filters.phpt
@@ -114,6 +114,13 @@ makeSpan('op.blocked.regex_require', 'GET /other4', [
     'http.method'     => 'DELETE',
 ]);
 
+// 7. BLOCKED by ignore_resources — resource is empty so name "GET /healthcheck" is used instead and matches the pattern (as per normalization rules).
+makeSpan('GET /healthcheck', '', [
+    'filter_required' => 'yes',
+    'http.method'     => 'GET',
+]);
+
+
 dd_trace_internal_fn('synchronous_flush');
 
 // Capture ALL trace requests from the second flush before consuming them.

--- a/tracer/trace_filter.c
+++ b/tracer/trace_filter.c
@@ -77,30 +77,11 @@ static const char *ddtrace_root_tag_value(const void *ctx, const char *key, uint
     return NULL;
 }
 
-// Slow-path iterator for regex-key filter entries: walks every string meta entry.
-static void ddtrace_meta_iter(const void *ctx, void *iter_ctx,
-                               bool (*cb)(void *, const char *, uintptr_t, const char *, uintptr_t)) {
-    ddtrace_span_data *root = (ddtrace_span_data *)ctx;
-    zend_array *meta = ddtrace_property_array(&root->property_meta);
-    if (!meta) {
-        return;
-    }
-    zend_string *key;
-    zval *val;
-    ZEND_HASH_FOREACH_STR_KEY_VAL(meta, key, val) {
-        if (key && Z_TYPE_P(val) == IS_STRING) {
-            if (!cb(iter_ctx, ZSTR_VAL(key), ZSTR_LEN(key), Z_STRVAL_P(val), Z_STRLEN_P(val))) {
-                break;
-            }
-        }
-    } ZEND_HASH_FOREACH_END();
-}
-
 bool ddtrace_trace_passes_filter(ddtrace_span_data *span) {
     zval *root_resource_zv = &span->root->property_resource;
     ZVAL_DEREF(root_resource_zv);
     ddog_CharSlice resource = Z_TYPE_P(root_resource_zv) == IS_STRING
         ? dd_zend_string_to_CharSlice(Z_STR_P(root_resource_zv))
         : DDOG_CHARSLICE_C("");
-    return ddog_check_stats_trace_filter(resource, span, ddtrace_root_tag_value, ddtrace_meta_iter);
+    return ddog_check_stats_trace_filter(resource, span, ddtrace_root_tag_value);
 }

--- a/tracer/trace_filter.c
+++ b/tracer/trace_filter.c
@@ -83,5 +83,14 @@ bool ddtrace_trace_passes_filter(ddtrace_span_data *span) {
     ddog_CharSlice resource = Z_TYPE_P(root_resource_zv) == IS_STRING
         ? dd_zend_string_to_CharSlice(Z_STR_P(root_resource_zv))
         : DDOG_CHARSLICE_C("");
+    // Temp normalize resource: if it's empty use the name instead
+    if (resource.len == 0) {
+      zval* root_name_zv = &span->root->property_name;
+      ZVAL_DEREF(root_name_zv);
+      resource =
+          Z_TYPE_P(root_name_zv) == IS_STRING
+              ? dd_zend_string_to_CharSlice(Z_STR_P(root_name_zv))
+              : DDOG_CHARSLICE_C("");
+    }
     return ddog_check_stats_trace_filter(resource, span, ddtrace_root_tag_value);
 }


### PR DESCRIPTION
### Description
Removes the current trace filter implementation and use libdatadog's implementation instead which more closely matches the agent's behavior.

- Currently the submodule points to an unmerged branch. This will be changed once https://github.com/DataDog/libdatadog/pull/1985 is merged
- ~I still have to figure out the resource normalization stuff (implies writing some C...)~ Done

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
