### PR TITLE
ci: pull php-5.6 loader test image from Docker Hub

### DIFF
--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -1406,12 +1406,13 @@ $system_tests_weblogs = [
 <?php foreach ($arch_targets as $arch): ?>
 "Loader test on <?= $arch ?> libc":
   stage: verify
-  image: "registry.ddbuild.io/ci/dd-trace-php/dd-trace-ci:php-${MAJOR_MINOR}_${CONTAINER_SUFFIX}"
+  image: "${LOADER_IMAGE_REPO}:php-${MAJOR_MINOR}_${CONTAINER_SUFFIX}"
   tags: [ "arch:$ARCH" ]
   variables:
     VALGRIND: false
     ARCH: "<?= $arch ?>"
     CONTAINER_SUFFIX: bookworm-9
+    LOADER_IMAGE_REPO: "registry.ddbuild.io/ci/dd-trace-php/dd-trace-ci"
   needs:
     - job: "package loader: [<?= $arch ?>]"
       artifacts: true
@@ -1422,6 +1423,7 @@ $system_tests_weblogs = [
           - "5.6"
         PHP_FLAVOUR: nts
         CONTAINER_SUFFIX: buster
+        LOADER_IMAGE_REPO: "registry.ddbuild.io/images/mirror/datadog/dd-trace-ci"
       - MAJOR_MINOR:
           - "7.0"
           - "7.1"


### PR DESCRIPTION
### Description

The `php-5.6_buster` CI image is not published to the internal registry (`registry.ddbuild.io/ci/dd-trace-php/dd-trace-ci`), so the **Loader test on amd64 libc: [5.6, nts, buster]** job started failing with `ErrImagePull` / `NotFound` ([example job](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-php/-/jobs/1847980492)).

We still need this job, so instead of removing it, this PR sources **only** the 5.6 image from Docker Hub via the ddbuild mirror (`registry.ddbuild.io/images/mirror/datadog/dd-trace-ci`).

This is done through a per-matrix `LOADER_IMAGE_REPO` override; the job-level default remains the internal registry, so all other PHP versions and the arm64 job are unaffected.