### PR TITLE
fix(system-tests): handle additional trace flags

### DIFF
--- a/src/DDTrace/OpenTelemetry/Context.php
+++ b/src/DDTrace/OpenTelemetry/Context.php
@@ -185,7 +185,7 @@ final class Context implements ContextInterface
         $currentTraceId = \DDTrace\root_span()->traceId;
         $traceContext = generate_distributed_tracing_headers(['tracecontext']);
         $traceFlags = isset($traceContext['traceparent'])
-            ? (substr($traceContext['traceparent'], -2) === '01' ? API\TraceFlags::SAMPLED : API\TraceFlags::DEFAULT)
+            ? hexdec(substr($traceContext['traceparent'], -2))
             : null;
         $traceState = new API\TraceState($traceContext['tracestate'] ?? null);
 

--- a/tests/OpenTelemetry/Integration/InteroperabilityTest.php
+++ b/tests/OpenTelemetry/Integration/InteroperabilityTest.php
@@ -35,6 +35,16 @@ final class InteroperabilityTest extends BaseTestCase
 {
     use TracerTestTrait, SpanAssertionTrait;
 
+    /**
+     * The OTel context level 2 random state flag.
+     *
+     * This exists instead of using ::RANDOM on the SDK because that requires v1.8 and we support
+     * older versions to support PHP 7.
+     *
+     * @see https://www.w3.org/TR/trace-context-2/#random-trace-id-flag
+     */
+    private const TRACE_FLAG_RANDOM = 0x02;
+
     // TODO: Implement AttributesBuilder and add a method to retrieve the attributeCountLimit
 
     public function ddSetUp(): void
@@ -250,6 +260,8 @@ final class InteroperabilityTest extends BaseTestCase
             $OTelScope = $OTelSpan->activate();
 
             $currentSpan = Span::getCurrent();
+            $traceFlags = $currentSpan->getContext()->getTraceFlags();
+            $this->assertSame(TraceFlags::SAMPLED | self::TRACE_FLAG_RANDOM, $traceFlags);
             $this->assertSame($ddSpan, $currentSpan->getDDSpan());
 
             $OTelScope->detach();


### PR DESCRIPTION
### Description

Preserve the complete W3C trace flags byte when converting an active Datadog span into an OpenTelemetry span context. Sampled traces with random trace IDs use both the sampled and random-ID flags (`0x03`); comparing the byte with `0x01` incorrectly treated those contexts as unsampled.

This fixes the deterministic OpenTelemetry interoperability system-test failures and adds regression coverage that verifies both flags are retained.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.