### PR TITLE
fix: report failed capture-expression evaluations instead of dropping

### DIFF
--- a/tests/ext/live-debugger/debugger_capture_expression_error.phpt
+++ b/tests/ext/live-debugger/debugger_capture_expression_error.phpt
@@ -1,0 +1,66 @@
+--TEST--
+A failed capture-expression evaluation is reported, not silently dropped
+--SKIPIF--
+<?php include __DIR__ . '/../includes/skipif_no_dev_env.inc'; ?>
+--ENV--
+DD_AGENT_HOST=request-replayer
+DD_TRACE_AGENT_PORT=80
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_DYNAMIC_INSTRUMENTATION_ENABLED=1
+DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS=0.1
+--INI--
+datadog.trace.agent_test_session_token=live-debugger/capture_expression_error
+--FILE--
+<?php
+
+require __DIR__ . "/live_debugger.inc";
+
+reset_request_replayer();
+
+class Bar {
+    function foo($arg1) {
+        return $arg1;
+    }
+}
+
+await_probe_installation(function() {
+    build_log_probe([
+        "where" => ["typeName" => "Bar", "methodName" => "foo"],
+        "segments" => [["str" => "log"]],
+        "captureExpressions" => [
+            // getmember on an int cannot evaluate -> per-expression error
+            ["name" => "bad", "expr" => ["json" => ["getmember" => [["ref" => "arg1"], "nope"]]]],
+        ],
+    ]);
+
+    \DDTrace\start_span(); // submit span data
+});
+
+(new Bar)->foo(10);
+
+$dlr = new DebuggerLogReplayer;
+$errors = null;
+for ($i = 0; $i < 3 && $errors === null; $i++) {
+    $log = json_decode($dlr->waitForDebuggerDataAndReplay()["body"], true)[0];
+    if (isset($log["debugger"]["snapshot"]["evaluationErrors"])) {
+        $errors = $log["debugger"]["snapshot"]["evaluationErrors"];
+    }
+}
+var_dump($errors);
+
+?>
+--CLEAN--
+<?php
+require __DIR__ . "/live_debugger.inc";
+reset_request_replayer();
+?>
+--EXPECTF--
+array(1) {
+  [0]=>
+  array(2) {
+    ["expr"]=>
+    string(%d) "%s"
+    ["message"]=>
+    string(%d) "%s"
+  }
+}

--- a/tracer/live_debugger.c
+++ b/tracer/live_debugger.c
@@ -572,7 +572,10 @@ static void dd_log_probe_add_capture_fields(ddog_DebuggerCapture *capture, dd_lo
         ddog_ValueEvaluationResult result = ddog_evaluate_value(exprs[i].expr, &ctx);
 
         if (result.tag == DDOG_VALUE_EVALUATION_RESULT_ERROR) {
-            ddog_evaluation_error_drop(result.error);
+            // Surface per-expression evaluation failures instead of dropping them,
+            // matching the metric-probe path and the other tracers (which report
+            // failed capture expressions rather than silently omitting them).
+            dd_submit_probe_eval_error_snapshot(&def->parent.probe, result.error);
             continue;
         }
 


### PR DESCRIPTION
## Motivation

When a capture expression fails to evaluate, we currently drop the error (`ddog_evaluation_error_drop(result.error); continue;` in `dd_log_probe_add_capture_fields`), so the customer sees neither a value nor any error signal. Every other tracer surfaces failed capture expressions, and our own metric-probe path already reports value-evaluation errors — this is the one spot that silently omits them.

## Change

Replace the drop with `dd_submit_probe_eval_error_snapshot(&def->parent.probe, result.error)`, the same call the metric-probe and template/condition paths use. The loop still `continue`s, so remaining expressions are unaffected.

## Test

`tests/ext/live-debugger/debugger_capture_expression_error.phpt`: a log probe whose capture expression cannot evaluate (getmember on an int) now emits an `evaluationErrors` entry instead of producing no output. I couldn't run it locally (needs the dev-env request-replayer + built extension; the test SKIPIFs without a dev env) — relying on CI.

## Notes

- Part of a chain to enable PHP capture expressions end-to-end. The companion rate-limit change is in libdatadog (DataDog/libdatadog#2241); once vendored, PHP capture-expression probes also default to the snapshot rate. This PR is the tracer-side error-reporting piece and stands on its own.
- Draft pending the rest of the chain (dd-source matrix + web-ui version gate).