### PR TITLE
Embed default ruleset in helper-rust

### DIFF
--- a/appsec/cmake/update_helper_rust_stamp.cmake
+++ b/appsec/cmake/update_helper_rust_stamp.cmake
@@ -1,13 +1,14 @@
 cmake_minimum_required(VERSION 3.14)
 # Called at build time via cmake -P with HELPER_RUST_DIR and STAMP_FILE
-# defined on the command line. Touches STAMP_FILE only when at least one Rust
-# source file (*.rs, Cargo.toml, Cargo.lock) is newer than the stamp, so that
-# cargo is not re-run on every build when nothing has changed.
+# defined on the command line. Touches STAMP_FILE only when at least one helper
+# input is newer than the stamp, so that cargo is not re-run on every build when
+# nothing has changed.
 set(_LIBDDWAF_RUST_DIR "${HELPER_RUST_DIR}/../third_party/libddwaf-rust")
 file(GLOB_RECURSE _sources
     "${HELPER_RUST_DIR}/*.rs"
     "${HELPER_RUST_DIR}/Cargo.toml"
     "${HELPER_RUST_DIR}/Cargo.lock"
+    "${HELPER_RUST_DIR}/../recommended.json"
     "${_LIBDDWAF_RUST_DIR}/*.rs"
     "${_LIBDDWAF_RUST_DIR}/Cargo.toml"
     "${_LIBDDWAF_RUST_DIR}/Cargo.lock"

--- a/appsec/helper-rust/src/service.rs
+++ b/appsec/helper-rust/src/service.rs
@@ -258,8 +258,7 @@ impl Service {
             waf_ruleset::WafRuleset::from_file(PathBuf::from(path))
                 .with_context(|| format!("Error loading WAF ruleset from file {:?}", path))
         } else {
-            waf_ruleset::WafRuleset::from_default_file()
-                .with_context(|| "Error loading WAF ruleset from default file")
+            Ok(waf_ruleset::WafRuleset::from_default())
         };
 
         let ruleset = match maybe_ruleset {

--- a/appsec/helper-rust/src/service/waf_ruleset.rs
+++ b/appsec/helper-rust/src/service/waf_ruleset.rs
@@ -1,11 +1,14 @@
 use crate::client::log;
 use std::{
     fs::File,
-    io::{BufRead, BufReader, Read, Seek},
-    path::{Path, PathBuf},
+    io::{BufReader, Read, Seek},
+    path::Path,
 };
 
-use anyhow::{anyhow, Context};
+use anyhow::Context;
+
+const DEFAULT_RULESET: &[u8] =
+    include_bytes!(concat!(env!("CARGO_MANIFEST_DIR"), "/../recommended.json"));
 
 pub struct WafRuleset {
     doc: libddwaf::object::WafObject,
@@ -36,9 +39,13 @@ impl WafRuleset {
         Ok(WafRuleset::new(doc, rules_version))
     }
 
-    pub fn from_default_file() -> anyhow::Result<WafRuleset> {
-        let file = get_default_rules_file()?;
-        WafRuleset::from_file(&file)
+    pub fn from_default() -> WafRuleset {
+        let ruleset = WafRuleset::from_slice(DEFAULT_RULESET)
+            .expect("embedded default ruleset is valid JSON");
+
+        log::info!("Loaded embedded default WAF ruleset");
+
+        ruleset
     }
 
     pub fn from_slice(slice: &[u8]) -> anyhow::Result<WafRuleset> {
@@ -72,61 +79,17 @@ fn extract_rules_version<R: Read>(reader: R) -> Option<String> {
     parsed.metadata?.rules_version
 }
 
-fn get_default_rules_file() -> anyhow::Result<PathBuf> {
-    let helper_path = get_helper_path();
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    let base_path: PathBuf = if let Ok(helper_path) = helper_path {
-        helper_path
-            .parent()
-            .ok_or(anyhow!("No parent for {:?}", helper_path))?
-            .to_path_buf()
-    } else {
-        get_self_path().with_context(|| "Could find neither lib path nor self exe path")?
-    };
+    #[test]
+    fn default_ruleset_is_embedded() {
+        let ruleset = WafRuleset::from_default();
+        let rules_version = ruleset
+            .rules_version()
+            .expect("default ruleset should expose its version");
 
-    let file = base_path.join("../etc/recommended.json");
-    if file.exists() {
-        return Ok(file);
+        assert!(!rules_version.is_empty());
     }
-
-    let file_legacy = base_path.join("../etc/dd-appsec/recommended.json");
-    if file_legacy.exists() {
-        return Ok(file_legacy);
-    }
-
-    Err(anyhow!(
-        "Could not find recommended.json in either ../etc/ or ../etc/dd-appsec/"
-    ))
-}
-
-fn get_helper_path() -> anyhow::Result<PathBuf> {
-    // Match both libddappsec-helper.so (C++ helper) and
-    // libddappsec-helper-rust.so (Rust helper)
-    const LIBNAME_PREFIX: &str = "/libddappsec-helper";
-    const MAPS_PATH: &str = "/proc/self/maps";
-
-    let file = File::open(MAPS_PATH)?;
-    let reader = BufReader::new(file);
-
-    for line in reader.lines() {
-        let line = line?;
-        if line.contains(LIBNAME_PREFIX) {
-            if let Some(pos) = line.find('/') {
-                return Ok(PathBuf::from(&line[pos..]));
-            } else {
-                return Err(anyhow!("Should not happen"));
-            }
-        }
-    }
-
-    Err(anyhow!(
-        "Could not find libddappsec-helper*.so in /proc/self/maps"
-    ))
-}
-
-pub fn get_self_path() -> anyhow::Result<PathBuf> {
-    const SELF_EXE: &str = "/proc/self/exe";
-
-    let path = std::fs::read_link(SELF_EXE)?;
-    Ok(path)
 }

--- a/appsec/tests/integration/build.gradle
+++ b/appsec/tests/integration/build.gradle
@@ -924,6 +924,7 @@ def helperRustInputs = [
                 '../../helper-rust/coverage_init.c',
                 '../../helper-rust/outline_atomics.c',
                 '../../helper-rust/.cargo/config.toml',
+                '../../recommended.json',
         ],
 ]
 

--- a/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/TelemetryTests.groovy
+++ b/appsec/tests/integration/src/test/groovy/com/datadog/appsec/php/integration/TelemetryTests.groovy
@@ -14,6 +14,7 @@ import org.junit.jupiter.api.Order
 import org.junit.jupiter.api.Test
 import org.junit.jupiter.api.TestMethodOrder
 import org.junit.jupiter.api.condition.DisabledIf
+import org.testcontainers.containers.BindMode
 import org.testcontainers.junit.jupiter.Container
 import org.testcontainers.junit.jupiter.Testcontainers
 
@@ -49,6 +50,12 @@ class TelemetryTests {
                 void configure() {
                     super.configure()
                     withEnv('RUST_LIB_BACKTRACE', '1')
+                    // This class strips appsec.rules from php.ini (see beforeAll) to exercise
+                    // the helpers' default-ruleset path, so both helpers must see the real
+                    // production ruleset here instead of the test fixture at
+                    // src/test/waf/recommended.json.
+                    setBinds(binds.findAll { it.volume.path != '/etc/recommended.json' })
+                    withFileSystemBind('../../recommended.json', '/etc/recommended.json', BindMode.READ_ONLY)
                 }
             }
 
@@ -935,10 +942,11 @@ class TelemetryTests {
         }
         assert requestSup.get() != null
 
-        // Blocking request: 80.80.80.80 hits the recommended.json IP blocklist rule
-        // (on_match: ["block"]). The WAF returns a block_request action.
+        // Blocking request: this User-Agent hits the recommended.json Datadog test
+        // scanner rule (ua0-600-56x, on_match: ["block"]). The WAF returns a
+        // block_request action.
         HttpRequest req = CONTAINER.buildReq('/hello.php')
-                .header('X-Forwarded-For', '80.80.80.80').GET().build()
+                .header('User-Agent', 'dd-test-scanner-log-block').GET().build()
         CONTAINER.traceFromRequest(req, ofString()) { HttpResponse<String> resp ->
             assert resp.statusCode() == 403
         }
@@ -1163,7 +1171,7 @@ class TelemetryTests {
                     ],
                     'datadog/2/ASM/rasp_lfi_block_override/config': [
                             rules_override: [[
-                                                     rules_target: [[rule_id: 'rasp-001-001']],
+                                                     rules_target: [[rule_id: 'rasp-930-100']],
                                                      on_match: ['block']
                                              ]]
                     ]

--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -2365,8 +2365,9 @@ function get_ini_settings($sourcesDir, $appsecHelperPath, $appsecRulesPath)
             'default' => $appsecRulesPath,
             'commented' => true,
             'description' => [
-                'The path to the rules json file. The sidecar process must be able to read the',
-                'file. This ini setting is configured by the installer',
+                'Optional path to a custom rules json file. When this setting is not configured,',
+                'the Rust helper uses its embedded default rules and the C++ helper uses the',
+                'default rules file installed next to the helper.',
             ],
         ],
         [


### PR DESCRIPTION
### Description

To avoids some occasional errors we see where recommended.json is not found (redeployments? upgrades?)

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
