### PR TITLE
[CIEXE-2016] Migrate GitLab CI jobs to pod-level resource variables

### DIFF
--- a/.gitlab/generate-appsec.php
+++ b/.gitlab/generate-appsec.php
@@ -73,14 +73,10 @@ stages:
   extends: .appsec_test
   image: registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:php-${PHP_MAJOR_MINOR}_bookworm-8
   variables:
-    KUBERNETES_CPU_REQUEST: 3
-    KUBERNETES_CPU_LIMIT: 3
-    KUBERNETES_MEMORY_REQUEST: 6Gi
-    KUBERNETES_MEMORY_LIMIT: 6Gi
-    KUBERNETES_HELPER_CPU_REQUEST: 1
-    KUBERNETES_HELPER_CPU_LIMIT: 1
-    KUBERNETES_HELPER_MEMORY_REQUEST: 3Gi
-    KUBERNETES_HELPER_MEMORY_LIMIT: 3Gi
+    KUBERNETES_POD_CPU_REQUEST: 3
+    KUBERNETES_POD_CPU_LIMIT: 3
+    KUBERNETES_POD_MEMORY_REQUEST: 6Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 6Gi
   parallel:
     matrix:
       - PHP_MAJOR_MINOR: *all_minor_major_targets
@@ -107,9 +103,9 @@ stages:
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:29.4.0-noble # TODO: use a proper docker image with java pre-installed?
   tags: [ "docker-in-docker:amd64" ]
   variables:
-    KUBERNETES_CPU_REQUEST: 8
-    KUBERNETES_MEMORY_REQUEST: 24Gi
-    KUBERNETES_MEMORY_LIMIT: 30Gi
+    KUBERNETES_POD_CPU_REQUEST: 8
+    KUBERNETES_POD_MEMORY_REQUEST: 24Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 30Gi
     DOCKER_LOOPBACK_SIZE: 30G
     ARCH: amd64
     HELPER_RUST_FLAG: ""
@@ -204,9 +200,9 @@ stages:
       interruptible: false
     - when: on_success
   variables:
-    KUBERNETES_CPU_REQUEST: 4
-    KUBERNETES_MEMORY_REQUEST: 8Gi
-    KUBERNETES_MEMORY_LIMIT: 10Gi
+    KUBERNETES_POD_CPU_REQUEST: 4
+    KUBERNETES_POD_MEMORY_REQUEST: 8Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 10Gi
     ARCH: amd64
   before_script:
 <?php echo $ecrLoginSnippet, "\n"; ?>
@@ -239,9 +235,9 @@ stages:
       interruptible: false
     - when: on_success
   variables:
-    KUBERNETES_CPU_REQUEST: 4
-    KUBERNETES_MEMORY_REQUEST: 8Gi
-    KUBERNETES_MEMORY_LIMIT: 10Gi
+    KUBERNETES_POD_CPU_REQUEST: 4
+    KUBERNETES_POD_MEMORY_REQUEST: 8Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 10Gi
     ARCH: amd64
   before_script:
 <?php echo $ecrLoginSnippet, "\n"; ?>
@@ -313,9 +309,9 @@ stages:
       interruptible: false
     - when: on_success
   variables:
-    KUBERNETES_CPU_REQUEST: 8
-    KUBERNETES_MEMORY_REQUEST: 24Gi
-    KUBERNETES_MEMORY_LIMIT: 30Gi
+    KUBERNETES_POD_CPU_REQUEST: 8
+    KUBERNETES_POD_MEMORY_REQUEST: 24Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 30Gi
     ARCH: amd64
     DD_EXPERIMENTAL_PROPAGATE_PROCESS_TAGS_ENABLED: "0"
   before_script:
@@ -395,9 +391,9 @@ stages:
   extends: .appsec_test
   image: registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:php-8.3_bookworm-8
   variables:
-    KUBERNETES_CPU_REQUEST: 3
-    KUBERNETES_MEMORY_REQUEST: 3Gi
-    KUBERNETES_MEMORY_LIMIT: 4Gi
+    KUBERNETES_POD_CPU_REQUEST: 3
+    KUBERNETES_POD_MEMORY_REQUEST: 3Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 4Gi
     ARCH: amd64
   script:
     - |
