### PR TITLE
fix(ci): make choco resolvable in 'verify windows' when already installed

### DIFF
--- a/dockerfiles/verify_packages/verify_windows.ps1
+++ b/dockerfiles/verify_packages/verify_windows.ps1
@@ -3,6 +3,11 @@
 if (-not $env:ChocolateyInstall) { $env:ChocolateyInstall = 'C:\ProgramData\chocolatey' }
 Import-Module $env:ChocolateyInstall\helpers\chocolateyProfile.psm1
 
+# install.ps1 only adds choco to the session PATH on a FRESH install. On runners where
+# Chocolatey is already present it short-circuits, leaving `choco` unresolvable in this
+# session. Prepend the known bin dir so the command resolves regardless of runner state.
+$env:Path = "$env:ChocolateyInstall\bin;$env:Path"
+
 choco install -y php
 choco install -y 7zip
 refreshenv


### PR DESCRIPTION
## Problem

The `verify windows` job (e.g. [job 1799902787](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-php/-/jobs/1799902787)) intermittently fails on shared Windows runners with:

```
WARNING: Files from a previous installation of Chocolatey were found at 'C:\ProgramData\chocolatey'.
WARNING: An existing Chocolatey installation was detected. Installation will not continue.
$ .\dockerfiles\verify_packages\verify_windows.ps1
choco : The term 'choco' is not recognized as the name of a cmdlet ...
ERROR: Job failed: exit status 1
```

## Root cause

The job bootstraps Chocolatey via the community `install.ps1` (with an exit-75 download-retry loop). On runners where Chocolatey is **already on disk**, `install.ps1` short-circuits and returns 0 **without** adding choco's bin dir to the current PowerShell session PATH — it only mutates the session PATH on a *fresh* install. `verify_windows.ps1` then calls `choco install -y php`, which isn't resolvable. The existing exit-75 retry only triggers on a `DownloadString` exception, so this path is not retried — it just fails with exit 1.

## Fix

Prepend the known Chocolatey bin dir to the session PATH in `verify_windows.ps1` before invoking `choco`, so the command resolves regardless of whether `install.ps1` refreshed the session PATH.