### PR TITLE
fix: bump ZAI_CONFIG_ENTRIES_COUNT_MAX to 400

### DIFF
--- a/zend_abstract_interface/config/config.h
+++ b/zend_abstract_interface/config/config.h
@@ -18,7 +18,7 @@ typedef uint16_t zai_config_id;
 #include "config_ini.h"
 #include "config_stable_file.h"
 
-#define ZAI_CONFIG_ENTRIES_COUNT_MAX 300
+#define ZAI_CONFIG_ENTRIES_COUNT_MAX 400
 #define ZAI_CONFIG_NAMES_COUNT_MAX 4
 #define ZAI_CONFIG_NAME_BUFSIZ 72
 


### PR DESCRIPTION
## Why

Master has been unable to publish a dev build since #3997 merged. That PR
added the `DD_TRACE_PROPAGATION_BEHAVIOR_EXTRACT` config plus new
per-integration entries, pushing the total number of registered config
entries to ~302 - over the compile-time cap of 300 in
`ZAI_CONFIG_ENTRIES_COUNT_MAX`.

This trips the static assert in `ext/configuration.c`:

```c
#define NUMBER_OF_CONFIGURATIONS sizeof((uint8_t[]){DD_ALL_CONFIGURATIONS})
_Static_assert(NUMBER_OF_CONFIGURATIONS < ZAI_CONFIG_ENTRIES_COUNT_MAX,
               "There are more config entries than ZAI_CONFIG_ENTRIES_COUNT_MAX.");
```

which breaks the `compile tracing extension` jobs

## Fix

Bump `ZAI_CONFIG_ENTRIES_COUNT_MAX` from 300 to 400 to restore extra
capacity above the current count (~302) for new config entries.
