### PR TITLE
build: fix Linux-specific gating

### DIFF
--- a/cbindgen.toml
+++ b/cbindgen.toml
@@ -11,9 +11,13 @@ no_includes = true
 sys_includes = ["stdbool.h", "stddef.h", "stdint.h"]
 includes = ["common.h", "telemetry.h", "sidecar.h"]
 
+[defines]
+"target_os = linux" = "__linux__"
+
 [export]
 prefix = "ddog_"
 renaming_overrides_prefixing = true
+exclude = ["posix_spawn_file_actions_addchdir_np"]
 
 [export.mangle]
 rename_types = "PascalCase"

--- a/components-rs/datadog.h
+++ b/components-rs/datadog.h
@@ -41,12 +41,11 @@ void datadog_generate_session_id(void);
 
 void datadog_format_runtime_id(uint8_t (*buf)[36]);
 
-#ifdef __linux__
+#if defined(__linux__)
 /**
  * Publish or update dd-trace-php's standard Linux OTel Process Context.
  */
 bool datadog_publish_otel_process_context(ddog_CharSlice process_tags);
-
 #endif
 
 ddog_CharSlice ddtrace_get_container_id(void);
@@ -85,8 +84,6 @@ ddog_MaybeError datadog_crashtracker_init(const struct ddog_Endpoint *endpoint,
                                           int32_t master_pid);
 
 ddog_Configurator *ddog_library_configurator_new_dummy(bool debug_logs, ddog_CharSlice language);
-
-int posix_spawn_file_actions_addchdir_np(void *file_actions, const char *path);
 
 uint64_t dd_fnv1a_64(const uint8_t *data, uintptr_t len);
 


### PR DESCRIPTION
### Description

The OTel Linux-specific `datadog_publish_otel_process_context` was manually made Linux-only in `datadog.h`. I noticed this when regenerating the header for a different reason. Oops.

So this part teaches cbindgen about it:

```toml
[defines]
"target_os = linux" = "__linux__"
```

And that had the un-intended side-effect of making this Linux-only:

```diff
+ #if defined(__linux__)
  int posix_spawn_file_actions_addchdir_np(void *file_actions, const char *path);
+ #endif
```

But this is just a musl-only declaration and shouldn't be exposed in the `datadog.h` file at all, so that's the reason for:

```diff
  [export]
  prefix = "ddog_"
  renaming_overrides_prefixing = true
+ exclude = ["posix_spawn_file_actions_addchdir_np"]
```

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
