### PR TITLE
test: xfail rc_fork_notify.phpt

### DIFF
--- a/tests/ext/remote_config/rc_fork_notify.phpt
+++ b/tests/ext/remote_config/rc_fork_notify.phpt
@@ -12,6 +12,8 @@ DD_TRACE_ENABLED=0
 DD_TRACE_GENERATE_ROOT_SPAN=0
 DD_REMOTE_CONFIG_POLL_INTERVAL_SECONDS=0.1
 DD_TRACE_AGENT_TEST_SESSION_TOKEN=remote-config/rc_fork_notify
+--XFAIL--
+SessionInfo should not contain process info
 --FILE--
 <?php
 

--- a/tests/ext/remote_config/rc_fork_notify.phpt
+++ b/tests/ext/remote_config/rc_fork_notify.phpt
@@ -2,6 +2,7 @@
 RC notifications must appear in forked processes
 --SKIPIF--
 <?php
+if (getenv('PHP_PEAR_RUNTESTS') === '1') die("skip: pecl run-tests does not support XFAIL");
 include __DIR__ . '/../includes/skipif_no_dev_env.inc';
 if (!extension_loaded('pcntl')) die('skip: pcntl extension required');
 ?>


### PR DESCRIPTION
### Description

Marks rc_fork_notify.phpt as XFAIL because `SessionInfo` currently contains process level info which is not correct after a fork, and sessions are intentionally shared between the parent and child. This can cause incorrect notifications. This usually exhibits as an output of `10` instead of `11` in this test.

Bob says he'll look into it soon, but xfailing for now so that it does not contribute to flaky CI, which is how I found it. The investigation was not simple.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
