### PR TITLE
fix(ci): PHP profiler language tests YAML invalid

### DIFF
--- a/.gitlab/generate-profiler.php
+++ b/.gitlab/generate-profiler.php
@@ -170,8 +170,8 @@ foreach ($profiler_minor_major_targets as $version) {
     - php -v
     # Fail loudly if the profiler did not load: otherwise the language tests
     # would run profiler-less and pass, giving a false green.
-    - php -m | grep -qx 'datadog-profiling' || { echo 'ERROR: datadog-profiling extension is not loaded'; exit 1; }
+    - php -m | grep -qx 'datadog-profiling' || { echo 'ERROR datadog-profiling extension is not loaded'; exit 1; }
     - cat "${XFAIL_LIST}" profiling/tests/php-language-xfail.list > /tmp/profiler-php-language-xfail.list
-    - if php -r 'exit(PHP_VERSION_ID < 80400 ? 0 : 1);'; then cat profiling/tests/php-language-xfail-pre84.list >> /tmp/profiler-php-language-xfail.list; fi
+    - "if php -r 'exit(PHP_VERSION_ID < 80400 ? 0 : 1);'; then cat profiling/tests/php-language-xfail-pre84.list >> /tmp/profiler-php-language-xfail.list; fi"
     - export XFAIL_LIST=/tmp/profiler-php-language-xfail.list
     - .gitlab/run_php_language_tests.sh


### PR DESCRIPTION
### Description

The last cleanup commit (failing if profiling is not loaded in PHP Language Tests) in #3364  actually broke the YAML and it failed in complete silence. Turns out: if there is a : sign somewhere in the list, it is not a array of strings in YAML anymore, but a map ...

On a personal note: YAML was a mistake

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
