### PR TITLE
bench(profiling): measure live heap tracking paths

### DIFF
--- a/profiling/Cargo.toml
+++ b/profiling/Cargo.toml
@@ -61,6 +61,10 @@ perfcnt = "0.8.0"
 name = "stack_walking"
 harness = false
 
+[[bench]]
+name = "heap_live_tracking"
+harness = false
+
 [features]
 default = ["io_profiling"]
 debug_stats = []

--- a/profiling/README.md
+++ b/profiling/README.md
@@ -62,7 +62,14 @@ tests.
 ## Benchmarks
 
 Benchmarks are implemented using
-[criterion](https://github.com/bheisler/criterion.rs). In order to execute them
+[criterion](https://github.com/bheisler/criterion.rs). The heap-live tracking
+benchmark can run directly:
+
+```sh
+cargo bench --bench heap_live_tracking
+```
+
+The stack-walking benchmark links the profiler as a Rust library. To execute it
 you need to change the `crate-type` in the `Cargo.toml` from `cdylib` to `rlib`
 (or add it):
 
@@ -73,10 +80,10 @@ you need to change the `crate-type` in the `Cargo.toml` from `cdylib` to `rlib`
  bench = false # disables cargo build in libtest bench
 ```
 
-After this change you can execute the benchmarks using:
+After this change you can execute the stack-walking benchmark using:
 
 ```sh
-cargo bench --features stack_walking_tests
+cargo bench --bench stack_walking --features stack_walking_tests
 ```
 
 Note: the `--features stack_walking_tests` is necessary as some code in the

--- a/profiling/benches/heap_live_tracking.rs
+++ b/profiling/benches/heap_live_tracking.rs
@@ -1,5 +1,7 @@
-use core::cell::{Cell, UnsafeCell};
-use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+use core::cell::UnsafeCell;
+use core::time::Duration;
+use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use std::time::Instant;
 
 // Compile the production tracker without linking the PHP extension executable.
 #[allow(dead_code)]
@@ -10,6 +12,7 @@ use live_heap::{LiveHeapTracker, LocalLiveHeapTracker};
 const BASE_ADDRESS: usize = 0x1000_0000;
 const TRACKED_ALLOCATIONS: usize = 2048;
 const ADDRESS_STRIDE: usize = 64;
+const BATCH_SIZE: u64 = 256;
 
 fn address(index: usize) -> usize {
     BASE_ADDRESS + index % TRACKED_ALLOCATIONS * ADDRESS_STRIDE
@@ -33,7 +36,7 @@ impl Tracker {
     }
 
     fn track(&self, ptr: usize, sample: [usize; 4]) -> bool {
-        // Criterion invokes setup and measured routines sequentially.
+        // SAFETY: Criterion invokes setup and measured routines sequentially.
         unsafe { (&mut *self.local.get()).track(&self.shared, ptr, sample) }
     }
 
@@ -51,60 +54,94 @@ fn populated_tracker() -> Tracker {
     tracker
 }
 
+fn measure_batched(
+    iterations: u64,
+    mut setup: impl FnMut(usize),
+    mut routine: impl FnMut(usize),
+    mut cleanup: impl FnMut(usize),
+) -> Duration {
+    let mut elapsed = Duration::ZERO;
+    let mut completed = 0;
+
+    while completed < iterations {
+        let count = BATCH_SIZE.min(iterations - completed);
+        for offset in 0..count {
+            setup((completed + offset) as usize);
+        }
+
+        let start = Instant::now();
+        for offset in 0..count {
+            routine((completed + offset) as usize);
+        }
+        elapsed += start.elapsed();
+
+        for offset in 0..count {
+            cleanup((completed + offset) as usize);
+        }
+        completed += count;
+    }
+
+    elapsed
+}
+
 fn benchmark(c: &mut Criterion) {
     let mut group = c.benchmark_group("heap_live_tracking");
 
     {
         let tracker = populated_tracker();
-        let next = Cell::new(0);
         group.bench_function("allocate_tracked", |b| {
-            b.iter_batched(
-                || {
-                    let index = next.get();
-                    next.set(index + 1);
-                    let ptr = untracked_address(index);
-                    let _ = tracker.untrack(ptr);
-                    (ptr, [0; 4])
-                },
-                |(ptr, sample)| black_box(tracker.track(ptr, sample)),
-                BatchSize::PerIteration,
-            )
+            b.iter_custom(|iterations| {
+                measure_batched(
+                    iterations,
+                    |index| {
+                        let _ = tracker.untrack(untracked_address(index));
+                    },
+                    |index| {
+                        black_box(tracker.track(untracked_address(index), [0; 4]));
+                    },
+                    |index| {
+                        let _ = tracker.untrack(untracked_address(index));
+                    },
+                )
+            })
         });
     }
 
     {
         let tracker = populated_tracker();
-        let next = Cell::new(0);
         group.bench_function("free_tracked", |b| {
-            b.iter_batched(
-                || {
-                    let index = next.get();
-                    next.set(index + 1);
-                    let ptr = untracked_address(index);
-                    assert!(tracker.track(ptr, [0; 4]));
-                    ptr
-                },
-                |ptr| black_box(tracker.untrack(ptr)),
-                BatchSize::PerIteration,
-            )
+            b.iter_custom(|iterations| {
+                measure_batched(
+                    iterations,
+                    |index| {
+                        assert!(tracker.track(untracked_address(index), [0; 4]));
+                    },
+                    |index| {
+                        black_box(tracker.untrack(untracked_address(index)));
+                    },
+                    |index| {
+                        let _ = tracker.untrack(untracked_address(index));
+                    },
+                )
+            })
         });
     }
 
     {
         let tracker = populated_tracker();
-        let next = Cell::new(0);
         group.bench_function("free_untracked", |b| {
-            b.iter_batched(
-                || {
-                    let index = next.get();
-                    next.set(index + 1);
-                    let ptr = untracked_address(index);
-                    let _ = tracker.untrack(ptr);
-                    ptr
-                },
-                |ptr| black_box(tracker.untrack(ptr)),
-                BatchSize::PerIteration,
-            )
+            b.iter_custom(|iterations| {
+                measure_batched(
+                    iterations,
+                    |index| {
+                        let _ = tracker.untrack(untracked_address(index));
+                    },
+                    |index| {
+                        black_box(tracker.untrack(untracked_address(index)));
+                    },
+                    |_| {},
+                )
+            })
         });
     }
 

--- a/profiling/benches/heap_live_tracking.rs
+++ b/profiling/benches/heap_live_tracking.rs
@@ -1,0 +1,115 @@
+use core::cell::{Cell, UnsafeCell};
+use criterion::{black_box, criterion_group, criterion_main, BatchSize, Criterion};
+
+// Compile the production tracker without linking the PHP extension executable.
+#[allow(dead_code)]
+#[path = "../src/profiling/live_heap.rs"]
+mod live_heap;
+use live_heap::{LiveHeapTracker, LocalLiveHeapTracker};
+
+const BASE_ADDRESS: usize = 0x1000_0000;
+const TRACKED_ALLOCATIONS: usize = 2048;
+const ADDRESS_STRIDE: usize = 64;
+
+fn address(index: usize) -> usize {
+    BASE_ADDRESS + index % TRACKED_ALLOCATIONS * ADDRESS_STRIDE
+}
+
+fn untracked_address(index: usize) -> usize {
+    address(index) + 8
+}
+
+struct Tracker {
+    shared: LiveHeapTracker<[usize; 4]>,
+    local: UnsafeCell<LocalLiveHeapTracker>,
+}
+
+impl Tracker {
+    fn new() -> Self {
+        Self {
+            shared: LiveHeapTracker::new(),
+            local: UnsafeCell::new(LocalLiveHeapTracker::new()),
+        }
+    }
+
+    fn track(&self, ptr: usize, sample: [usize; 4]) -> bool {
+        // Criterion invokes setup and measured routines sequentially.
+        unsafe { (&mut *self.local.get()).track(&self.shared, ptr, sample) }
+    }
+
+    fn untrack(&self, ptr: usize) -> Option<[usize; 4]> {
+        // SAFETY: same sequential access as `track`.
+        unsafe { (&mut *self.local.get()).untrack(&self.shared, ptr) }
+    }
+}
+
+fn populated_tracker() -> Tracker {
+    let tracker = Tracker::new();
+    for index in 0..TRACKED_ALLOCATIONS {
+        assert!(tracker.track(address(index), [0; 4]));
+    }
+    tracker
+}
+
+fn benchmark(c: &mut Criterion) {
+    let mut group = c.benchmark_group("heap_live_tracking");
+
+    {
+        let tracker = populated_tracker();
+        let next = Cell::new(0);
+        group.bench_function("allocate_tracked", |b| {
+            b.iter_batched(
+                || {
+                    let index = next.get();
+                    next.set(index + 1);
+                    let ptr = untracked_address(index);
+                    let _ = tracker.untrack(ptr);
+                    (ptr, [0; 4])
+                },
+                |(ptr, sample)| black_box(tracker.track(ptr, sample)),
+                BatchSize::PerIteration,
+            )
+        });
+    }
+
+    {
+        let tracker = populated_tracker();
+        let next = Cell::new(0);
+        group.bench_function("free_tracked", |b| {
+            b.iter_batched(
+                || {
+                    let index = next.get();
+                    next.set(index + 1);
+                    let ptr = untracked_address(index);
+                    assert!(tracker.track(ptr, [0; 4]));
+                    ptr
+                },
+                |ptr| black_box(tracker.untrack(ptr)),
+                BatchSize::PerIteration,
+            )
+        });
+    }
+
+    {
+        let tracker = populated_tracker();
+        let next = Cell::new(0);
+        group.bench_function("free_untracked", |b| {
+            b.iter_batched(
+                || {
+                    let index = next.get();
+                    next.set(index + 1);
+                    let ptr = untracked_address(index);
+                    let _ = tracker.untrack(ptr);
+                    ptr
+                },
+                |ptr| black_box(tracker.untrack(ptr)),
+                BatchSize::PerIteration,
+            )
+        });
+    }
+
+    group.finish();
+}
+
+criterion_group!(benches, benchmark);
+criterion_main!(benches);

--- a/profiling/src/allocation/mod.rs
+++ b/profiling/src/allocation/mod.rs
@@ -5,6 +5,7 @@ pub use profiling_stats::*;
 use crate::bindings::{self as zend};
 use crate::config::SystemSettings;
 use crate::module_globals;
+use crate::profiling::live_heap::LocalLiveHeapTracker;
 use crate::profiling::Profiler;
 use crate::{RefCellExt, REQUEST_LOCALS};
 use core::cell::Cell;
@@ -98,6 +99,7 @@ pub struct AllocationProfilingStats {
     rng: ThreadRng,
     #[cfg(not(php_zts))]
     rng: StdRng,
+    live_heap: LocalLiveHeapTracker,
 }
 
 impl AllocationProfilingStats {
@@ -111,6 +113,7 @@ impl AllocationProfilingStats {
             rng: rand::rng(),
             #[cfg(not(php_zts))]
             rng: StdRng::from_os_rng(),
+            live_heap: LocalLiveHeapTracker::new(),
         };
         stats.next_sampling_interval();
         stats

--- a/profiling/src/allocation/profiling_stats.rs
+++ b/profiling/src/allocation/profiling_stats.rs
@@ -4,6 +4,7 @@
 //! can be used but expose a relatively safe API.
 
 use super::{AllocationProfilingStats, ALLOCATION_PROFILING_INTERVAL};
+use crate::profiling::live_heap::LiveHeapTracker;
 use libc::size_t;
 use std::mem::MaybeUninit;
 
@@ -99,6 +100,28 @@ pub fn allocation_profiling_stats_should_collect(len: size_t) -> bool {
     // it. Even if the destructor were called, AllocationProfilingStats's dtor
     // doesn't access the TLS variable (it can't, it doesn't have access).
     unsafe { allocation_profiling_stats_mut(f) }
+}
+
+pub(crate) fn live_heap_track<T>(tracker: &LiveHeapTracker<T>, ptr: usize, sample: T) -> bool {
+    // SAFETY: allocation stats are initialized before allocation hooks run,
+    // and the closure does not retain or recursively borrow them.
+    unsafe {
+        allocation_profiling_stats_mut(|stats| {
+            stats
+                .assume_init_mut()
+                .live_heap
+                .track(tracker, ptr, sample)
+        })
+    }
+}
+
+pub(crate) fn live_heap_untrack<T>(tracker: &LiveHeapTracker<T>, ptr: usize) -> Option<T> {
+    // SAFETY: same lifecycle and borrowing guarantees as `live_heap_track`.
+    unsafe {
+        allocation_profiling_stats_mut(|stats| {
+            stats.assume_init_mut().live_heap.untrack(tracker, ptr)
+        })
+    }
 }
 
 /// Initializes the allocation profiler's globals.

--- a/profiling/src/profiling/live_heap.rs
+++ b/profiling/src/profiling/live_heap.rs
@@ -1,0 +1,90 @@
+use dashmap::DashMap;
+use rustc_hash::FxBuildHasher;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Maximum number of allocations to track for live heap profiling.
+const MAX_SIZE: usize = 4096;
+
+/// Tracks live heap samples by allocation address. FxHasher spreads sequential
+/// ZendMM addresses across DashMap's shards without hashing already-randomized
+/// pointer bytes with SipHash.
+pub(crate) struct LiveHeapTracker<T> {
+    allocations: DashMap<usize, T, FxBuildHasher>,
+    count: AtomicUsize,
+}
+
+impl<T> LiveHeapTracker<T> {
+    pub(crate) fn new() -> Self {
+        Self {
+            allocations: DashMap::with_hasher(FxBuildHasher),
+            count: AtomicUsize::new(0),
+        }
+    }
+
+    pub(crate) fn len(&self) -> usize {
+        self.count.load(Ordering::Relaxed)
+    }
+
+    pub(crate) fn clear(&self) {
+        self.allocations.clear();
+        self.count.store(0, Ordering::Relaxed);
+    }
+
+    fn track(&self, ptr: usize, sample: T) -> bool {
+        // Best-effort cap: in ZTS the count check and insert still race, so
+        // the map can briefly exceed MAX_SIZE.
+        if self.len() >= MAX_SIZE {
+            return false;
+        }
+
+        if self.allocations.insert(ptr, sample).is_none() {
+            self.count.fetch_add(1, Ordering::Relaxed);
+        }
+        true
+    }
+
+    fn untrack(&self, ptr: usize) -> Option<T> {
+        let result = self.allocations.remove(&ptr).map(|(_, sample)| sample);
+        if result.is_some() {
+            self.count.fetch_sub(1, Ordering::Relaxed);
+        }
+        result
+    }
+}
+
+impl<T: Clone> LiveHeapTracker<T> {
+    pub(crate) fn snapshot(&self) -> Vec<T> {
+        self.allocations
+            .iter()
+            .map(|entry| entry.value().clone())
+            .collect()
+    }
+}
+
+impl<T> Default for LiveHeapTracker<T> {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+pub(crate) struct LocalLiveHeapTracker;
+
+impl LocalLiveHeapTracker {
+    pub(crate) const fn new() -> Self {
+        Self
+    }
+
+    pub(crate) fn track<T>(&mut self, tracker: &LiveHeapTracker<T>, ptr: usize, sample: T) -> bool {
+        tracker.track(ptr, sample)
+    }
+
+    pub(crate) fn untrack<T>(&mut self, tracker: &LiveHeapTracker<T>, ptr: usize) -> Option<T> {
+        tracker.untrack(ptr)
+    }
+}
+
+impl Default for LocalLiveHeapTracker {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -1,5 +1,6 @@
 mod backtrace;
 mod interrupts;
+pub(crate) mod live_heap;
 mod sample_type_filter;
 pub mod stack_walking;
 mod thread_utils;
@@ -30,7 +31,6 @@ use core::mem::forget;
 use core::{ptr, str};
 use cpu_time::ThreadTime;
 use crossbeam_channel::{Receiver, Sender, TrySendError};
-use dashmap::DashMap;
 use libdd_common::tag::Tag;
 use libdd_profiling::api::{
     Function, Label as ApiLabel, Location, Period, Sample, SampleType as ApiSampleType,
@@ -38,12 +38,11 @@ use libdd_profiling::api::{
 };
 use libdd_profiling::internal::Profile as InternalProfile;
 use log::{debug, info, trace, warn};
-use rustc_hash::FxBuildHasher;
 use std::borrow::Cow;
 use std::collections::HashMap;
 use std::hash::Hash;
 use std::num::NonZeroI64;
-use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicU64, AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicBool, AtomicPtr, AtomicU64, Ordering};
 use std::sync::{Arc, Barrier, OnceLock};
 use std::thread::JoinHandle;
 use std::time::{Duration, Instant, SystemTime, UNIX_EPOCH};
@@ -66,13 +65,6 @@ pub const NO_TIMESTAMP: i64 = 0;
 // Guide: upload period / upload timeout should give about the order of
 // magnitude for the capacity.
 const UPLOAD_CHANNEL_CAPACITY: usize = 8;
-
-/// HeapTracker uses FxHasher (rustc-hash) instead of the default SipHash.
-/// FxHasher's multiply-rotate mix fully avalanches bits, spreading sequential
-/// ZendMM bump-allocator addresses evenly across DashMap's 16 shards and
-/// avoiding lock hot-spots under concurrent ZTS workloads.
-/// FxBuildHasher satisfies Clone, which DashMap requires.
-type HeapTracker = DashMap<usize, LiveHeapSample, FxBuildHasher>;
 
 /// The global profiler. Profiler gets made during the first rinit after an
 /// minit, and is destroyed on mshutdown.
@@ -273,9 +265,7 @@ pub(crate) struct LiveHeapSample {
     pub allocation_size: i64,
 }
 
-/// Maximum number of allocations to track for live heap profiling.
-/// This bounds memory usage. When full, new allocations are not tracked.
-pub(crate) const LIVE_HEAP_TRACKER_MAX_SIZE: usize = 4096;
+use live_heap::LiveHeapTracker;
 
 pub struct Profiler {
     fork_barrier: Arc<Barrier>,
@@ -292,14 +282,8 @@ pub struct Profiler {
     /// through this pointer.
     system_settings: AtomicPtr<SystemSettings>,
 
-    /// Tracks sampled allocations for live heap profiling.
-    /// Maps allocation pointer -> sample data for batched emission at export time.
-    /// Wrapped in Arc to share with TimeCollector for batched sample emission.
-    /// Uses a fast pointer hasher since addresses are already well-distributed.
-    live_heap_tracker: Arc<HeapTracker>,
-    /// Cached entry count for live_heap_tracker. A single Relaxed load replaces
-    /// the 16 shard read-locks that DashMap::len() acquires per sampled allocation.
-    live_heap_tracker_count: Arc<AtomicUsize>,
+    /// Shared with TimeCollector for batched heap-live sample emission.
+    live_heap_tracker: Arc<LiveHeapTracker<LiveHeapSample>>,
 }
 
 struct TimeCollector {
@@ -309,9 +293,7 @@ struct TimeCollector {
     upload_sender: Sender<UploadMessage>,
     upload_period: Duration,
     /// Shared tracker for batched heap-live sample emission at export time.
-    live_heap_tracker: Arc<HeapTracker>,
-    /// See Profiler::live_heap_tracker_count.
-    live_heap_tracker_count: Arc<AtomicUsize>,
+    live_heap_tracker: Arc<LiveHeapTracker<LiveHeapSample>>,
     /// Used to build correctly-positioned sample_values for heap-live samples
     /// without duplicating the type-string → index mapping.
     sample_types_filter: SampleTypeFilter,
@@ -325,7 +307,7 @@ impl TimeCollector {
         profiles: &mut HashMap<Arc<ProfileIndex>, InternalProfile>,
         started_at: &WallTime,
     ) {
-        let tracker_len = self.live_heap_tracker_count.load(Ordering::Relaxed);
+        let tracker_len = self.live_heap_tracker.len();
         if tracker_len == 0 {
             return;
         }
@@ -336,11 +318,7 @@ impl TimeCollector {
         // for the duration of the Arc::clone calls, not for handle_sample_message.
         // This prevents concurrent efree calls on PHP threads from stalling on
         // shards that the TimeCollector is reading during a full export iteration.
-        let snapshot: Vec<LiveHeapSample> = self
-            .live_heap_tracker
-            .iter()
-            .map(|entry| entry.value().clone())
-            .collect();
+        let snapshot = self.live_heap_tracker.snapshot();
 
         for tracked in snapshot {
             let sample_values = self.sample_types_filter.filter(SampleValues {
@@ -837,8 +815,7 @@ impl Profiler {
         let interrupt_manager = Arc::new(InterruptManager::new());
         let (message_sender, message_receiver) = crossbeam_channel::bounded(100);
         let (upload_sender, upload_receiver) = crossbeam_channel::bounded(UPLOAD_CHANNEL_CAPACITY);
-        let live_heap_tracker = Arc::new(DashMap::with_hasher(FxBuildHasher));
-        let live_heap_tracker_count = Arc::new(AtomicUsize::new(0));
+        let live_heap_tracker = Arc::new(LiveHeapTracker::new());
         let sample_types_filter = SampleTypeFilter::new(system_settings);
         let time_collector = TimeCollector {
             fork_barrier: fork_barrier.clone(),
@@ -847,7 +824,6 @@ impl Profiler {
             upload_sender: upload_sender.clone(),
             upload_period: UPLOAD_PERIOD,
             live_heap_tracker: live_heap_tracker.clone(),
-            live_heap_tracker_count: live_heap_tracker_count.clone(),
             sample_types_filter: sample_types_filter.clone(),
         };
 
@@ -888,7 +864,6 @@ impl Profiler {
             sample_types_filter,
             system_settings: AtomicPtr::new(system_settings as *const _ as *mut _),
             live_heap_tracker,
-            live_heap_tracker_count,
         }
     }
 
@@ -945,31 +920,12 @@ impl Profiler {
     /// Track an allocation for live heap profiling.
     /// Returns true if tracked, false if tracking is disabled or limit reached.
     pub(crate) fn track_allocation(&self, ptr: usize, sample: LiveHeapSample) -> bool {
-        // Best-effort cap: in ZTS the count check and insert still race, so
-        // the map can briefly exceed LIVE_HEAP_TRACKER_MAX_SIZE. A single
-        // Relaxed load is equivalent correctness-wise to the former
-        // DashMap::len() but avoids 16 shard read-locks per sampled alloc.
-        if self.live_heap_tracker_count.load(Ordering::Relaxed) >= LIVE_HEAP_TRACKER_MAX_SIZE {
-            return false;
-        }
-
-        let old = self.live_heap_tracker.insert(ptr, sample);
-        if old.is_none() {
-            self.live_heap_tracker_count.fetch_add(1, Ordering::Relaxed);
-        }
-        true
+        crate::allocation::live_heap_track(&self.live_heap_tracker, ptr, sample)
     }
 
     /// Untrack an allocation. Returns the sample if it was tracked.
     pub(crate) fn untrack_allocation(&self, ptr: usize) -> Option<LiveHeapSample> {
-        let result = self
-            .live_heap_tracker
-            .remove(&ptr)
-            .map(|(_, sample)| sample);
-        if result.is_some() {
-            self.live_heap_tracker_count.fetch_sub(1, Ordering::Relaxed);
-        }
-        result
+        crate::allocation::live_heap_untrack(&self.live_heap_tracker, ptr)
     }
 
     pub fn send_local_root_span_resource(
@@ -1087,7 +1043,6 @@ impl Profiler {
 
             // Clear live heap tracker to avoid stale entries from parent process
             profiler.live_heap_tracker.clear();
-            profiler.live_heap_tracker_count.store(0, Ordering::Relaxed);
 
             // But we're not 100% sure everything is safe to drop, notably the
             // join handles, so we leak the rest.


### PR DESCRIPTION
### Description

This PR extracts the existing heap-live map and count into `LiveHeapTracker<T>` and routes the existing thread-local allocation state through `LocalLiveHeapTracker` without changing behavior. The Criterion benchmark compiles and calls these production `track` and `untrack` methods directly, without linking a PHP executable.

The fixture keeps 2,048 32-byte samples in the tracker and rotates eight-byte-aligned target addresses through the same application pages. It times batches of 256 production calls so fixture mutation and per-operation timer overhead are excluded. The three measured paths are adding a tracked allocation, freeing a tracked allocation, and freeing an untracked allocation.

Run it with `cargo bench -p datadog-php-profiling --bench heap_live_tracking`.

DashMap-only baseline on an Apple M4 Max:
- `allocate_tracked`: 5.484–5.504 ns
- `free_tracked`: 5.512–5.539 ns
- `free_untracked`: 2.634–2.651 ns

Validation performed: profiler Rust unit tests passed (22 tests), profiler clippy passed with the unrelated pre-existing `got_macho.rs` lint suppressed, and the benchmark completed successfully.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.

