### PR TITLE
build: remove RUSTC_BOOSTRAP=1/nightly requirements

### DIFF
--- a/.claude/ci/compile-artifacts.md
+++ b/.claude/ci/compile-artifacts.md
@@ -29,7 +29,7 @@ If you need to run this step outside a build script and your host lacks `binutil
 - `.gitlab/generate-common.php` -- shared PHP-version and arch matrices
 - `.gitlab/compile_extension.sh` -- build script for tracer-pipeline `compile extension` jobs
 - `compile_rust.sh` -- shared Rust build wrapper invoked by `compile_extension.sh`
-  and `build-sidecar.sh`; sets `RUSTFLAGS`, `RUSTC_BOOTSTRAP=1`, and `SIDECAR_VERSION`
+  and `build-sidecar.sh`; sets `RUSTFLAGS` and `SIDECAR_VERSION`
 - `.gitlab/build-tracing.sh` -- builds NTS + ZTS `.a` (static archives) for the package pipeline
 - `.gitlab/build-sidecar.sh` -- builds `libdatadog_php.{a,so}` (Rust sidecar)
 - `.gitlab/link-tracing-extension.sh` -- links `.a` archives with the sidecar into final `.so` files

--- a/appsec/cmake/ddtrace.cmake
+++ b/appsec/cmake/ddtrace.cmake
@@ -60,7 +60,7 @@ ExternalProject_Add(components_rs_proj
     PREFIX ${CMAKE_BINARY_DIR}/components_rs
     SOURCE_DIR ${CMAKE_SOURCE_DIR}/../components-rs
     CONFIGURE_COMMAND ""
-    BUILD_COMMAND sh -c RUSTC_BOOTSTRAP=1\ ${CARGO_BUILD_ENV}\ ${CARGO_BUILD_CMD}\ --target-dir=${CMAKE_BINARY_DIR}/components_rs
+    BUILD_COMMAND sh -c ${CARGO_BUILD_ENV}\ ${CARGO_BUILD_CMD}\ --target-dir=${CMAKE_BINARY_DIR}/components_rs
     INSTALL_COMMAND ""
     DEPENDS libdatadog_stamp
     BUILD_IN_SOURCE TRUE

--- a/compile_rust.sh
+++ b/compile_rust.sh
@@ -21,4 +21,4 @@ if test -n "$COMPILE_ASAN"; then
   export CFLAGS="$LDFLAGS -fno-omit-frame-pointer" # the cc buildtools will only pick up CFLAGS it seems
 fi
 
-SIDECAR_VERSION=$(cat ../VERSION) RUSTFLAGS="$RUSTFLAGS" RUSTC_BOOTSTRAP=1 "${DDTRACE_CARGO:-cargo}" build $(test "${PROFILE:-debug}" = "debug" || echo --profile "$PROFILE") "$@"
+SIDECAR_VERSION=$(cat ../VERSION) RUSTFLAGS="$RUSTFLAGS" "${DDTRACE_CARGO:-cargo}" build $(test "${PROFILE:-debug}" = "debug" || echo --profile "$PROFILE") "$@"

--- a/components-rs/lib.rs
+++ b/components-rs/lib.rs
@@ -1,6 +1,3 @@
-#![allow(internal_features)]
-#![feature(allow_internal_unstable)]
-#![feature(linkage)]
 #![allow(static_mut_refs)] // remove with move to Rust 2024 edition
 
 pub mod agent_info;
@@ -222,6 +219,9 @@ pub unsafe extern "C" fn datadog_crashtracker_init(
 ) -> MaybeError {
     use libdd_crashtracker::{CrashtrackerConfiguration, StacktraceCollection};
 
+    #[cfg(not(target_os = "linux"))]
+    let _ = master_pid;
+
     let result = (|| -> anyhow::Result<()> {
         let metadata: libdd_crashtracker::Metadata = metadata.try_into()?;
 
@@ -298,7 +298,7 @@ pub unsafe extern "C" fn datadog_crashtracker_init(
 
         #[cfg(not(any(target_os = "linux", target_os = "macos")))]
         {
-            let _ = (master_pid, builder, metadata);
+            let _ = (builder, metadata);
             Ok(())
         }
     })();

--- a/config.w32
+++ b/config.w32
@@ -174,8 +174,6 @@ if (PHP_DDTRACE != 'no') {
 	// Promote to env var
 	frag_out.WriteLine("!if [set CARGO_TARGET_DIR=$(CARGO_TARGET_DIR)]");
 	frag_out.WriteLine("!endif");
-	frag_out.WriteLine("!if [set RUSTC_BOOTSTRAP=1]");
-	frag_out.WriteLine("!endif");
 	frag_out.WriteLine("!if [set RUSTFLAGS=--cfg windows_seh_wrapper]");
 	// Not supported yet on Windows: --cfg tokio_unstable --cfg tokio_taskdump
 	frag_out.WriteLine("!endif");

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,7 +35,6 @@ x-aliases:
         - REDIS_HOSTNAME=redis-integration
         - DDAGENT_HOSTNAME=ddagent_integration
         - HTTPBIN_HOSTNAME=httpbin-integration
-        - RUSTC_BOOTSTRAP=1
         - COMPOSER_MEMORY_LIMIT=-1
         - PHP_IDE_CONFIG=serverName=docker
         - DD_TRACE_DOCKER_DEBUG

--- a/zend_abstract_interface/components_rs.cmake
+++ b/zend_abstract_interface/components_rs.cmake
@@ -56,7 +56,7 @@ ExternalProject_Add(components_rs_proj
     PREFIX ${CMAKE_BINARY_DIR}/components_rs
     SOURCE_DIR ${CMAKE_SOURCE_DIR}/../components-rs
     CONFIGURE_COMMAND ""
-    BUILD_COMMAND RUSTC_BOOTSTRAP=1 ${CARGO_BUILD_ENV} ${CARGO_BUILD_CMD} --target-dir=${CMAKE_BINARY_DIR}/components_rs
+    BUILD_COMMAND ${CARGO_BUILD_ENV} ${CARGO_BUILD_CMD} --target-dir=${CMAKE_BINARY_DIR}/components_rs
     INSTALL_COMMAND ""
     DEPENDS libdatadog_stamp
     BUILD_IN_SOURCE TRUE


### PR DESCRIPTION
### Description

We haven't needed these things since a bit.

My motivation now is that codex tooling regularly trips up on this. When I told codex about it, it pointed out to me these requirements were actually unused now. I'm not sure if that's macOS specific or not, so we should be cautious about CI results.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
