### PR TITLE
fix(build): MacOS profiler build

### DIFF
--- a/profiling/build.rs
+++ b/profiling/build.rs
@@ -575,6 +575,8 @@ fn apple_linker_flags() {
         // Debug builds: allow all undefined symbols.
         println!("cargo:rustc-cdylib-link-arg=-undefined");
         println!("cargo:rustc-cdylib-link-arg=dynamic_lookup");
+        println!("cargo:rustc-link-arg=-undefined");
+        println!("cargo:rustc-link-arg=dynamic_lookup");
         return;
     }
 
@@ -622,6 +624,7 @@ fn apple_linker_flags() {
         "_zend_empty_string",
         "_zend_extensions",
         "_zend_flf_functions",
+        "_zend_flf_handlers",
         "_zend_gc_get_status",
         "_zend_generator_check_placeholder_frame",
         "_zend_get_executed_filename_ex",


### PR DESCRIPTION
### Description

This PR fixes build problems on MacOS with frameless functions and ZTS DEBUG builds

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
