### PR TITLE
chore: modify fix for security advisories

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -554,7 +554,8 @@ TEST_EXTRA_ENV ?=
 
 ### DDTrace tests ###
 TESTS_ROOT = ./tests
-COMPOSER = $(if $(ASAN), ASAN_OPTIONS=detect_leaks=0) COMPOSER_MEMORY_LIMIT=-1 composer --no-interaction
+# Note: We disable composer's security blocking so that pinned dependency versions flagged by a security advisory (e.g. Laravel/framework PKSA-mdq4-51ck-6kdq / CVE-2026-48019) still resolve.
+COMPOSER = $(if $(ASAN), ASAN_OPTIONS=detect_leaks=0) COMPOSER_NO_SECURITY_BLOCKING=1 COMPOSER_MEMORY_LIMIT=-1 composer --no-interaction
 DDPROF_IDENTIFIER ?=
 PHPUNIT_OPTS ?=
 PHPUNIT_JUNIT ?=
@@ -1212,12 +1213,7 @@ FILTER ?= .
 MAX_RETRIES := 3
 RUN_WEB_BENCHES_WITH_DDPROF ?=
 
-# Note: The "composer show" command below outputs a csv with pairs of dependency;version such as "phpunit/phpunit;9.6.17"
-# Note: We disable composer's "block-insecure" audit so that pinned dependency versions flagged by a
-# security advisory still resolve. The audit.block-insecure setting only exists since Composer 2.4;
-# the Composer 2.2 LTS used for PHP < 7.2 has no such resolver block, so we ignore the failure there.
 define run_composer_with_retry
-	$(COMPOSER) --working-dir=$(if $1,$1,.) config audit.block-insecure false || true
 	for i in $$(seq 1 $(MAX_RETRIES)); do \
 		echo "Attempting composer update (attempt $$i of $(MAX_RETRIES))..."; \
 		$(COMPOSER) --working-dir=$(if $1,$1,.) update $2 && break || (echo "Retry $$i failed, waiting 5 seconds before next attempt..." && sleep 5); \


### PR DESCRIPTION
### Description

Use Env variable instead of config to disable composer security advisories
