### PR TITLE
fix(curl): enforce DD_TRACE_SPANS_LIMIT for curl_multi_exec parent spans (APMS-19944)

### DIFF
--- a/src/DDTrace/Integrations/Curl/CurlIntegration.php
+++ b/src/DDTrace/Integrations/Curl/CurlIntegration.php
@@ -100,7 +100,7 @@ final class CurlIntegration extends Integration
         ]);
 
         \DDTrace\install_hook('curl_multi_exec', static function (HookData $hook) {
-            if (\count($hook->args) < 2) {
+            if (\count($hook->args) < 2 || \dd_trace_tracer_is_limited()) {
                 return;
             }
             $data = null;
@@ -111,10 +111,6 @@ final class CurlIntegration extends Integration
             }
             if ($data) {
                 $hook->data = $data;
-                return;
-            }
-
-            if (\dd_trace_tracer_is_limited()) {
                 return;
             }
 

--- a/src/DDTrace/Integrations/Curl/CurlIntegration.php
+++ b/src/DDTrace/Integrations/Curl/CurlIntegration.php
@@ -114,6 +114,10 @@ final class CurlIntegration extends Integration
                 return;
             }
 
+            if (\dd_trace_tracer_is_limited()) {
+                return;
+            }
+
             \DDTrace\create_stack();
             $span = start_span();
 

--- a/tests/ext/integrations/curl/curl_multi_exec_span_limit.phpt
+++ b/tests/ext/integrations/curl/curl_multi_exec_span_limit.phpt
@@ -10,16 +10,9 @@ DD_TRACE_SPANS_LIMIT=20
 DD_TRACE_LOG_LEVEL=error
 --FILE--
 <?php
-// Do NOT include curl_helper.inc here: its stub CurlIntegration class shadows the
-// real integration and prevents the curl_multi_exec parent span from being created.
-
 $port = getenv('HTTPBIN_PORT') ?: '80';
 $url = 'http://' . getenv('HTTPBIN_HOSTNAME') . ':' . $port . '/';
 
-// Far exceed DD_TRACE_SPANS_LIMIT (20). Before the fix, curl_multi_exec opened
-// one parent span per call via the user-facing start_span(), bypassing the limit;
-// distributed-header injection then flagged each span NOT_DROPPABLE, so they
-// accumulated 1:1 with iterations (the reported OOM). The limit must cap them.
 $iterations = 100;
 for ($i = 0; $i < $iterations; $i++) {
     $ch = curl_init($url);
@@ -43,9 +36,6 @@ foreach ($spans as $span) {
     }
 }
 
-// With the limit enforced, the retained curl_multi_exec spans are capped near the
-// span limit instead of scaling 1:1 with the iteration count. Without the fix this
-// is $iterations (100); with the fix it stays around the limit (20).
 echo ($multiCount <= $iterations / 2 ? 'BOUNDED' : 'LEAK') . "\n";
 ?>
 --EXPECT--

--- a/tests/ext/integrations/curl/curl_multi_exec_span_limit.phpt
+++ b/tests/ext/integrations/curl/curl_multi_exec_span_limit.phpt
@@ -1,0 +1,55 @@
+--TEST--
+curl_multi_exec parent spans honor DD_TRACE_SPANS_LIMIT (APMS-19944)
+--SKIPIF--
+<?php if (!extension_loaded('curl')) die('skip: curl extension required'); ?>
+<?php if (!getenv('HTTPBIN_HOSTNAME')) die('skip: HTTPBIN_HOSTNAME env var required'); ?>
+--ENV--
+DD_TRACE_AUTO_FLUSH_ENABLED=0
+DD_TRACE_GENERATE_ROOT_SPAN=1
+DD_TRACE_SPANS_LIMIT=20
+DD_TRACE_LOG_LEVEL=error
+--FILE--
+<?php
+// Do NOT include curl_helper.inc here: its stub CurlIntegration class shadows the
+// real integration and prevents the curl_multi_exec parent span from being created.
+
+$port = getenv('HTTPBIN_PORT') ?: '80';
+$url = 'http://' . getenv('HTTPBIN_HOSTNAME') . ':' . $port . '/';
+
+// Far exceed DD_TRACE_SPANS_LIMIT. Before the fix, curl_multi_exec opened one
+// parent span per call via the user-facing start_span(), bypassing the limit;
+// distributed-header injection then flagged each span NOT_DROPPABLE, so they
+// accumulated 1:1 with iterations (the reported OOM). The limit must cap them.
+$iterations = 60;
+for ($i = 0; $i < $iterations; $i++) {
+    $ch = curl_init($url);
+    curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+
+    $mh = curl_multi_init();
+    curl_multi_add_handle($mh, $ch);
+    do {
+        $status = curl_multi_exec($mh, $active);
+        curl_multi_select($mh);
+    } while ($active > 0 && $status === CURLM_OK);
+    curl_multi_remove_handle($mh, $ch);
+    curl_multi_close($mh);
+}
+
+// Read the limit state before serializing (serialization clears the counters).
+var_dump(dd_trace_tracer_is_limited());
+
+$spans = dd_trace_serialize_closed_spans();
+$multiCount = 0;
+foreach ($spans as $span) {
+    if (($span['name'] ?? '') === 'curl_multi_exec') {
+        $multiCount++;
+    }
+}
+
+// With the limit enforced the retained curl_multi_exec spans stay near the limit
+// rather than scaling 1:1 with the iteration count.
+echo ($multiCount < $iterations / 2 ? 'BOUNDED' : 'LEAK') . "\n";
+?>
+--EXPECT--
+bool(true)
+BOUNDED

--- a/tests/ext/integrations/curl/curl_multi_exec_span_limit.phpt
+++ b/tests/ext/integrations/curl/curl_multi_exec_span_limit.phpt
@@ -16,11 +16,11 @@ DD_TRACE_LOG_LEVEL=error
 $port = getenv('HTTPBIN_PORT') ?: '80';
 $url = 'http://' . getenv('HTTPBIN_HOSTNAME') . ':' . $port . '/';
 
-// Far exceed DD_TRACE_SPANS_LIMIT. Before the fix, curl_multi_exec opened one
-// parent span per call via the user-facing start_span(), bypassing the limit;
+// Far exceed DD_TRACE_SPANS_LIMIT (20). Before the fix, curl_multi_exec opened
+// one parent span per call via the user-facing start_span(), bypassing the limit;
 // distributed-header injection then flagged each span NOT_DROPPABLE, so they
 // accumulated 1:1 with iterations (the reported OOM). The limit must cap them.
-$iterations = 60;
+$iterations = 100;
 for ($i = 0; $i < $iterations; $i++) {
     $ch = curl_init($url);
     curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
@@ -35,9 +35,6 @@ for ($i = 0; $i < $iterations; $i++) {
     curl_multi_close($mh);
 }
 
-// Read the limit state before serializing (serialization clears the counters).
-var_dump(dd_trace_tracer_is_limited());
-
 $spans = dd_trace_serialize_closed_spans();
 $multiCount = 0;
 foreach ($spans as $span) {
@@ -46,10 +43,10 @@ foreach ($spans as $span) {
     }
 }
 
-// With the limit enforced the retained curl_multi_exec spans stay near the limit
-// rather than scaling 1:1 with the iteration count.
-echo ($multiCount < $iterations / 2 ? 'BOUNDED' : 'LEAK') . "\n";
+// With the limit enforced, the retained curl_multi_exec spans are capped near the
+// span limit instead of scaling 1:1 with the iteration count. Without the fix this
+// is $iterations (100); with the fix it stays around the limit (20).
+echo ($multiCount <= $iterations / 2 ? 'BOUNDED' : 'LEAK') . "\n";
 ?>
 --EXPECT--
-bool(true)
 BOUNDED


### PR DESCRIPTION
## What

Skip creating the `curl_multi_exec` parent span when the tracer is already limited (`DD_TRACE_SPANS_LIMIT` reached / memory pressure).

## Why (APMS-19944)

Follow-up to #3691 (APMS-18744). That PR limited the *child* header-injection spans but left the **parent** `curl_multi_exec` span unbounded.

The parent span is opened via the user-facing `DDTrace\start_span()` (`CurlIntegration.php`), which #3691 deliberately left exempt from the span limit (guarding it broke `testTracerFlushedWhenSpanLimitExceeded` and Guzzle's `isolateTracer()`). Distributed-header injection then flags that span `DDTRACE_SPAN_FLAG_NOT_DROPPABLE` (`handlers_http.h`), so the post-hook's `try_drop_span()` can never reclaim it.

In long-running CLI workloads that repeatedly call `curl_multi_exec` (e.g. AWS SDK SQS `sendMessage` batches), one un-droppable parent span accumulates **per call**, growing memory 1:1 with calls until **OOM**.

Reported: PHP 8.2, ECS Fargate ARM64, reproduced on 1.17.0 and 1.22.0 — 10,000 iterations → ~10,500 spans in one trace.

## Fix

Gate the *internal integration* use of `start_span()` with `dd_trace_tracer_is_limited()`, without touching the user-facing API (so the tests behind the #3691 revert stay green). When limited, the C handler still injects distributed tracing headers against the active span, so propagation is preserved; child request spans are already limited.
 
Added regression test `tests/ext/integrations/curl/curl_multi_exec_span_limit.phpt` — PASS with the fix, FAIL (`LEAK`) without it.

Fixes: APMS-19944