### PR TITLE
fix(installer): set explicit modes instead of inheriting the umask

### DIFF
--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -30,6 +30,14 @@ const OPT_INI_SETTING = 'd';
 // Release version is set while generating the final release files
 const RELEASE_VERSION = '@release_version@';
 
+// Modes set explicitly, so that the install does not depend on the caller's umask
+const MODE_FILE = 0644;
+const MODE_EXECUTABLE = 0755;
+const MODE_DIR = 0755;
+
+// The INI file the installer creates in the INI scan directory
+const DEFAULT_INI_FILE_NAME = '98-ddtrace.ini';
+
 // phpcs:disable Generic.Files.LineLength.TooLong
 // For testing purposes, we need an alternate repo where we can push bundles that includes changes that we are
 // trying to test, as the previously released versions would not have those changes.
@@ -351,6 +359,7 @@ function cmd_config_set(array $options)
                         }
                         continue;
                     } else {
+                        set_mode($iniFile, MODE_FILE);
                         echo "Success.\n";
                     }
                 }
@@ -573,16 +582,16 @@ function install($options)
     $installDirSourcesDir = $installDir . '/dd-trace-sources';
     $installDirSrcDir = $installDirSourcesDir . '/src';
     // copying sources to the final destination
-    if (!file_exists($installDirSourcesDir)) {
-        execute_or_exit(
-            "Cannot create directory '$installDirSourcesDir'",
-            "mkdir " . (IS_WINDOWS ? "" : "-p ") . escapeshellarg($installDirSourcesDir)
-        );
-    }
+    create_directory_or_exit("Cannot create directory '$installDirSourcesDir'", $installDirSourcesDir);
     execute_or_exit(
         "Cannot copy files from '$tmpSrcDir' to '$installDirSourcesDir'",
         (IS_WINDOWS ? "echo d | xcopy /s /e /y /g /b /o /h " : "cp -r ") . escapeshellarg("$tmpSrcDir") . ' ' . escapeshellarg($installDirSrcDir)
     );
+    // These two are ours whether we created them or not, so repair a bad umask
+    set_mode($options[OPT_INSTALL_DIR], MODE_DIR);
+    set_mode($installDir, MODE_DIR);
+    set_mode_recursive($installDirSourcesDir);
+    warn_if_not_traversable($installDir);
     echo "Installed required source files to '$installDir'\n";
 
     // Appsec helper and rules
@@ -595,6 +604,8 @@ function install($options)
             "Cannot copy files from '$tmpArchiveAppsecEtc' to '$installDir'",
             (IS_WINDOWS ? "xcopy /s /e /y /g /b /o /h " : "cp -r ") . escapeshellarg("$tmpArchiveAppsecEtc") . ' ' . escapeshellarg($installDir)
         );
+        set_mode_recursive($installDir . '/lib');
+        set_mode_recursive($installDir . '/etc');
     }
     $appSecRulesPath = $installDir . '/etc/recommended.json';
 
@@ -633,6 +644,7 @@ function install($options)
 
         $extDir = isset($options[OPT_EXTENSION_DIR]) ? $options[OPT_EXTENSION_DIR] : $phpProperties[EXTENSION_DIR];
         echo "Installing extension to $extDir\n";
+        warn_if_not_traversable($extDir);
 
         // Trace
         $extensionRealPath = "$tmpArchiveTraceRoot/ext/$extensionVersion/"
