### PR TITLE
fix(profiling): avoid extra profiles without `DD_ENV`

### DIFF
--- a/profiling/src/profiling/mod.rs
+++ b/profiling/src/profiling/mod.rs
@@ -1797,7 +1797,7 @@ impl Profiler {
             let custom_tags = locals.custom_tags.as_ref().map(Arc::clone);
             let thread_context = crate::process_context::thread_context(ProcessIdentityRef {
                 service: locals.identity.service.as_deref(),
-                env: locals.identity.env.as_deref(),
+                env: locals.identity.env.as_deref().or(Some("none")),
                 version: locals.identity.version.as_deref(),
             });
             (git_tags, custom_tags, thread_context)


### PR DESCRIPTION
### Description

Since #4077, the profiler reads service metadata from the tracer's OTel thread context. The tracer represents an unset `DD_ENV` as the internal `"none"` sentinel, while the profiler's inactive-context fallback omitted the environment. Because profile aggregation includes Unified Service Tags in its identity, each PHP-FPM worker created separate active and inactive profile buckets when profiling and tracing were enabled together.

With two PHP-FPM workers, dd-trace-doe therefore received four profile payloads instead of two. This was released in 1.24.0, and can be seen in [the first observed failing job](https://github.com/DataDog/dd-trace-doe/actions/runs/32010991313/job/95331004484) and [a 1.24.1 failure](https://github.com/DataDog/dd-trace-doe/actions/runs/32834912829/job/97762849413).

Normalize a missing environment to `"none"` in the profiler context fallback so active and inactive samples use the same profile identity. Explicit process-context and `DD_ENV` values still take precedence.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
