### PR TITLE
refactor(profiling): remove locks and simplify PROFILER_NAME_STR/PROFILER_VERSION_STR

### DIFF
--- a/profiling/src/allocation/allocation_ge84.rs
+++ b/profiling/src/allocation/allocation_ge84.rs
@@ -327,7 +327,7 @@ unsafe fn alloc_prof_prev_alloc(len: size_t) -> *mut c_void {
     let alloc = tls_zend_mm_state_get!(prev_custom_mm_alloc).unwrap();
     #[cfg(php_debug)]
     {
-        return alloc(len, ptr::null(), 0, ptr::null(), 0);
+        alloc(len, ptr::null(), 0, ptr::null(), 0)
     }
     #[cfg(not(php_debug))]
     alloc(len)
@@ -407,7 +407,7 @@ unsafe fn alloc_prof_prev_free(ptr: *mut c_void) {
     let free = tls_zend_mm_state_get!(prev_custom_mm_free).unwrap();
     #[cfg(php_debug)]
     {
-        return free(ptr, core::ptr::null(), 0, core::ptr::null(), 0);
+        free(ptr, core::ptr::null(), 0, core::ptr::null(), 0)
     }
     #[cfg(not(php_debug))]
     free(ptr)
@@ -530,7 +530,7 @@ unsafe fn alloc_prof_prev_realloc(prev_ptr: *mut c_void, len: size_t) -> *mut c_
     let realloc = tls_zend_mm_state_get!(prev_custom_mm_realloc).unwrap();
     #[cfg(php_debug)]
     {
-        return realloc(prev_ptr, len, ptr::null(), 0, ptr::null(), 0);
+        realloc(prev_ptr, len, ptr::null(), 0, ptr::null(), 0)
     }
     #[cfg(not(php_debug))]
     realloc(prev_ptr, len)

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -53,7 +53,7 @@ use uuid::Uuid;
 static PROFILER_NAME: &CStr = c"datadog-profiling";
 
 // SAFETY: PROFILER_NAME is a valid utf8 string.
-static PROFILER_NAME_STR: &'static str = match PROFILER_NAME.to_str() {
+static PROFILER_NAME_STR: &str = match PROFILER_NAME.to_str() {
     Ok(s) => s,
     // Panic: we own this string and it should be UTF8 (see PROFILER_NAME above).
     Err(_) => panic!(""),
@@ -64,7 +64,7 @@ static PROFILER_NAME_STR: &'static str = match PROFILER_NAME.to_str() {
 static PROFILER_VERSION: &[u8] = concat!(env!("PROFILER_VERSION"), "\0").as_bytes();
 
 // SAFETY: PROFILER_VERSION is a byte slice that satisfies the safety requirements.
-static PROFILER_VERSION_STR: &'static str = const {
+static PROFILER_VERSION_STR: &str = const {
     match unsafe { CStr::from_ptr(PROFILER_VERSION.as_ptr() as *const c_char).to_str() } {
         Ok(v) => v,
         // Panic: we own this string and it should be UTF8 (see PROFILER_VERSION above).

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -622,8 +622,9 @@ extern "C" fn rinit(_type: c_int, _module_number: c_int) -> ZendResult {
                 warn!("{err}");
             }
             locals.tags = tags;
-            locals.profiling_experimental_heap_live_enabled =
-                system_settings.as_ref().profiling_experimental_heap_live_enabled
+            locals.profiling_experimental_heap_live_enabled = system_settings
+                .as_ref()
+                .profiling_experimental_heap_live_enabled
                 && config::profiling_experimental_heap_live_enabled_current();
         }
         locals.system_settings = system_settings;

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -52,9 +52,25 @@ use uuid::Uuid;
 /// interior null bytes and must be null terminated.
 static PROFILER_NAME: &CStr = c"datadog-profiling";
 
+// SAFETY: PROFILER_NAME is a valid utf8 string.
+static PROFILER_NAME_STR: &'static str = match PROFILER_NAME.to_str() {
+    Ok(s) => s,
+    // Panic: we own this string and it should be UTF8 (see PROFILER_NAME above).
+    Err(_) => panic!(""),
+};
+
 /// Version of the profiling module and zend_extension. Must not contain any
 /// interior null bytes and must be null terminated.
 static PROFILER_VERSION: &[u8] = concat!(env!("PROFILER_VERSION"), "\0").as_bytes();
+
+// SAFETY: PROFILER_VERSION is a byte slice that satisfies the safety requirements.
+static PROFILER_VERSION_STR: &'static str = const {
+    match unsafe { CStr::from_ptr(PROFILER_VERSION.as_ptr() as *const c_char).to_str() } {
+        Ok(v) => v,
+        // Panic: we own this string and it should be UTF8 (see PROFILER_VERSION above).
+        Err(_) => panic!("PROFILER_VERSION was not a valid utf-8 string"),
+    }
+};
 
 /// Version ID of PHP at run-time, not the version it was built against at
 /// compile-time. Its value is overwritten during minit.
@@ -128,18 +144,6 @@ static SAPI: LazyLock<Sapi> = LazyLock::new(|| {
     {
         Sapi::Unknown
     }
-});
-
-// SAFETY: PROFILER_NAME is a byte slice that satisfies the safety requirements.
-// Panic: we own this string and it should be UTF8 (see PROFILER_NAME above).
-static PROFILER_NAME_STR: LazyLock<&'static str> = LazyLock::new(|| PROFILER_NAME.to_str().unwrap());
-
-// SAFETY: PROFILER_VERSION is a byte slice that satisfies the safety requirements.
-static PROFILER_VERSION_STR: LazyLock<&'static str> = LazyLock::new(|| {
-    unsafe { CStr::from_ptr(PROFILER_VERSION.as_ptr() as *const c_char) }
-        .to_str()
-        // Panic: we own this string and it should be UTF8 (see PROFILER_VERSION above).
-        .unwrap()
 });
 
 /// The runtime ID, which is basically a universally unique "pid". This makes

--- a/profiling/src/profiling/uploader.rs
+++ b/profiling/src/profiling/uploader.rs
@@ -107,15 +107,13 @@ impl Uploader {
         let index = Arc::unwrap_or_clone(message.index);
         let profile = message.profile;
 
-        let profiling_library_name: &str = &PROFILER_NAME_STR;
-        let profiling_library_version: &str = &PROFILER_VERSION_STR;
         let agent_endpoint = &self.endpoint;
         let endpoint = Endpoint::try_from(agent_endpoint)?;
 
         let tags = Arc::unwrap_or_clone(index.tags);
         let mut exporter = libdd_profiling::exporter::ProfileExporter::new(
-            profiling_library_name,
-            profiling_library_version,
+            PROFILER_NAME_STR,
+            PROFILER_VERSION_STR,
             "php",
             tags,
             endpoint,


### PR DESCRIPTION
### Description

In a recent PR we refactored to use LazyLocks instead of `lazy_static` macros. While reviewing that, I suspected these could remove the lazy lock altogether and be made const. It's true, we can, but it was not as "idiomatic" as I expected. Nonetheless, I think it's an improvement.

Note that if we panic, it will be at build time, as these are const contexts.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
