### PR TITLE
fix(stats): scan all peer tag keys sent by the agent

### DIFF
--- a/tests/ext/request-replayer/client_side_stats_peer_tags.phpt
+++ b/tests/ext/request-replayer/client_side_stats_peer_tags.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Client-side SHM span stats include peer tags configured via agent info
+Client-side SHM span stats include peer tags configured via agent info, wherever they sit in the key list
 --SKIPIF--
 <?php include __DIR__ . '/../includes/skipif_no_dev_env.inc'; ?>
 <?php
@@ -7,6 +7,16 @@ if (PHP_VERSION_ID < 70400) die("skip: Before PHP 7.4, the skip-task would cause
 if (PHP_VERSION_ID >= 80100) {
     echo "nocache\n";
 }
+// Keys are looked up in the order the agent sent them. The real list is derived from the agent's
+// semantic registry, is sorted alphabetically and is currently 44 keys long, so pad the list here
+// and keep one matching key at each end: that catches any truncation of the key scan (a regression
+// that dropped, among others, network.destination.name and out.host).
+$peerTags = ['db.hostname'];
+for ($i = 0; $i < 40; $i++) {
+    $peerTags[] = sprintf('peer.unused.%02d', $i);
+}
+$peerTags[] = 'out.host';
+
 $ctx = stream_context_create([
     'http' => [
         'method' => 'PUT',
@@ -14,7 +24,7 @@ $ctx = stream_context_create([
             'Content-Type: application/json',
             'X-Datadog-Test-Session-Token: client_side_stats_peer_tags',
         ],
-        'content' => json_encode(['version' => '7.65.0', 'client_drop_p0s' => true, 'peer_tags' => ['db.hostname']]),
+        'content' => json_encode(['version' => '7.65.0', 'client_drop_p0s' => true, 'peer_tags' => $peerTags]),
     ]
 ]);
 file_get_contents('http://request-replayer/set-agent-info', false, $ctx);
@@ -45,12 +55,15 @@ dd_trace_internal_fn('await_agent_info');
 // Now create the span whose stats we want to inspect. When this span is fed to the
 // concentrator, ddog_apply_agent_info_concentrator_config() is called first, picks up
 // the peer_tags update from the SHM, and the concentrator extracts db.hostname from meta.
+// db.hostname is the first key the agent sent and out.host the last one (index 41): both must end
+// up in the stats payload, no matter where they sit in the list.
 $root = \DDTrace\start_trace_span();
 $root->name = "web.request";
 $root->resource = "GET /db";
 $root->service = "stats-test-service";
 $root->meta['span.kind'] = 'client';
 $root->meta['db.hostname'] = 'my-db-host';
+$root->meta['out.host'] = 'my-remote-host';
 \DDTrace\close_span();
 
 dd_trace_internal_fn('synchronous_flush');
@@ -90,4 +103,4 @@ if (!$found) {
 
 ?>
 --EXPECT--
-peer_tags: ["db.hostname:my-db-host"]
+peer_tags: ["db.hostname:my-db-host","out.host:my-remote-host"]

--- a/tracer/span_stats.c
+++ b/tracer/span_stats.c
@@ -349,10 +349,6 @@ static void ddtrace_span_concentrator_feed_cb(const ddog_SpanConcentrator *c, vo
         size_t peer_tag_keys_count = 0;
         const ddog_CharSlice *peer_tag_keys = ddog_span_concentrator_peer_tag_keys(c, &peer_tag_keys_count);
         if (peer_tag_keys_count > 0 && peer_tag_keys) {
-            // All configured keys are looked up: the cap bounds how many tags we *collect*, not how
-            // many keys we scan. The agent's key list is sorted alphabetically and already longer
-            // than DDTRACE_MAX_PEER_TAGS, so capping the scan would silently ignore whichever keys
-            // happen to sort last (e.g. out.host, peer.hostname, server.address).
             for (size_t i = 0; i < peer_tag_keys_count && actual_peer_tags < DDTRACE_MAX_PEER_TAGS; i++) {
                 const ddog_CharSlice *k = &peer_tag_keys[i];
                 zval *val = zend_hash_str_find(pre->meta, k->ptr, k->len);

--- a/tracer/span_stats.c
+++ b/tracer/span_stats.c
@@ -34,7 +34,9 @@ static const size_t GRPC_META_KEY_LENS[] = {
     sizeof("grpc.status.code") - 1,
 };
 
-// Maximum number of peer tags we handle per span (a hard cap to bound stack usage).
+// Maximum number of peer tags we collect per span (a hard cap to bound stack usage).
+// This bounds matched tags on a single span, not the number of peer tag keys configured by the
+// agent, which is larger and must be scanned in full.
 #define DDTRACE_MAX_PEER_TAGS 32
 
 void ddtrace_precompute_span(ddtrace_span_data *span, ddtrace_span_precomputed *pre) {
@@ -346,11 +348,12 @@ static void ddtrace_span_concentrator_feed_cb(const ddog_SpanConcentrator *c, vo
     if (pre->span_kind && (zend_string_equals_literal(pre->span_kind, "client") || zend_string_equals_literal(pre->span_kind, "producer") || zend_string_equals_literal(pre->span_kind, "consumer"))) {
         size_t peer_tag_keys_count = 0;
         const ddog_CharSlice *peer_tag_keys = ddog_span_concentrator_peer_tag_keys(c, &peer_tag_keys_count);
-        if (peer_tag_keys_count > DDTRACE_MAX_PEER_TAGS) {
-            peer_tag_keys_count = DDTRACE_MAX_PEER_TAGS;
-        }
         if (peer_tag_keys_count > 0 && peer_tag_keys) {
-            for (size_t i = 0; i < peer_tag_keys_count; i++) {
+            // All configured keys are looked up: the cap bounds how many tags we *collect*, not how
+            // many keys we scan. The agent's key list is sorted alphabetically and already longer
+            // than DDTRACE_MAX_PEER_TAGS, so capping the scan would silently ignore whichever keys
+            // happen to sort last (e.g. out.host, peer.hostname, server.address).
+            for (size_t i = 0; i < peer_tag_keys_count && actual_peer_tags < DDTRACE_MAX_PEER_TAGS; i++) {
                 const ddog_CharSlice *k = &peer_tag_keys[i];
                 zval *val = zend_hash_str_find(pre->meta, k->ptr, k->len);
                 if (val && Z_TYPE_P(val) == IS_STRING) {


### PR DESCRIPTION
### Description

`DDTRACE_MAX_PEER_TAGS` is meant to bound how many peer tags a single span collects, but it was also truncating the key list received from the agent's `/info` before lookup. That list is sorted alphabetically and is already longer than the cap, so keys sorting last (`out.host`, `peer.hostname`, `peer.service`, `server.address`) never matched.

It became visible when the agent added `db.system.name` to its semantic registry: the key sorts at index 16 and pushed `network.destination.name` from 31 to 32, out of the scanned window. Guzzle client spans carry only that key, so client-side stats reported no peer tags at all and system-tests `Test_Peer_Tags` started failing on every PHP PR.

The existing `client_side_stats_peer_tags.phpt` now advertises a key list longer than the cap with a matching key at each end. It fails without the fix (`out.host` dropped) and passes with it. Verified against system-tests `TRACE_STATS_COMPUTATION` on `datadog/agent-dev:master-py3` with a locally built package.

[APMSP-3911](https://datadoghq.atlassian.net/browse/APMSP-3911)

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.


[APMSP-3911]: https://datadoghq.atlassian.net/browse/APMSP-3911?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