### PR TITLE
feat(ffe): send the split serial id on exposure events [EX-3425]

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2922,6 +2922,7 @@ dependencies = [
  "tracing",
  "uuid",
  "web-time",
+ "zrip",
  "zstd",
 ]
 
@@ -3129,6 +3130,7 @@ dependencies = [
  "thiserror 2.0.18",
  "tokio",
  "tokio-util",
+ "zrip",
  "zstd",
 ]
 
@@ -3151,6 +3153,7 @@ dependencies = [
  "chrono",
  "futures",
  "futures-util",
+ "getrandom 0.2.15",
  "hashbrown 0.15.2",
  "http 1.4.2",
  "http-body-util",
@@ -3165,6 +3168,7 @@ dependencies = [
  "manual_future",
  "prost",
  "rand 0.8.5",
+ "ring",
  "serde",
  "serde_json",
  "serde_with",
@@ -3375,6 +3379,7 @@ dependencies = [
  "tokio",
  "tracing",
  "urlencoding",
+ "zrip",
  "zstd",
 ]
 
@@ -7202,6 +7207,41 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
+
+[[package]]
+name = "zrip"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "964fe9f1ea10a0d183fc143a7525266cbe16978883dbe304725da34b314c04cf"
+dependencies = [
+ "zrip-core",
+ "zrip-decode",
+ "zrip-encode",
+]
+
+[[package]]
+name = "zrip-core"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cbc201ba56175f86e67cc88bdaf1a7af9c061815c7dde719c7a6a1ed5aaa186b"
+
+[[package]]
+name = "zrip-decode"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "038f795e49887bdeaab197fff84c8165644484a98dc3f2354e5df3d2e5f4f978"
+dependencies = [
+ "zrip-core",
+]
+
+[[package]]
+name = "zrip-encode"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f3dfdcbb503db2045716492d5ab31cd82f2852d0d93d8edf6a9235653d9da685"
+dependencies = [
+ "zrip-core",
+]
 
 [[package]]
 name = "zstd"

--- a/components-rs/common.h
+++ b/components-rs/common.h
@@ -437,6 +437,7 @@ typedef enum ddog_RemoteConfigProduct {
   DDOG_REMOTE_CONFIG_PRODUCT_FFE_FLAGS,
   DDOG_REMOTE_CONFIG_PRODUCT_LIVE_DEBUGGING,
   DDOG_REMOTE_CONFIG_PRODUCT_LIVE_DEBUGGING_SYMBOL_DB,
+  DDOG_REMOTE_CONFIG_PRODUCT_DEBUG,
 } ddog_RemoteConfigProduct;
 
 typedef enum ddog_SpanProbeTarget {
@@ -1246,6 +1247,8 @@ typedef struct ddog_FfeExposure {
   ddog_CharSlice subject_attributes_json;
   ddog_CharSlice allocation_key;
   ddog_CharSlice variant;
+  int32_t serial_id;
+  bool has_serial_id;
 } ddog_FfeExposure;
 
 typedef struct ddog_Slice_FfeExposure {

--- a/components-rs/sidecar.h
+++ b/components-rs/sidecar.h
@@ -307,6 +307,27 @@ ddog_MaybeError ddog_sidecar_send_trace_v04_bytes(struct ddog_SidecarTransport *
                                                   ddog_CharSlice data,
                                                   const struct ddog_TracerHeaderTags *tracer_header_tags);
 
+/**
+ * Sends a V1-encoded trace to the sidecar via shared memory. The sidecar decodes the V1
+ * `TracerPayload`, can inspect it, and re-encodes it as V1 msgpack on the way to the agent's
+ * `/v1.0/traces` endpoint.
+ */
+ddog_MaybeError ddog_sidecar_send_trace_v1_shm(struct ddog_SidecarTransport **transport,
+                                               const struct ddog_InstanceId *instance_id,
+                                               struct ddog_ShmHandle *shm_handle,
+                                               uintptr_t len,
+                                               const struct ddog_TracerHeaderTags *tracer_header_tags);
+
+/**
+ * Sends a V1-encoded trace as bytes to the sidecar. The sidecar decodes the V1 `TracerPayload`,
+ * can inspect it, and re-encodes it as V1 msgpack on the way to the agent's `/v1.0/traces`
+ * endpoint.
+ */
+ddog_MaybeError ddog_sidecar_send_trace_v1_bytes(struct ddog_SidecarTransport **transport,
+                                                 const struct ddog_InstanceId *instance_id,
+                                                 ddog_CharSlice data,
+                                                 const struct ddog_TracerHeaderTags *tracer_header_tags);
+
 ddog_MaybeError ddog_sidecar_send_debugger_data(struct ddog_SidecarTransport **transport,
                                                 const struct ddog_InstanceId *instance_id,
                                                 ddog_QueueId queue_id,

--- a/tracer/ffe.c
+++ b/tracer/ffe.c
@@ -31,6 +31,8 @@ typedef struct {
     zend_string *subject_attributes_json;
     zend_string *allocation_key;
     zend_string *variant;
+    int32_t serial_id;
+    bool has_serial_id;
 } dd_ffe_exposure;
 
 static void dd_ffe_release_metric(dd_ffe_metric *metric) {
@@ -168,7 +170,9 @@ void ddtrace_ffe_record_exposure(
     zend_string *targeting_key,
     zend_string *subject_attributes_json,
     zend_string *allocation_key,
-    zend_string *variant
+    zend_string *variant,
+    int32_t serial_id,
+    bool has_serial_id
 ) {
     if (ZSTR_LEN(flag_key) == 0 || ZSTR_LEN(variant) == 0) {
         return;
@@ -200,6 +204,8 @@ void ddtrace_ffe_record_exposure(
     exposure->subject_attributes_json = zend_string_copy(subject_attributes_json);
     exposure->allocation_key = zend_string_copy(allocation_key);
     exposure->variant = zend_string_copy(variant);
+    exposure->serial_id = serial_id;
+    exposure->has_serial_id = has_serial_id;
 }
 
 bool ddtrace_ffe_flush_exposures(void) {
@@ -224,6 +230,8 @@ bool ddtrace_ffe_flush_exposures(void) {
             .subject_attributes_json = dd_zend_string_to_CharSlice(buffer[i].subject_attributes_json),
             .allocation_key = dd_zend_string_to_CharSlice(buffer[i].allocation_key),
             .variant = dd_zend_string_to_CharSlice(buffer[i].variant),
+            .serial_id = buffer[i].serial_id,
+            .has_serial_id = buffer[i].has_serial_id,
         };
     }
 

--- a/tracer/ffe.h
+++ b/tracer/ffe.h
@@ -3,12 +3,13 @@
 
 #include <stdbool.h>
 #include <stddef.h>
+#include <stdint.h>
 #include <zend.h>
 
 bool ddtrace_ffe_record_evaluation_metric(zend_string *flag_key, zend_string *variant, const char *reason, const char *error_type, zend_string *allocation_key);
 bool ddtrace_ffe_flush_evaluation_metrics(void);
 
-void ddtrace_ffe_record_exposure(zend_string *flag_key, zend_string *targeting_key, zend_string *subject_attributes_json, zend_string *allocation_key, zend_string *variant);
+void ddtrace_ffe_record_exposure(zend_string *flag_key, zend_string *targeting_key, zend_string *subject_attributes_json, zend_string *allocation_key, zend_string *variant, int32_t serial_id, bool has_serial_id);
 bool ddtrace_ffe_flush_exposures(void);
 
 #endif // DDTRACE_FFE_H

--- a/tracer/functions.c
+++ b/tracer/functions.c
@@ -1900,7 +1900,9 @@ PHP_FUNCTION(DDTrace_ffe_evaluate) {
             targeting_key,
             subject_attributes_json,
             allocation_key,
-            variant
+            variant,
+            result.serial_id,
+            result.has_serial_id
         );
         zend_string_release(subject_attributes_json);
     }


### PR DESCRIPTION
### Description

Sends the split serial id on the exposure events that `dd-trace-php` emits. The exposures intake uses the serial id to find the holdout an allocation comes from. The compiler rewrites a holdout into an ordinary allocation before an SDK receives it, so the serial id is the only link back to it.

The serial id travels from the evaluation result, through the exposure buffer, into the sidecar FFI struct. Serial ids are zero-based per organization, so `0` is a real value and cannot signal absence. The value therefore carries a separate presence flag, matching the existing `FfeResult` convention in this file.

| File | Change |
|---|---|
| `tracer/functions.c` | pass `result.serial_id` and `result.has_serial_id` into the recorder |
| `tracer/ffe.c` | hold both on the buffered exposure, set both on `ddog_FfeExposure` |
| `tracer/ffe.h` | recorder signature |
| `libdatadog` | advance to `0c0c60b96` |
| `components-rs/common.h`, `components-rs/sidecar.h`, `Cargo.lock` | regenerated |

Serialization, the wire key, and exposure deduplication live in libdatadog and are done there: DataDog/libdatadog#2402. That PR also fixed the deduplication cache, which compared only allocation key and variant, so a serial id that appeared or changed on an otherwise unchanged assignment was suppressed.

The submodule bump is required, not incidental: `ddog_FfeExposure` gains its two fields in `0c0c60b96`, so the header and the compiled Rust struct must move together.

`components-rs/sidecar.h` and `Cargo.lock` are generated output, regenerated here with `make cbindgen`. Their churn is accumulated drift rather than a consequence of this change. The checked-in headers were last regenerated in 018f21296, and the submodule pointer has advanced twice since then (#4118, #4123) without a regeneration, so this run sweeps up everything in between. Concretely, `sidecar.h` gains two additive `ddog_sidecar_send_trace_v1_*` declarations from 69df7ed9b, which nothing in this repo calls, and `Cargo.lock` gains the `zrip` crates. Reviewing `tracer/` plus the three added lines in `common.h` covers the whole behavioural change.

This overlaps DataDog/dd-trace-php#4125, which bumps to a commit that predates `0c0c60b96`; whichever lands second needs a rebase.

No validation is applied to the value. The flag configuration layer owns that.

### Testing

PHP 8.3 debug on `bookworm`, submodule at `0c0c60b96`:

- `make -j4 all` links `ffe.o` and `functions.o` with no new warnings
- `make test_c TESTS=tests/ext/ffe` passes 6/6, none skipped
- an evaluation on a split declaring `serialId: 0` reports `serialId=0` with `doLog=true`, a split omitting it reports `null`, and `flush_ffe_exposures()` hands the batch to the sidecar

No test here covers the buffer-to-FFI hop. The exposure buffer is not observable from PHP, and no test in this repo asserts an exposure reaching the agent. Cross-language coverage comes from system-tests, where `Test_FFE_Exposure_Serial_Id` and the three serial-id caching classes already exist; `manifests/php.yml` gets flipped off `missing_feature (EX-3425)` in a follow-up once this ships.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.

*This description was generated by Claude.*