@@ -482,9 +478,9 @@ stages:
   extends: .docker_push_job
   tags: [ "docker-in-docker:${ARCH}" ]
   variables:
-    KUBERNETES_CPU_REQUEST: 8
-    KUBERNETES_MEMORY_REQUEST: 16Gi
-    KUBERNETES_MEMORY_LIMIT: 24Gi
+    KUBERNETES_POD_CPU_REQUEST: 8
+    KUBERNETES_POD_MEMORY_REQUEST: 16Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 24Gi
   parallel:
     matrix:
 # XXX: docker-in-docker:arm64 is not supported yet
@@ -500,9 +496,9 @@ stages:
 "push appsec docker images multiarch":
   extends: .docker_push_job
   variables:
-    KUBERNETES_CPU_REQUEST: 2
-    KUBERNETES_MEMORY_REQUEST: 4Gi
-    KUBERNETES_MEMORY_LIMIT: 6Gi
+    KUBERNETES_POD_CPU_REQUEST: 2
+    KUBERNETES_POD_MEMORY_REQUEST: 4Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 6Gi
     ARCH: amd64
   rules:
     - when: on_success
@@ -517,9 +513,9 @@ stages:
   extends: .appsec_test
   image: registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:php-8.3_bookworm-8
   variables:
-    KUBERNETES_CPU_REQUEST: 3
-    KUBERNETES_MEMORY_REQUEST: 9Gi
-    KUBERNETES_MEMORY_LIMIT: 10Gi
+    KUBERNETES_POD_CPU_REQUEST: 3
+    KUBERNETES_POD_MEMORY_REQUEST: 9Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 10Gi
     ARCH: amd64
   script:
     - sudo apt install -y clang-format-20
@@ -539,9 +535,9 @@ stages:
   extends: .appsec_test
   image: registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:bookworm-8
   variables:
-    KUBERNETES_CPU_REQUEST: 3
-    KUBERNETES_MEMORY_REQUEST: 3Gi
-    KUBERNETES_MEMORY_LIMIT: 4Gi
+    KUBERNETES_POD_CPU_REQUEST: 3
+    KUBERNETES_POD_MEMORY_REQUEST: 3Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 4Gi
   parallel:
     matrix:
       - ARCH: *arch_targets
@@ -565,9 +561,9 @@ stages:
 #  extends: .appsec_test
 #  image: registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:bookworm-8
 #  variables:
-#    KUBERNETES_CPU_REQUEST: 3
-#    KUBERNETES_MEMORY_REQUEST: 5Gi
-#    KUBERNETES_MEMORY_LIMIT: 6Gi
+#    KUBERNETES_POD_CPU_REQUEST: 3
+#    KUBERNETES_POD_MEMORY_REQUEST: 5Gi
+#    KUBERNETES_POD_MEMORY_LIMIT: 6Gi
 #  parallel:
 #    matrix:
 #      - ARCH: *arch_targets