@@ -678,24 +690,29 @@ function install($options)
 
             if (!file_exists($iniFilePath)) {
                 $iniDir = dirname($iniFilePath);
-                if (!file_exists($iniDir)) {
-                    execute_or_exit(
-                        "Cannot create directory '$iniDir'",
-                        "mkdir " . (IS_WINDOWS ? "" : "-p ") . escapeshellarg($iniDir)
-                    );
-                }
+                create_directory_or_exit("Cannot create directory '$iniDir'", $iniDir);
 
                 if (false === file_put_contents($iniFilePath, '')) {
                     print_error_and_exit("Cannot create INI file $iniFilePath");
                 }
+                // Unconditional: we just created it, so there is no user mode to preserve
+                set_mode($iniFilePath, MODE_FILE);
                 echo "Created INI file '$iniFilePath'\n";
             } else {
                 echo "Updating existing INI file '$iniFilePath'";
                 if (is_link($iniFilePath)) {
-                    $iniFilePath = readlink($iniFilePath);
+                    // realpath(), not readlink(): the target may be relative
+                    $iniFilePath = realpath($iniFilePath);
                     echo " which is a symlink to '$iniFilePath'";
                 }
                 echo "\n";
+
+                // A previous run may have created it with a restrictive umask
+                if (is_managed_ini_file($iniFilePath, $phpProperties)) {
+                    set_mode($iniFilePath, MODE_FILE);
+                } else {
+                    warn_if_not_world_readable($iniFilePath);
+                }
 
                 $replacements += [
                     // Old name is deprecated
@@ -831,7 +848,7 @@ function find_all_ini_files(array $phpProperties)
                 continue;
             }
             $iniFile = $path . '/' . $ini;
-            if (strpos($ini, '98-ddtrace.ini') !== false) {
+            if (strpos($ini, DEFAULT_INI_FILE_NAME) !== false) {
                 array_unshift($iniFilePaths, $iniFile);
             } else {
                 $iniFilePaths[] = $iniFile;
@@ -887,7 +904,7 @@ function find_main_ini_files(array $phpProperties)
             $phpProperties[INI_SCANDIR] = current(array_filter(explode(\PATH_SEPARATOR, $phpProperties[INI_SCANDIR])));
         }
 
-        $iniFileName = '98-ddtrace.ini';
+        $iniFileName = DEFAULT_INI_FILE_NAME;
         // Search for pre-existing files with extension = ddtrace.so to avoid conflicts
         // See issue https://github.com/DataDog/dd-trace-php/issues/1833
         if (is_dir($phpProperties[INI_SCANDIR])) {
@@ -926,6 +943,197 @@ function find_main_ini_files(array $phpProperties)
 }
 
 /**
+ * Whether the installer owns `$iniFilePath` and may therefore set its mode.
+ *
+ * Only drop-ins in an INI scan directory qualify, whatever name
+ * `find_main_ini_files()` adopted for ours: those exist to load extensions and
+ * are world-readable on every distribution. Anything else - in particular a
+ * php.ini, which `--ini` can point at - is the user's, and may deliberately not
+ * be world-readable as it can hold credentials.
+ *
+ * @param string $iniFilePath
+ * @param array $phpProperties
+ * @return bool
+ */
+function is_managed_ini_file($iniFilePath, array $phpProperties)
+{
+    if (!isset($phpProperties[INI_SCANDIR])) {
+        return false;
+    }
+
+    $iniDir = realpath(dirname($iniFilePath));
+    if ($iniDir === false) {
+        return false;
+    }
+
+    $scanDirs = [];
+    // https://www.php.net/manual/en/configuration.file.php#configuration.file.scandir
+    foreach (array_filter(explode(\PATH_SEPARATOR, $phpProperties[INI_SCANDIR])) as $scanDir) {
+        $scanDirs[] = $scanDir;
+        // find_main_ini_files() also writes to the apache2 sibling on debian
+        $scanDirs[] = str_replace('/cli/conf.d', '/apache2/conf.d', $scanDir);
+    }
+
+    foreach ($scanDirs as $scanDir) {
+        if (realpath($scanDir) === $iniDir) {
+            return true;
+        }
+    }
+
+    return false;
+}
+
+/**
+ * Sets the mode of `$path` explicitly, so that the installed files do not depend
+ * on the umask of the user running the installer. A chmod may legitimately fail
+ * (not the owner, exotic filesystem, ...), which is only worth a warning.
+ *
+ * @param string $path
+ * @param int $mode
+ * @return void
+ */
+function set_mode($path, $mode)
+{
+    if (IS_WINDOWS) {
+        // chmod is essentially a no-op on Windows, so don't risk a spurious warning
+        return;
+    }
+    if (!@chmod($path, $mode)) {
+        print_warning(sprintf(
+            "Cannot set the permissions of '%s' to %o. It might not be readable by the user running PHP.",
+            $path,
+            $mode
+        ));
+    }
+}
+
+/**
+ * Same as `set_mode()`, applied to a whole installed tree: directories and
+ * executables get MODE_EXECUTABLE, anything else MODE_FILE. Symlinks are
+ * skipped, as chmod would follow them outside of the tree.
+ *
+ * @param string $path
+ * @return void
+ */
+function set_mode_recursive($path)
+{
+    if (IS_WINDOWS || is_link($path)) {
+        return;
+    }
+
+    if (!is_dir($path)) {
+        set_mode($path, is_executable($path) ? MODE_EXECUTABLE : MODE_FILE);
+        return;
+    }
+
+    set_mode($path, MODE_DIR);
+    $entries = @scandir($path);
+    if ($entries === false) {
+        print_warning("Cannot list '$path'. Its contents might not be readable by the user running PHP.");
+        return;
+    }
+    foreach ($entries as $entry) {
+        if ($entry !== '.' && $entry !== '..') {
+            set_mode_recursive($path . '/' . $entry);
+        }
+    }
+}
+
+/**
+ * Warns when an INI file we wrote to but do not own is not world-readable. We
+ * leave its mode alone on purpose - a php.ini can hold credentials - but if the
+ * PHP user cannot read it the extension is never loaded, silently.
+ *
+ * A group-readable file is taken as deliberately restricted - the `0640
+ * root:www-data` layout is common and works - and left unmentioned, so that the
+ * warning stays advisory rather than nagging.
+ *
+ * @param string $iniFilePath
+ * @return void
+ */
+function warn_if_not_world_readable($iniFilePath)
+{
+    if (IS_WINDOWS) {
+        return;
+    }
+
+    $perms = @fileperms($iniFilePath);
+    if ($perms === false || ($perms & 0004) || ($perms & 0040)) {
+        return;
+    }
+
+    print_warning(
+        "INI file '$iniFilePath' is not readable by other users, and the "
+        . "installer does not change the mode of files it does not own. php-fpm "
+        . "and mod_php read it as root before dropping privileges, so this may "
+        . "not apply; if PHP reads it as another user, it will not load the "
+        . "extension. Run: chmod o+r " . escapeshellarg($iniFilePath)
+    );
+}
+
+/**
+ * Warns about the ancestors of `$path` that other users cannot traverse. We only
+ * set the mode of the directories we create, so a pre-existing restrictive parent
+ * would otherwise make the install silently unusable (dlopen() fails EACCES).
+ *
+ * @param string $path
+ * @return void
+ */
+function warn_if_not_traversable($path)
+{
+    if (IS_WINDOWS) {
+        return;
+    }
+
+    $dir = $path;
+    while (true) {
+        $perms = @fileperms($dir);
+        if ($perms !== false && !($perms & 0001)) {
+            print_warning(
+                "Directory '$dir' cannot be traversed by other users, so the "
+                . "user running PHP might not be able to load the extension. "
+                . "If PHP runs as another user, run: chmod o+x " . escapeshellarg($dir)
+            );
+        }
+        $parent = dirname($dir);
+        if ($parent === $dir) {
+            return;
+        }
+        $dir = $parent;
+    }
+}
+
+/**
+ * Creates `$dir` and its missing parents, then sets the mode of every directory
+ * it had to create. Parents that already existed are not touched, as they may
+ * belong to the user; `install()` re-asserts the modes of the ones we own.
+ *
+ * @param string $errorMessage
+ * @param string $dir
+ * @return void
+ */
+function create_directory_or_exit($errorMessage, $dir)
+{
+    $created = [];
+    for ($path = $dir; !file_exists($path); $path = dirname($path)) {
+        $created[] = $path;
+        if (dirname($path) === $path) {
+            break;
+        }
+    }
+
+    if (empty($created)) {
+        return;
+    }
+
+    execute_or_exit($errorMessage, "mkdir " . (IS_WINDOWS ? "" : "-p ") . escapeshellarg($dir));
+
+    foreach ($created as $path) {
+        set_mode($path, MODE_DIR);
+    }
+}
+
+/**
  * Copies an extension's file to a destination using copy+rename to avoid segfault if the file is loaded by php.
  *
  * @param string $source
@@ -943,15 +1151,14 @@ function safe_copy_extension($source, $destination)
     }
 
     $destinationDir = dirname($destination);
-    if (!file_exists($destinationDir)) {
-        execute_or_exit(
-            "Cannot create directory '$destinationDir'",
-            "mkdir " . (IS_WINDOWS ? "" : "-p ") . escapeshellarg($destinationDir)
-        );
-    }
+    create_directory_or_exit("Cannot create directory '$destinationDir'", $destinationDir);
 
     $tmpName = $destination . '.tmp';
-    copy($source, $tmpName);
+    if (!copy($source, $tmpName)) {
+        print_error_and_exit("Cannot copy '$source' to '$tmpName'");
+    }
+    // Before the rename, so the final path is never briefly unreadable by php
+    set_mode($tmpName, MODE_FILE);
     rename($tmpName, $destination);
     echo "Copied '$source' to '$destination'\n";
 }
@@ -973,7 +1180,7 @@ function uninstall($options)
             $extensionDir . '/' . EXTENSION_PREFIX . 'ddappsec.' . EXTENSION_SUFFIX,
         ];
 
-        $iniFileName = '98-ddtrace.ini';
+        $iniFileName = DEFAULT_INI_FILE_NAME;
         if (isset($phpProperties[INI_SCANDIR])) {
             $iniFilePaths = [$phpProperties[INI_SCANDIR] . '/' . $iniFileName];
 

--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -590,7 +590,8 @@ function install($options)
     // These two are ours whether we created them or not, so repair a bad umask
     set_mode($options[OPT_INSTALL_DIR], MODE_DIR);
     set_mode($installDir, MODE_DIR);
-    set_mode_recursive($installDirSourcesDir);
+    // Nothing here is ever invoked directly, so no file needs an exec bit
+    set_mode_recursive($installDirSourcesDir, true);
     warn_if_not_traversable($installDir);
     echo "Installed required source files to '$installDir'\n";
 
@@ -679,7 +680,8 @@ function install($options)
         }
         $appSecHelperPath = $installDir . '/lib/libddappsec-helper.so';
 
-        if (isset($options[OPT_PHP_INI])) {
+        $iniPathsFromUser = isset($options[OPT_PHP_INI]);
+        if ($iniPathsFromUser) {
             $iniFilePaths = $options[OPT_PHP_INI];
         } else {
             $iniFilePaths = find_main_ini_files($phpProperties);
@@ -708,7 +710,7 @@ function install($options)
                 echo "\n";
 
                 // A previous run may have created it with a restrictive umask
-                if (is_managed_ini_file($iniFilePath, $phpProperties)) {
+                if (is_managed_ini_file($iniFilePath, $phpProperties, $iniPathsFromUser)) {
                     set_mode($iniFilePath, MODE_FILE);
                 } else {
                     warn_if_not_world_readable($iniFilePath);
@@ -910,13 +912,8 @@ function find_main_ini_files(array $phpProperties)
         if (is_dir($phpProperties[INI_SCANDIR])) {
             foreach (scandir($phpProperties[INI_SCANDIR]) as $ini) {
                 $path = "{$phpProperties[INI_SCANDIR]}/$ini";
-                if (is_file($path)) {
-                    // match /path/to/ddtrace.so, plain extension = ddtrace or future extensions like ddtrace.dll
-                    if (preg_match("(^\s*extension\s*=\s*(\S*ddtrace)\b)m", file_get_contents($path), $res)) {
-                        if (basename($res[1]) == "ddtrace") {
-                            $iniFileName = $ini;
-                        }
-                    }
+                if (is_file($path) && loads_ddtrace_extension(file_get_contents($path))) {
+                    $iniFileName = $ini;
                 }
             }
         }
@@ -943,19 +940,38 @@ function find_main_ini_files(array $phpProperties)
 }
 
 /**
+ * Whether `$contents` enables our extension, which is what makes an INI file the
+ * one loading ddtrace. Shared with `is_managed_ini_file()` so that the file we
+ * adopt is exactly the file we consider ours.
+ *
+ * @param string $contents
+ * @return bool
+ */
+function loads_ddtrace_extension($contents)
+{
+    // match /path/to/ddtrace.so, plain extension = ddtrace or future extensions like ddtrace.dll
+    if (!preg_match("(^\s*extension\s*=\s*(\S*ddtrace)\b)m", $contents, $res)) {
+        return false;
+    }
+
+    return basename($res[1]) == "ddtrace";
+}
+
+/**
  * Whether the installer owns `$iniFilePath` and may therefore set its mode.
  *
- * Only drop-ins in an INI scan directory qualify, whatever name
- * `find_main_ini_files()` adopted for ours: those exist to load extensions and
- * are world-readable on every distribution. Anything else - in particular a
- * php.ini, which `--ini` can point at - is the user's, and may deliberately not
- * be world-readable as it can hold credentials.
+ * A file qualifies only if it sits in an INI scan directory *and* is evidently
+ * ours. Being in a scan directory is not enough on its own: a drop-in there may
+ * be the user's and deliberately unreadable because it holds credentials, and so
+ * may a php.ini, which `--ini` can point at.
  *
  * @param string $iniFilePath
  * @param array $phpProperties
+ * @param bool $userSupplied Whether the path comes from `--ini` rather than from
+ *                           `find_main_ini_files()`
  * @return bool
  */
-function is_managed_ini_file($iniFilePath, array $phpProperties)
+function is_managed_ini_file($iniFilePath, array $phpProperties, $userSupplied)
 {
     if (!isset($phpProperties[INI_SCANDIR])) {
         return false;
@@ -974,13 +990,33 @@ function is_managed_ini_file($iniFilePath, array $phpProperties)
         $scanDirs[] = str_replace('/cli/conf.d', '/apache2/conf.d', $scanDir);
     }
 
+    $inScanDir = false;
     foreach ($scanDirs as $scanDir) {
         if (realpath($scanDir) === $iniDir) {
-            return true;
+            $inScanDir = true;
+            break;
         }
     }
 
-    return false;
+    if (!$inScanDir) {
+        return false;
+    }
+
+    // The name we install under is ours wherever the path came from
+    if (basename($iniFilePath) === DEFAULT_INI_FILE_NAME) {
+        return true;
+    }
+
+    // A path handed to us with --ini is the user's, scan directory or not
+    if ($userSupplied) {
+        return false;
+    }
+
+    // Otherwise find_main_ini_files() adopted it, and it only adopts a file that
+    // already loads ddtrace, i.e. one an earlier run of ours wrote
+    $contents = @file_get_contents($iniFilePath);
+
+    return $contents !== false && loads_ddtrace_extension($contents);
 }
 
 /**
@@ -1012,17 +1048,21 @@ function set_mode($path, $mode)
  * executables get MODE_EXECUTABLE, anything else MODE_FILE. Symlinks are
  * skipped, as chmod would follow them outside of the tree.
  *
+ * `$dataOnly` marks a tree with no runnable file, so that an exec bit recorded
+ * in the package - a few of the shipped PHP sources carry one - is dropped.
+ *
  * @param string $path
+ * @param bool $dataOnly
  * @return void
  */
-function set_mode_recursive($path)
+function set_mode_recursive($path, $dataOnly = false)
 {
     if (IS_WINDOWS || is_link($path)) {
         return;
     }
 
     if (!is_dir($path)) {
-        set_mode($path, is_executable($path) ? MODE_EXECUTABLE : MODE_FILE);
+        set_mode($path, !$dataOnly && is_executable($path) ? MODE_EXECUTABLE : MODE_FILE);
         return;
     }
 
@@ -1034,7 +1074,7 @@ function set_mode_recursive($path)
     }
     foreach ($entries as $entry) {
         if ($entry !== '.' && $entry !== '..') {
-            set_mode_recursive($path . '/' . $entry);
+            set_mode_recursive($path . '/' . $entry, $dataOnly);
         }
     }
 }

--- a/datadog-setup.php
+++ b/datadog-setup.php
@@ -32,7 +32,6 @@ const RELEASE_VERSION = '@release_version@';
 
 // Modes set explicitly, so that the install does not depend on the caller's umask
 const MODE_FILE = 0644;
-const MODE_EXECUTABLE = 0755;
 const MODE_DIR = 0755;
 
 // The INI file the installer creates in the INI scan directory
@@ -590,8 +589,7 @@ function install($options)
     // These two are ours whether we created them or not, so repair a bad umask
     set_mode($options[OPT_INSTALL_DIR], MODE_DIR);
     set_mode($installDir, MODE_DIR);
-    // Nothing here is ever invoked directly, so no file needs an exec bit
-    set_mode_recursive($installDirSourcesDir, true);
+    set_mode_recursive($installDirSourcesDir);
     warn_if_not_traversable($installDir);
     echo "Installed required source files to '$installDir'\n";
 
@@ -1044,25 +1042,22 @@ function set_mode($path, $mode)
 }
 
 /**
- * Same as `set_mode()`, applied to a whole installed tree: directories and
- * executables get MODE_EXECUTABLE, anything else MODE_FILE. Symlinks are
- * skipped, as chmod would follow them outside of the tree.
- *
- * `$dataOnly` marks a tree with no runnable file, so that an exec bit recorded
- * in the package - a few of the shipped PHP sources carry one - is dropped.
+ * Same as `set_mode()`, applied to a whole installed tree: directories get
+ * MODE_DIR, files MODE_FILE. We install no executable, only shared objects,
+ * which are dlopen()ed and need no exec bit. Symlinks are skipped, as chmod
+ * would follow them outside of the tree.
  *
  * @param string $path
- * @param bool $dataOnly
  * @return void
  */
