### PR TITLE
fix(profiling): skip realloc heap-live untracking when disabled

### DIFF
--- a/profiling/src/allocation/allocation_ge84.rs
+++ b/profiling/src/allocation/allocation_ge84.rs
@@ -152,6 +152,7 @@ pub fn alloc_prof_rinit(heap_live_enabled: bool) {
         }
 
         let free_handler = alloc_prof_free_handler(heap_live_enabled);
+        let realloc_handler = alloc_prof_realloc_handler(heap_live_enabled);
 
         // install our custom handler to ZendMM
         unsafe {
@@ -159,7 +160,7 @@ pub fn alloc_prof_rinit(heap_live_enabled: bool) {
                 heap,
                 Some(alloc_prof_malloc),
                 Some(free_handler),
-                Some(alloc_prof_realloc),
+                Some(realloc_handler),
                 Some(alloc_prof_gc),
                 Some(alloc_prof_shutdown),
             );
@@ -214,9 +215,10 @@ pub fn alloc_prof_rshutdown(heap_live_enabled: bool) {
             );
         }
         let free_handler = alloc_prof_free_handler(heap_live_enabled);
+        let realloc_handler = alloc_prof_realloc_handler(heap_live_enabled);
         if custom_mm_free != Some(free_handler)
             || custom_mm_malloc != Some(alloc_prof_malloc)
