### PR TITLE
Onboard CI image publication off the public-images job-token trigger

### DIFF
--- a/.gitlab/generate-ci-images.php
+++ b/.gitlab/generate-ci-images.php
@@ -126,6 +126,19 @@ variables:
     # pod uses cluster defaults. MAKE_JOBS sets the builder's compile parallelism.
     MAKE_JOBS: "8"
 
+# Mirrors an existing registry.ddbuild.io tag to Docker Hub by calling
+# `dd-pkg publish-image` against artifact-gateway. This replaced a
+# `trigger: project: DataDog/public-images` bridge job: the old GitLab
+# job-token mechanism could not identify which project requested a
+# publication, whereas artifact-gateway verifies the caller and checks an
+# authorization policy (audit-only at the time of writing). Registries,
+# sources and destinations are unchanged, so what gets published is the same.
+#
+# Unlike the bridge job this runs on a runner, hence image: and tags:. The
+# parent pipeline has no `default:` block and this generated child pipeline
+# inherits nothing from it, so the tag has to be explicit here. amd64 to match
+# every other job in this repo; dd-pkg ships a multi-arch image, so arm64 would
+# also work if this project's runner fleet offers it.
 .image_publish:
   stage: ci-publish
   rules:
@@ -134,16 +147,24 @@ variables:
   # No deps: a publish just mirrors whatever already exists in
   # registry.ddbuild.io to Docker Hub, so it can run without (re)building.
   needs: []
-  trigger:
-    project: DataDog/public-images
-    branch: main
-    strategy: depend
+  image: registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.3
+  tags: ["arch:amd64"]
   # $TAG is supplied per matrix entry by the generated publish jobs.
   variables:
     IMG_REGISTRIES: "dockerhub"
-    IMG_SIGNING: false
+    IMG_SIGNING: "false"
     IMG_SOURCES: "${CI_REGISTRY_IMAGE}:${TAG}"
     IMG_DESTINATIONS: "dd-trace-ci:${TAG}"
+    PUBLIC_IMAGES_PUBLISH_TIMEOUT: "1800"
+  script:
+    - |
+      set -euo pipefail
+      dd-pkg version
+      args=(publish-image --timeout "${PUBLIC_IMAGES_PUBLISH_TIMEOUT}" --poll-interval 30 --signing="${IMG_SIGNING}")
+      if [[ -n "${IMG_REGISTRIES:-}" ]]; then args+=(--registries "${IMG_REGISTRIES}"); fi
+      if [[ -n "${IMG_SOURCES:-}" ]]; then args+=(--sources "${IMG_SOURCES}"); fi
+      if [[ -n "${IMG_DESTINATIONS:-}" ]]; then args+=(--destinations "${IMG_DESTINATIONS}"); fi
+      dd-pkg "${args[@]}"
 
 # Signs an already-pushed tag in registry.ddbuild.io. Used for the Windows
 # images: they're built without buildx (see .windows_image_build), so unlike

--- a/.gitlab/generate-ci-images.php
+++ b/.gitlab/generate-ci-images.php
@@ -126,19 +126,9 @@ variables:
     # pod uses cluster defaults. MAKE_JOBS sets the builder's compile parallelism.
     MAKE_JOBS: "8"
 
-# Mirrors an existing registry.ddbuild.io tag to Docker Hub by calling
-# `dd-pkg publish-image` against artifact-gateway. This replaced a
-# `trigger: project: DataDog/public-images` bridge job: the old GitLab
-# job-token mechanism could not identify which project requested a
-# publication, whereas artifact-gateway verifies the caller and checks an
-# authorization policy (audit-only at the time of writing). Registries,
-# sources and destinations are unchanged, so what gets published is the same.
-#
-# Unlike the bridge job this runs on a runner, hence image: and tags:. The
-# parent pipeline has no `default:` block and this generated child pipeline
-# inherits nothing from it, so the tag has to be explicit here. amd64 to match
-# every other job in this repo; dd-pkg ships a multi-arch image, so arm64 would
-# also work if this project's runner fleet offers it.
+# Mirrors an existing registry.ddbuild.io tag to Docker Hub via artifact-gateway.
+# tags: is required — this replaced a trigger/bridge job, which needed no runner,
+# and neither the parent pipeline nor this generated child sets a `default:`.
 .image_publish:
   stage: ci-publish
   rules:

--- a/.gitlab/generate-ci-images.php
+++ b/.gitlab/generate-ci-images.php
@@ -12,8 +12,8 @@
  * This script prints a literal preamble (stages, job templates), then loops
  * over the parsed compose services to emit, per Linux OS, one build matrix job
  * over PHP versions (bake builds and pushes the multi-arch image, then ddsign
- * signs it) plus a manual publish matrix job that mirrors the tags to Docker
- * Hub. Windows is emitted the same way but single-arch (no manifest) with its
+ * signs it) plus a manual publish matrix job that mirrors the tags to the public
+ * registries. Windows is emitted the same way but single-arch (no manifest) with its
  * own build runner/script; its images are signed by a separate Linux job
  * (ddsign has no Windows binary), see .image_sign.
  */
@@ -126,22 +126,23 @@ variables:
     # pod uses cluster defaults. MAKE_JOBS sets the builder's compile parallelism.
     MAKE_JOBS: "8"
 
-# Mirrors an existing registry.ddbuild.io tag to Docker Hub via artifact-gateway.
-# tags: is required — this replaced a trigger/bridge job, which needed no runner,
-# and neither the parent pipeline nor this generated child sets a `default:`.
+# Mirrors an existing registry.ddbuild.io tag to the public registries via
+# artifact-gateway. tags: is required — this replaced a trigger/bridge job, which
+# needed no runner, and neither the parent pipeline nor this generated child sets
+# a `default:`.
 .image_publish:
   stage: ci-publish
   rules:
     - when: manual
       allow_failure: true
   # No deps: a publish just mirrors whatever already exists in
