### PR TITLE
style(loader): format extension config

### DIFF
--- a/loader/dd_library_loader.c
+++ b/loader/dd_library_loader.c
@@ -306,12 +306,37 @@ static void profiling_pre_minit_hook(injected_ext *config, zend_module_entry *mo
 // Declare the extension we want to load
 injected_ext ddloader_injected_ext_config[EXT_COUNT] = {
     // Tracer must be the first
-    [EXT_DDTRACE] = DECLARE_INJECTED_EXT("ddtrace", "trace", PHP_70_VERSION, ddtrace_pre_load_hook, ddtrace_pre_minit_hook,
-                         ((zend_module_dep[]){ZEND_MOD_OPTIONAL("json") ZEND_MOD_OPTIONAL("standard") ZEND_MOD_OPTIONAL("ddtrace") ZEND_MOD_END})),
-    [EXT_DATADOG_PROFILING] = DECLARE_INJECTED_EXT("datadog-profiling", "profiling", PHP_71_VERSION, NULL, profiling_pre_minit_hook,
-                        ((zend_module_dep[]){ZEND_MOD_OPTIONAL("json") ZEND_MOD_OPTIONAL("standard") ZEND_MOD_OPTIONAL("ddtrace") ZEND_MOD_OPTIONAL("ddtrace_injected") ZEND_MOD_OPTIONAL("datadog-profiling") ZEND_MOD_OPTIONAL("ev") ZEND_MOD_OPTIONAL("event") ZEND_MOD_OPTIONAL("libevent") ZEND_MOD_OPTIONAL("uv") ZEND_MOD_END})),
-    [EXT_DDAPPSEC] = DECLARE_INJECTED_EXT("ddappsec", "appsec", PHP_70_VERSION, NULL, appsec_pre_minit_hook,
-                        ((zend_module_dep[]){ZEND_MOD_OPTIONAL("json") ZEND_MOD_OPTIONAL("ddtrace") ZEND_MOD_OPTIONAL("ddtrace_injected") ZEND_MOD_OPTIONAL("ddappsec") ZEND_MOD_END})),
+    [EXT_DDTRACE] = DECLARE_INJECTED_EXT(
+        "ddtrace", "trace", PHP_70_VERSION, ddtrace_pre_load_hook, ddtrace_pre_minit_hook,
+        ((zend_module_dep[]){
+            ZEND_MOD_OPTIONAL("json")
+            ZEND_MOD_OPTIONAL("standard")
+            ZEND_MOD_OPTIONAL("ddtrace")
+            ZEND_MOD_END
+        })),
+    [EXT_DATADOG_PROFILING] = DECLARE_INJECTED_EXT(
+        "datadog-profiling", "profiling", PHP_71_VERSION, NULL, profiling_pre_minit_hook,
+        ((zend_module_dep[]){
+            ZEND_MOD_OPTIONAL("json")
+            ZEND_MOD_OPTIONAL("standard")
+            ZEND_MOD_OPTIONAL("ddtrace")
+            ZEND_MOD_OPTIONAL("ddtrace_injected")
+            ZEND_MOD_OPTIONAL("datadog-profiling")
+            ZEND_MOD_OPTIONAL("ev")
+            ZEND_MOD_OPTIONAL("event")
+            ZEND_MOD_OPTIONAL("libevent")
+            ZEND_MOD_OPTIONAL("uv")
+            ZEND_MOD_END
+        })),
+    [EXT_DDAPPSEC] = DECLARE_INJECTED_EXT(
+        "ddappsec", "appsec", PHP_70_VERSION, NULL, appsec_pre_minit_hook,
+        ((zend_module_dep[]){
+            ZEND_MOD_OPTIONAL("json")
+            ZEND_MOD_OPTIONAL("ddtrace")
+            ZEND_MOD_OPTIONAL("ddtrace_injected")
+            ZEND_MOD_OPTIONAL("ddappsec")
+            ZEND_MOD_END
+        })),
 };
 
 void ddloader_logv(injected_ext *config, log_level level, const char *format, va_list va) {


### PR DESCRIPTION
### Description

Reformats the extension config lines because in another PR I need to add something in there, and it's unmanageable. This section looks like this file was auto-formatted in the distant past, but it has many diffs on a recent clang-format so it hasn't been run in a while.

If we do want to return to auto-formatting, this section should be wrapped in `// clang-format off`/`on` and formatted manually, as the auto formatter does not do well here.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