-function set_mode_recursive($path, $dataOnly = false)
+function set_mode_recursive($path)
 {
     if (IS_WINDOWS || is_link($path)) {
         return;
     }
 
     if (!is_dir($path)) {
-        set_mode($path, !$dataOnly && is_executable($path) ? MODE_EXECUTABLE : MODE_FILE);
+        set_mode($path, MODE_FILE);
         return;
     }
 
@@ -1074,7 +1069,7 @@ function set_mode_recursive($path, $dataOnly = false)
     }
     foreach ($entries as $entry) {
         if ($entry !== '.' && $entry !== '..') {
-            set_mode_recursive($path . '/' . $entry, $dataOnly);
+            set_mode_recursive($path . '/' . $entry);
         }
     }
 }

--- a/dockerfiles/verify_packages/Makefile
+++ b/dockerfiles/verify_packages/Makefile
@@ -83,6 +83,7 @@ test_install_custom_installation_root.sh \
 test_install_non_root_user.sh \
 test_install_subdir_from_file.sh \
 test_install_subdir_from_version.sh \
+test_install_umask_permissions.sh \
 test_install_uninstall_install_tracer_appsec.sh \
 test_install_uninstall_install_tracer_profiling.sh \
 test_install_uninstall_install_tracer.sh \

--- a/dockerfiles/verify_packages/installer/test_install_umask_permissions.sh
+++ b/dockerfiles/verify_packages/installer/test_install_umask_permissions.sh
@@ -21,14 +21,24 @@ bundle="build/packages/dd-library-php-${version}-${arch}-linux-gnu.tar.gz"
 # The symptom the permissions are about: another user must be able to load ddtrace.
 # cd / so that su does not fail on a working directory it cannot reach.
 useradd -m ddtracetest
