### PR TITLE
fix(profiling): restore OPcache restart hook on shutdown

### DIFF
--- a/profiling/src/timeline.rs
+++ b/profiling/src/timeline.rs
@@ -542,6 +542,13 @@ pub(crate) fn timeline_mshutdown() {
         }
     }
 
+    #[cfg(php_opcache_restart_hook)]
+    {
+        unsafe {
+            zend::zend_accel_schedule_restart_hook = PREV_ZEND_ACCEL_SCHEDULE_RESTART_HOOK;
+        }
+    }
+
     #[cfg(php_zts)]
     timeline_gshutdown();
 }


### PR DESCRIPTION
### Description

Apache graceful reloads can run `MSHUTDOWN` followed by another `MINIT` in the same process. The profiler installed `ddog_php_prof_zend_accel_schedule_restart_hook` during `MINIT` but did not restore the previous OPcache restart hook during `MSHUTDOWN`. The next `MINIT` could therefore capture the profiler callback as its own predecessor, causing infinite recursion and a stack-overflow SIGSEGV when OPcache scheduled a restart.

This restores the previous OPcache restart hook during timeline shutdown, before a subsequent module initialization can install it again.

Jira: [SCP-1307](https://datadoghq.atlassian.net/browse/SCP-1307)

### Testing

Reproduced locally with PHP 8.4.22 NTS, Apache `mod_php`, OPcache enabled, the profiler loaded. After an Apache graceful reload, `opcache_reset()` caused the unmodified `master` worker to exit with SIGSEGV and returned an empty HTTP response. With this change, `opcache_reset()` returned `true` over HTTP 200 and Apache logged no signal exit.

- `cargo fmt --check`
- `cargo build -p datadog-php-profiling`

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.

[SCP-1307]: https://datadoghq.atlassian.net/browse/SCP-1307?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