### PR TITLE
fix(loader): surface SSI incompatible runtime

### DIFF
--- a/loader/dd_library_loader.c
+++ b/loader/dd_library_loader.c
@@ -40,6 +40,8 @@ static void *libdatadog_php_handle = NULL;
 static unsigned int php_api_no = 0;
 static const char *runtime_version = "unknown";
 static bool injection_forced = false;
+static bool ddtrace_disabled_by_incompatible_runtime = false;
+static char ddtrace_disabled_result_reason[384] = {0};
 
 static bool already_done = false;
 
@@ -72,6 +74,19 @@ PHP_INI_END()
 
 
 static void ddloader_telemetryf(telemetry_reason reason, injected_ext *config, const char *error, const char *format, ...);
+
+static void ddloader_set_ddtrace_disabled_by_incompatible_runtime(const char *format, ...) {
+    if (ddtrace_disabled_by_incompatible_runtime) {
+        return;
+    }
+
+    ddtrace_disabled_by_incompatible_runtime = true;
+
+    va_list va;
+    va_start(va, format);
+    vsnprintf(ddtrace_disabled_result_reason, sizeof(ddtrace_disabled_result_reason), format, va);
+    va_end(va);
+}
 
 static char *ddtrace_pre_load_hook(injected_ext *config) {
     // Load libdatadog_php.so, on which ddtrace.so implicitly depends. Implicit
@@ -225,8 +240,6 @@ static void ddtrace_pre_minit_hook(injected_ext *config, zend_module_entry *modu
     }
 
     // Load, but disable the tracer if runtime configuration is not safe for auto-injection
-    bool disable_tracer = false;
-
     char *incompatible_exts[] = {"Xdebug", "the ionCube PHP Loader", "ionCube Loader", "the ionCube PHP Loader + ionCube24", "newrelic", "blackfire", "pcov"};
     for (size_t i = 0; i < sizeof(incompatible_exts) / sizeof(incompatible_exts[0]); ++i) {
         if (ddloader_is_ext_loaded(incompatible_exts[i])) {
@@ -234,7 +247,10 @@ static void ddtrace_pre_minit_hook(injected_ext *config, zend_module_entry *modu
                 LOG(config, WARN, "Potentially incompatible extension detected: %s. Ignoring as DD_INJECT_FORCE is enabled", incompatible_exts[i]);
             } else {
                 LOG(config, WARN, "Potentially incompatible extension detected: %s. ddtrace will be disabled unless the environment DD_INJECT_FORCE is set to '1', 'true', 'yes' or 'on'", incompatible_exts[i]);
-                disable_tracer = true;
+                ddloader_set_ddtrace_disabled_by_incompatible_runtime(
+                    "The PHP tracer was disabled because potentially incompatible extension '%s' is loaded. Set DD_INJECT_FORCE to force tracing.",
+                    incompatible_exts[i]
+                );
             }
         }
     }
@@ -244,11 +260,13 @@ static void ddtrace_pre_minit_hook(injected_ext *config, zend_module_entry *modu
             LOG(config, WARN, "OPcache JIT is enabled and may cause instability. Ignoring as DD_INJECT_FORCE is enabled");
         } else {
             LOG(config, WARN, "OPcache JIT is enabled and may cause instability. ddtrace will be disabled unless the environment DD_INJECT_FORCE is set to '1', 'true', 'yes' or 'on'");
-            disable_tracer = true;
+            ddloader_set_ddtrace_disabled_by_incompatible_runtime(
+                "The PHP tracer was disabled because OPcache JIT is enabled. Set DD_INJECT_FORCE to force tracing."
+            );
         }
     }
 
