### PR TITLE
feat(profiling): add build compatibility with PHP 8.6

### DIFF
--- a/profiling/build.rs
+++ b/profiling/build.rs
@@ -176,8 +176,8 @@ fn build_zend_php_ffis(
                 .chain([Path::new("../zend_abstract_interface")])
                 .chain([Path::new("../")]),
         )
-        .flag_if_supported("-std=c11")
-        .flag_if_supported("-std=c17");
+        .flag_if_supported("-std=gnu11")
+        .flag_if_supported("-std=gnu17");
     #[cfg(feature = "test")]
     build.define("CFG_TEST", "1");
     build.compile("php_ffi");

--- a/profiling/src/bindings/mod.rs
+++ b/profiling/src/bindings/mod.rs
@@ -162,7 +162,7 @@ impl _zend_function {
     #[inline]
     pub fn is_internal(&self) -> bool {
         // SAFETY: the function's type field is always safe to access.
-        unsafe { self.type_ == ZEND_INTERNAL_FUNCTION }
+        unsafe { self.type_ == 1 } // ZEND_INTERNAL_FUNCTION
     }
 
     /// Returns the op_array if this is a user function or eval code.

--- a/profiling/src/bindings/mod.rs
+++ b/profiling/src/bindings/mod.rs
@@ -162,7 +162,7 @@ impl _zend_function {
     #[inline]
     pub fn is_internal(&self) -> bool {
         // SAFETY: the function's type field is always safe to access.
-        unsafe { self.type_ == 1 } // ZEND_INTERNAL_FUNCTION
+        unsafe { self.type_ == ZEND_INTERNAL_FUNCTION }
     }
 
     /// Returns the op_array if this is a user function or eval code.

--- a/profiling/src/config.rs
+++ b/profiling/src/config.rs
@@ -916,6 +916,8 @@ unsafe extern "C" fn parse_profiling_enabled(
 
 /// Display the profiling enabled config value
 unsafe extern "C" fn display_profiling_enabled(ini_entry: *mut zend_ini_entry, type_: c_int) {
+    // PHP 8.6 changed this field from u8 to bool, so the cast is redundant only on older PHP.
+    #[allow(clippy::unnecessary_cast)]
     let tmp_value: *mut zend_string =
         if type_ as u32 == ZEND_INI_DISPLAY_ORIG && (*ini_entry).modified as u8 != 0 {
             if !(*ini_entry).orig_value.is_null() {

--- a/profiling/src/config.rs
+++ b/profiling/src/config.rs
@@ -917,7 +917,7 @@ unsafe extern "C" fn parse_profiling_enabled(
 /// Display the profiling enabled config value
 unsafe extern "C" fn display_profiling_enabled(ini_entry: *mut zend_ini_entry, type_: c_int) {
     let tmp_value: *mut zend_string =
-        if type_ as u32 == ZEND_INI_DISPLAY_ORIG && (*ini_entry).modified != 0 {
+        if type_ as u32 == ZEND_INI_DISPLAY_ORIG && (*ini_entry).modified as u8 != 0 {
             if !(*ini_entry).orig_value.is_null() {
                 (*ini_entry).orig_value
             } else {

--- a/profiling/src/php_ffi.c
+++ b/profiling/src/php_ffi.c
@@ -654,7 +654,7 @@ bool ddog_php_jit_enabled() {
     }
 
     // Check opcache.jit_buffer_size, no buffer -> no JIT
-    char *buffer_size_str = zend_ini_string("opcache.jit_buffer_size", sizeof("opcache.jit_buffer_size") - 1, 0);
+    const char *buffer_size_str = zend_ini_string("opcache.jit_buffer_size", sizeof("opcache.jit_buffer_size") - 1, 0);
     if (!buffer_size_str || strlen(buffer_size_str) == 0 || strcmp(buffer_size_str, "0") == 0) {
         return false;
     }
@@ -666,7 +666,7 @@ bool ddog_php_jit_enabled() {
     }
 
     // Finally check the opcache.jit setting
-    char *jit_str = zend_ini_string("opcache.jit", sizeof("opcache.jit") - 1, 0);
+    const char *jit_str = zend_ini_string("opcache.jit", sizeof("opcache.jit") - 1, 0);
     if (!jit_str || strlen(jit_str) == 0 ||
         strcmp(jit_str, "disable") == 0 ||
         strcmp(jit_str, "off") == 0 ||
@@ -685,6 +685,8 @@ bool ddog_php_jit_enabled() {
 #if PHP_VERSION_ID < 70200
 #define zend_parse_parameters_none_throw() \
     (EXPECTED(ZEND_NUM_ARGS() == 0) ? SUCCESS : zend_parse_parameters_throw(ZEND_NUM_ARGS(), ""))
+#elif PHP_VERSION_ID >= 80600
+#define zend_parse_parameters_none_throw() zend_parse_parameters_none()
 #endif
 
 #if CFG_TRIGGER_TIME_SAMPLE

--- a/profiling/src/php_ffi.h
+++ b/profiling/src/php_ffi.h
@@ -1,4 +1,7 @@
 #include <SAPI.h>
+#if PHP_VERSION_ID >= 80600
+#include <Zend/zend_compile.h>
+#endif
 #include <Zend/zend_extensions.h>
 #include <Zend/zend_exceptions.h>
 #include <Zend/zend_types.h>

--- a/profiling/src/php_ffi.h
+++ b/profiling/src/php_ffi.h
@@ -38,10 +38,12 @@
 // Used to communicate strings from C -> Rust.
 #include <zai_string/string.h>
 
+#if PHP_VERSION_ID < 80600
 /* C11 allows a duplicate typedef provided they are the same, so this should be
  * fine as long as we compile with C11 or higher.
  */
 typedef ZEND_RESULT_CODE zend_result;
+#endif
 
 /**
  * Returns macro expansion of ZEND_EXTENSION_BUILD_ID, which bindgen cannot


### PR DESCRIPTION
### Description

Add PHP 8.6 build compatibility in the profiler by:
- removing the `ZEND_RESULT_CODE` alias
- including `Zend/zend_compile.h` for the `ZEND_INTERNAL_FUNCTION` const
- the C compilation mode changes from strict C11/C17 to GNU11/GNU17 because PHP 8.6's `ZEND_CONTAINER_OF` uses `typeof`, which is a GNU extension before C23, using the GNU dialect keeps the existing C standard baseline without requiring C23-capable toolchains
- Documents and locally allows the version-dependent `zend_ini_entry.modified` cast: it converts PHP 8.6's `bool` to `u8` and is only redundant for PHP 8.5 and older

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
