### PR TITLE
fix(ci): exclude hook_does_not_leak_error from windows test_c (php-cgi stderr deadlock)

### DIFF
--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -141,6 +141,13 @@ stages:
     # Set test environment variables
     docker exec ${CONTAINER_NAME} powershell.exe "setx DD_AUTOLOAD_NO_COMPILE true; setx DATADOG_HAVE_DEV_ENV 1; setx DD_TRACE_GIT_METADATA_ENABLED 0"
 
+    # Exclude tests that deadlock the php-cgi SKIPIF skip-task on Windows.
+<?php foreach ([
+        "tests/ext/sandbox/hook_function/hook_does_not_leak_error.phpt",
+    ] as $win_excluded_test): ?>
+    docker exec ${CONTAINER_NAME} powershell.exe "Remove-Item -Force -ErrorAction SilentlyContinue C:\Users\ContainerAdministrator\app\<?= str_replace('/', '\\', $win_excluded_test) ?>"
+<?php endforeach ?>
+
     # Run extension tests
     docker exec ${CONTAINER_NAME} powershell.exe 'cd app; $env:_DD_DEBUG_SIDECAR_LOG_LEVEL=trace; $env:_DD_DEBUG_SIDECAR_LOG_METHOD="""file://${pwd}\sidecar.log"""; C:\php\php.exe -n -d memory_limit=-1 -d output_buffering=0 run-tests.php -g FAIL,XFAIL,BORK,WARN,LEAK,XLEAK,SKIP --show-diff -p C:\php\php.exe -d "extension=${pwd}\x64\Release\php_ddtrace.dll" "${pwd}\tests\ext"'
   after_script:


### PR DESCRIPTION
## What
- Exclude `tests/ext/sandbox/hook_function/hook_does_not_leak_error.phpt` from the Windows `test_c` job (list-based, Windows-only) to stop `windows test_c [7.2]`/`[7.3]` hanging to the 1h timeout.

## Why
`windows test_c [7.2]/[7.3]` were timing out at 1h. Root cause: the **`php-cgi` SKIPIF skip-task** for this test deadlocks on Windows. At `datadog.trace.log_level >= warn`, ddtrace emits a `Error loading deferred integration … not autoloadable` warning **per integration**; under Windows CGI the runner does not drain that process's stderr, so the pipe fills and ddtrace's synchronous `WriteFile` to stderr blocks forever (`dd_log_callback` → `php_log_err` → `WriteFile`).

- The default log level is `error`, which suppresses those warnings — so the other CGI tests are unaffected (this is the only CGI test that runs ddtrace at `info`).

## How
A small, documented, list-based carve-out in `.gitlab/generate-tracer.php`: before `run-tests`, the Windows job `Remove-Item`s the listed test(s). The test **already skips on Windows** (`die('skip: On Windows cgi skips stderr output')`), so removing it from the Windows run loses no coverage.