### PR TITLE
fix(profiling): `free()` always untracking

### DIFF
--- a/profiling/src/allocation/allocation_ge84.rs
+++ b/profiling/src/allocation/allocation_ge84.rs
@@ -108,7 +108,7 @@ pub fn first_rinit_should_disable_due_to_jit() -> bool {
         && *JIT_ENABLED
 }
 
-pub fn alloc_prof_rinit() {
+pub fn alloc_prof_rinit(heap_live_enabled: bool) {
     let zend_mm_state_init = |mut zend_mm_state: ZendMMState| -> ZendMMState {
         // Safety: `zend_mm_get_heap()` always returns a non-null pointer to a valid heap structure
         let heap = unsafe { zend::zend_mm_get_heap() };
@@ -151,12 +151,14 @@ pub fn alloc_prof_rinit() {
             zend_mm_state.prev_custom_mm_shutdown = None;
         }
 
+        let free_handler = alloc_prof_free_handler(heap_live_enabled);
+
         // install our custom handler to ZendMM
         unsafe {
             zend::zend_mm_set_custom_handlers_ex(
                 heap,
                 Some(alloc_prof_malloc),
-                Some(alloc_prof_free),
+                Some(free_handler),
                 Some(alloc_prof_realloc),
                 Some(alloc_prof_gc),
                 Some(alloc_prof_shutdown),
@@ -178,7 +180,7 @@ pub fn alloc_prof_rinit() {
 }
 
 #[allow(unknown_lints, unpredictable_function_pointer_comparisons)]
-pub fn alloc_prof_rshutdown() {
+pub fn alloc_prof_rshutdown(heap_live_enabled: bool) {
     // If `is_zend_mm()` is true, the custom handlers have already been reset
     // to `None`. This is unexpected, therefore we will not touch the ZendMM
     // handlers anymore as resetting to prev handlers might result in segfaults
@@ -211,7 +213,8 @@ pub fn alloc_prof_rshutdown() {
                 &mut custom_mm_shutdown,
             );
         }
-        if custom_mm_free != Some(alloc_prof_free)
+        let free_handler = alloc_prof_free_handler(heap_live_enabled);
+        if custom_mm_free != Some(free_handler)
             || custom_mm_malloc != Some(alloc_prof_malloc)
             || custom_mm_realloc != Some(alloc_prof_realloc)
             || custom_mm_gc != Some(alloc_prof_gc)
@@ -361,11 +364,33 @@ unsafe extern "C" fn alloc_prof_free(
     alloc_prof_free_impl(ptr);
 }
 
+fn alloc_prof_free_handler(heap_live_enabled: bool) -> zend::VmMmCustomFreeFn {
+    if heap_live_enabled {
+        alloc_prof_free
+    } else {
+        alloc_prof_free_noop
+    }
+}
+
+#[cfg(not(php_debug))]
+unsafe extern "C" fn alloc_prof_free_noop(ptr: *mut c_void) {
+    tls_zend_mm_state_get!(free)(ptr);
+}
+
+#[cfg(php_debug)]
+unsafe extern "C" fn alloc_prof_free_noop(
+    ptr: *mut c_void,
+    _file: *const c_char,
+    _line: c_uint,
+    _orig_file: *const c_char,
+    _orig_line: c_uint,
+) {
+    tls_zend_mm_state_get!(free)(ptr);
+}
+
 #[inline(always)]
 unsafe fn alloc_prof_free_impl(ptr: *mut c_void) {
-    // Check if this was a tracked allocation before freeing. This intentionally
-    // avoids a process-wide heap-live fast-path flag: ZTS SAPIs can run requests
-    // with different INI state on different threads.
+    // Heap-live is enabled when this handler is registered.
     if !ptr.is_null() {
         untrack_allocation(ptr);
     }
@@ -522,6 +547,18 @@ unsafe fn alloc_prof_orig_shutdown(full: bool, silent: bool) {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn free_handler_tracks_only_when_heap_live_is_enabled() {
+        assert_eq!(
+            alloc_prof_free_handler(true) as usize,
+            alloc_prof_free as zend::VmMmCustomFreeFn as usize
+        );
+        assert_eq!(
+            alloc_prof_free_handler(false) as usize,
+            alloc_prof_free_noop as zend::VmMmCustomFreeFn as usize
+        );
+    }
 
     #[test]
     fn check_versions_that_allocation_profiling_needs_disabled_with_active_jit() {

--- a/profiling/src/allocation/allocation_le83.rs
+++ b/profiling/src/allocation/allocation_le83.rs
@@ -91,7 +91,7 @@ pub fn first_rinit_should_disable_due_to_jit() -> bool {
         && *JIT_ENABLED
 }
 
-pub fn alloc_prof_rinit() {
+pub fn alloc_prof_rinit(heap_live_enabled: bool) {
     let zend_mm_state_init = |mut zend_mm_state: ZendMMState| -> ZendMMState {
         // Safety: `zend_mm_get_heap()` always returns a non-null pointer to a valid heap structure
         let heap = unsafe { zend::zend_mm_get_heap() };
@@ -129,12 +129,14 @@ pub fn alloc_prof_rinit() {
             zend_mm_state.prev_custom_mm_realloc = None;
         }
 
+        let free_handler = alloc_prof_free_handler(heap_live_enabled);
+
         // install our custom handler to ZendMM
         unsafe {
             zend::ddog_php_prof_zend_mm_set_custom_handlers(
                 heap,
                 Some(alloc_prof_malloc),
-                Some(alloc_prof_free),
+                Some(free_handler),
                 Some(alloc_prof_realloc),
             );
         }
@@ -154,7 +156,7 @@ pub fn alloc_prof_rinit() {
 }
 
 #[allow(unknown_lints, unpredictable_function_pointer_comparisons)]
-pub fn alloc_prof_rshutdown() {
+pub fn alloc_prof_rshutdown(heap_live_enabled: bool) {
     // If `is_zend_mm()` is true, the custom handlers have already been reset
     // to `None`. This is unexpected, therefore we will not touch the ZendMM
     // handlers anymore as resetting to prev handlers might result in segfaults
@@ -183,7 +185,8 @@ pub fn alloc_prof_rshutdown() {
                 &mut custom_mm_realloc,
             );
         }
-        if custom_mm_free != Some(alloc_prof_free)
+        let free_handler = alloc_prof_free_handler(heap_live_enabled);
+        if custom_mm_free != Some(free_handler)
             || custom_mm_malloc != Some(alloc_prof_malloc)
             || custom_mm_realloc != Some(alloc_prof_realloc)
         {
@@ -335,13 +338,23 @@ unsafe fn alloc_prof_orig_alloc(len: size_t) -> *mut c_void {
 /// custom handlers won't be installed. We cannot just point to the original
 /// `zend::_zend_mm_free()` as the function definitions differ.
 unsafe extern "C" fn alloc_prof_free(ptr: *mut c_void) {
-    // Check if this was a tracked allocation before freeing. This intentionally
-    // avoids a process-wide heap-live fast-path flag: ZTS SAPIs can run requests
-    // with different INI state on different threads.
+    // Heap-live is enabled when this handler is registered.
     if !ptr.is_null() {
         untrack_allocation(ptr);
     }
 
+    tls_zend_mm_state_get!(free)(ptr);
+}
+
+fn alloc_prof_free_handler(heap_live_enabled: bool) -> zend::VmMmCustomFreeFn {
+    if heap_live_enabled {
+        alloc_prof_free
+    } else {
+        alloc_prof_free_noop
+    }
+}
+
+unsafe extern "C" fn alloc_prof_free_noop(ptr: *mut c_void) {
     tls_zend_mm_state_get!(free)(ptr);
 }
 
@@ -436,6 +449,18 @@ fn is_zend_mm() -> bool {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    #[test]
+    fn free_handler_tracks_only_when_heap_live_is_enabled() {
+        assert_eq!(
+            alloc_prof_free_handler(true) as usize,
+            alloc_prof_free as usize
+        );
+        assert_eq!(
+            alloc_prof_free_handler(false) as usize,
+            alloc_prof_free_noop as usize
+        );
+    }
 
     #[test]
     fn check_versions_that_allocation_profiling_needs_disabled_with_active_jit() {

--- a/profiling/src/allocation/mod.rs
+++ b/profiling/src/allocation/mod.rs
@@ -212,13 +212,18 @@ pub unsafe fn minit(settings: &SystemSettings) {
 }
 
 pub fn rinit() {
-    let allocation_enabled = REQUEST_LOCALS
-        .try_with_borrow(|locals| locals.system_settings().profiling_allocation_enabled)
+    let (allocation_enabled, heap_live_enabled) = REQUEST_LOCALS
+        .try_with_borrow(|locals| {
+            (
+                locals.system_settings().profiling_allocation_enabled,
+                locals.profiling_experimental_heap_live_enabled,
+            )
+        })
         .unwrap_or_else(|err| {
             // Debug rather than error because this is every request, could
             // be very spammy.
             debug!("Allocation profiling rinit failed because it failed to borrow the request locals. Please report this to Datadog: {err}");
-            false
+            (false, false)
         });
 
     if !allocation_enabled {
@@ -226,19 +231,24 @@ pub fn rinit() {
     }
 
     #[cfg(not(php_zend_mm_set_custom_handlers_ex))]
-    allocation_le83::alloc_prof_rinit();
+    allocation_le83::alloc_prof_rinit(heap_live_enabled);
     #[cfg(php_zend_mm_set_custom_handlers_ex)]
-    allocation_ge84::alloc_prof_rinit();
+    allocation_ge84::alloc_prof_rinit(heap_live_enabled);
 }
 
 pub fn alloc_prof_rshutdown() {
-    let allocation_enabled = REQUEST_LOCALS
-        .try_with_borrow(|locals| locals.system_settings().profiling_allocation_enabled)
+    let (allocation_enabled, heap_live_enabled) = REQUEST_LOCALS
+        .try_with_borrow(|locals| {
+            (
+                locals.system_settings().profiling_allocation_enabled,
+                locals.profiling_experimental_heap_live_enabled,
+            )
+        })
         .unwrap_or_else(|err| {
             // Debug rather than error because this is every request, could
             // be very spammy.
             debug!("Allocation profiling rshutdown failed because it failed to borrow the request locals. Please report this to Datadog: {err}");
-            false
+            (false, false)
         });
 
     if !allocation_enabled {
@@ -246,9 +256,9 @@ pub fn alloc_prof_rshutdown() {
     }
 
     #[cfg(not(php_zend_mm_set_custom_handlers_ex))]
-    allocation_le83::alloc_prof_rshutdown();
+    allocation_le83::alloc_prof_rshutdown(heap_live_enabled);
     #[cfg(php_zend_mm_set_custom_handlers_ex)]
-    allocation_ge84::alloc_prof_rshutdown();
+    allocation_ge84::alloc_prof_rshutdown(heap_live_enabled);
 }
 
 #[track_caller]


### PR DESCRIPTION
### Description

Since https://github.com/DataDog/dd-trace-php/pull/3623 got merged, our overhead rose which is due to an oversight: even when heap live profiling is disabled, the `free()` path would always got the untrack allocation route:
<img width="1448" height="1028" alt="image" src="https://github.com/user-attachments/assets/d3804129-4be1-4869-bd38-505e4dbf0e36" />

This PR makes sure to inject the NO-OP `free()` implementation in `zend_mm_set_custom_handlers_ex()`/`zend_mm_set_custom_handlers()` when heap live is disabled and only the untracking `free()` version when heap live is enabled.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.

PROF-13688
