### PR TITLE
ci: don't let allow_failure jobs fail the merge gate

### DIFF
--- a/.gitlab/merge-gate.sh
+++ b/.gitlab/merge-gate.sh
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
-# Merge gate: passes iff every non-flaky job in this pipeline (and its triggered
-# child pipelines) succeeded. It collects failed jobs via the GitLab API and
-# classifies each against the glob patterns in .gitlab/flaky-jobs.txt; a failure
-# matching no pattern is a real regression and fails the gate. See the
-# `merge-gate` job in .gitlab-ci.yml.
+# Merge gate: passes iff every required job in this pipeline (and its triggered
+# child pipelines) succeeded. Required means: not allow_failure, and not matching
+# a glob in .gitlab/flaky-jobs.txt. A failure that is neither is a real
+# regression and fails the gate. See the `merge-gate` job in .gitlab-ci.yml.
 set -uo pipefail
 
 # Short-lived GitLab API token, same path as `analyze and create pr`
@@ -35,21 +34,28 @@ while read -r child; do
   [ -n "${child}" ] && pipelines+=("${child}")
 done < <(echo "${bridges}" | jq -r '.[] | select(.downstream_pipeline != null) | .downstream_pipeline.id')
 
-# Collect the names of all failed jobs across those pipelines.
+# Collect the names of all failed jobs across those pipelines. `scope[]=failed`
+# also returns allow_failure jobs (their status is "failed" too).
 : > failed_jobs.txt
+: > allowed_failures.txt
 for pid in "${pipelines[@]}"; do
   for page in 1 2 3 4 5; do
     data=$(curl -g -sf -H "${AUTH}" \
       "${GITLAB_API}/projects/${CI_PROJECT_ID}/pipelines/${pid}/jobs?scope[]=failed&per_page=100&page=${page}" || echo "[]")
-    echo "${data}" | jq -r '.[] | select(.status == "failed") | .name' >> failed_jobs.txt
+    echo "${data}" | jq -r '.[] | select(.status == "failed" and .allow_failure != true) | .name' >> failed_jobs.txt
+    echo "${data}" | jq -r '.[] | select(.status == "failed" and .allow_failure == true) | .name' >> allowed_failures.txt
     [ "$(echo "${data}" | jq 'length')" -lt 100 ] && break
   done
 done
 sort -u failed_jobs.txt -o failed_jobs.txt
+sort -u allowed_failures.txt -o allowed_failures.txt
 
 # Load flaky globs and classify each failure.
 mapfile -t GLOBS < <(grep -vE '^[[:space:]]*(#|$)' .gitlab/flaky-jobs.txt)
-echo "Loaded ${#GLOBS[@]} flaky patterns; $(wc -l < failed_jobs.txt) distinct failed job(s)."
+echo "Loaded ${#GLOBS[@]} flaky patterns; $(wc -l < failed_jobs.txt) required failed job(s), $(wc -l < allowed_failures.txt) allowed-to-fail."
+while IFS= read -r job; do
+  [ -n "${job}" ] && echo "  ~ allowed to fail:   ${job}"
+done < allowed_failures.txt
 blocking=0
 while IFS= read -r job; do
   [ -z "${job}" ] && continue


### PR DESCRIPTION
## Problem
The required `merge-gate` job blocks merge because of jobs declared `allow_failure: true`.
Example: gate job https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-php/-/jobs/1982854836 failed solely because of https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-php/-/jobs/1982861494 (`publish docker image for system tests`, `allow_failure: true`, which failed on a GHCR permission error).

## Root cause
`.gitlab/merge-gate.sh` enumerates failures via the GitLab jobs API with `scope[]=failed`. That scope ALSO returns `allow_failure: true` jobs — such a job's `status` is literally `"failed"`, and only the separate `allow_failure` field distinguishes it (the pipeline itself is `success_with_warnings`, i.e. green). The jq filter looked at `.status` alone (`select(.status == "failed")`), so allowed failures entered the blocking set. This is entirely in the gate's own API status check; `needs:` semantics are not involved.

## Fix
Filter on the API's `allow_failure` field as well, and log the allowed failures so the verdict stays auditable.
The API field is the EVALUATED per-pipeline value, which is what makes this correct rather than parsing the generators: `bundle for reliability env` carries `allow_failure` only on its `when: manual` rule branch, so on a `$NIGHTLY_BUILD` pipeline the API reports `allow_failure: false` and it still blocks. A static YAML parse would have wrongly excused it. Same for `System Tests: [...]` and `aggregate tested versions`, blocking on master and manual off it.

## Impact
Across the 60 most recent pipelines, 26 hit this — mostly `publish docker image for system tests` (unconditional `allow_failure: true` in `generate-package.php`, runs on every non-default branch). None of the affected job names are covered by `.gitlab/flaky-jobs.txt`, so the pre-fix gate was spuriously blocking nearly every feature branch.

## Verification
Replayed the real script body against actual pipelines with a `curl` -> `glab api` shim:
- Pipeline 133158618 (the reported failure) — before: `non-flaky failure: publish docker image for system tests`, exit 1 (reproduces CI verbatim); after: `allowed to fail`, gate PASSED, exit 0.
- Negative control on 3 other real failed pipelines (133218652, 133227272, 133252914): the fixed gate still blocks every genuine failure (xDebug tests, appsec integration tests, verify alpine, benchmarks-tracer, ...).
All six `.gitlab/generate-*.php` generators re-run byte-identical; no generator emits `merge-gate`, so nothing needs regenerating. `bash -n` clean.

## Not addressed here
Three PRE-EXISTING fail-open holes in the same script (unvalidated `GITLAB_TOKEN`; `|| echo "[]"` conflating API errors with "nothing failed"; no `set -e`), plus grandchild pipelines not being traversed. Those make the gate go green over real breakage and follow in a separate PR — bundling "make the gate stricter" with "stop the gate over-blocking" would muddy both.