### PR TITLE
test: increase watchdog's RSS limit under ASAN

### DIFF
--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -226,6 +226,9 @@ stages:
   extends: .base_test
   variables:
     SWITCH_PHP_VERSION: debug-zts-asan
+    # Keep this at twice the default in libdatadog/datadog-sidecar/src/watchdog.rs;
+    # update it whenever that default changes.
+    _DD_SIDECAR_WATCHDOG_MAX_MEMORY: 2147483648
     ASAN_OPTIONS: abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1
 
 <?php


### PR DESCRIPTION
### Description

Increases the watchdog's memory limit for the ASAN family of jobs. When running the address sanitizer, the sidecar can hit the watchdog's memory limit because of red zones, quarantines, etc using 2x-3x more memory than without ASAN.

We could reduce ASAN's quarantines to reduce memory usage under ASAN, but this also reduces effectiveness. Seems better to increase the limit instead.


#### Impact to CI

The symptom we see in CI looks like this:

> [ddtrace] [datadog_sidecar::service::blocking] [7155] The sidecar transport is closed. Reconnecting... This generally indicates a problem with the sidecar, most likely a crash. Check the logs / core dump locations and possibly report a bug.

But there is no crash, and `sidecar.log` says `Watchdog memory exceeded`.

Currently, we're averaging 2 of these failures per CI run, and that's _after_ retries. This will hopefully reduce the amount of failures we get and the need for automatic retries, shortening our CI runs and cost.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
