### PR TITLE
ci(profiling): upload PHP language test results

### DIFF
--- a/.gitlab/generate-profiler.php
+++ b/.gitlab/generate-profiler.php
@@ -146,6 +146,7 @@ foreach ($profiler_minor_major_targets as $version) {
     libdir: /tmp/datadog-profiling
     SKIP_ONLINE_TESTS: "1"
     REPORT_EXIT_STATUS: "1"
+    TEST_PHP_JUNIT: "${CI_PROJECT_DIR}/artifacts/tests/php-tests.xml"
     DD_PROFILING_OUTPUT_PPROF: /tmp/
     XFAIL_LIST: dockerfiles/ci/xfail_tests/${PHP_MAJOR_MINOR}.list
   parallel:
@@ -214,6 +215,7 @@ foreach ($profiler_minor_major_targets as $version) {
           /usr/local/bin/php "${core}" > "${output}/gdb-backtrace-${i}.txt" 2>&1 || true
         mv "${core}" "${output}/core-${i}"
       done
+    - .gitlab/silent-upload-junit-to-datadog.sh "test.source.file:profiling/"
   artifacts:
     when: on_failure
     paths:


### PR DESCRIPTION
### Description

For our "Green CI" initiative those jobs where assigned to Language-Platforms, because we did not upload junit.xml files for the test. This changes that, so we are actually assigning profiling CI errors to the Profiling product

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
