### PR TITLE
ci(profiling): collect PHP language test core dumps

### DIFF
--- a/.gitlab/generate-profiler.php
+++ b/.gitlab/generate-profiler.php
@@ -164,4 +164,24 @@ foreach ($profiler_minor_major_targets as $version) {
     - cat "${XFAIL_LIST}" profiling/tests/php-language-xfail.list > /tmp/profiler-php-language-xfail.list
     - "if php -r 'exit(PHP_VERSION_ID < 80400 ? 0 : 1);'; then cat profiling/tests/php-language-xfail-pre84.list >> /tmp/profiler-php-language-xfail.list; fi"
     - export XFAIL_LIST=/tmp/profiler-php-language-xfail.list
+    - ulimit -c unlimited
     - .gitlab/run_php_language_tests.sh
+  after_script:
+    - |
+      core=/usr/local/src/php/core
+      if [ -f "${core}" ]; then
+        output="${CI_PROJECT_DIR}/artifacts/php-language-tests"
+        mkdir -p "${output}"
+        gdb --batch \
+          -ex "set pagination off" \
+          -ex "info threads" \
+          -ex "thread apply all bt full" \
+          -ex "thread apply all info registers" \
+          -ex "info sharedlibrary" \
+          /usr/local/bin/php "${core}" > "${output}/gdb-backtrace.txt" 2>&1 || true
+        mv "${core}" "${output}/core"
+      fi
+  artifacts:
+    when: on_failure
+    paths:
+      - artifacts/php-language-tests/


### PR DESCRIPTION
### Description

Enables core dumps for profiler PHP language tests and, when a core is present after a failed job, uploads both the raw core and a GDB report containing all thread backtraces, locals, registers, and shared libraries.

The runner's `core_pattern=core` and `core_uses_pid=0` settings mean this captures at most one core per job.

### Why

While working on https://github.com/DataDog/dd-trace-php/pull/4060 one of PHP language tests faild with:

```
2026-07-25T09:15:44.954690Z 01O ========DIFF========
2026-07-25T09:15:44.954694Z 01O [1;31m001- array(3) {[0m
2026-07-25T09:15:44.954795Z 01O [1;31m002-   [0]=>[0m
2026-07-25T09:15:44.954802Z 01O [1;31m003-   int(1)[0m
2026-07-25T09:15:44.954832Z 01O [1;31m004-   [1]=>[0m
2026-07-25T09:15:44.954840Z 01O [1;31m005-   bool(true)[0m
2026-07-25T09:15:44.954846Z 01O [1;31m006-   [2]=>[0m
2026-07-25T09:15:44.954852Z 01O [1;31m007-   int(2)[0m
2026-07-25T09:15:44.954855Z 01O [1;31m008- }[0m
2026-07-25T09:15:44.954859Z 01O [1;32m001+ Segmentation fault[0m
2026-07-25T09:15:44.954865Z 01O ========DONE========
2026-07-25T09:15:44.954868Z 01O [1;31mFAIL[0m Bug #81577: (Exceptions in interrupt handlers: ADD_ARRAY_ELEMENT) [ext/pcntl/tests/bug81577_2.phpt] 
```

I was not able to reproduce locally, but if it ever happens again, we should have a core dump to poke.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
