### PR TITLE
fix(profiling): avoid pulling PHP globals into cargo tests

### DIFF
--- a/profiling/src/allocation/allocation_ge84.rs
+++ b/profiling/src/allocation/allocation_ge84.rs
@@ -608,18 +608,6 @@ mod tests {
     }
 
     #[test]
-    fn realloc_handler_tracks_only_when_heap_live_is_enabled() {
-        assert_eq!(
-            alloc_prof_realloc_handler(true) as usize,
-            alloc_prof_realloc as zend::VmMmCustomReallocFn as usize
-        );
-        assert_eq!(
-            alloc_prof_realloc_handler(false) as usize,
-            alloc_prof_realloc_no_untrack as zend::VmMmCustomReallocFn as usize
-        );
-    }
-
-    #[test]
     fn check_versions_that_allocation_profiling_needs_disabled_with_active_jit() {
         // versions that need disabled allocation profiling with active jit
         assert!(alloc_prof_needs_disabled_for_jit(80400));

--- a/profiling/src/allocation/allocation_le83.rs
+++ b/profiling/src/allocation/allocation_le83.rs
@@ -502,18 +502,6 @@ mod tests {
     }
 
     #[test]
-    fn realloc_handler_tracks_only_when_heap_live_is_enabled() {
-        assert_eq!(
-            alloc_prof_realloc_handler(true) as usize,
-            alloc_prof_realloc as usize
-        );
-        assert_eq!(
-            alloc_prof_realloc_handler(false) as usize,
-            alloc_prof_realloc_no_untrack as usize
-        );
-    }
-
-    #[test]
     fn check_versions_that_allocation_profiling_needs_disabled_with_active_jit() {
         // versions that need disabled allocation profiling with active jit
         assert!(alloc_prof_needs_disabled_for_jit(80000));


### PR DESCRIPTION
### Description

Follow-up to #3993.

The realloc handler-selection unit tests made the standalone Rust test binary retain the realloc sampling path. That path references `ddog_php_prof_get_current_execute_data`, which pulls `php_ffi.o` from `libphp_ffi.a`; on `cargo test --all-features` this then fails to link because PHP's `executor_globals` is not available to the test binary.

This removes those two tests.