### PR TITLE
Preserve ci-images manual job availability on development branches (docs and generator)

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -94,6 +94,12 @@ appsec-trigger:
 # Manual maintenance pipeline that (re)builds the CI Docker images. Generated
 # from dockerfiles/ci/*/docker-compose.yml + .env so versions live in one place.
 # No strategy: depend — the parent must not wait on these manual jobs.
+#
+# This job MUST remain available on development branches: image changes are
+# built and validated from their branch before merge. Do not restrict it with
+# CI_COMMIT_REF_PROTECTED or CI_DEFAULT_BRANCH. This pipeline runs only in the
+# private Datadog GitLab; external pull requests cannot trigger it. Access to
+# manual jobs is controlled by that GitLab project's membership and settings.
 ci-images:
   stage: ci-build
   rules:

--- a/.gitlab/generate-ci-images.php
+++ b/.gitlab/generate-ci-images.php
@@ -107,6 +107,10 @@ stages:
 variables:
   CI_REGISTRY_IMAGE: "registry.ddbuild.io/ci/dd-trace-php/dd-trace-ci"
 
+# These manual jobs intentionally run on development branches so image changes
+# can be built and validated before merge. Do not add protected/default-branch
+# rules here. The parent pipeline is private to Datadog GitLab, where project
+# membership and settings control who can run manual jobs.
 .linux_image_build:
   stage: ci-build
   rules:

--- a/dockerfiles/ci/README.md
+++ b/dockerfiles/ci/README.md
@@ -45,6 +45,16 @@ repo.
 
 This is the preferred way of building the images.
 
+> [!IMPORTANT]
+> Image jobs are intentionally available from development branches. Maintainers
+> must be able to build and validate an image change before merging it, so do
+> not restrict `ci-images` or its generated jobs with
+> `CI_COMMIT_REF_PROTECTED` or `CI_DEFAULT_BRANCH`. The pipeline runs only in
+> Datadog's private GitLab: external pull requests cannot trigger it, and
+> access to its manual jobs is governed by the GitLab project's membership and
+> settings. A protected-ref rule identifies the ref, not whether the person
+> starting a manual job has the Maintainer role.
+
 In your pipeline
 ([GitLab-CI](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-php/-/pipelines)),
 manually start the `ci-images` job (stage `ci-build`) to spawn the child


### PR DESCRIPTION
### Motivation

- Ensure the `ci-images` manual job and generated image-build jobs remain runnable from development branches so image changes can be built and validated before merge.
- Prevent maintainers from accidentally restricting those manual jobs with `CI_COMMIT_REF_PROTECTED` or `CI_DEFAULT_BRANCH` rules.
- Clarify that these pipelines run only in the private Datadog GitLab instance and that access to manual jobs is governed by project membership and settings.

### Description

- Add explanatory comment to `.gitlab-ci.yml` above the `ci-images` job explaining why it must remain available on development branches and not be restricted by protected-ref rules.
- Add the same guidance to the generated CI images generator `.gitlab/generate-ci-images.php` so generated child pipelines include the note in their header and template snippets.
- Update `dockerfiles/ci/README.md` with an important admonition block describing that image-build jobs are intentionally available from development branches and how access is controlled.

### Testing

- No automated tests were run because the changes are non-functional documentation and generator comments only.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a675b084460832696759c07c6b8dda9)

The sad reality about this PR: Codex keeps stumbling over this over and over and pings to me to fix a problem that does not exist. Hopefully, with some documentation, it stops wasting my time.