### PR TITLE
Fix memory leak on roadrunner/frankenphp/etc due to appsec telemetry

### DIFF
--- a/ext/telemetry.c
+++ b/ext/telemetry.c
@@ -194,10 +194,25 @@ DATADOG_PUBLIC bool datadog_metric_add_point(zend_string *name, double value, ze
     return true;
 }
 
-static void dd_commit_metrics() {
+void datadog_telemetry_commit_user_request_metrics(void) {
     if (!DATADOG_G(metrics_buffer)) {
         return;
     }
+
+    if (!DATADOG_G(sidecar) || !get_global_DD_INSTRUMENTATION_TELEMETRY_ENABLED()) {
+        ddog_sidecar_telemetry_buffer_drop(DATADOG_G(metrics_buffer));
+        DATADOG_G(metrics_buffer) = NULL;
+        return;
+    }
+
+    dd_commit_metrics();
+}
+
+static void dd_commit_metrics(void) {
+    if (!DATADOG_G(metrics_buffer)) {
+        return;
+    }
+
     ddog_sidecar_telemetry_buffer_flush(
         &DATADOG_G(sidecar), datadog_sidecar_instance_id, &DATADOG_G(sidecar_queue_id), DATADOG_G(metrics_buffer));
     DATADOG_G(metrics_buffer) = NULL;

--- a/ext/telemetry.h
+++ b/ext/telemetry.h
@@ -28,6 +28,7 @@ const char *ddtrace_telemetry_redact_file(const char *file);
 void datadog_telemetry_rinit(void);
 void datadog_telemetry_rshutdown(void);
 void datadog_telemetry_finalize(void);
+void datadog_telemetry_commit_user_request_metrics(void);
 void datadog_telemetry_lifecycle_end(void);
 void datadog_telemetry_register_services(ddog_SidecarTransport **sidecar);
 

--- a/tracer/user_request.c
+++ b/tracer/user_request.c
@@ -2,6 +2,7 @@
 #include <main/SAPI.h>
 #include "configuration.h"
 #include "ddtrace.h"
+#include <ext/telemetry.h>
 #include "span.h"
 
 #define NS "DDTrace\\UserRequest\\"
@@ -196,6 +197,8 @@ void ddtrace_user_req_notify_finish(ddtrace_span_data *span)
         ddtrace_user_req_listeners *listener = reg_listeners.listeners[i];
         listener->finish_user_req(listener, &span->std);
     }
+
+    datadog_telemetry_commit_user_request_metrics();
 }
 
 PHP_FUNCTION(DDTrace_UserRequest_set_blocking_function);


### PR DESCRIPTION
### Description

During "user request mode" (one of FrankenPHP's modes, roadrunner, etc.), the telemetry buffer would grow at constant rate of 300 bytes/req, never being drained, draining would only happen at rshutdown

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
