### PR TITLE
fix: preserve W3C trace flags in OpenTelemetry contexts

### DIFF
--- a/src/DDTrace/OpenTelemetry/Context.php
+++ b/src/DDTrace/OpenTelemetry/Context.php
@@ -185,7 +185,7 @@ final class Context implements ContextInterface
         $currentTraceId = \DDTrace\root_span()->traceId;
         $traceContext = generate_distributed_tracing_headers(['tracecontext']);
         $traceFlags = isset($traceContext['traceparent'])
-            ? (substr($traceContext['traceparent'], -2) === '01' ? API\TraceFlags::SAMPLED : API\TraceFlags::DEFAULT)
+            ? hexdec(substr($traceContext['traceparent'], -2))
             : null;
         $traceState = new API\TraceState($traceContext['tracestate'] ?? null);
 

--- a/tests/OpenTelemetry/Integration/InteroperabilityTest.php
+++ b/tests/OpenTelemetry/Integration/InteroperabilityTest.php
@@ -113,6 +113,25 @@ final class InteroperabilityTest extends BaseTestCase
         $this->assertArrayNotHasKey('parent_id', $span['meta']);
     }
 
+    public function testDatadogSpanTraceFlagsArePreserved()
+    {
+        $this->isolateTracer(function () {
+            start_span();
+            \DDTrace\root_span()->samplingPriority = \DD_TRACE_PRIORITY_SAMPLING_USER_KEEP;
+
+            $currentSpan = Span::getCurrent();
+            $spanContext = $currentSpan->getContext();
+
+            $this->assertSame(TraceFlags::SAMPLED | TraceFlags::RANDOM, $spanContext->getTraceFlags());
+
+            $carrier = [];
+            TraceContextPropagator::getInstance()->inject($carrier);
+            $this->assertStringEndsWith('-03', $carrier[TraceContextPropagator::TRACEPARENT]);
+
+            close_span();
+        });
+    }
+
     /** @noinspection PhpParamsInspection */
     public function testMixingOpenTelemetrylAndDatadogBasic()
     {


### PR DESCRIPTION
### Description

Preserve the full W3C trace-flags byte when converting an active Datadog span into an OpenTelemetry span context.

Locally generated 128-bit trace IDs carry the random flag (`0x02`), so sampled traces use `0x03`. Comparing that byte directly with `0x01` classified these traces as unsampled. Decoding the full byte keeps both sampling state and random trace-ID provenance intact when OpenTelemetry creates or propagates child contexts.

Adds regression coverage for the converted span context and W3C reinjection.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
