### PR TITLE
feat(ci): integrate PHP apm-sdks-benchmarks into main pipeline

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -3,6 +3,12 @@ stages:
   - tests
   - deploy
   - ci-build
+  - php-laravel-realworld-parallel
+  - php-laravel-realworld-parallel-slo
+  - php-symfony-realworld-parallel
+  - php-symfony-realworld-parallel-slo
+  - php-wordpress-parallel
+  - php-wordpress-parallel-slo
 
 variables:
   GIT_SUBMODULE_STRATEGY: recursive
@@ -18,6 +24,7 @@ include:
     ref: 5826819695d93286569e70ed087ae6bf906ce2c3
     file: templates/ci_authenticated_job.yml
   - local: .gitlab/ci-images.yml
+  - local: .gitlab/apm-sdks-benchmarks.yml
 
 generate-templates:
   stage: build

--- a/.gitlab/apm-sdks-benchmarks.yml
+++ b/.gitlab/apm-sdks-benchmarks.yml
@@ -1,0 +1,10 @@
+include:
+  - project: 'DataDog/apm-reliability/apm-sdks-benchmarks'
+    file: '.gitlab/ci-php-laravel-realworld-parallel.yml'
+    ref: 'main'
+  - project: 'DataDog/apm-reliability/apm-sdks-benchmarks'
+    file: '.gitlab/ci-php-symfony-realworld-parallel.yml'
+    ref: 'main'
+  - project: 'DataDog/apm-reliability/apm-sdks-benchmarks'
+    file: '.gitlab/ci-php-wordpress-parallel.yml'
+    ref: 'main'


### PR DESCRIPTION
### Description

Integrates the PHP benchmark jobs from `apm-sdks-benchmarks` into the `dd-trace-php` GitLab pipeline, so benchmarks run against the tracer built from the current commit SHA. This provides deeper insight into the performance of the library across representative PHP workloads (Laravel Realworld, Symfony Realworld, WordPress).

See companion PR for implementation details: https://github.com/DataDog/apm-sdks-benchmarks/pull/186