### PR TITLE
Update libddwaf to 2.0.1 on the rust helper

### DIFF
--- a/appsec/helper-rust/CLAUDE.md
+++ b/appsec/helper-rust/CLAUDE.md
@@ -318,11 +318,8 @@ The appsec child pipeline IID can be found in the parent pipeline's downstream p
 The GitLab MCP tools don't include a job trace/log reader. To read job logs via the API:
 
 ```bash
-# Extract the token from MCP config (project ID 355 = DataDog/apm-reliability/dd-trace-php)
-jq -r '.mcpServers.gitlab.env.GITLAB_PERSONAL_ACCESS_TOKEN' ~/.claude.json
-
-# Then fetch job trace using the token
-curl -s -H "PRIVATE-TOKEN: <TOKEN>" "https://gitlab.ddbuild.io/api/v4/projects/355/jobs/<JOB_ID>/trace" > /tmp/...
+# project ID 355 = DataDog/apm-reliability/dd-trace-php
+curl -s -H "PRIVATE-TOKEN: $GITLAB_PERSONAL_ACCESS_TOKEN" "https://gitlab.ddbuild.io/api/v4/projects/355/jobs/<JOB_ID>/trace" > /tmp/...
 ```
 
 ### Monitoring CI Jobs

--- a/appsec/helper-rust/Cargo.lock
+++ b/appsec/helper-rust/Cargo.lock
@@ -848,7 +848,7 @@ checksum = "37c93d8daa9d8a012fd8ab92f088405fb202ea0b6ab73ee2482ae66af4f42091"
 
 [[package]]
 name = "libddwaf"
-version = "2.0.0-alpha0"
+version = "2.0.1"
 dependencies = [
  "libddwaf-sys",
  "serde",
@@ -856,7 +856,7 @@ dependencies = [
 
 [[package]]
 name = "libddwaf-sys"
-version = "2.0.0-alpha0"
+version = "2.0.1"
 dependencies = [
  "bindgen",
  "flate2",

--- a/appsec/helper-rust/scripts/check-ci-jobs.py
+++ b/appsec/helper-rust/scripts/check-ci-jobs.py
@@ -13,7 +13,6 @@ Exit codes:
 """
 
 import argparse
-import json
 import os
 import subprocess
 import sys
@@ -50,18 +49,12 @@ ARTIFACT_JOBS: dict[str, str] = {
 
 
 def get_token() -> str:
-    config_path = Path.home() / ".claude.json"
-    config = json.loads(config_path.read_text())
-    token = (
-        config.get("mcpServers", {})
-        .get("gitlab", {})
-        .get("env", {})
-        .get("GITLAB_PERSONAL_ACCESS_TOKEN")
-    )
-    if not token or token == "null":
-        print("ERROR: Could not extract GitLab token from ~/.claude.json", file=sys.stderr)
-        sys.exit(1)
-    return token
+    token = os.environ.get("GITLAB_PERSONAL_ACCESS_TOKEN")
+    if token and token != "null":
+        return token
+
+    print("ERROR: GITLAB_PERSONAL_ACCESS_TOKEN is not set", file=sys.stderr)
+    sys.exit(1)
 
 
 def api_get(token: str, path: str, params: dict | None = None) -> list | dict:

--- a/appsec/helper-rust/src/client.rs
+++ b/appsec/helper-rust/src/client.rs
@@ -709,6 +709,17 @@ impl ReqContext {
                     RunnableCtx::Owned(ctx) => ctx.run(data, timeout),
                 }
             }
+
+            fn run_batches(
+                &mut self,
+                data: libddwaf::object::WafArray,
+                timeout: Duration,
+            ) -> Result<libddwaf::RunResult, libddwaf::RunError> {
+                match self {
+                    RunnableCtx::Borrowed(ctx) => ctx.run_batches(data, timeout),
+                    RunnableCtx::Owned(ctx) => ctx.run_batches(data, timeout),
+                }
+            }
         }
         match options.subctx_id.as_ref() {
             None => Ok(RunnableCtx::Borrowed(&mut self.waf_ctx)),


### PR DESCRIPTION
### Description

Updates libddwaf-rust (and libddwaf, as used in the rust helper) to 2.0.1.
<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