-    if (disable_tracer) {
+    if (ddtrace_disabled_by_incompatible_runtime) {
         ddloader_ini_set_configuration(config, ZEND_STRL("ddtrace.disable"), ZEND_STRL("1"));
     }
 
@@ -728,6 +746,8 @@ static PHP_MINIT_FUNCTION(ddloader_injected_extension_minit) {
     zend_result ret = module->module_startup_func(INIT_FUNC_ARGS_PASSTHRU);
     if (ret == FAILURE) {
         TELEMETRY(REASON_ERROR, config, "error_minit", "'%s' MINIT function failed", config->ext_name);
+    } else if (strcmp(config->ext_name, "ddtrace") == 0 && ddtrace_disabled_by_incompatible_runtime) {
+        TELEMETRY(REASON_INCOMPATIBLE_RUNTIME, config, NULL, "%s", ddtrace_disabled_result_reason)
     } else {
         TELEMETRY(REASON_COMPLETE, config, NULL, "Application instrumentation bootstrapping complete ('%s')", config->ext_name)
     }
@@ -1028,6 +1048,8 @@ static void ddloader_zend_extension_shutdown(zend_extension *ext) {
     }
 
     injection_forced = false;
+    ddtrace_disabled_by_incompatible_runtime = false;
+    *ddtrace_disabled_result_reason = 0;
     already_done = false;
 }
 

--- a/loader/tests/functional/test_incompatibility_jit.php
+++ b/loader/tests/functional/test_incompatibility_jit.php
@@ -11,6 +11,7 @@ if (PHP_MAJOR_VERSION === 8 && PHP_MINOR_VERSION === 0 && php_uname('m') === 'aa
 
 $msg_disabled = "OPcache JIT is enabled and may cause instability. ddtrace will be disabled unless the environment DD_INJECT_FORCE is set to '1', 'true', 'yes' or 'on'";
 $msg_forced = "OPcache JIT is enabled and may cause instability. Ignoring as DD_INJECT_FORCE is enabled";
+$jitTelemetryLogPath = tempnam(sys_get_temp_dir(), 'test_loader_');
 
 $tests = [
     // OPcache disabled in CLI
@@ -73,6 +74,10 @@ EOT
     // JIT enabled
     [
         "config" => "-dzend_extension=opcache -dopcache.enable_cli=1 -ddatadog.trace.cli_enabled=1 -dopcache.jit_buffer_size=32M -dopcache.jit=tracing",
+        "env" => [
+            'FAKE_FORWARDER_LOG_PATH='.$jitTelemetryLogPath,
+            'DD_TELEMETRY_FORWARDER_PATH='.__DIR__.'/../../bin/fake_forwarder.sh',
+        ],
         "must_not_contain" => [],
         "must_contain" => [
             $msg_disabled,
@@ -94,8 +99,8 @@ Author => Datadog
 
   => ddtrace
 Version => %s
-Injection success => true
-Injection error =>
+Injection success => false
+Injection error => Incompatible runtime
 Extra config => datadog.trace.sources_path=%s/trace/src
 ddtrace.disable=1
 
@@ -104,6 +109,34 @@ OPcache JIT is enabled and may cause instability. ddtrace will be disabled unles
 %A
 EOT
         ],
+        "telemetry_log_path" => $jitTelemetryLogPath,
+        "telemetry" => <<<EOS
+{
+    "metadata": {
+        "runtime_name": "php",
+        "runtime_version": "%d.%d.%d%S",
+        "language_name": "php",
+        "language_version": "%d.%d.%d%S",
+        "tracer_version": "%s",
+        "pid": %d,
+        "result": "abort",
+        "result_reason": "The PHP tracer was disabled because OPcache JIT is enabled. Set DD_INJECT_FORCE to force tracing.",
+        "result_class": "incompatible_runtime"
+    },
+    "points": [
+        {
+            "name": "library_entrypoint.abort",
+            "tags": [
+                "reason:incompatible_runtime",
+                "product:ddtrace"
+            ]
+        },
+        {
+            "name": "library_entrypoint.abort.runtime"
+        }
+    ]
+}
+EOS
     ],
     // JIT enabled + force injection via ENV
     [
@@ -197,5 +230,10 @@ foreach ($tests as $data) {
 
     foreach ($data['must_match'] as $pattern) {
         assertMatchesFormat($output, $pattern);
+    }
+    if (isset($data['telemetry'])) {
+        // Let time to the fork to write the telemetry log
+        usleep(5000);
+        assertTelemetry($data['telemetry_log_path'], $data['telemetry']);
     }
 }

--- a/loader/tests/functional/test_incompatibility_xdebug.php
+++ b/loader/tests/functional/test_incompatibility_xdebug.php
@@ -54,7 +54,8 @@ assertTelemetry($telemetryLogPath, <<<EOS
         }
     ]
 }
-EOS);
+EOS
+);
 
 $output = runCLI('-dzend_extension='.getenv("XDEBUG_SO_NAME").' -v', true, ['DD_TRACE_DEBUG=1', 'DD_INJECT_FORCE=1']);
 assertContains($output, 'Found extension file');

