### PR TITLE
build: use Clang for CentOS sidecar jobs

### DIFF
--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -443,6 +443,11 @@ foreach ($build_platforms as $platform) {
     TRIPLET: "<?= $platform['triplet'] ?>"
     ARCH: "<?= $platform['arch'] ?>"
     HOST_OS: "<?= $platform['host_os'] ?>"
+<?php if ($platform['host_os'] === "linux-gnu"): ?>
+    CC: clang
+    CXX: clang++
+    CARGO_TARGET_<?= strtoupper(str_replace('-', '_', $platform['triplet'])) ?>_LINKER: clang
+<?php endif; ?>
     CARGO_BUILD_JOBS: 16
     KUBERNETES_CPU_REQUEST: 16
     KUBERNETES_MEMORY_REQUEST: 5Gi


### PR DESCRIPTION
### Description

The CentOS 7 static linker is too old to understand the TLS relocation for `otel_thread_ctx_v1` emitted by Rust/LLVM as part of the upcoming OTel thread-context work. We cannot simply pass `-fuse-ld=lld` because the
 compiler is also too old to support that option. Accordingly, this PR uses `clang` as the compiler driver.

I am backporting this change because CI on the OTel context branch is not yet healthy enough to validate it reliably, and it also reduces the scope of that PR.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
