### PR TITLE
fix: Only trigger CuSim/RelEnv deploys on nightly scheduled runs or manual triggers [APMLP-1610]

### DIFF
--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -1709,7 +1709,7 @@ deploy_to_reliability_env:
   needs:
     - job: "bundle for reliability env"
   rules:
-    - if: $NIGHTLY_BUILD
+    - if: $NIGHTLY_BUILD == "true"
       when: on_success
     - when: manual
       allow_failure: true

--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -1709,7 +1709,10 @@ deploy_to_reliability_env:
   needs:
     - job: "bundle for reliability env"
   rules:
-   - when: on_success
+    - if: $NIGHTLY_BUILD
+      when: on_success
+    - when: manual
+      allow_failure: true
   trigger:
     project: DataDog/apm-reliability/datadog-reliability-env
     branch: $RELIABILITY_ENV_BRANCH


### PR DESCRIPTION
### Description
Currently, every commit will trigger a deploy to CuSim. This is unintentional, and can be scoped down to just the nightly build schedule (set [here](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-php/-/pipeline_schedules)), or for manual triggers only.

<!---
Any description you feel is relevant and gives more background to this PR, if necessary.
-->

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
