### PR TITLE
fix: vsnprintf off-by-one errors

### DIFF
--- a/appsec/src/extension/request_abort.c
+++ b/appsec/src/extension/request_abort.c
@@ -585,7 +585,7 @@ static void _emit_error(const char *format, ...)
     char *msg = NULL;
     bool free_msg = false;
     if (len >= (int)sizeof(buf)) {
-        msg = safe_emalloc(len, 1, 0);
+        msg = safe_emalloc(len, 1, 1);
         if (vsnprintf(msg, len + 1, format, args2) < 0) {
             char default_msg[] = "Datadog blocked the request.";
             msg = default_msg;

--- a/components/log/log.c
+++ b/components/log/log.c
@@ -14,7 +14,7 @@ static void ddog_logf_va(ddog_Log source, bool once, const char *format, va_list
     va_list va2;
     va_copy(va2, va);
     int len = vsnprintf(buf, sizeof(buf), format, va);
-    if (len > (int)sizeof(buf)) {
+    if (len >= (int)sizeof(buf)) {
         char *msg = malloc(len + 1);
         len = vsnprintf(msg, len + 1, format, va2);
         ddog_log(source, once || (source & ddog_LOG_ONCE), (ddog_CharSlice){ .ptr = msg, .len = (uintptr_t)len });

--- a/ext/logging.c
+++ b/ext/logging.c
@@ -177,8 +177,8 @@ int datadog_signal_safe_logf(const char *fmt, ...) {
         int needed_len = vsnprintf(NULL, 0, fmt, args_copy);
         va_end(args_copy);
 
-        char *msgbuf = malloc(needed_len);
-        vsnprintf(msgbuf, needed_len, fmt, args);
+        char *msgbuf = malloc(needed_len + 1);
+        vsnprintf(msgbuf, needed_len + 1, fmt, args);
         va_end(args);
 
         ret = datadog_log_with_time(error_log_fd, msgbuf, needed_len);

--- a/tracer/tracer_telemetry.c
+++ b/tracer/tracer_telemetry.c
@@ -60,7 +60,7 @@ void ddtrace_integration_error_telemetryf(ddog_Log source, const char *format, .
     va_copy(va2, va);
     int len = vsnprintf(buf, sizeof(buf), format, va2);
     va_end(va2);
-    if (len > (int)sizeof(buf)) {
+    if (len >= (int)sizeof(buf)) {
         char *msg = malloc(len + 1);
         len = vsnprintf(msg, len + 1, format, va);
         ddog_sidecar_telemetry_add_integration_log_buffer(source, buffer, (ddog_CharSlice){ .ptr = msg, .len = (uintptr_t)len });


### PR DESCRIPTION
### Description

Fixes some off-by-one errors when using `vsnprintf`.

`vsnprintf` returns the required character count excluding the null terminator. To write an N-sized message, you need an N+1 (or larger) sized buffer. If you don't, then `vsnprintf` will truncate the message. Since this is usually used with logs, this is usually not that consequential, and in some cases the length is correctly tracked so it's truly harmless.

BUT in appsec's `_emit_error`, the buffer was sized `len` and `vsnprintf` was told `len + 1`, so there's a genuine heap-buffer-overflow there.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