--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -217,9 +217,9 @@ foreach ($build_platforms as $platform) {
     ABI_NO: "<?= $abi_no ?>"
     PHP_VERSION: "<?= $major_minor ?>"
     CARGO_BUILD_JOBS: 12
-    KUBERNETES_CPU_REQUEST: 12
-    KUBERNETES_MEMORY_REQUEST: 4Gi
-    KUBERNETES_MEMORY_LIMIT: 8Gi
+    KUBERNETES_POD_CPU_REQUEST: 12
+    KUBERNETES_POD_MEMORY_REQUEST: 4Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 8Gi
   script:
     - .gitlab/build-profiler.sh "datadog-profiling/${TRIPLET}/lib/php/${ABI_NO}" "nts"
     - .gitlab/build-profiler.sh "datadog-profiling/${TRIPLET}/lib/php/${ABI_NO}" "zts"
@@ -259,9 +259,9 @@ foreach ($build_platforms as $platform) {
     ABI_NO: "<?= $abi_no ?>"
     PHP_VERSION: "<?= $major_minor ?>"
     MAKE_JOBS: 12
-    KUBERNETES_CPU_REQUEST: 12
-    KUBERNETES_MEMORY_REQUEST: 4Gi
-    KUBERNETES_MEMORY_LIMIT: 8Gi
+    KUBERNETES_POD_CPU_REQUEST: 12
+    KUBERNETES_POD_MEMORY_REQUEST: 4Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 8Gi
   script:
     # Fix for $BASH_ENV not having a newline at the end of the file
     - echo "" >> "$BASH_ENV"
@@ -293,9 +293,9 @@ if ($suffix == "-alpine") {
       - ARCH: ["amd64", "arm64" ]
   variables:
     MAKE_JOBS: 12
-    KUBERNETES_CPU_REQUEST: 12
-    KUBERNETES_MEMORY_REQUEST: 4Gi
-    KUBERNETES_MEMORY_LIMIT: 8Gi
+    KUBERNETES_POD_CPU_REQUEST: 12
+    KUBERNETES_POD_MEMORY_REQUEST: 4Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 8Gi
   script: .gitlab/build-appsec-helper.sh
   artifacts:
     paths:
@@ -311,9 +311,9 @@ if ($suffix == "-alpine") {
       - ARCH: ["amd64", "arm64" ]
   variables:
     MAKE_JOBS: 12
-    KUBERNETES_CPU_REQUEST: 12
-    KUBERNETES_MEMORY_REQUEST: 8Gi
-    KUBERNETES_MEMORY_LIMIT: 12Gi
+    KUBERNETES_POD_CPU_REQUEST: 12
+    KUBERNETES_POD_MEMORY_REQUEST: 8Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 12Gi
   script: .gitlab/build-appsec-helper-rust.sh
   artifacts:
     paths:
@@ -350,9 +350,9 @@ foreach ($build_platforms as $platform) {
     ABI_NO: "<?= $abi_no ?>"
     PHP_VERSION: "<?= $major_minor ?>"
     MAKE_JOBS: 12
-    KUBERNETES_CPU_REQUEST: 12
-    KUBERNETES_MEMORY_REQUEST: 4Gi
-    KUBERNETES_MEMORY_LIMIT: 8Gi
+    KUBERNETES_POD_CPU_REQUEST: 12
+    KUBERNETES_POD_MEMORY_REQUEST: 4Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 8Gi
   script:
     # Fix for $BASH_ENV not having a newline at the end of the file
     - echo "" >> "$BASH_ENV"
@@ -418,9 +418,9 @@ foreach ($build_platforms as $platform) {
     ARCH: "<?= $platform['arch'] ?>"
     HOST_OS: "<?= $platform['host_os'] ?>"
     CARGO_BUILD_JOBS: 16
-    KUBERNETES_CPU_REQUEST: 16
-    KUBERNETES_MEMORY_REQUEST: 5Gi
-    KUBERNETES_MEMORY_LIMIT: 8Gi
+    KUBERNETES_POD_CPU_REQUEST: 16
+    KUBERNETES_POD_MEMORY_REQUEST: 5Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 8Gi
   script:
     - echo "" >> "$BASH_ENV"
     - ./.gitlab/build-sidecar.sh "<?= $suffix ?>"
@@ -465,9 +465,9 @@ foreach ($php_versions_to_abi as $major_minor => $abi_no) {
     TRIPLET: "<?= $platform['triplet'] ?>"
     ARCH: "<?= $platform['arch'] ?>"
     ABI_NO: "<?= $abi_no ?>"
-    KUBERNETES_CPU_REQUEST: 12
-    KUBERNETES_MEMORY_REQUEST: 8Gi
-    KUBERNETES_MEMORY_LIMIT: 16Gi
+    KUBERNETES_POD_CPU_REQUEST: 12
+    KUBERNETES_POD_MEMORY_REQUEST: 8Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 16Gi
   script:
     # Fix for $BASH_ENV not having a newline at the end of the file
     - echo "" >> "$BASH_ENV"
@@ -499,9 +499,9 @@ foreach ($asan_build_platforms as $platform) {
     ABI_NO: "<?= $abi_no ?>"
     PHP_VERSION: "<?= $major_minor ?>"
     MAKE_JOBS: 12
-    KUBERNETES_CPU_REQUEST: 12
-    KUBERNETES_MEMORY_REQUEST: 4Gi
-    KUBERNETES_MEMORY_LIMIT: 8Gi
+    KUBERNETES_POD_CPU_REQUEST: 12
+    KUBERNETES_POD_MEMORY_REQUEST: 4Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 8Gi
   script: ./.gitlab/build-tracing-asan.sh
   artifacts:
     paths:
@@ -791,9 +791,9 @@ endforeach;
   stage: verify
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:29.4.0-noble # TODO: use a proper docker image with make, php and git pre-installed
   variables:
-    KUBERNETES_CPU_REQUEST: 7
-    KUBERNETES_MEMORY_REQUEST: 30Gi
-    KUBERNETES_MEMORY_LIMIT: 40Gi
+    KUBERNETES_POD_CPU_REQUEST: 7
+    KUBERNETES_POD_MEMORY_REQUEST: 30Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 40Gi
     RUST_BACKTRACE: 1
     DOCKER_COMPOSE_DOWNLOAD_NAME: docker-compose-linux-x86_64
   before_script:
@@ -873,9 +873,9 @@ endforeach;
     - job: datadog-setup.php
       artifacts: true
   variables:
-    KUBERNETES_CPU_REQUEST: 2
-    KUBERNETES_MEMORY_REQUEST: 2Gi
-    KUBERNETES_MEMORY_LIMIT: 4Gi
+    KUBERNETES_POD_CPU_REQUEST: 2
+    KUBERNETES_POD_MEMORY_REQUEST: 2Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 4Gi
     RUST_BACKTRACE: 1
   before_script:
 <?php dockerhub_login() ?>
@@ -895,9 +895,9 @@ endforeach;
     - job: datadog-setup.php
       artifacts: true
   variables:
-    KUBERNETES_CPU_REQUEST: 2
-    KUBERNETES_MEMORY_REQUEST: 2Gi
-    KUBERNETES_MEMORY_LIMIT: 4Gi
+    KUBERNETES_POD_CPU_REQUEST: 2
+    KUBERNETES_POD_MEMORY_REQUEST: 2Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 4Gi
     RUST_BACKTRACE: 1
   before_script:
 <?php unset_dd_runner_env_vars() ?>
@@ -914,9 +914,9 @@ endforeach;
   image: 486234852809.dkr.ecr.us-east-1.amazonaws.com/docker:29.4.0-noble
   tags: [ "docker-in-docker:amd64" ]
   variables:
-    KUBERNETES_CPU_REQUEST: 2
-    KUBERNETES_MEMORY_REQUEST: 2Gi
-    KUBERNETES_MEMORY_LIMIT: 4Gi
+    KUBERNETES_POD_CPU_REQUEST: 2
+    KUBERNETES_POD_MEMORY_REQUEST: 2Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 4Gi
   needs:
     - job: "package extension: [amd64, x86_64-unknown-linux-gnu]"
       artifacts: true
@@ -963,9 +963,9 @@ endforeach;
   services:
     - !reference [.services, request-replayer]
   variables:
-    KUBERNETES_CPU_REQUEST: 2
-    KUBERNETES_MEMORY_REQUEST: 2Gi
-    KUBERNETES_MEMORY_LIMIT: 4Gi
+    KUBERNETES_POD_CPU_REQUEST: 2
+    KUBERNETES_POD_MEMORY_REQUEST: 2Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 4Gi
     DD_AGENT_HOST: request-replayer
     DD_TRACE_AGENT_PORT: 80
     DD_TRACE_AGENT_FLUSH_INTERVAL: 1000
@@ -1086,9 +1086,9 @@ endforeach;
   image: registry.ddbuild.io/images/mirror/debian:bullseye-slim
   tags: [ "arch:<?= $arch ?>" ]
   variables:
-    KUBERNETES_CPU_REQUEST: 2
-    KUBERNETES_MEMORY_REQUEST: 2Gi
-    KUBERNETES_MEMORY_LIMIT: 4Gi
+    KUBERNETES_POD_CPU_REQUEST: 2
+    KUBERNETES_POD_MEMORY_REQUEST: 2Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 4Gi
     PHP_VERSION: "<?= $major_minor ?>"
   needs:
     - job: "package extension: [<?= $arch ?>, <?= $pkgprefix ?>-unknown-linux-gnu]"
@@ -1108,9 +1108,9 @@ endforeach;
   image: registry.ddbuild.io/images/mirror/alpine:3.12
   tags: [ "arch:amd64" ]
   variables:
-    KUBERNETES_CPU_REQUEST: 2
-    KUBERNETES_MEMORY_REQUEST: 2Gi
-    KUBERNETES_MEMORY_LIMIT: 4Gi
+    KUBERNETES_POD_CPU_REQUEST: 2
+    KUBERNETES_POD_MEMORY_REQUEST: 2Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 4Gi
   needs:
     - job: "package extension: [amd64, x86_64-alpine-linux-musl]"
       artifacts: true
@@ -1160,9 +1160,9 @@ endforeach;
     - !reference [.services, request-replayer]
     - !reference [.services, httpbin-integration]
   variables:
-    KUBERNETES_CPU_REQUEST: 4
-    KUBERNETES_MEMORY_REQUEST: 3Gi
-    KUBERNETES_MEMORY_LIMIT: 5Gi
+    KUBERNETES_POD_CPU_REQUEST: 4
+    KUBERNETES_POD_MEMORY_REQUEST: 3Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 5Gi
   parallel:
     matrix:
       - PHP_VERSION: <?= json_encode($all_minor_major_targets), "\n" ?>
@@ -1220,10 +1220,10 @@ endforeach;
   tags: [ "docker-in-docker:amd64" ]
   variables:
     TEST_LIBRARY: php
-    KUBERNETES_CPU_REQUEST: 8
+    KUBERNETES_POD_CPU_REQUEST: 8
     PYTEST_XDIST_AUTO_NUM_WORKERS: 8
-    KUBERNETES_MEMORY_REQUEST: 3Gi
-    KUBERNETES_MEMORY_LIMIT: 4Gi
+    KUBERNETES_POD_MEMORY_REQUEST: 3Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 4Gi
     RUST_BACKTRACE: 1
     BUILD_SH_ARGS: php
     PIP_CACHE_DIR: $CI_PROJECT_DIR/.cache/pip
@@ -1630,8 +1630,8 @@ foreach ($arch_targets as $arch) {
   image: registry.ddbuild.io/images/mirror/php:8.2-cli
   tags: [ "arch:amd64" ]
   variables: # enough memory for the individual artifacts
-    KUBERNETES_MEMORY_REQUEST: 4Gi
-    KUBERNETES_MEMORY_LIMIT: 5Gi
+    KUBERNETES_POD_MEMORY_REQUEST: 4Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 5Gi
   only:
     refs:
       - /^ddtrace-.*$/

--- a/.gitlab/generate-profiler.php
+++ b/.gitlab/generate-profiler.php
@@ -27,18 +27,13 @@ foreach ($profiler_minor_major_targets as $version) {
   stage: test
   tags: [ "arch:${ARCH}" ]
   image: registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:${IMAGE_PREFIX}${PHP_MAJOR_MINOR}${IMAGE_SUFFIX}
-  # Setting the *_REQUEST and *_LIMIT variables to be the same, and setting
-  # them for both the build and helper allows using Guaranteed QoS instead of
-  # Burstable. This means nproc and similar tools will work as expected.
+  # Setting pod-level *_REQUEST and *_LIMIT to the same value uses Guaranteed QoS
+  # instead of Burstable, so nproc and similar tools work as expected.
   variables:
-    KUBERNETES_CPU_REQUEST: 3
-    KUBERNETES_CPU_LIMIT: 3
-    KUBERNETES_MEMORY_REQUEST: 6Gi
-    KUBERNETES_MEMORY_LIMIT: 6Gi
-    KUBERNETES_HELPER_CPU_REQUEST: 1
-    KUBERNETES_HELPER_CPU_LIMIT: 1
-    KUBERNETES_HELPER_MEMORY_REQUEST: 2Gi
-    KUBERNETES_HELPER_MEMORY_LIMIT: 2Gi
+    KUBERNETES_POD_CPU_REQUEST: 3
+    KUBERNETES_POD_CPU_LIMIT: 3
+    KUBERNETES_POD_MEMORY_REQUEST: 6Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 6Gi
     CARGO_TARGET_DIR: /mnt/ramdisk/cargo # ramdisk??
     libdir: /tmp/datadog-profiling
   parallel:
@@ -59,7 +54,7 @@ foreach ($profiler_minor_major_targets as $version) {
 
     - cd profiling
     - 'echo "nproc: $(nproc)"'
-    - 'echo "KUBERNETES_CPU_REQUEST: ${KUBERNETES_CPU_REQUEST:-<unset>}"'
+    - 'echo "KUBERNETES_POD_CPU_REQUEST: ${KUBERNETES_POD_CPU_REQUEST:-<unset>}"'
     - export TEST_PHP_EXECUTABLE=$(which php)
     - run_tests_php=$(find $(php-config --prefix) -name run-tests.php) # don't anticipate there being more than one
     - cp -v "${run_tests_php}" tests
@@ -97,14 +92,10 @@ foreach ($profiler_minor_major_targets as $version) {
   tags: [ "arch:amd64" ]
   image: registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:php-${PHP_MAJOR_MINOR}_bookworm-8
   variables:
-    KUBERNETES_CPU_REQUEST: 5
-    KUBERNETES_CPU_LIMIT: 5
-    KUBERNETES_MEMORY_REQUEST: 3Gi
-    KUBERNETES_MEMORY_LIMIT: 3Gi
-    KUBERNETES_HELPER_CPU_REQUEST: 1
-    KUBERNETES_HELPER_CPU_LIMIT: 1
-    KUBERNETES_HELPER_MEMORY_REQUEST: 2Gi
-    KUBERNETES_HELPER_MEMORY_LIMIT: 2Gi
+    KUBERNETES_POD_CPU_REQUEST: 5
+    KUBERNETES_POD_CPU_LIMIT: 5
+    KUBERNETES_POD_MEMORY_REQUEST: 3Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 3Gi
     # CARGO_TARGET_DIR: /mnt/ramdisk/cargo # ramdisk??
     libdir: /tmp/datadog-profiling
   parallel:
@@ -121,14 +112,10 @@ foreach ($profiler_minor_major_targets as $version) {
   tags: [ "arch:amd64" ]
   image: registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:php-8.5_bookworm-8
   variables:
-    KUBERNETES_CPU_REQUEST: 5
-    KUBERNETES_CPU_LIMIT: 5
-    KUBERNETES_MEMORY_REQUEST: 3Gi
-    KUBERNETES_MEMORY_LIMIT: 3Gi
-    KUBERNETES_HELPER_CPU_REQUEST: 1
-    KUBERNETES_HELPER_CPU_LIMIT: 1
-    KUBERNETES_HELPER_MEMORY_REQUEST: 2Gi
-    KUBERNETES_HELPER_MEMORY_LIMIT: 2Gi
+    KUBERNETES_POD_CPU_REQUEST: 5
+    KUBERNETES_POD_CPU_LIMIT: 5
+    KUBERNETES_POD_MEMORY_REQUEST: 3Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 3Gi
     # CARGO_TARGET_DIR: /mnt/ramdisk/cargo # ramdisk??
     libdir: /tmp/datadog-profiling
   script:
@@ -141,14 +128,10 @@ foreach ($profiler_minor_major_targets as $version) {
   tags: [ "arch:${ARCH}" ]
   image: registry.ddbuild.io/images/mirror/datadog/dd-trace-ci:php-${PHP_MAJOR_MINOR}_bookworm-8
   variables:
-    KUBERNETES_CPU_REQUEST: 5
-    KUBERNETES_CPU_LIMIT: 5
-    KUBERNETES_MEMORY_REQUEST: 3Gi
-    KUBERNETES_MEMORY_LIMIT: 3Gi
-    KUBERNETES_HELPER_CPU_REQUEST: 1
-    KUBERNETES_HELPER_CPU_LIMIT: 1
-    KUBERNETES_HELPER_MEMORY_REQUEST: 2Gi
-    KUBERNETES_HELPER_MEMORY_LIMIT: 2Gi
+    KUBERNETES_POD_CPU_REQUEST: 5
+    KUBERNETES_POD_CPU_LIMIT: 5
+    KUBERNETES_POD_MEMORY_REQUEST: 3Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 3Gi
     CARGO_TARGET_DIR: /tmp/cargo
     libdir: /tmp/datadog-profiling
     SKIP_ONLINE_TESTS: "1"

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -77,9 +77,9 @@ stages:
     WITH_ASAN: "0"
     CARGO_HOME: "/rust/cargo/"
     SWITCH_PHP_VERSION: "debug"
-    KUBERNETES_CPU_REQUEST: 12
-    KUBERNETES_MEMORY_REQUEST: 4Gi
-    KUBERNETES_MEMORY_LIMIT: 8Gi
+    KUBERNETES_POD_CPU_REQUEST: 12
+    KUBERNETES_POD_MEMORY_REQUEST: 4Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 8Gi
   script: .gitlab/compile_extension.sh
   after_script: |
     export out_dir="modules/${PHP_MAJOR_MINOR}-${SWITCH_PHP_VERSION}-${host_os}-${ARCH}/"
@@ -171,8 +171,8 @@ stages:
   tags: [ "arch:amd64" ]
   needs: []
   variables:
-    KUBERNETES_CPU_REQUEST: 1
-    KUBERNETES_MEMORY_REQUEST: 2Gi
+    KUBERNETES_POD_CPU_REQUEST: 1
+    KUBERNETES_POD_MEMORY_REQUEST: 2Gi
   before_script:
     - apt update && apt install -y unzip
     - php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && php composer-setup.php && mv composer.phar /usr/local/bin/composer
@@ -233,10 +233,10 @@ foreach ($asan_minor_major_targets as $major_minor):
   retry: 2
   variables:
     WAIT_FOR: test-agent:9126
-    KUBERNETES_CPU_REQUEST: 6
-    KUBERNETES_CPU_LIMIT: 6
-    KUBERNETES_MEMORY_REQUEST: 4Gi
-    KUBERNETES_MEMORY_LIMIT: 4Gi
+    KUBERNETES_POD_CPU_REQUEST: 6
+    KUBERNETES_POD_CPU_LIMIT: 6
+    KUBERNETES_POD_MEMORY_REQUEST: 4Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 4Gi
     MAX_TEST_PARALLELISM: 2
     PHP_MAJOR_MINOR: "<?= $major_minor ?>"
     ARCH: "<?= $arch ?>"
@@ -306,7 +306,7 @@ foreach ($asan_minor_major_targets as $major_minor):
       artifacts: true
   variables:
     WAIT_FOR: test-agent:9126
-    KUBERNETES_CPU_REQUEST: 12
+    KUBERNETES_POD_CPU_REQUEST: 12
     MAX_TEST_PARALLELISM: 4
     PHP_MAJOR_MINOR: "<?= $major_minor ?>"
     ARCH: "amd64"
@@ -361,7 +361,7 @@ foreach ($all_minor_major_targets as $major_minor):
       artifacts: true
   variables:
     WAIT_FOR: test-agent:9126
-    KUBERNETES_CPU_REQUEST: 12
+    KUBERNETES_POD_CPU_REQUEST: 12
     MAX_TEST_PARALLELISM: 4
     PHP_MAJOR_MINOR: "<?= $major_minor ?>"
     ARCH: "amd64"
@@ -438,10 +438,10 @@ foreach ($all_minor_major_targets as $major_minor):
     PHP_MAJOR_MINOR: "<?= $major_minor ?>"
     ARCH: "amd64"
 <?php if (version_compare($major_minor, "7.4", ">=")): ?>
-    KUBERNETES_CPU_REQUEST: 8
+    KUBERNETES_POD_CPU_REQUEST: 8
     MAX_TEST_PARALLELISM: 16
 <?php else: /* no test parallelism */ ?>
-    KUBERNETES_CPU_REQUEST: 1
+    KUBERNETES_POD_CPU_REQUEST: 1
   timeout: 40m
 <?php endif; ?>
   script:
@@ -508,20 +508,16 @@ foreach ($all_minor_major_targets as $major_minor):
     SKIP_ONLINE_TESTS: "1"
     WAIT_FOR: test-agent:9126
 <?php if (version_compare($major_minor, "7.4", ">=")): ?>
-    KUBERNETES_CPU_REQUEST: 8
-    KUBERNETES_CPU_LIMIT: 8
-    KUBERNETES_MEMORY_REQUEST: 7Gi
-    KUBERNETES_MEMORY_LIMIT: 7Gi
+    KUBERNETES_POD_CPU_REQUEST: 8
+    KUBERNETES_POD_CPU_LIMIT: 8
+    KUBERNETES_POD_MEMORY_REQUEST: 7Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 7Gi
 <?php else: ?>
-    KUBERNETES_CPU_REQUEST: 1
-    KUBERNETES_CPU_LIMIT: 1
-    KUBERNETES_MEMORY_REQUEST: 4Gi
-    KUBERNETES_MEMORY_LIMIT: 4Gi
+    KUBERNETES_POD_CPU_REQUEST: 1
+    KUBERNETES_POD_CPU_LIMIT: 1
+    KUBERNETES_POD_MEMORY_REQUEST: 4Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 4Gi
 <?php endif; ?>
-    KUBERNETES_HELPER_CPU_REQUEST: 1
-    KUBERNETES_HELPER_CPU_LIMIT: 1
-    KUBERNETES_HELPER_MEMORY_REQUEST: 1Gi
-    KUBERNETES_HELPER_MEMORY_LIMIT: 1Gi
     KUBERNETES_POD_ANNOTATIONS_1: "ci.ddbuild.io/enforce-static-cpus=true"
 <?php if (version_compare($major_minor, "7.2", ">=")): /* too expensive */ ?>
     DD_INSTRUMENTATION_TELEMETRY_ENABLED: 0
@@ -552,9 +548,9 @@ endforeach;
   variables:
     DD_TRACE_TEST_SAPI: cli-server
     COMPOSER_PROCESS_TIMEOUT: 0
-    KUBERNETES_CPU_REQUEST: 2 # generally one for PHP and one for the webserver
-    KUBERNETES_MEMORY_REQUEST: 4Gi
-    KUBERNETES_MEMORY_LIMIT: 4Gi
+    KUBERNETES_POD_CPU_REQUEST: 2 # generally one for PHP and one for the webserver
+    KUBERNETES_POD_MEMORY_REQUEST: 4Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 4Gi
     SWITCH_PHP_VERSION: debug
     COMPOSER_VERSION: 2
   before_script:
@@ -646,8 +642,8 @@ foreach ($services as $part => $service) {
     COMPOSER_VERSION: 2.2
 <?php endif; ?>
 <?php if (preg_match("(test_web_laravel_octane)", $target)): ?>
-    KUBERNETES_MEMORY_REQUEST: 6Gi
-    KUBERNETES_MEMORY_LIMIT: 6Gi
+    KUBERNETES_POD_MEMORY_REQUEST: 6Gi
+    KUBERNETES_POD_MEMORY_LIMIT: 6Gi
 <?php endif; ?>
 
 <?php


### PR DESCRIPTION
### Description

This is a "cherry-pick" of #4008 by @henryvo117 onto a branch in this repo so that the GitLab CI pipelines run (the original PR comes from a fork and does not trigger our GitLab CI).

Original PR: #4008

> Replace per-container Kubernetes CPU/memory variables with a single
> KUBERNETES_POD_* budget in the generated CI templates so helper setup
> and build work share one pod resource reservation.

All credit to the original author; commit authorship is preserved.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
