### PR TITLE
fix(ci): skip rc_process_tags.phpt before PHP 7.4 (skip-task sidecar leak)

### DIFF
--- a/tests/ext/remote_config/rc_process_tags.phpt
+++ b/tests/ext/remote_config/rc_process_tags.phpt
@@ -2,6 +2,9 @@
 Test remote config request payload
 --SKIPIF--
 <?php include __DIR__ . '/../includes/skipif_no_dev_env.inc'; ?>
+<?php
+if (PHP_VERSION_ID < 70400) die("skip: Before PHP 7.4, the skip-task would cause the sidecar to fetch the info already.");
+?>
 --ENV--
 DD_AGENT_HOST=request-replayer
 DD_TRACE_AGENT_PORT=80


### PR DESCRIPTION
## What this does

Adds the request-replayer family's standard SKIPIF guard to `tests/ext/remote_config/rc_process_tags.phpt`:

```php
if (PHP_VERSION_ID < 70400) die("skip: Before PHP 7.4, the skip-task would cause the sidecar to fetch the info already.");
```

On PHP < 7.4 the SKIPIF/skip-task makes the sidecar fetch process tags during the skip phase, leaking the `.skip` entrypoint into the FILE-phase RC request (`entrypoint.name:rc_process_tags.skip`). RC is polled by the sidecar (`ext/sidecar.c` `dd_sidecar_post_connect` passes `process_tags` + RC config to the session), so the leak is a sidecar-state leak. This matches `client_side_stats*`, `dd_trace_agent_env`, `shm_data_internal_fns`.

## Scope / honesty note

This fixes a **real but non-fatal** sub-failure: `rc_process_tags.phpt` was reporting **FAIL** on Windows 7.2/7.3 (now correctly SKIP).

It does **NOT** make the `windows test_c [7.2]/[7.3]` jobs green. Those jobs fail via a **1-hour timeout / hang** that is independent of this test: with this fix applied, `rc_process_tags` is cleanly skipped but the job still hangs ~52 min after `tests/ext/sandbox/die_in_sandbox.phpt` and is killed at the 1h limit (identical hang point on master without this change). That hang is a separate issue (tracked separately) — likely a thread-mode sidecar shutdown deadlock on Windows.

So: merge this as a legitimate test-correctness cleanup, but it should not be expected to turn `windows test_c` green on its own.