+# Match a module line exactly, and keep the streams apart: the failure prints
+# "Unable to load dynamic library 'ddtrace.so'", which contains "ddtrace", so a
+# substring match over both streams passes on the failure it must catch.
 assert_ddtrace_loadable_by_other_user() {
-    output=$(su ddtracetest -c "cd / && php -m" 2>&1)
-    if [ -z "${output##*ddtrace*}" ]; then
-        echo "Ok: ddtrace is loadable by another user\n"
-    else
-        echo "Error: ddtrace is not loadable by another user\n---\n${output}\n---\n"
+    modules=/tmp/php-m.out
+    diagnostics=/tmp/php-m.err
+    su ddtracetest -c "cd / && php -m" > "${modules}" 2> "${diagnostics}" || true
+    if ! grep -qx ddtrace "${modules}"; then
+        echo "Error: ddtrace is not loadable by another user\n---\n$(cat "${modules}" "${diagnostics}")\n---\n"
         exit 1
     fi
+    # A second layer, for when ddtrace loads but another extension did not.
+    # The warning goes to stderr, but display_errors can route it to stdout.
+    if grep -q 'Unable to load dynamic library' "${modules}" "${diagnostics}"; then
+        echo "Error: a library failed to load for another user\n---\n$(cat "${modules}" "${diagnostics}")\n---\n"
+        exit 1
+    fi
+    echo "Ok: ddtrace is loadable by another user\n"
 }
 
 # Install with a umask that hides everything from "other": the installed files
