### PR TITLE
chore(ci): pin benchmarking base image to :newest tag

### DIFF
--- a/.claude/ci/benchmarks.md
+++ b/.claude/ci/benchmarks.md
@@ -12,7 +12,7 @@
 | `benchmarks-appsec` | same | Runs appsec microbenchmarks; produces `candidate.tar.gz` and `baseline.tar.gz` artifacts |
 | `benchmarks-profiler` | same | Runs profiler microbenchmarks |
 | `macrobenchmarks: [{PHP_VERSION}]` | `486234852809.dkr.ecr.us-east-1.amazonaws.com/ci/benchmarking-platform:php_laravel-realworld` | Runs a Laravel Realworld application under k6 load at three traffic levels; PHP 7.4 and 8.1 |
-| `check-big-regressions` | `registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:latest` | Post-benchmark gate: fails if `benchmarks-tracer` results contain a regression above threshold |
+| `check-big-regressions` | `registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:newest` | Post-benchmark gate: fails if `benchmarks-tracer` results contain a regression above threshold |
 | `check-slo-breaches` | (benchmarking-platform-tools template) | Post-macrobenchmark gate: evaluates SLO breaches |
 | `notify-slo-breaches` | (benchmarking-platform-tools template) | Posts SLO breach notifications to `#guild-dd-php` Slack channel |
 

--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -208,7 +208,7 @@ check-big-regressions:
   stage: gate
   needs: [ "benchmarks-tracer" ]
   tags: [ "arch:amd64" ]
-  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:latest
+  image: registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:newest
   script: |
     if [ -f "reports/skip-reason.txt" ]; then
       echo "Benchmarks were skipped (no relevant file changes) - regression check not needed"


### PR DESCRIPTION
### Description

Platform policy will no longer allow workloads to reference the `:latest` image tag. This PR switches the benchmarking base image from `registry.ddbuild.io/images/benchmarking-platform-tools-ubuntu:latest` to the new `:newest` rolling tag.

Files changed:
- `.gitlab/benchmarks.yml` (the live `check-big-regressions` CI job)
- `.claude/ci/benchmarks.md` (documentation table)

> ⚠️ **Blocked:** Do not merge until DataDog/benchmarking-platform-tools#283 is merged and the base image is republished. That PR introduces the `:newest` tag this change depends on.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)