### PR TITLE
fix(ci): `apt-get update` before `apt install` in docker-image jobs

### DIFF
--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -798,6 +798,7 @@ endforeach;
     DOCKER_COMPOSE_DOWNLOAD_NAME: docker-compose-linux-x86_64
   before_script:
 <?php dockerhub_login() ?>
+    - apt-get update
     - apt install -y php git make curl
     - curl -L --fail https://github.com/docker/compose/releases/download/v2.36.0/${DOCKER_COMPOSE_DOWNLOAD_NAME} -o /usr/local/bin/docker-compose
     - chmod +x /usr/local/bin/docker-compose
@@ -879,6 +880,7 @@ endforeach;
     RUST_BACKTRACE: 1
   before_script:
 <?php dockerhub_login() ?>
+    - apt-get update
     - apt install -y make
     - mkdir build
     - mv packages build
@@ -944,6 +946,7 @@ endforeach;
         # - symfony
   before_script:
 <?php dockerhub_login() ?>
+    - apt-get update
     - apt install -y make curl
     - curl -L --fail https://github.com/docker/compose/releases/download/v2.36.0/docker-compose-linux-x86_64 -o /usr/local/bin/docker-compose
     - chmod +x /usr/local/bin/docker-compose


### PR DESCRIPTION
### Description

While working on #4002 all `randomized tests` job suddenly started failing. This is because of the apt index is stale on the image and we are not updating it before running `apt install -y php git make curl`, so that fails with:

```
Err … libxml2 2.9.14+dfsg-1.3ubuntu3.7  404 Not Found
E: Failed to fetch …/libxml2_2.9.14%2bdfsg-1.3ubuntu3.7_amd64.deb  404  Not Found
E: Unable to fetch some archives, maybe run apt-get update?
```

This also fails on `master` since today: https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-php/-/jobs/1799170178

This PR adds `apt-get update` before each of the three `apt install` steps in `.gitlab/generate-package.php`. The other apt-based jobs in this file already do this.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
