### PR TITLE
ci: bump Alpine Linux matrix

### DIFF
--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -1031,9 +1031,7 @@ endforeach;
         IMAGE:
           - alpine:3.8
           - alpine:3.9
-          - alpine:3.10
           - alpine:3.11
-          - alpine:3.12
           - alpine:3.15
         INSTALL_TYPE: &verify_install_types
         - php_installer
@@ -1042,9 +1040,8 @@ endforeach;
         IMAGE:
           - alpine:3.15
           - alpine:3.16
-          - alpine:3.17
-          - alpine:3.20
-          - alpine@sha256:28bd5fe8b56d1bd048e5babf5b10710ebe0bae67db86916198a6eec434943f8b
+          - alpine:3.21
+          - alpine:3.24
         INSTALL_TYPE: *verify_install_types
       - IMAGE: <?= json_encode(array_map(function ($v) { return "php:$v-fpm-alpine"; }, $all_minor_major_targets)), "\n" ?>
         INSTALL_TYPE: *verify_install_types


### PR DESCRIPTION
### Description

This switches us to use the latest supported images (mostly). Note that the sha hash that was dropped corresponds to 3.24.1. Versions 3.20 and earlier are EOL. I retained some versions, notably 3.15, because they are interesting, as they have both PHP 7 and PHP 8 packages available.

These changes make the "verify alpine" family of jobs more reliable by using versions mirrored in the Datadog image registry. Versions 3.21 and 3.24 were added to that mirror by me (Levi Morrison), so aside from very brief period where a new Alpine release e.g. 3.24.2 is made but not yet mirrored, it should not fail. The image registry tracks these tags for updates, so it happens automatically. Version 3.17 is not mirrored, and I see no reason to, so I dropped it.


<!-- Fixes #{issue} -->
<!-- Documented in #{doc pr} -->

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
