### PR TITLE
Fix issue when more than 65536 are delivered by RC

### DIFF
--- a/appsec/helper-rust/src/service.rs
+++ b/appsec/helper-rust/src/service.rs
@@ -338,7 +338,6 @@ impl Service {
                 asm_feature_config_manager: AsmFeatureConfigManager::new(),
                 pending_telemetry_metrics: TelemetryMetricsCollector::default(),
                 pending_init_diagnostics_legacy: Some(init_diagnostics_legacy),
-                extra_chunk_paths: HashMap::new(),
             }),
             config_snapshot: ArcSwap::from_pointee(ConfigSnapshot::new(
                 asm_always_enabled,
@@ -386,44 +385,14 @@ impl Service {
         let mut rules_version: Option<String> = None;
 
         // Handle removal of configs
-        let removed_paths: Vec<rc::RcPath> = state
+        for old_path in state
             .last_configs
             .keys()
             .filter(|k| !new_configs.contains_key(*k))
-            .cloned()
-            .collect();
-        for old_path in &removed_paths {
+        {
             if old_path.as_str().contains("/ASM_FEATURES/") {
                 state.asm_feature_config_manager.remove(old_path);
             } else {
-                // Remove any extra chunk paths registered for this config
-                if let Some(chunk_paths) = state.extra_chunk_paths.remove(old_path) {
-                    for chunk_path in chunk_paths {
-                        match self.waf.remove_config(&chunk_path) {
-                            Ok(true) => {
-                                debug!(
-                                    "Removed WAF chunk config for {:?}: {}",
-                                    old_path, chunk_path
-                                );
-                                waf_changed = true;
-                            }
-                            Ok(false) => {
-                                warning!(
-                                    "No WAF chunk config found to remove for {:?}: {}",
-                                    old_path,
-                                    chunk_path
-                                );
-                            }
-                            Err(e) => {
-                                self.log_general_rc_error(&e.context(format!(
-                                    "Failed to remove WAF chunk config for {:?}: {}",
-                                    old_path, chunk_path
-                                )));
-                            }
-                        }
-                    }
-                }
-
                 let res = self.waf.remove_config(old_path.as_str());
                 match res {
                     Ok(true) => {
@@ -591,93 +560,33 @@ impl Service {
                 let shmem = cfg.read()?;
                 let data = unsafe { shmem.as_slice() };
 
-                // Parse and split first; only remove old chunk paths after successful
-                // registration so a malformed update doesn't drop last-known-good chunks.
-                let chunks = split_asm_data_if_needed(data)
-                    .with_context(|| format!("Failed to split ASM_DATA for {:?}", rc_path))?;
+                let truncated = truncate_asm_data_if_needed(data)
+                    .with_context(|| format!("Failed to parse WAF config for {:?}", rc_path))?;
+                let data = truncated.as_deref().unwrap_or(data);
 
-                let mut new_chunk_paths: Vec<String> = Vec::new();
-                let mut first_result = Ok(());
+                let ruleset = waf_ruleset::WafRuleset::from_slice(data)
+                    .with_context(|| format!("Failed to parse WAF config for {:?}", rc_path))?;
 
-                for (i, chunk_data) in chunks.iter().enumerate() {
-                    let chunk_path = if i == 0 {
-                        rc_path.as_str().to_string()
-                    } else {
-                        // Use a delimiter that cannot appear in real RC paths but is safe for C-string interop
-                        let p = format!("{}#chunk_{}", rc_path.as_str(), i);
-                        p
-                    };
+                let waf_obj: libddwaf::object::WafObject = ruleset.into();
+                let mut diagnostics = Default::default();
 
-                    let ruleset =
-                        waf_ruleset::WafRuleset::from_slice(chunk_data).with_context(|| {
-                            format!("Failed to parse WAF config chunk {} for {:?}", i, rc_path)
-                        })?;
+                let upd_result = self.waf.add_or_update_config(
+                    rc_path.as_str(),
+                    &waf_obj,
+                    Some(&mut diagnostics),
+                );
 
-                    let waf_obj: libddwaf::object::WafObject = ruleset.into();
-                    let mut diagnostics = Default::default();
-
-                    let upd_result = self.waf.add_or_update_config(
-                        &chunk_path,
-                        &waf_obj,
-                        Some(&mut diagnostics),
-                    );
-
-                    // Collect diagnostics for every chunk under the original RC path so
-                    // errors in chunks beyond the first are not silently discarded.
-                    all_diagnostics.push((rc_path.clone(), diagnostics));
-
-                    match upd_result {
-                        Ok(()) => {
-                            debug!("Added/updated WAF config chunk {}: {:?}", i, rc_path);
-                            if product.name() == "ASM_DD" && i == 0 {
-                                if let Some((_, diag)) = all_diagnostics.last() {
-                                    *rules_version = waf_diag::extract_ruleset_version(diag);
-                                }
-                                *new_snapshot =
-                                    new_snapshot.with_new_rules_version(rules_version.clone());
-                            }
-                            *waf_changed = true;
-                            if i > 0 {
-                                new_chunk_paths.push(chunk_path);
-                            }
-                        }
-                        Err(e) => {
-                            if i == 0 {
-                                first_result = Err(e);
-                            } else {
-                                // Propagate failures from any chunk: a partial update
-                                // would silently leave the WAF with an incomplete denylist.
-                                return Err(e).with_context(|| {
-                                    format!(
-                                        "Failed to add WAF config chunk {} for {:?}",
-                                        i, rc_path
-                                    )
-                                });
-                            }
-                        }
+                if upd_result.is_ok() {
+                    debug!("Added/updated WAF config: {:?}", rc_path);
+                    if product.name() == "ASM_DD" {
+                        *rules_version = waf_diag::extract_ruleset_version(&diagnostics);
+                        *new_snapshot = new_snapshot.with_new_rules_version(rules_version.clone());
                     }
+                    *waf_changed = true;
                 }
 
-                // All chunks accepted — now remove stale chunk paths from the previous
-                // update of this RC path and record the newly registered ones.
-                if let Some(old_chunk_paths) = state.extra_chunk_paths.remove(rc_path) {
-                    for chunk_path in old_chunk_paths {
-                        if let Err(e) = self.waf.remove_config(&chunk_path) {
-                            debug!(
-                                "Failed to remove old WAF chunk config for {:?}: {:#}",
-                                rc_path, e
-                            );
-                        }
-                    }
-                }
-
-                if !new_chunk_paths.is_empty() {
-                    state
-                        .extra_chunk_paths
-                        .insert(rc_path.clone(), new_chunk_paths);
-                }
-
-                first_result
+                all_diagnostics.push((rc_path.clone(), diagnostics));
+                upd_result
             }
             _ => {
                 debug!("Ignoring unknown product: {:?}", product);
@@ -892,88 +801,44 @@ struct RcUpdateState {
     asm_feature_config_manager: AsmFeatureConfigManager,
     pending_telemetry_metrics: TelemetryMetricsCollector,
     pending_init_diagnostics_legacy: Option<InitDiagnosticsLegacy>,
-    // Extra WAF config paths created when splitting large ASM_DATA arrays into chunks.
-    // Maps original RC path -> list of extra chunk WAF paths to remove when the original is removed.
-    extra_chunk_paths: HashMap<rc::RcPath, Vec<String>>,
 }
 
 // libddwaf v2.x uses u16 for WafArray capacity (max 65535 entries per array).
-// When ASM_DATA contains a rules_data[*].data array exceeding this limit, we split it
-// into chunks that each fit within the limit, using separate WAF config paths per chunk.
-// libddwaf merges rules_data entries with the same id from multiple config paths.
+// When ASM_DATA delivers a rules_data[*].data array larger than this, we truncate
+// it to the limit rather than panic. Entries beyond the limit are silently dropped.
 const MAX_WAF_ARRAY_ENTRIES: usize = u16::MAX as usize;
 
-fn split_asm_data_if_needed(data: &[u8]) -> anyhow::Result<Vec<Vec<u8>>> {
-    let value: serde_json::Value =
-        serde_json::from_slice(data).context("Failed to parse ASM_DATA JSON")?;
+fn truncate_asm_data_if_needed(data: &[u8]) -> anyhow::Result<Option<Vec<u8>>> {
+    let mut value: serde_json::Value =
+        serde_json::from_slice(data).context("Failed to parse WAF config JSON")?;
 
-    let rules_data = match value.get("rules_data").and_then(|v| v.as_array()) {
+    let rules_data = match value.get_mut("rules_data").and_then(|v| v.as_array_mut()) {
         Some(rd) => rd,
-        None => return Ok(vec![data.to_vec()]),
+        None => return Ok(None),
     };
 
-    let any_large = rules_data.iter().any(|entry| {
-        entry
-            .get("data")
-            .and_then(|d| d.as_array())
-            .map(|arr| arr.len() > MAX_WAF_ARRAY_ENTRIES)
-            .unwrap_or(false)
-    });
-
-    if !any_large {
-        return Ok(vec![data.to_vec()]);
-    }
-
-    // Build the first chunk (with all small entries + first slice of large entries).
-    // Additional chunks carry subsequent slices of large entries.
-    let mut first_entries: Vec<serde_json::Value> = Vec::new();
-    let mut extra_jsons: Vec<Vec<u8>> = Vec::new();
-
-    for entry in rules_data {
-        let data_arr = entry.get("data").and_then(|d| d.as_array());
-        match data_arr {
-            Some(arr) if arr.len() > MAX_WAF_ARRAY_ENTRIES => {
-                let id = entry.get("id").cloned().unwrap_or(serde_json::Value::Null);
-                let type_ = entry
-                    .get("type")
-                    .cloned()
-                    .unwrap_or(serde_json::Value::Null);
-                let mut first = true;
-                for chunk in arr.chunks(MAX_WAF_ARRAY_ENTRIES) {
-                    let chunk_entry = serde_json::json!({
-                        "id": id.clone(),
-                        "type": type_.clone(),
-                        "data": serde_json::Value::Array(chunk.to_vec())
-                    });
-                    if first {
-                        first_entries.push(chunk_entry);
-                        first = false;
-                    } else {
-                        extra_jsons.push(
-                            serde_json::to_vec(&serde_json::json!({"rules_data": [chunk_entry]}))
-                                .context("Failed to serialize ASM_DATA chunk")?,
-                        );
-                    }
-                }
+    let mut truncated = false;
+    for entry in rules_data.iter_mut() {
+        if let Some(data_arr) = entry.get_mut("data").and_then(|d| d.as_array_mut()) {
+            if data_arr.len() > MAX_WAF_ARRAY_ENTRIES {
+                warning!(
+                    "ASM_DATA rules_data entry has {} IPs, truncating to {} (WAF limit)",
+                    data_arr.len(),
+                    MAX_WAF_ARRAY_ENTRIES
+                );
+                data_arr.truncate(MAX_WAF_ARRAY_ENTRIES);
+                truncated = true;
             }
-            _ => first_entries.push(entry.clone()),
         }
     }
 
-    let mut first_value = value.clone();
-    if let Some(obj) = first_value.as_object_mut() {
-        obj.insert(
-            "rules_data".to_string(),
-            serde_json::Value::Array(first_entries),
-        );
+    if !truncated {
+        return Ok(None);
     }
 
-    let first_json =
-        serde_json::to_vec(&first_value).context("Failed to serialize first ASM_DATA chunk")?;
-
-    let mut result = vec![first_json];
-    result.extend(extra_jsons);
-    Ok(result)
+    let serialized =
+        serde_json::to_vec(&value).context("Failed to serialize truncated WAF config")?;
+    Ok(Some(serialized))
 }
 
 // --- Tests ---
@@ -1160,7 +1025,7 @@ mod tests {
     }
 
     #[test]
-    fn split_asm_data_no_split_when_small() {
+    fn truncate_asm_data_no_truncate_when_small() {
         let data = serde_json::json!({
             "rules_data": [{
                 "id": "blocked_ips",
@@ -1169,18 +1034,17 @@ mod tests {
             }]
         });
         let bytes = serde_json::to_vec(&data).unwrap();
-        let chunks = split_asm_data_if_needed(&bytes).unwrap();
-        assert_eq!(chunks.len(), 1);
-        // Content should be the original bytes unchanged
-        assert_eq!(chunks[0], bytes);
+        let result = truncate_asm_data_if_needed(&bytes).unwrap();
+        assert!(result.is_none(), "small array should not be truncated");
     }
 
     #[test]
-    fn split_asm_data_splits_large_array() {
-        // Build a rules_data entry with MAX_WAF_ARRAY_ENTRIES + 1 items
-        let count = MAX_WAF_ARRAY_ENTRIES + 1;
+    fn truncate_asm_data_truncates_large_array() {
+        let count = MAX_WAF_ARRAY_ENTRIES + 10;
         let entries: Vec<serde_json::Value> = (0..count)
-            .map(|i| serde_json::json!({"value": format!("1.{}.{}.{}", i >> 16, (i >> 8) & 0xff, i & 0xff), "expiration": 0}))
+            .map(|i| {
+                serde_json::json!({"value": format!("1.{}.{}.{}", i >> 16, (i >> 8) & 0xff, i & 0xff), "expiration": 0})
+            })
             .collect();
         let data = serde_json::json!({
             "rules_data": [{
@@ -1190,30 +1054,21 @@ mod tests {
             }]
         });
         let bytes = serde_json::to_vec(&data).unwrap();
-        let chunks = split_asm_data_if_needed(&bytes).unwrap();
-        // Should produce 2 chunks: first with MAX_WAF_ARRAY_ENTRIES, second with 1
-        assert_eq!(chunks.len(), 2);
-
-        let chunk0: serde_json::Value = serde_json::from_slice(&chunks[0]).unwrap();
-        let chunk1: serde_json::Value = serde_json::from_slice(&chunks[1]).unwrap();
-
-        let data0 = chunk0["rules_data"][0]["data"].as_array().unwrap();
-        let data1 = chunk1["rules_data"][0]["data"].as_array().unwrap();
-
-        assert_eq!(data0.len(), MAX_WAF_ARRAY_ENTRIES);
-        assert_eq!(data1.len(), 1);
-
-        // Verify IDs are preserved
-        assert_eq!(chunk0["rules_data"][0]["id"], "blocked_ips");
-        assert_eq!(chunk1["rules_data"][0]["id"], "blocked_ips");
+        let result = truncate_asm_data_if_needed(&bytes).unwrap();
+        let truncated = result.expect("large array should trigger truncation");
+        let parsed: serde_json::Value = serde_json::from_slice(&truncated).unwrap();
+        let data_arr = parsed["rules_data"][0]["data"].as_array().unwrap();
+        assert_eq!(data_arr.len(), MAX_WAF_ARRAY_ENTRIES);
     }
 
     #[test]
-    fn split_asm_data_no_rules_data_passthrough() {
+    fn truncate_asm_data_no_rules_data_passthrough() {
         let data = serde_json::json!({"rules": []});
         let bytes = serde_json::to_vec(&data).unwrap();
-        let chunks = split_asm_data_if_needed(&bytes).unwrap();
-        assert_eq!(chunks.len(), 1);
-        assert_eq!(chunks[0], bytes);
+        let result = truncate_asm_data_if_needed(&bytes).unwrap();
+        assert!(
+            result.is_none(),
+            "config without rules_data should pass through"
+        );
     }
 }

--- a/appsec/helper-rust/src/service.rs
+++ b/appsec/helper-rust/src/service.rs
@@ -933,6 +933,7 @@ fn split_asm_data_if_needed(data: &[u8]) -> anyhow::Result<Vec<Vec<u8>>> {
                         );
                     }
                 }
+            }
             _ => first_entries.push(entry.clone()),
         }
     }
@@ -945,8 +946,8 @@ fn split_asm_data_if_needed(data: &[u8]) -> anyhow::Result<Vec<Vec<u8>>> {
         );
     }
 
-    let first_json = serde_json::to_vec(&first_value)
-        .context("Failed to serialize first ASM_DATA chunk")?;
+    let first_json =
+        serde_json::to_vec(&first_value).context("Failed to serialize first ASM_DATA chunk")?;
 
     let mut result = vec![first_json];
     result.extend(extra_jsons);

--- a/appsec/helper-rust/src/service.rs
+++ b/appsec/helper-rust/src/service.rs
@@ -591,23 +591,13 @@ impl Service {
                 let shmem = cfg.read()?;
                 let data = unsafe { shmem.as_slice() };
 
-                // Remove stale chunk paths from a previous update of the same RC path
-                if let Some(old_chunk_paths) = state.extra_chunk_paths.remove(rc_path) {
-                    for chunk_path in old_chunk_paths {
-                        if let Err(e) = self.waf.remove_config(&chunk_path) {
-                            debug!(
-                                "Failed to remove old WAF chunk config for {:?}: {:#}",
-                                rc_path, e
-                            );
-                        }
-                    }
-                }
-
+                // Parse and split first; only remove old chunk paths after successful
+                // registration so a malformed update doesn't drop last-known-good chunks.
                 let chunks = split_asm_data_if_needed(data)
                     .with_context(|| format!("Failed to split ASM_DATA for {:?}", rc_path))?;
 
                 let mut new_chunk_paths: Vec<String> = Vec::new();
-                let mut last_result = Ok(());
+                let mut first_result = Ok(());
 
                 for (i, chunk_data) in chunks.iter().enumerate() {
                     let chunk_path = if i == 0 {
@@ -615,7 +605,6 @@ impl Service {
                     } else {
                         // Use a delimiter that cannot appear in real RC paths but is safe for C-string interop
                         let p = format!("{}#chunk_{}", rc_path.as_str(), i);
-                        new_chunk_paths.push(p.clone());
                         p
                     };
 
@@ -633,19 +622,52 @@ impl Service {
                         Some(&mut diagnostics),
                     );
 
-                    if upd_result.is_ok() {
-                        debug!("Added/updated WAF config chunk {}: {:?}", i, rc_path);
-                        if product.name() == "ASM_DD" && i == 0 {
-                            *rules_version = waf_diag::extract_ruleset_version(&diagnostics);
-                            *new_snapshot =
-                                new_snapshot.with_new_rules_version(rules_version.clone());
-                        }
-                        *waf_changed = true;
-                    }
+                    // Collect diagnostics for every chunk under the original RC path so
+                    // errors in chunks beyond the first are not silently discarded.
+                    all_diagnostics.push((rc_path.clone(), diagnostics));
 
-                    if i == 0 {
-                        all_diagnostics.push((rc_path.clone(), diagnostics));
-                        last_result = upd_result;
+                    match upd_result {
+                        Ok(()) => {
+                            debug!("Added/updated WAF config chunk {}: {:?}", i, rc_path);
+                            if product.name() == "ASM_DD" && i == 0 {
+                                if let Some((_, diag)) = all_diagnostics.last() {
+                                    *rules_version = waf_diag::extract_ruleset_version(diag);
+                                }
+                                *new_snapshot =
+                                    new_snapshot.with_new_rules_version(rules_version.clone());
+                            }
+                            *waf_changed = true;
+                            if i > 0 {
+                                new_chunk_paths.push(chunk_path);
+                            }
+                        }
+                        Err(e) => {
+                            if i == 0 {
+                                first_result = Err(e);
+                            } else {
+                                // Propagate failures from any chunk: a partial update
+                                // would silently leave the WAF with an incomplete denylist.
+                                return Err(e).with_context(|| {
+                                    format!(
+                                        "Failed to add WAF config chunk {} for {:?}",
+                                        i, rc_path
+                                    )
+                                });
+                            }
+                        }
+                    }
+                }
+
+                // All chunks accepted — now remove stale chunk paths from the previous
+                // update of this RC path and record the newly registered ones.
+                if let Some(old_chunk_paths) = state.extra_chunk_paths.remove(rc_path) {
+                    for chunk_path in old_chunk_paths {
+                        if let Err(e) = self.waf.remove_config(&chunk_path) {
+                            debug!(
+                                "Failed to remove old WAF chunk config for {:?}: {:#}",
+                                rc_path, e
+                            );
+                        }
                     }
                 }
 
@@ -655,7 +677,7 @@ impl Service {
                         .insert(rc_path.clone(), new_chunk_paths);
                 }
 
-                last_result
+                first_result
             }
             _ => {
                 debug!("Ignoring unknown product: {:?}", product);

--- a/appsec/helper-rust/src/service.rs
+++ b/appsec/helper-rust/src/service.rs
@@ -613,8 +613,8 @@ impl Service {
                     let chunk_path = if i == 0 {
                         rc_path.as_str().to_string()
                     } else {
-                        // Use null byte as separator to guarantee no collision with real RC paths
-                        let p = format!("{}\x00chunk_{}", rc_path.as_str(), i);
+                        // Use a delimiter that cannot appear in real RC paths but is safe for C-string interop
+                        let p = format!("{}#chunk_{}", rc_path.as_str(), i);
                         new_chunk_paths.push(p.clone());
                         p
                     };

--- a/appsec/helper-rust/src/service.rs
+++ b/appsec/helper-rust/src/service.rs
@@ -937,7 +937,15 @@ fn split_asm_data_if_needed(data: &[u8]) -> anyhow::Result<Vec<Vec<u8>>> {
         }
     }
 
-    let first_json = serde_json::to_vec(&serde_json::json!({"rules_data": first_entries}))
+    let mut first_value = value.clone();
+    if let Some(obj) = first_value.as_object_mut() {
+        obj.insert(
+            "rules_data".to_string(),
+            serde_json::Value::Array(first_entries),
+        );
+    }
+
+    let first_json = serde_json::to_vec(&first_value)
         .context("Failed to serialize first ASM_DATA chunk")?;
 
     let mut result = vec![first_json];

--- a/appsec/helper-rust/src/service.rs
+++ b/appsec/helper-rust/src/service.rs
@@ -917,6 +917,7 @@ fn split_asm_data_if_needed(data: &[u8]) -> anyhow::Result<Vec<Vec<u8>>> {
                     .cloned()
                     .unwrap_or(serde_json::Value::Null);
                 let mut first = true;
+                for chunk in arr.chunks(MAX_WAF_ARRAY_ENTRIES) {
                     let chunk_entry = serde_json::json!({
                         "id": id.clone(),
                         "type": type_.clone(),
@@ -932,7 +933,6 @@ fn split_asm_data_if_needed(data: &[u8]) -> anyhow::Result<Vec<Vec<u8>>> {
                         );
                     }
                 }
-            }
             _ => first_entries.push(entry.clone()),
         }
     }

--- a/appsec/helper-rust/src/service.rs
+++ b/appsec/helper-rust/src/service.rs
@@ -401,11 +401,18 @@ impl Service {
                     for chunk_path in chunk_paths {
                         match self.waf.remove_config(&chunk_path) {
                             Ok(true) => {
-                                debug!("Removed WAF chunk config for {:?}: {}", old_path, chunk_path);
+                                debug!(
+                                    "Removed WAF chunk config for {:?}: {}",
+                                    old_path, chunk_path
+                                );
                                 waf_changed = true;
                             }
                             Ok(false) => {
-                                warning!("No WAF chunk config found to remove for {:?}: {}", old_path, chunk_path);
+                                warning!(
+                                    "No WAF chunk config found to remove for {:?}: {}",
+                                    old_path,
+                                    chunk_path
+                                );
                             }
                             Err(e) => {
                                 self.log_general_rc_error(&e.context(format!(
@@ -588,7 +595,10 @@ impl Service {
                 if let Some(old_chunk_paths) = state.extra_chunk_paths.remove(rc_path) {
                     for chunk_path in old_chunk_paths {
                         if let Err(e) = self.waf.remove_config(&chunk_path) {
-                            debug!("Failed to remove old WAF chunk config for {:?}: {:#}", rc_path, e);
+                            debug!(
+                                "Failed to remove old WAF chunk config for {:?}: {:#}",
+                                rc_path, e
+                            );
                         }
                     }
                 }
@@ -609,8 +619,10 @@ impl Service {
                         p
                     };
 
-                    let ruleset = waf_ruleset::WafRuleset::from_slice(chunk_data)
-                        .with_context(|| format!("Failed to parse WAF config chunk {} for {:?}", i, rc_path))?;
+                    let ruleset =
+                        waf_ruleset::WafRuleset::from_slice(chunk_data).with_context(|| {
+                            format!("Failed to parse WAF config chunk {} for {:?}", i, rc_path)
+                        })?;
 
                     let waf_obj: libddwaf::object::WafObject = ruleset.into();
                     let mut diagnostics = Default::default();
@@ -625,7 +637,8 @@ impl Service {
                         debug!("Added/updated WAF config chunk {}: {:?}", i, rc_path);
                         if product.name() == "ASM_DD" && i == 0 {
                             *rules_version = waf_diag::extract_ruleset_version(&diagnostics);
-                            *new_snapshot = new_snapshot.with_new_rules_version(rules_version.clone());
+                            *new_snapshot =
+                                new_snapshot.with_new_rules_version(rules_version.clone());
                         }
                         *waf_changed = true;
                     }
@@ -637,7 +650,9 @@ impl Service {
                 }
 
                 if !new_chunk_paths.is_empty() {
-                    state.extra_chunk_paths.insert(rc_path.clone(), new_chunk_paths);
+                    state
+                        .extra_chunk_paths
+                        .insert(rc_path.clone(), new_chunk_paths);
                 }
 
                 last_result
@@ -867,8 +882,8 @@ struct RcUpdateState {
 const MAX_WAF_ARRAY_ENTRIES: usize = u16::MAX as usize;
 
 fn split_asm_data_if_needed(data: &[u8]) -> anyhow::Result<Vec<Vec<u8>>> {
-    let value: serde_json::Value = serde_json::from_slice(data)
-        .context("Failed to parse ASM_DATA JSON")?;
+    let value: serde_json::Value =
+        serde_json::from_slice(data).context("Failed to parse ASM_DATA JSON")?;
 
     let rules_data = match value.get("rules_data").and_then(|v| v.as_array()) {
         Some(rd) => rd,

--- a/appsec/helper-rust/src/service.rs
+++ b/appsec/helper-rust/src/service.rs
@@ -917,10 +917,9 @@ fn split_asm_data_if_needed(data: &[u8]) -> anyhow::Result<Vec<Vec<u8>>> {
                     .cloned()
                     .unwrap_or(serde_json::Value::Null);
                 let mut first = true;
-                for chunk in arr.chunks(MAX_WAF_ARRAY_ENTRIES) {
                     let chunk_entry = serde_json::json!({
-                        "id": id,
-                        "type": type_,
+                        "id": id.clone(),
+                        "type": type_.clone(),
                         "data": serde_json::Value::Array(chunk.to_vec())
                     });
                     if first {

--- a/appsec/helper-rust/src/service.rs
+++ b/appsec/helper-rust/src/service.rs
@@ -338,6 +338,7 @@ impl Service {
                 asm_feature_config_manager: AsmFeatureConfigManager::new(),
                 pending_telemetry_metrics: TelemetryMetricsCollector::default(),
                 pending_init_diagnostics_legacy: Some(init_diagnostics_legacy),
+                extra_chunk_paths: HashMap::new(),
             }),
             config_snapshot: ArcSwap::from_pointee(ConfigSnapshot::new(
                 asm_always_enabled,
@@ -385,14 +386,37 @@ impl Service {
         let mut rules_version: Option<String> = None;
 
         // Handle removal of configs
-        for old_path in state
+        let removed_paths: Vec<rc::RcPath> = state
             .last_configs
             .keys()
             .filter(|k| !new_configs.contains_key(*k))
-        {
+            .cloned()
+            .collect();
+        for old_path in &removed_paths {
             if old_path.as_str().contains("/ASM_FEATURES/") {
                 state.asm_feature_config_manager.remove(old_path);
             } else {
+                // Remove any extra chunk paths registered for this config
+                if let Some(chunk_paths) = state.extra_chunk_paths.remove(old_path) {
+                    for chunk_path in chunk_paths {
+                        match self.waf.remove_config(&chunk_path) {
+                            Ok(true) => {
+                                debug!("Removed WAF chunk config for {:?}: {}", old_path, chunk_path);
+                                waf_changed = true;
+                            }
+                            Ok(false) => {
+                                warning!("No WAF chunk config found to remove for {:?}: {}", old_path, chunk_path);
+                            }
+                            Err(e) => {
+                                self.log_general_rc_error(&e.context(format!(
+                                    "Failed to remove WAF chunk config for {:?}: {}",
+                                    old_path, chunk_path
+                                )));
+                            }
+                        }
+                    }
+                }
+
                 let res = self.waf.remove_config(old_path.as_str());
                 match res {
                     Ok(true) => {
@@ -560,29 +584,63 @@ impl Service {
                 let shmem = cfg.read()?;
                 let data = unsafe { shmem.as_slice() };
 
-                let ruleset = waf_ruleset::WafRuleset::from_slice(data)
-                    .with_context(|| format!("Failed to parse WAF config for {:?}", rc_path))?;
-
-                let waf_obj: libddwaf::object::WafObject = ruleset.into();
-                let mut diagnostics = Default::default();
-
-                let upd_result = self.waf.add_or_update_config(
-                    rc_path.as_str(),
-                    &waf_obj,
-                    Some(&mut diagnostics),
-                );
-
-                if upd_result.is_ok() {
-                    debug!("Added/updated WAF config: {:?}", rc_path);
-                    if product.name() == "ASM_DD" {
-                        *rules_version = waf_diag::extract_ruleset_version(&diagnostics);
-                        *new_snapshot = new_snapshot.with_new_rules_version(rules_version.clone());
+                // Remove stale chunk paths from a previous update of the same RC path
+                if let Some(old_chunk_paths) = state.extra_chunk_paths.remove(rc_path) {
+                    for chunk_path in old_chunk_paths {
+                        if let Err(e) = self.waf.remove_config(&chunk_path) {
+                            debug!("Failed to remove old WAF chunk config for {:?}: {:#}", rc_path, e);
+                        }
                     }
-                    *waf_changed = true;
                 }
 
-                all_diagnostics.push((rc_path.clone(), diagnostics));
-                upd_result
+                let chunks = split_asm_data_if_needed(data)
+                    .with_context(|| format!("Failed to split ASM_DATA for {:?}", rc_path))?;
+
+                let mut new_chunk_paths: Vec<String> = Vec::new();
+                let mut last_result = Ok(());
+
+                for (i, chunk_data) in chunks.iter().enumerate() {
+                    let chunk_path = if i == 0 {
+                        rc_path.as_str().to_string()
+                    } else {
+                        // Use null byte as separator to guarantee no collision with real RC paths
+                        let p = format!("{}\x00chunk_{}", rc_path.as_str(), i);
+                        new_chunk_paths.push(p.clone());
+                        p
+                    };
+
+                    let ruleset = waf_ruleset::WafRuleset::from_slice(chunk_data)
+                        .with_context(|| format!("Failed to parse WAF config chunk {} for {:?}", i, rc_path))?;
+
+                    let waf_obj: libddwaf::object::WafObject = ruleset.into();
+                    let mut diagnostics = Default::default();
+
+                    let upd_result = self.waf.add_or_update_config(
+                        &chunk_path,
+                        &waf_obj,
+                        Some(&mut diagnostics),
+                    );
+
+                    if upd_result.is_ok() {
+                        debug!("Added/updated WAF config chunk {}: {:?}", i, rc_path);
+                        if product.name() == "ASM_DD" && i == 0 {
+                            *rules_version = waf_diag::extract_ruleset_version(&diagnostics);
+                            *new_snapshot = new_snapshot.with_new_rules_version(rules_version.clone());
+                        }
+                        *waf_changed = true;
+                    }
+
+                    if i == 0 {
+                        all_diagnostics.push((rc_path.clone(), diagnostics));
+                        last_result = upd_result;
+                    }
+                }
+
+                if !new_chunk_paths.is_empty() {
+                    state.extra_chunk_paths.insert(rc_path.clone(), new_chunk_paths);
+                }
+
+                last_result
             }
             _ => {
                 debug!("Ignoring unknown product: {:?}", product);
@@ -797,6 +855,80 @@ struct RcUpdateState {
     asm_feature_config_manager: AsmFeatureConfigManager,
     pending_telemetry_metrics: TelemetryMetricsCollector,
     pending_init_diagnostics_legacy: Option<InitDiagnosticsLegacy>,
+    // Extra WAF config paths created when splitting large ASM_DATA arrays into chunks.
+    // Maps original RC path -> list of extra chunk WAF paths to remove when the original is removed.
+    extra_chunk_paths: HashMap<rc::RcPath, Vec<String>>,
+}
+
+// libddwaf v2.x uses u16 for WafArray capacity (max 65535 entries per array).
+// When ASM_DATA contains a rules_data[*].data array exceeding this limit, we split it
+// into chunks that each fit within the limit, using separate WAF config paths per chunk.
+// libddwaf merges rules_data entries with the same id from multiple config paths.
+const MAX_WAF_ARRAY_ENTRIES: usize = u16::MAX as usize;
+
+fn split_asm_data_if_needed(data: &[u8]) -> anyhow::Result<Vec<Vec<u8>>> {
+    let value: serde_json::Value = serde_json::from_slice(data)
+        .context("Failed to parse ASM_DATA JSON")?;
+
+    let rules_data = match value.get("rules_data").and_then(|v| v.as_array()) {
+        Some(rd) => rd,
+        None => return Ok(vec![data.to_vec()]),
+    };
+
+    let any_large = rules_data.iter().any(|entry| {
+        entry
+            .get("data")
+            .and_then(|d| d.as_array())
+            .map(|arr| arr.len() > MAX_WAF_ARRAY_ENTRIES)
+            .unwrap_or(false)
+    });
+
+    if !any_large {
+        return Ok(vec![data.to_vec()]);
+    }
+
+    // Build the first chunk (with all small entries + first slice of large entries).
+    // Additional chunks carry subsequent slices of large entries.
+    let mut first_entries: Vec<serde_json::Value> = Vec::new();
+    let mut extra_jsons: Vec<Vec<u8>> = Vec::new();
+
+    for entry in rules_data {
+        let data_arr = entry.get("data").and_then(|d| d.as_array());
+        match data_arr {
+            Some(arr) if arr.len() > MAX_WAF_ARRAY_ENTRIES => {
+                let id = entry.get("id").cloned().unwrap_or(serde_json::Value::Null);
+                let type_ = entry
+                    .get("type")
+                    .cloned()
+                    .unwrap_or(serde_json::Value::Null);
+                let mut first = true;
+                for chunk in arr.chunks(MAX_WAF_ARRAY_ENTRIES) {
+                    let chunk_entry = serde_json::json!({
+                        "id": id,
+                        "type": type_,
+                        "data": serde_json::Value::Array(chunk.to_vec())
+                    });
+                    if first {
+                        first_entries.push(chunk_entry);
+                        first = false;
+                    } else {
+                        extra_jsons.push(
+                            serde_json::to_vec(&serde_json::json!({"rules_data": [chunk_entry]}))
+                                .context("Failed to serialize ASM_DATA chunk")?,
+                        );
+                    }
+                }
+            }
+            _ => first_entries.push(entry.clone()),
+        }
+    }
+
+    let first_json = serde_json::to_vec(&serde_json::json!({"rules_data": first_entries}))
+        .context("Failed to serialize first ASM_DATA chunk")?;
+
+    let mut result = vec![first_json];
+    result.extend(extra_jsons);
+    Ok(result)
 }
 
 // --- Tests ---
@@ -980,5 +1112,63 @@ mod tests {
              client_init disabled RC, but got: {:?}",
             result
         );
+    }
+
+    #[test]
+    fn split_asm_data_no_split_when_small() {
+        let data = serde_json::json!({
+            "rules_data": [{
+                "id": "blocked_ips",
+                "type": "ip_with_expiration",
+                "data": [{"value": "1.2.3.4", "expiration": 0}]
+            }]
+        });
+        let bytes = serde_json::to_vec(&data).unwrap();
+        let chunks = split_asm_data_if_needed(&bytes).unwrap();
+        assert_eq!(chunks.len(), 1);
+        // Content should be the original bytes unchanged
+        assert_eq!(chunks[0], bytes);
+    }
+
+    #[test]
+    fn split_asm_data_splits_large_array() {
+        // Build a rules_data entry with MAX_WAF_ARRAY_ENTRIES + 1 items
+        let count = MAX_WAF_ARRAY_ENTRIES + 1;
+        let entries: Vec<serde_json::Value> = (0..count)
+            .map(|i| serde_json::json!({"value": format!("1.{}.{}.{}", i >> 16, (i >> 8) & 0xff, i & 0xff), "expiration": 0}))
+            .collect();
+        let data = serde_json::json!({
+            "rules_data": [{
+                "id": "blocked_ips",
+                "type": "ip_with_expiration",
+                "data": entries
+            }]
+        });
+        let bytes = serde_json::to_vec(&data).unwrap();
+        let chunks = split_asm_data_if_needed(&bytes).unwrap();
+        // Should produce 2 chunks: first with MAX_WAF_ARRAY_ENTRIES, second with 1
+        assert_eq!(chunks.len(), 2);
+
+        let chunk0: serde_json::Value = serde_json::from_slice(&chunks[0]).unwrap();
+        let chunk1: serde_json::Value = serde_json::from_slice(&chunks[1]).unwrap();
+
+        let data0 = chunk0["rules_data"][0]["data"].as_array().unwrap();
+        let data1 = chunk1["rules_data"][0]["data"].as_array().unwrap();
+
+        assert_eq!(data0.len(), MAX_WAF_ARRAY_ENTRIES);
+        assert_eq!(data1.len(), 1);
+
+        // Verify IDs are preserved
+        assert_eq!(chunk0["rules_data"][0]["id"], "blocked_ips");
+        assert_eq!(chunk1["rules_data"][0]["id"], "blocked_ips");
+    }
+
+    #[test]
+    fn split_asm_data_no_rules_data_passthrough() {
+        let data = serde_json::json!({"rules": []});
+        let bytes = serde_json::to_vec(&data).unwrap();
+        let chunks = split_asm_data_if_needed(&bytes).unwrap();
+        assert_eq!(chunks.len(), 1);
+        assert_eq!(chunks[0], bytes);
     }
 }


### PR DESCRIPTION
### Description

**Fix**: prevent crash when `ASM_DATA` IP denylist exceeds 65,535 entries

**libddwaf v2.x** uses `uint16_t` for `WafArray` capacity, which hard-caps any single array at 65,535 entries. When Remote Config delivers an `ASM_DATA` payload whose `rules_data[*].data` array exceeds this limit (e.g. the system-test scenario `APPSEC_BLOCKING_FULL_DENYLIST` with 65,536 IPs), the helper process panics trying to convert the array length to `u16`

Since the WAF cannot enforce more than 65,535 IP entries regardless, the correct fix is to truncate the array to the limit rather than attempt to register entries the WAF cannot use.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