@@ -100,3 +110,24 @@ assert_file_not_contains "${install_log}" 'is not readable by other users'
 # Already readable: nothing to say either.
 install_with_other_sapi_ini 0644
 assert_file_not_contains "${install_log}" 'is not readable by other users'
+
+# A scan directory drop-in is not ours just by sitting there: --ini can name the
+# user's own, kept unreadable on purpose because it holds an api key. Only the
+# name we install under, or a file we adopted ourselves, may be widened. Run
+# twice, because the first run writes our directives into it and that must not be
+# enough to make the second run treat it as ours. The file adopted above is
+# removed first, so this one is the only one loading ddtrace.
+rm "${custom_ini_file}"
+user_ini="${conf_dir}/50-datadog-secrets.ini"
+echo "datadog.api_key = secret" > "${user_ini}"
+chmod 0600 "${user_ini}"
+
+for _ in 1 2; do
+    php ./build/packages/datadog-setup.php --php-bin php --file "${bundle}" \
+        --ini "${user_ini}" > "${install_log}" 2>&1
+    cat "${install_log}"
+    assert_file_contains "${user_ini}" 'extension = ddtrace'
+    assert_file_contains "${user_ini}" 'datadog.api_key = secret'
+    assert_not_world_readable "${user_ini}"
+    assert_file_contains "${install_log}" 'is not readable by other users'
+done