-            || custom_mm_realloc != Some(alloc_prof_realloc)
+            || custom_mm_realloc != Some(realloc_handler)
             || custom_mm_gc != Some(alloc_prof_gc)
             || custom_mm_shutdown != Some(alloc_prof_shutdown)
         {
@@ -424,6 +426,14 @@ unsafe fn alloc_prof_orig_free(ptr: *mut c_void) {
     zend::_zend_mm_free(heap, ptr);
 }
 
+fn alloc_prof_realloc_handler(heap_live_enabled: bool) -> zend::VmMmCustomReallocFn {
+    if heap_live_enabled {
+        alloc_prof_realloc
+    } else {
+        alloc_prof_realloc_no_untrack
+    }
+}
+
 #[cfg(not(php_debug))]
 unsafe extern "C" fn alloc_prof_realloc(prev_ptr: *mut c_void, len: size_t) -> *mut c_void {
     alloc_prof_realloc_impl(prev_ptr, len)
@@ -439,6 +449,26 @@ unsafe extern "C" fn alloc_prof_realloc(
     _orig_line: c_uint,
 ) -> *mut c_void {
     alloc_prof_realloc_impl(prev_ptr, len)
+}
+
+#[cfg(not(php_debug))]
+unsafe extern "C" fn alloc_prof_realloc_no_untrack(
+    prev_ptr: *mut c_void,
+    len: size_t,
+) -> *mut c_void {
+    alloc_prof_realloc_no_untrack_impl(prev_ptr, len)
+}
+
+#[cfg(php_debug)]
+unsafe extern "C" fn alloc_prof_realloc_no_untrack(
+    prev_ptr: *mut c_void,
+    len: size_t,
+    _file: *const c_char,
+    _line: c_uint,
+    _orig_file: *const c_char,
+    _orig_line: c_uint,
+) -> *mut c_void {
+    alloc_prof_realloc_no_untrack_impl(prev_ptr, len)
 }
 
 #[inline(always)]
@@ -458,6 +488,23 @@ unsafe fn alloc_prof_realloc_impl(prev_ptr: *mut c_void, len: size_t) -> *mut c_
         untrack_allocation(prev_ptr);
     }
 
+    alloc_prof_realloc_sample(ptr, len)
+}
+
+#[inline(always)]
+unsafe fn alloc_prof_realloc_no_untrack_impl(prev_ptr: *mut c_void, len: size_t) -> *mut c_void {
+    #[cfg(feature = "debug_stats")]
+    ALLOCATION_PROFILING_COUNT.fetch_add(1, Relaxed);
+    #[cfg(feature = "debug_stats")]
+    ALLOCATION_PROFILING_SIZE.fetch_add(len as u64, Relaxed);
+
+    let ptr = tls_zend_mm_state_get!(realloc)(prev_ptr, len);
+
+    alloc_prof_realloc_sample(ptr, len)
+}
+
+#[inline(always)]
+unsafe fn alloc_prof_realloc_sample(ptr: *mut c_void, len: size_t) -> *mut c_void {
     // during startup, minit, rinit, ... current_execute_data is null
     // we are only interested in allocations during userland operations
     if zend::ddog_php_prof_get_current_execute_data().is_null() {
@@ -557,6 +604,18 @@ mod tests {
         assert_eq!(
             alloc_prof_free_handler(false) as usize,
             alloc_prof_free_noop as zend::VmMmCustomFreeFn as usize
+        );
+    }
+
+    #[test]
+    fn realloc_handler_tracks_only_when_heap_live_is_enabled() {
+        assert_eq!(
+            alloc_prof_realloc_handler(true) as usize,
+            alloc_prof_realloc as zend::VmMmCustomReallocFn as usize
+        );
+        assert_eq!(
+            alloc_prof_realloc_handler(false) as usize,
+            alloc_prof_realloc_no_untrack as zend::VmMmCustomReallocFn as usize
         );
     }
 

--- a/profiling/src/allocation/allocation_le83.rs
+++ b/profiling/src/allocation/allocation_le83.rs
@@ -130,6 +130,7 @@ pub fn alloc_prof_rinit(heap_live_enabled: bool) {
         }
 
         let free_handler = alloc_prof_free_handler(heap_live_enabled);
+        let realloc_handler = alloc_prof_realloc_handler(heap_live_enabled);
 
         // install our custom handler to ZendMM
         unsafe {
@@ -137,7 +138,7 @@ pub fn alloc_prof_rinit(heap_live_enabled: bool) {
                 heap,
                 Some(alloc_prof_malloc),
                 Some(free_handler),
-                Some(alloc_prof_realloc),
+                Some(realloc_handler),
             );
         }
         zend_mm_state
@@ -186,9 +187,10 @@ pub fn alloc_prof_rshutdown(heap_live_enabled: bool) {
             );
         }
         let free_handler = alloc_prof_free_handler(heap_live_enabled);
+        let realloc_handler = alloc_prof_realloc_handler(heap_live_enabled);
         if custom_mm_free != Some(free_handler)
             || custom_mm_malloc != Some(alloc_prof_malloc)
-            || custom_mm_realloc != Some(alloc_prof_realloc)
+            || custom_mm_realloc != Some(realloc_handler)
         {
             // Custom handlers are installed, but it's not us. Someone, somewhere might have
             // function pointers to our custom handlers. Best bet to avoid segfaults is to not
@@ -376,7 +378,27 @@ unsafe fn alloc_prof_orig_free(ptr: *mut c_void) {
     zend::_zend_mm_free(heap, ptr);
 }
 
+fn alloc_prof_realloc_handler(heap_live_enabled: bool) -> zend::VmMmCustomReallocFn {
+    if heap_live_enabled {
+        alloc_prof_realloc
+    } else {
+        alloc_prof_realloc_no_untrack
+    }
+}
+
 unsafe extern "C" fn alloc_prof_realloc(prev_ptr: *mut c_void, len: size_t) -> *mut c_void {
+    alloc_prof_realloc_impl(prev_ptr, len)
+}
+
+unsafe extern "C" fn alloc_prof_realloc_no_untrack(
+    prev_ptr: *mut c_void,
+    len: size_t,
+) -> *mut c_void {
+    alloc_prof_realloc_no_untrack_impl(prev_ptr, len)
+}
+
+#[inline(always)]
+unsafe fn alloc_prof_realloc_impl(prev_ptr: *mut c_void, len: size_t) -> *mut c_void {
     #[cfg(feature = "debug_stats")]
     ALLOCATION_PROFILING_COUNT.fetch_add(1, Relaxed);
     #[cfg(feature = "debug_stats")]
@@ -392,6 +414,23 @@ unsafe extern "C" fn alloc_prof_realloc(prev_ptr: *mut c_void, len: size_t) -> *
         untrack_allocation(prev_ptr);
     }
 
+    alloc_prof_realloc_sample(ptr, len)
+}
+
+#[inline(always)]
+unsafe fn alloc_prof_realloc_no_untrack_impl(prev_ptr: *mut c_void, len: size_t) -> *mut c_void {
+    #[cfg(feature = "debug_stats")]
+    ALLOCATION_PROFILING_COUNT.fetch_add(1, Relaxed);
+    #[cfg(feature = "debug_stats")]
+    ALLOCATION_PROFILING_SIZE.fetch_add(len as u64, Relaxed);
+
+    let ptr = tls_zend_mm_state_get!(realloc)(prev_ptr, len);
+
+    alloc_prof_realloc_sample(ptr, len)
+}
+
+#[inline(always)]
+unsafe fn alloc_prof_realloc_sample(ptr: *mut c_void, len: size_t) -> *mut c_void {
     // during startup, minit, rinit, ... current_execute_data is null
     // we are only interested in allocations during userland operations
     if zend::ddog_php_prof_get_current_execute_data().is_null() {
@@ -459,6 +498,18 @@ mod tests {
         assert_eq!(
             alloc_prof_free_handler(false) as usize,
             alloc_prof_free_noop as usize
+        );
+    }
+
+    #[test]
+    fn realloc_handler_tracks_only_when_heap_live_is_enabled() {
+        assert_eq!(
+            alloc_prof_realloc_handler(true) as usize,
+            alloc_prof_realloc as usize
+        );
+        assert_eq!(
+            alloc_prof_realloc_handler(false) as usize,
+            alloc_prof_realloc_no_untrack as usize
         );
     }
 


### PR DESCRIPTION
### Description

Follow up PR to #3988

This PR removes the remaining heap-live overhead from allocation profiling when heap-live is disabled.

`free()` already selects a no-untrack handler for heap-live-disabled requests. `realloc()` now does the same: request init installs a tracking realloc handler only when heap-live is enabled, otherwise it installs a no-untrack handler that keeps allocation sampling but skips `untrack_allocation(prev_ptr)`.

The tracking and no-untrack realloc paths are separate implementations, so the hot path does not pay a heap-live flag branch.


PROF-13688