### PR TITLE
test(tracing): migrate off backtick operator

### DIFF
--- a/tests/Integrations/Custom/Autoloaded/GitMetadataTest.php
+++ b/tests/Integrations/Custom/Autoloaded/GitMetadataTest.php
@@ -144,8 +144,8 @@ CONFIG
 
         $rootSpanMeta = $traces[0][0]['meta'];
 
-        $gitCommitSha = trim(`git rev-parse HEAD`);
-        $gitRepositoryURL = preg_replace('((?<=//)[^@]+@)', '', trim(`git config --get remote.origin.url`));
+        $gitCommitSha = trim(shell_exec('git rev-parse HEAD'));
+        $gitRepositoryURL = preg_replace('((?<=//)[^@]+@)', '', trim(shell_exec('git config --get remote.origin.url')));
 
         $this->assertEquals($gitCommitSha, $rootSpanMeta['_dd.git.commit.sha']);
         $this->assertEquals($gitRepositoryURL, $rootSpanMeta['_dd.git.repository_url']);

--- a/tests/Integrations/Laravel/V8_x/RouteCachingTest.php
+++ b/tests/Integrations/Laravel/V8_x/RouteCachingTest.php
@@ -140,12 +140,12 @@ class RouteCachingTest extends WebFrameworkTestCase
     private function routeCache()
     {
         $appRoot = \dirname(\dirname(self::getAppIndexScript()));
-        `cd $appRoot && DD_TRACE_CLI_ENABLED=0 php artisan route:cache`;
+        \shell_exec('cd ' . \escapeshellarg($appRoot) . ' && DD_TRACE_CLI_ENABLED=0 php artisan route:cache');
     }
 
     private function routeClear()
     {
         $appRoot = \dirname(\dirname(self::getAppIndexScript()));
-        `cd $appRoot && DD_TRACE_CLI_ENABLED=0 php artisan route:clear`;
+        \shell_exec('cd ' . \escapeshellarg($appRoot) . ' && DD_TRACE_CLI_ENABLED=0 php artisan route:clear');
     }
 }


### PR DESCRIPTION
### Description

Removes our own usage of the backtick operator because this operator was deprecated in PHP 8.5. This removes deprecation warnings in the logs.

<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