-  # registry.ddbuild.io to Docker Hub, so it can run without (re)building.
+  # registry.ddbuild.io, so it can run without (re)building.
   needs: []
   image: registry.ddbuild.io/agent-delivery/dd-pkg:v0.9.3
-  tags: ["arch:amd64"]
+  tags: ["arch:arm64"]
   # $TAG is supplied per matrix entry by the generated publish jobs.
   variables:
-    IMG_REGISTRIES: "dockerhub"
+    IMG_REGISTRIES: "public"
     IMG_SIGNING: "false"
     IMG_SOURCES: "${CI_REGISTRY_IMAGE}:${TAG}"
     IMG_DESTINATIONS: "dd-trace-ci:${TAG}"

--- a/dockerfiles/ci/README.md
+++ b/dockerfiles/ci/README.md
@@ -38,8 +38,9 @@ repo.
   (ddsign only ships for Linux/Mac), so they're signed by a separate `Windows
   sign` job that runs on Linux and looks up the pushed tag's digest with
   `docker buildx imagetools inspect` instead.
-* **Publish:** a `trigger` to the `DataDog/public-images` service mirrors the
-  internal image to Docker Hub. It has no dependency on the build (see below).
+* **Publish:** a `dd-pkg publish-image` call against artifact-gateway mirrors the
+  internal image to the public registries. It has no dependency on the build (see
+  below).
 
 ## Building via GitLab-CI
 
@@ -55,8 +56,10 @@ pipeline. Per OS it has two kinds of jobs:
    `ddsign`. Run the version(s) you need. Authentication to the internal
    registry is automatic via the runner's native credentials.
 2. **`<OS> publish`** (manual, a matrix with one instance per tag) — mirrors
-   `…:<tag>` from the internal registry to the public Docker Hub
-   (`datadog/dd-trace-ci`) via a downstream `public-images` pipeline.
+   `…:<tag>` from the internal registry to the `dd-trace-ci` repository on the
+   public registries, by calling `dd-pkg publish-image` against
+   artifact-gateway. There is no downstream pipeline to follow: the job itself
+   reports success or failure, so troubleshoot it in its own log.
 
 Windows has an extra manual job, **`Windows sign`** (a matrix with one
 instance per tag), since `Windows build` can't sign its own images (see

--- a/dockerfiles/ci/README.md
+++ b/dockerfiles/ci/README.md
@@ -58,8 +58,9 @@ pipeline. Per OS it has two kinds of jobs:
 2. **`<OS> publish`** (manual, a matrix with one instance per tag) — mirrors
    `…:<tag>` from the internal registry to the `dd-trace-ci` repository on the
    public registries, by calling `dd-pkg publish-image` against
-   artifact-gateway. There is no downstream pipeline to follow: the job itself
-   reports success or failure, so troubleshoot it in its own log.
+   artifact-gateway. A `public-images` pipeline still performs the copy, but you
+   no longer trigger or watch it: `dd-pkg` polls it and this job succeeds or
+   fails with it, so start troubleshooting from the job log.
 
 Windows has an extra manual job, **`Windows sign`** (a matrix with one
 instance per tag), since `Windows build` can't sign its own images (see


### PR DESCRIPTION
Replaces the legacy `trigger: project: DataDog/public-images` job with a direct `dd-pkg publish-image` call against artifact-gateway.

## Why

The GitLab job-token bridge cannot tell **who** triggered a publish — any project holding a token could publish anything. Calling artifact-gateway instead adds:

- **Authentication** — the caller's identity is verified.
- **Authorization** — a policy states which Directory Service group may release each image tier (dev vs prod).
- An audit trail of every publication.

**Authorization is in audit-only mode for now** — nothing is blocked, publications are only recorded. So this is safe to merge, and the rollout stays reversible behind a feature flag.

## What changed

Only the `.image_publish` template in `.gitlab/generate-ci-images.php` (the generator, not the generated file). `IMG_SOURCES` and `IMG_DESTINATIONS` are untouched, so the same tags are mirrored; `IMG_REGISTRIES` changes as described below.

Bridge jobs need no runner; ordinary jobs do. The parent pipeline has no `default:` block and this generated child pipeline inherits nothing from it, so `image:` and `tags:` are explicit. The job runs on `arch:arm64` (the dd-pkg image is multi-arch, and arm runners are cheaper).

`IMG_REGISTRIES` moves from the `dockerhub` registry ID to the `public` selection tag. `IMG_REGISTRIES` selects tags from the public-images `registries.yaml` rather than individual registries, and `public` is the standard public set. **This widens where `dd-trace-ci` is published** — from Docker Hub alone to the full public set. The additional repositories (GCR, GAR, ACR, `registry.datadoghq.com`) are created on first publish, so no manual setup is needed.

## Validation

Ran the generator in `php:8.2-cli` and diffed its output against the pre-change generator. The only difference is the `.image_publish` template — all four publish jobs (Windows, Bookworm, CentOS, Alpine) and every matrix `TAG` value are byte-identical. Generated YAML parses, and the four jobs resolve to the new template with `tags: ["arch:arm64"]`, `IMG_REGISTRIES: public` and no `trigger:` key. `.image_sign` is untouched and stays on `arch:amd64`.

- Jira: [BARX-1968](https://datadoghq.atlassian.net/browse/BARX-1968)
- How-to: [Publish public images with dd-pkg](https://datadoghq.atlassian.net/wiki/x/ooQkngE)



[BARX-1968]: https://datadoghq.atlassian.net/browse/BARX-1968?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