### PR TITLE
fix(ci): version-portable assert shims in ProcessTagsWebTest (PHP 7.0)

### DIFF
--- a/tests/Integrations/Custom/Autoloaded/ProcessTagsWebTest.php
+++ b/tests/Integrations/Custom/Autoloaded/ProcessTagsWebTest.php
@@ -79,14 +79,14 @@ class ProcessTagsWebTest extends WebFrameworkTestCase
             return $this->call(new RequestSpec(__FUNCTION__ . '_user', 'GET', '/set_service', []));
         });
         $userTags = $tracesUser[0][0]['meta']['_dd.tags.process'];
-        $this->assertStringContainsString('svc.user:true', $userTags);
-        $this->assertStringNotContainsString('svc.auto:', $userTags);
+        $this->assertStringContains('svc.user:true', $userTags);
+        $this->assertStringNotContains('svc.auto:', $userTags);
 
         $tracesAuto = $this->tracesFromWebRequest(function () {
             return $this->call(new RequestSpec(__FUNCTION__ . '_auto', 'GET', '/simple', []));
         });
         $autoTags = $tracesAuto[0][0]['meta']['_dd.tags.process'];
-        $this->assertStringNotContainsString('svc.user', $autoTags);
-        $this->assertStringContainsString('svc.auto:', $autoTags);
+        $this->assertStringNotContains('svc.user', $autoTags);
+        $this->assertStringContains('svc.auto:', $autoTags);
     }
 }


### PR DESCRIPTION
## What failed

`test_web_custom: [7.0]` fails on every master pipeline (14x in the last 2 days).

```
Error: Call to undefined method DDTrace\Tests\...\ProcessTagsWebTest::assertStringContainsString()
tests/Integrations/Custom/Autoloaded/ProcessTagsWebTest.php:82
```

## Why

Commit 18ca64641e added `testSvcTagDoesNotLeakBetweenRequests`, which calls the native PHPUnit methods `assertStringContainsString()` / `assertStringNotContainsString()`. These exist only in PHPUnit >= 7.5. PHP 7.0's pinned PHPUnit is 6.x and lacks them, so only the 7.0 matrix cell breaks (7.1+ ships a newer PHPUnit and passes).

## Fix

Replace the native calls with the repo's existing version-portable shims from `tests/Common/BaseTestCase.php`:
- `assertStringContains($needle, $haystack)` (wraps `assertStringContainsString` on PHPUnit >= 8, `assertContains` otherwise)
- `assertStringNotContains($needle, $haystack)` (wraps `assertStringNotContainsString` / `assertNotContains`)

The shim argument order matches the native (needle, haystack), so this is a pure method-name swap. Test-only change, no production code touched.