### PR TITLE
fix(tracing): OTel extension name

### DIFF
--- a/ext/datadog.c
+++ b/ext/datadog.c
@@ -716,7 +716,7 @@ void datadog_internal_handle_fork(void) {
 static const zend_module_dep datadog_module_deps[] = {
     ZEND_MOD_REQUIRED("json")
     ZEND_MOD_REQUIRED("standard")
-    ZEND_MOD_OPTIONAL("openetelemetry") // make sure we load after otel to insert the hook function if it doesn't exist yet
+    ZEND_MOD_OPTIONAL("opentelemetry") // make sure we load after otel to insert the hook function if it doesn't exist yet
     ZEND_MOD_END};
 
 zend_module_entry datadog_module_entry = {STANDARD_MODULE_HEADER_EX, NULL,


### PR DESCRIPTION
### Description

This fixes a typo in the `opentelemetry` extension name, as it had an extra 'e': `openetelemetry`.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
