### PR TITLE
fix(live-debugger): retire removed probe configs to prevent use-after-free

### DIFF
--- a/components-rs/datadog.h
+++ b/components-rs/datadog.h
@@ -187,6 +187,8 @@ void ddog_set_dynamic_instrumentation_enabled(struct ddog_RemoteConfigState *rem
 
 void ddog_rshutdown_remote_config(struct ddog_RemoteConfigState *remote_config);
 
+void ddog_live_debugger_free_retired(struct ddog_RemoteConfigState *remote_config);
+
 void ddog_shutdown_remote_config(struct ddog_RemoteConfigState*);
 
 void ddog_log_debugger_data(const struct ddog_Vec_DebuggerPayload *payloads);

--- a/components-rs/remote_config.rs
+++ b/components-rs/remote_config.rs
@@ -111,6 +111,13 @@ pub struct LiveDebuggerCallbacks {
 pub struct LiveDebuggerState {
     pub spans_map: HashMap<String, i64>,
     pub active: HashMap<String, Box<(RemoteConfigParsed, MaybeShmLimiter)>>, // Box<> for stable heap address!
+    // Parsed configs removed (or replaced) from `active` whose probe hooks may still be
+    // installed: the C side stores shallow `ddog_Probe` copies that borrow `CharSlice`s
+    // (probe id, capture config, shm limiter, ...) into these boxes, and `zai_hook_remove`
+    // can defer the actual teardown of those hooks past this point. Dropping the box here
+    // would free the borrowed strings while a deferred hook can still fire and read them
+    // (use-after-free). Keep them alive until request shutdown, when all hooks are gone.
+    pub retired: Vec<Box<(RemoteConfigParsed, MaybeShmLimiter)>>,
     pub config_id: String,
     pub allow_dfa: Option<Regex>,
     pub deny_dfa: Option<Regex>,
@@ -392,10 +399,13 @@ pub extern "C" fn ddog_process_remote_configs(remote_config: &mut RemoteConfigSt
                         RemoteConfigProduct::LiveDebugger => {
                             let val = Box::new((data, MaybeShmLimiter::open(limiter_index)));
                             let rc_ref: &mut RemoteConfigState = unsafe { mem::transmute(remote_config as *mut _) }; // sigh, borrow checker
+                            let mut retired_old = None;
                             let entry = remote_config.live_debugger.active.entry(value.config_id);
                             let (parsed, limiter) = match entry {
                                 Entry::Occupied(mut e) => {
-                                    e.insert(val);
+                                    // Retire (don't drop) the replaced box: an orphaned hook may
+                                    // still borrow its strings until request shutdown.
+                                    retired_old = Some(e.insert(val));
                                     let r = e.into_mut();
                                     (&r.0, &r.1)
                                 }
@@ -406,6 +416,9 @@ pub extern "C" fn ddog_process_remote_configs(remote_config: &mut RemoteConfigSt
                             };
                             if let Some(debugger) = parsed.downcast::<LiveDebuggingData>() {
                                 apply_config(rc_ref, debugger, limiter);
+                            }
+                            if let Some(old) = retired_old {
+                                rc_ref.live_debugger.retired.push(old);
                             }
                         }
                         RemoteConfigProduct::ApmTracing => {
@@ -442,6 +455,9 @@ pub extern "C" fn ddog_process_remote_configs(remote_config: &mut RemoteConfigSt
                         if let Some(debugger) = boxed.0.downcast::<LiveDebuggingData>() {
                             remove_config(remote_config, debugger);
                         }
+                        // Don't drop `boxed` here: a deferred hook teardown can still borrow
+                        // its strings. Retire it until request shutdown instead.
+                        remote_config.live_debugger.retired.push(boxed);
                     }
                 }
                 RemoteConfigProduct::ApmTracing => {
@@ -738,6 +754,9 @@ pub extern "C" fn ddog_set_dynamic_instrumentation_enabled(
 #[no_mangle]
 pub extern "C" fn ddog_rshutdown_remote_config(remote_config: &mut RemoteConfigState) {
     remote_config.live_debugger.spans_map.clear();
+    // All probe hooks are torn down by request shutdown, so the borrowed strings in
+    // retired parsed configs are no longer referenced and can be freed.
+    remote_config.live_debugger.retired.clear();
     remote_config.dynamic_config.old_config_values.clear();
     remote_config.dynamic_config.active_configs.clear();
     remote_config.dynamic_config.merged_configs.clear();

--- a/components-rs/remote_config.rs
+++ b/components-rs/remote_config.rs
@@ -116,7 +116,9 @@ pub struct LiveDebuggerState {
     // (probe id, capture config, shm limiter, ...) into these boxes, and `zai_hook_remove`
     // can defer the actual teardown of those hooks past this point. Dropping the box here
     // would free the borrowed strings while a deferred hook can still fire and read them
-    // (use-after-free). Keep them alive until request shutdown, when all hooks are gone.
+    // (use-after-free). Keep them alive until the probe hooks are torn down, then free
+    // them via `ddog_live_debugger_free_retired` (called from ddtrace_live_debugger_rshutdown,
+    // after zai_hook_clean), which bounds growth to a single request's config churn.
     pub retired: Vec<Box<(RemoteConfigParsed, MaybeShmLimiter)>>,
     pub config_id: String,
     pub allow_dfa: Option<Regex>,
@@ -754,9 +756,6 @@ pub extern "C" fn ddog_set_dynamic_instrumentation_enabled(
 #[no_mangle]
 pub extern "C" fn ddog_rshutdown_remote_config(remote_config: &mut RemoteConfigState) {
     remote_config.live_debugger.spans_map.clear();
-    // All probe hooks are torn down by request shutdown, so the borrowed strings in
-    // retired parsed configs are no longer referenced and can be freed.
-    remote_config.live_debugger.retired.clear();
     remote_config.dynamic_config.old_config_values.clear();
     remote_config.dynamic_config.active_configs.clear();
     remote_config.dynamic_config.merged_configs.clear();
@@ -764,6 +763,19 @@ pub extern "C" fn ddog_rshutdown_remote_config(remote_config: &mut RemoteConfigS
         RemoteConfigProduct::ApmTracing,
         RemoteConfigProduct::LiveDebugger,
     ]);
+}
+
+/// Free the parsed configs retired during this request (see `LiveDebuggerState::retired`).
+///
+/// MUST be called only after all live debugger probe hooks have been torn down for the
+/// request (i.e. after `zai_hook_clean`), since those hooks hold C-side `def->probe`
+/// shallow copies whose `CharSlice`s / limiter pointer borrow into these boxes. It is
+/// invoked from `ddtrace_live_debugger_rshutdown()` right after the hook table is
+/// destroyed — NOT from `ddog_rshutdown_remote_config`, which runs at the very start of
+/// RSHUTDOWN, before the shutdown-time flush that can still fire (and tear down) probes.
+#[no_mangle]
+pub extern "C" fn ddog_live_debugger_free_retired(remote_config: &mut RemoteConfigState) {
+    remote_config.live_debugger.retired.clear();
 }
 
 #[no_mangle]

--- a/tracer/live_debugger.c
+++ b/tracer/live_debugger.c
@@ -1677,6 +1677,12 @@ void ddtrace_live_debugger_rinit(void) {
 
 void ddtrace_live_debugger_rshutdown(void) {
     zend_hash_destroy(&DDTRACE_G(active_live_debugger_hooks));
+    // The probe hooks (and their def->probe shallow copies borrowing into retired
+    // parsed configs) are now fully torn down, so it is finally safe to free the
+    // configs retired during this request.
+    if (DATADOG_G(remote_config_state)) {
+        ddog_live_debugger_free_retired(DATADOG_G(remote_config_state));
+    }
 }
 
 bool ddtrace_alter_dynamic_instrumentation_config(zval *old_value, zval *new_value, zend_string *new_str) {


### PR DESCRIPTION
## Problem

`test_extension_ci: [7.1]` (the **valgrind** master job) fails with a `LEAKED TEST SUMMARY` on `tests/ext/live-debugger/debugger_enable_dynamic_config.phpt`. The `.mem` artifact shows it is **not a leak but a use-after-free**:

```
Invalid read of size 1
  ... probe.id.to_utf8_lossy()                    send_data.rs:523
  ddog_send_debugger_diagnostics                  remote_config.rs:786
  dd_probe_mark_active                            tracer/live_debugger.c:226
  dd_span_probe_begin                             tracer/live_debugger.c:239
 Address ... is 0 bytes inside a block of size 1 free'd
  drop String -> Probe -> ... -> Box<(RemoteConfigParsed, MaybeShmLimiter)>
  ddog_process_remote_configs                     components-rs/remote_config.rs:445  (LiveDebugger Remove)
```

The freed block is **size 1** — the 1-byte probe id `"1"` the test generates.

## Root cause

The C side (`tracer/live_debugger.c:162`, `def->probe = *probe`) keeps a shallow copy of the FFI `ddog_Probe`, whose `ddog_CharSlice` fields (`id`, capture config, shm limiter, …) **borrow** strings owned by the boxed `RemoteConfigParsed` stored in `live_debugger.active`. The `Box<>` exists *specifically* to give that data a stable heap address for these borrows (per its own comment).

On a LiveDebugger **Remove** (and on an `Entry::Occupied` re-add) the box was dropped immediately, freeing those strings. But `zai_hook_remove` can **defer** the actual hook teardown, so a still-installed probe can fire afterwards and read the freed strings via `ddog_send_debugger_diagnostics(&def->probe, …)` → UAF.

Latent since the feature landed (`f87446c4d`, 2024-10); only the valgrind job observes it because plain runs read the freed-but-intact bytes and pass. It is timing-gated, which is why it surfaces in the full shuffled valgrind suite rather than in isolation.

## Fix

Retire removed/replaced boxes into a new `live_debugger.retired` vec instead of dropping them, and free them in `ddog_rshutdown_remote_config` — by which point all probe hooks are torn down and no PHP user code can fire a probe. `retired` is cleared every request, so it stays bounded.

## Verification

- Builds on PHP 7.1 with the master-pinned libdatadog (`6a6d4a535`).
- The previously-leaking test passes **10/10 under valgrind** with the fix; non-regressing.
- Note: the UAF needs full-suite (shared request-replayer + shuffle) timing and does not reproduce in isolation, so the authoritative signal is the `test_extension_ci: [7.1]` valgrind job on this branch.