--- a/loader/tests/functional/test_incompatibility_xdebug.php
+++ b/loader/tests/functional/test_incompatibility_xdebug.php
@@ -11,13 +11,50 @@ if (!getenv("XDEBUG_SO_NAME")) {
 $msg_disabled = "Potentially incompatible extension detected: Xdebug. ddtrace will be disabled unless the environment DD_INJECT_FORCE is set to '1', 'true', 'yes' or 'on'";
 $msg_forced = "Potentially incompatible extension detected: Xdebug. Ignoring as DD_INJECT_FORCE is enabled";
 
-$output = runCLI('-dzend_extension='.getenv("XDEBUG_SO_NAME").' -v', true, ['DD_TRACE_DEBUG=1']);
+$telemetryLogPath = tempnam(sys_get_temp_dir(), 'test_loader_');
+
+$output = runCLI('-dzend_extension='.getenv("XDEBUG_SO_NAME").' -v', true, [
+    'DD_TRACE_DEBUG=1',
+    'FAKE_FORWARDER_LOG_PATH='.$telemetryLogPath,
+    'DD_TELEMETRY_FORWARDER_PATH='.__DIR__.'/../../bin/fake_forwarder.sh',
+]);
 assertContains($output, 'Found extension file');
 assertContains($output, $msg_disabled);
 assertNotContains($output, $msg_forced);
 assertContains($output, 'with dd_library_loader v');
 assertContains($output, 'with Xdebug v');
 assertContains($output, 'with ddtrace v');
+
+// Let time to the fork to write the telemetry log
+usleep(5000);
+
+assertTelemetry($telemetryLogPath, <<<EOS
+{
+    "metadata": {
+        "runtime_name": "php",
+        "runtime_version": "%d.%d.%d%S",
+        "language_name": "php",
+        "language_version": "%d.%d.%d%S",
+        "tracer_version": "%s",
+        "pid": %d,
+        "result": "abort",
+        "result_reason": "The PHP tracer was disabled because potentially incompatible extension 'Xdebug' is loaded. Set DD_INJECT_FORCE to force tracing.",
+        "result_class": "incompatible_runtime"
+    },
+    "points": [
+        {
+            "name": "library_entrypoint.abort",
+            "tags": [
+                "reason:incompatible_runtime",
+                "product:ddtrace"
+            ]
+        },
+        {
+            "name": "library_entrypoint.abort.runtime"
+        }
+    ]
+}
+EOS);
 
 $output = runCLI('-dzend_extension='.getenv("XDEBUG_SO_NAME").' -v', true, ['DD_TRACE_DEBUG=1', 'DD_INJECT_FORCE=1']);
 assertContains($output, 'Found extension file');

--- a/loader/tests/functional/test_incompatibility_xdebug.php
+++ b/loader/tests/functional/test_incompatibility_xdebug.php
@@ -28,7 +28,7 @@ assertContains($output, 'with ddtrace v');
 // Let time to the fork to write the telemetry log
 usleep(5000);
 
-assertTelemetry($telemetryLogPath, <<<EOS
+$metrics = [<<<EOS
 {
     "metadata": {
         "runtime_name": "php",
@@ -55,7 +55,39 @@ assertTelemetry($telemetryLogPath, <<<EOS
     ]
 }
 EOS
-);
+];
+
+if ('7.0' === php_minor_version()) {
+    $metrics[] = <<<EOS
+{
+    "metadata": {
+        "runtime_name": "php",
+        "runtime_version": "%d.%d.%d%S",
+        "language_name": "php",
+        "language_version": "%d.%d.%d%S",
+        "tracer_version": "%s",
+        "pid": %d,
+        "result": "abort",
+        "result_reason": "%s",
+        "result_class": "incompatible_runtime"
+    },
+    "points": [
+        {
+            "name": "library_entrypoint.abort",
+            "tags": [
+                "reason:incompatible_runtime",
+                "product:datadog-profiling"
+            ]
+        },
+        {
+            "name": "library_entrypoint.abort.runtime"
+        }
+    ]
+}
+EOS;
+}
+
+assertTelemetry($telemetryLogPath, $metrics);
 
 $output = runCLI('-dzend_extension='.getenv("XDEBUG_SO_NAME").' -v', true, ['DD_TRACE_DEBUG=1', 'DD_INJECT_FORCE=1']);
 assertContains($output, 'Found extension file');


### PR DESCRIPTION
## Description

Surface PHP SSI cases where the loader keeps the extension loaded but disables the tracer because an incompatible runtime configuration was detected, such as Xdebug or OPcache JIT. The loader now reports this as `incompatible_runtime` injection metadata so diagnostics can explain why profiles appear while traces are missing.

## Related Issue

N/A

## Type of Change

- [x] Bug fix
- [ ] New feature
- [ ] Breaking change
- [ ] Refactor / cleanup
- [ ] CI / tooling
- [ ] Documentation

## Checklist

- [ ] Documentation updated if needed
- [x] Tests added or updated
- [x] No unintended breaking changes

## How Has This Been Tested?

- `make -C loader -j$(nproc)`

## Additional Notes

The focused Xdebug functional test was updated to assert the telemetry payload. It was not run locally because the available `php` binary fails to start due to a missing `libicuio.so.70` shared library.