### PR TITLE
fix(tests): pin symfony/deprecation-contracts to ^2.5 in Drupal 9.5 fixture

### DIFF
--- a/tests/Frameworks/Drupal/Version_9_5/composer.json
+++ b/tests/Frameworks/Drupal/Version_9_5/composer.json
@@ -12,7 +12,8 @@
         "composer/installers": "^1.9",
         "drupal/core": "self.version",
         "drupal/core-project-message": "self.version",
-        "drupal/core-vendor-hardening": "self.version"
+        "drupal/core-vendor-hardening": "self.version",
+        "symfony/deprecation-contracts": "^2.5"
     },
     "require-dev": {
         "behat/mink": "^1.8",


### PR DESCRIPTION
## What

- Pin `symfony/deprecation-contracts` to `^2.5` in the `require` block of
  `tests/Frameworks/Drupal/Version_9_5/composer.json`.

## Why

`test_web_drupal_95` was failing with a fatal `TypeError` during Drupal's
install script on PHP 7.4.

The Drupal 9.5 test fixture ships a `composer.json` with no accompanying
lock file, and the job installs dependencies with
`composer install --ignore-platform-reqs`. Without a lock file, composer's
solver is free to pick the latest compatible releases of every
transitive dependency; `--ignore-platform-reqs` additionally defeats the
fixture's `platform.php` PHP-version pin, so composer happily resolves a
dependency graph that isn't actually compatible with the PHP version the
job runs on.

Concretely, composer resolves `guzzlehttp/guzzle` to `7.15.1`, which
requires `symfony/deprecation-contracts` and drifts to `v3.7.1`. That
version's `trigger_deprecation()` function declares a `mixed ...$args`
variadic parameter — a typehint combination only valid on PHP 8.0+.
Loading/calling it on PHP 7.4 is a fatal `TypeError`, which aborts
Drupal's install script and fails the job.

## How

Add an explicit `"symfony/deprecation-contracts": "^2.5"` entry to the
fixture's `require` block. This constrains composer's solver to a
`deprecation-contracts` release whose API predates the PHP 8-only
variadic typehint, regardless of what `guzzle` (or any other transitive
dependency) would otherwise pull in.