--- a/dockerfiles/verify_packages/installer/test_install_umask_permissions.sh
+++ b/dockerfiles/verify_packages/installer/test_install_umask_permissions.sh
@@ -1,0 +1,102 @@
+#!/usr/bin/env sh
+
+set -e
+
+. "$(dirname ${0})/utils.sh"
+
+# Initially no ddtrace
+assert_no_ddtrace
+
+uname=$(uname -a)
+arch=$(if [ -z "${uname##*arm*}" ] || [ -z "${uname##*aarch*}" ]; then echo aarch64; else echo x86_64; fi)
+version=$(cat VERSION)
+
+if ! [ -f "build/packages/dd-library-php-${version}-${arch}-linux-gnu.tar.gz" ]; then
+    echo "SKIPPED: this test runs only in CI as it requires the .tar.gz at a specific path"
+    exit 0
+fi
+
+bundle="build/packages/dd-library-php-${version}-${arch}-linux-gnu.tar.gz"
+
+# The symptom the permissions are about: another user must be able to load ddtrace.
+# cd / so that su does not fail on a working directory it cannot reach.
+useradd -m ddtracetest
+assert_ddtrace_loadable_by_other_user() {
+    output=$(su ddtracetest -c "cd / && php -m" 2>&1)
+    if [ -z "${output##*ddtrace*}" ]; then
+        echo "Ok: ddtrace is loadable by another user\n"
+    else
+        echo "Error: ddtrace is not loadable by another user\n---\n${output}\n---\n"
+        exit 1
+    fi
+}
+
+# Install with a umask that hides everything from "other": the installed files
+# must still be readable, as php-fpm workers usually run as another user.
+umask 0027
+
+php ./build/packages/datadog-setup.php --php-bin php --file "${bundle}"
+
+extension_dir=$(get_php_extension_dir)
+conf_dir=$(get_php_conf_dir)
+
+assert_world_readable_tree "${extension_dir}/ddtrace.so"
+assert_world_readable_tree /opt/datadog/dd-library/${version}
+assert_world_traversable /opt/datadog
+assert_world_traversable /opt/datadog/dd-library
+assert_world_readable_tree "${conf_dir}/98-ddtrace.ini"
+assert_ddtrace_loadable_by_other_user
+
+# Re-installing must repair a scan directory file left unreadable by an earlier
+# run, whatever its name: the installer adopts the name of the file already
+# loading ddtrace (see find_main_ini_files). The php.ini sitting next to the scan
+# directory - the mainstream Debian/RHEL layout - must not be widened: it is the
+# user's and can hold credentials.
+custom_ini_file="${conf_dir}/40-ddtrace.ini"
+mv "${conf_dir}/98-ddtrace.ini" "${custom_ini_file}"
+chmod 0640 "${custom_ini_file}"
+
+main_ini="$(dirname "${conf_dir}")/php.ini"
+if ! [ -f "${main_ini}" ]; then
+    echo "" > "${main_ini}"
+fi
+chmod 0640 "${main_ini}"
+
+php ./build/packages/datadog-setup.php --php-bin php --file "${bundle}"
+
+assert_file_not_exists "${conf_dir}/98-ddtrace.ini"
+assert_world_readable_tree "${custom_ini_file}"
+assert_not_world_readable "${main_ini}"
+assert_ddtrace_loadable_by_other_user
+
+# --ini can point at a php.ini outside the scan directory - debian ships one per
+# SAPI, and find_main_ini_files() only derives the apache2 sibling, so this is the
+# documented way to reach fpm. Such a file is the user's: we write to it, but we
+# must not widen it, even though it is not the php.ini this SAPI loaded.
+other_sapi_ini="$(dirname "${conf_dir}")/fpm-php.ini"
+echo "" > "${other_sapi_ini}"
+
+install_log=/tmp/install-other-sapi.log
+install_with_other_sapi_ini() (
+    chmod "${1}" "${other_sapi_ini}"
+    php ./build/packages/datadog-setup.php --php-bin php --file "${bundle}" \
+        --ini "${other_sapi_ini}" > "${install_log}" 2>&1
+)
+
+# Unreadable by anyone but the owner: we will not fix the mode, so the user has
+# to be told rather than left with a tracer that silently never loads.
+install_with_other_sapi_ini 0600
+cat "${install_log}"
+assert_file_contains "${other_sapi_ini}" 'extension = ddtrace'
+assert_not_world_readable "${other_sapi_ini}"
+assert_file_contains "${install_log}" 'is not readable by other users'
+
+# Group-readable is the deliberate '0640 root:www-data' hardening, which works:
+# advise nothing, and above all do not widen it.
+install_with_other_sapi_ini 0640
+assert_not_world_readable "${other_sapi_ini}"
+assert_file_not_contains "${install_log}" 'is not readable by other users'
+
+# Already readable: nothing to say either.
+install_with_other_sapi_ini 0644
+assert_file_not_contains "${install_log}" 'is not readable by other users'

