### PR TITLE
fix(ci): harden first telemetry retrieval predicate in InstrumentationTest

### DIFF
--- a/tests/Integrations/Custom/Autoloaded/InstrumentationTest.php
+++ b/tests/Integrations/Custom/Autoloaded/InstrumentationTest.php
@@ -57,7 +57,7 @@ final class InstrumentationTest extends WebFrameworkTestCase
 
         $this->call(GetSpec::create("autoloaded", "/telemetry"));
         usleep(500000);
-        $response = $this->retrieveDumpedData($this->untilTelemetryRequest("spans_created"));
+        $response = $this->retrieveDumpedData($this->untilTelemetryRequest("logs_created"));
 
         $this->assertGreaterThanOrEqual(3, $response);
         $payloads = $this->readTelemetryPayloads($response);
@@ -101,12 +101,12 @@ final class InstrumentationTest extends WebFrameworkTestCase
 
         $this->assertEquals("app-started", $payloads[0]["request_type"]);
         $this->assertEquals("app-dependencies-loaded", $payloads[1]["request_type"]);
-        $this->assertEquals([[
-            "name" => "nikic/fast-route",
-            "version" => "v1.3.0",
-        ]], array_filter($payloads[1]["payload"]["dependencies"], function ($i) {
+        $deps = array_values(array_filter($payloads[1]["payload"]["dependencies"], function ($i) {
             return strpos($i["name"], "ext-") !== 0;
         }));
+        $this->assertCount(1, $deps);
+        $this->assertEquals("nikic/fast-route", $deps[0]["name"]);
+        $this->assertNotEmpty($deps[0]["version"]);
         $this->assertEquals("app-integrations-change", $payloads[2]["request_type"]);
         $this->assertEquals([
             [


### PR DESCRIPTION
## What

Makes the custom autoloaded telemetry integration test (`tests/Integrations/Custom/Autoloaded/InstrumentationTest.php`) resilient to `nikic/fast-route` release drift, and hardens its first telemetry-wait predicate.

## Root cause

The CI fixture (`Frameworks/Custom/Version_Autoloaded`) is built with `composer update` against `nikic/fast-route:^1.3` with **no committed lock file** — the `Makefile` removes `composer.lock-php*` before running `composer update`, so the resolved dependency version tracks whatever the latest `1.3.x` release is at build time.

The test hard-coded the exact dependency version in the `app-dependencies-loaded` assertion (`"version" => "v1.3.0"`), so every new `nikic/fast-route` release broke that assertion. The resulting failure/retry cascade surfaced as the flaky window-1 `logs_created` telemetry failure.

## Fix

- Replace the exact-version dependency assertion with a **version-agnostic** check: exactly one non-`ext-` dependency, named `nikic/fast-route`, with a non-empty reported version. This still verifies the real signal (the tracer reports the app's single composer dependency) without pinning to a release that drifts.
- Harden the window-1 telemetry wait predicate to gate on `logs_created` (instead of `spans_created`), so the first window reliably captures the `logs_created` metric it later asserts on.