--- a/dockerfiles/verify_packages/installer/utils.sh
+++ b/dockerfiles/verify_packages/installer/utils.sh
@@ -159,6 +159,48 @@ assert_file_not_exists() {
     fi
 }
 
+assert_world_traversable() {
+    dir="${1}"
+    if ! [ -d "${dir}" ]; then
+        echo "Error: Directory '${dir}' does not exist\n"
+        exit 1
+    fi
+    if [ -n "$(find "${dir}" -maxdepth 0 ! -perm -001)" ]; then
+        echo "Error: Directory '${dir}' is not traversable by other users\n"
+        exit 1
+    fi
+    echo "Ok: Directory '${dir}' is traversable by other users\n"
+}
+
+assert_not_world_readable() {
+    file="${1}"
+    if ! [ -f "${file}" ]; then
+        echo "Error: '${file}' does not exist\n"
+        exit 1
+    fi
+    if [ -n "$(find "${file}" -maxdepth 0 -perm -004)" ]; then
+        echo "Error: '${file}' was widened to be readable by other users\n"
+        exit 1
+    fi
+    echo "Ok: '${file}' was left unreadable by other users\n"
+}
+
+# The installer must not let its umask leak into what it installs, as the PHP
+# process reading those files usually runs as another user.
+assert_world_readable_tree() {
+    path="${1}"
+    if ! [ -e "${path}" ]; then
+        echo "Error: '${path}' does not exist\n"
+        exit 1
+    fi
+    unreadable=$(find "${path}" \( -type f ! -perm -004 \) -o \( -type d ! -perm -005 \))
+    if [ -n "${unreadable}" ]; then
+        echo "Error: not readable by other users under '${path}':\n${unreadable}\n"
+        exit 1
+    fi
+    echo "Ok: Everything under '${path}' is readable by other users\n"
+}
+
 install_legacy_ddtrace() (
     version=$1
     curl -L --output "/tmp/legacy-${version}.tar.gz" \


### PR DESCRIPTION
### Description

`datadog-setup.php` never set explicit modes on anything it installed, so
permissions fell out of whatever umask the invoking user happened to have.

**Symptom.** A customer on Arch Linux/arm64 ran the installer as root with
`umask 0027`. `/usr/lib/php/modules/ddtrace.so` and the
`/opt/datadog/dd-library/` tree came out with no read bit for "other".
php-fpm workers run as a different user (`http`), so loading the extension
failed with `EACCES` — which surfaced confusingly as:

```
Failed connecting to the sidecar (subprocess mode): Connection refused (os error 111)
```

The spawned sidecar subprocess couldn't load the extension. The customer
worked around it by hand with `chmod a+r`, having had to do the same earlier
for `/opt/datadog/dd-library/`.

The INI file was affected the same way, and that case is worse: a `0640`
`98-ddtrace.ini` means PHP can't read `extension=ddtrace.so` at all, so the
tracer just vanishes with *no* permission error anywhere. That is likely why
this took a while to diagnose.

### What changed

- Explicit modes on everything installed, independent of umask: `0644` for
  data files (`.so`, `.ini`, PHP sources), `0755` for directories and
  executables.
- Re-running the installer now repairs a previously-broken install, including
  a stale restrictive INI.
- Extensions are chmod'd at their temp name *before* the atomic rename, so the
  live `.so` path is never briefly unreadable.
- No `chown`. Non-root installs into a user-owned prefix are unaffected.

The policy is **chmod what we own, warn about what we don't**:

- Directories the installer did not create are never chmod'd — silently
  widening a user-supplied `--install-dir` isn't acceptable — it warns with an
  actionable command instead.
- Files the installer does not own are never chmod'd. Only INI drop-ins in a
  scan directory qualify (whatever name was adopted). A `php.ini`, which
  `--ini` can point at, is the user's and may deliberately not be
  world-readable since it can hold credentials; those get a warning.

### Testing

New `dockerfiles/verify_packages/installer/test_install_umask_permissions.sh`
— the package-verification harness previously had no permission assertions at
all. It installs under `umask 0027`, asserts modes in both affected locations,
and finishes on the real symptom: `php -m` as another user must list ddtrace.
It fails on the pre-fix installer and passes after.
