### PR TITLE
ci: shard tracer-release system tests four ways

### DIFF
--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -168,6 +168,26 @@ requirements_json_test:
     REQUIREMENTS_BLOCK_JSON_PATH: "loader/packaging/block_tests.json"
     REQUIREMENTS_ALLOW_JSON_PATH: "loader/packaging/allow_tests.json"
 
+"system tests shard selector test":
+  stage: prepare
+  image: registry.ddbuild.io/images/mirror/python:3.12-slim-bullseye
+  tags: [ "arch:amd64" ]
+  needs: []
+  variables:
+    GIT_SUBMODULE_STRATEGY: none
+  script:
+    - python3 .gitlab/tests/test_package_system_tests_sharding.py -v
+
+"system tests pinning contract test":
+  stage: prepare
+  image: registry.ddbuild.io/images/mirror/php:8.2-cli
+  tags: [ "arch:amd64" ]
+  needs: []
+  variables:
+    GIT_SUBMODULE_STRATEGY: none
+  script:
+    - php .gitlab/tests/test_package_system_tests_pinning.php
+
 
 # dd-trace-php release packaging
 "prepare code":
@@ -176,6 +196,13 @@ requirements_json_test:
   tags: [ "arch:amd64" ]
   script:
     - ./.gitlab/append-build-id.sh
+    - |
+      SYSTEM_TESTS_SHA=$(git ls-remote https://github.com/DataDog/system-tests.git refs/heads/main | awk 'NR == 1 { print $1 }')
+      if ! printf '%s\n' "$SYSTEM_TESTS_SHA" | grep -Eq '^[0-9a-f]{40}$'; then
+        echo "Failed to resolve a valid system-tests commit: $SYSTEM_TESTS_SHA"
+        exit 1
+      fi
+      printf 'SYSTEM_TESTS_SHA=%s\n' "$SYSTEM_TESTS_SHA" > system-tests.env
     # Upgrading composer
     - composer self-update --no-interaction
     # Installing dependencies with composer
@@ -190,6 +217,8 @@ requirements_json_test:
     paths:
       - VERSION
       - ./src/bridge/_generated*.php
+    reports:
+      dotenv: system-tests.env
 
 <?php
 foreach ($build_platforms as $platform) {
@@ -1305,7 +1334,20 @@ endforeach;
       pip install -U pip virtualenv
 <?php dockerhub_login() ?>
     - /tmp/vault kv get --format=json "kv/k8s/gitlab-runner/dd-trace-php/datadoghq-api-key" 2>/dev/null | python3 -c "import sys,json;print(json.load(sys.stdin)['data']['data']['key'])" > /tmp/.dd-api-key 2>/dev/null || true
-    - git clone https://github.com/DataDog/system-tests.git
+    - |
+      if ! printf '%s\n' "${SYSTEM_TESTS_SHA:-}" | grep -Eq '^[0-9a-f]{40}$'; then
+        echo "Missing or invalid SYSTEM_TESTS_SHA: ${SYSTEM_TESTS_SHA:-}"
+        exit 1
+      fi
+      git init -q system-tests
+      git -C system-tests remote add origin https://github.com/DataDog/system-tests.git
+      git -C system-tests fetch --depth=1 origin "$SYSTEM_TESTS_SHA"
+      git -C system-tests checkout --detach "$SYSTEM_TESTS_SHA"
+      CHECKED_OUT_SYSTEM_TESTS_SHA=$(git -C system-tests rev-parse HEAD)
+      if [ "$CHECKED_OUT_SYSTEM_TESTS_SHA" != "$SYSTEM_TESTS_SHA" ]; then
+        echo "Checked out system-tests $CHECKED_OUT_SYSTEM_TESTS_SHA, expected $SYSTEM_TESTS_SHA"
+        exit 1
+      fi
     - mv packages/{datadog-setup.php,dd-library-php-*x86_64-linux-gnu.tar.gz} system-tests/binaries
     - cd system-tests
     - ./build.sh $BUILD_SH_ARGS
@@ -1385,6 +1427,7 @@ $system_tests_weblogs = [
 "System Tests: [<?= $weblog ?>, tracer-release]":
   extends: .system_tests
   timeout: 4h
+  parallel: 4
   variables:
     BUILD_SH_ARGS: -w <?= $weblog ?> php
     # Expand the DinD loopback volume to avoid running out of disk space.
@@ -1400,7 +1443,12 @@ $system_tests_weblogs = [
   script:
     - DD_API_KEY=$(cat /tmp/.dd-api-key 2>/dev/null) || { echo "Failed to fetch DD_API_KEY"; exit 1; }
     - export DD_API_KEY
-    - SCENARIOS=$(PYTHONPATH=. venv/bin/python utils/scripts/compute-workflow-parameters.py php -g tracer_release -f json | python3 -c "import sys,json;d=json.load(sys.stdin);s=set();[s.update(v['scenarios']) for v in d.values() if isinstance(v,dict) and 'scenarios' in v];print(' '.join(sorted(s)))")
+    - |
+      set -o pipefail
+      SCENARIOS=$(
+        PYTHONPATH=. venv/bin/python utils/scripts/compute-workflow-parameters.py php -g tracer_release -f json |
+          python3 "$CI_PROJECT_DIR/.gitlab/select-system-tests-shard.py"
+      ) || exit $?
     - FAILED=""; for S in $SCENARIOS; do echo "=== Running $S ==="; ./run.sh $S || FAILED="$FAILED $S"; done; if [ -n "$FAILED" ]; then echo "Failed scenarios:$FAILED"; exit 1; fi
 
 <?php endforeach; ?>

--- a/.gitlab/select-system-tests-shard.py
+++ b/.gitlab/select-system-tests-shard.py
@@ -1,0 +1,70 @@
+import json
+import os
+import sys
+
+
+def fail(message):
+    raise SystemExit(f"Failed to select tracer-release scenarios: {message}")
+
+
+def validate_scenario_group(group, location):
+    if not isinstance(group, list) or any(
+        not isinstance(scenario, str) or not scenario or any(character.isspace() for character in scenario)
+        for scenario in group
+    ):
+        fail(f"expected {location} to be a list of non-empty names without whitespace")
+    return group
+
+
+def main():
+    try:
+        data = json.load(sys.stdin)
+    except (json.JSONDecodeError, UnicodeDecodeError) as error:
+        fail(f"invalid scenario JSON: {error}")
+
+    if not isinstance(data, dict):
+        fail("expected a JSON object")
+
+    try:
+        shard_count = int(os.environ["CI_NODE_TOTAL"])
+        shard_number = int(os.environ["CI_NODE_INDEX"])
+    except (KeyError, ValueError) as error:
+        fail(f"invalid shard configuration: {error}")
+
+    if shard_count != 4 or not 1 <= shard_number <= shard_count:
+        fail(f"invalid shard {shard_number} of {shard_count}")
+
+    endtoend_defs = data.get("endtoend_defs")
+    if not isinstance(endtoend_defs, dict):
+        fail("expected endtoend_defs to be an object")
+
+    parallel_jobs = endtoend_defs.get("parallel_jobs")
+    if not isinstance(parallel_jobs, list) or not parallel_jobs:
+        fail("expected endtoend_defs.parallel_jobs to be a non-empty list")
+
+    scenarios = set()
+    for index, job in enumerate(parallel_jobs):
+        if not isinstance(job, dict) or "scenarios" not in job:
+            fail(f"expected endtoend_defs.parallel_jobs[{index}] to contain scenarios")
+        scenarios.update(
+            validate_scenario_group(
+                job["scenarios"],
+                f"endtoend_defs.parallel_jobs[{index}].scenarios",
+            )
+        )
+
+    for name, value in data.items():
+        if name in ("endtoend", "endtoend_defs"):
+            continue
+        if isinstance(value, dict) and "scenarios" in value:
+            scenarios.update(validate_scenario_group(value["scenarios"], f"{name}.scenarios"))
+
+    selected = sorted(scenarios)[shard_number - 1::shard_count]
+    if not selected:
+        fail(f"shard {shard_number} of {shard_count} is empty")
+
+    print(" ".join(selected))
+
+
+if __name__ == "__main__":
+    main()

--- a/.gitlab/tests/test_package_system_tests_pinning.php
+++ b/.gitlab/tests/test_package_system_tests_pinning.php
@@ -1,0 +1,137 @@
+<?php
+
+function fail(string $message): void
+{
+    fwrite(STDERR, "$message\n");
+    exit(1);
+}
+
+function require_contains(string $configuration, string $expected, string $contract): void
+{
+    if (!str_contains($configuration, $expected)) {
+        fail("Generated pipeline is missing $contract");
+    }
+}
+
+function generated_definition(string $configuration, string $name): string
+{
+    $marker = "$name:\n";
+    $start = strpos($configuration, $marker);
+    if ($start === false) {
+        fail("Generated pipeline is missing $name");
+    }
+
+    $following = substr($configuration, $start + strlen($marker));
+    if (!preg_match('/^(?=(?:"[^\n]+"|[A-Za-z_.][^:\n]*):\n)/m', $following, $match, PREG_OFFSET_CAPTURE)) {
+        return substr($configuration, $start);
+    }
+
+    return substr($configuration, $start, strlen($marker) + $match[0][1]);
+}
+
+$root = dirname(__DIR__, 2);
+$original_directory = getcwd();
+chdir("$root/.gitlab");
+ob_start();
+require "$root/.gitlab/generate-package.php";
+$configuration = ob_get_clean();
+chdir($original_directory);
+
+$prepare_code = generated_definition($configuration, '"prepare code"');
+require_contains(
+    $prepare_code,
+    "SYSTEM_TESTS_SHA=\$(git ls-remote https://github.com/DataDog/system-tests.git refs/heads/main | " .
+        "awk 'NR == 1 { print \$1 }')",
+    'system-tests revision resolution'
+);
+require_contains(
+    $prepare_code,
+    "if ! printf '%s\\n' \"\$SYSTEM_TESTS_SHA\" | grep -Eq '^[0-9a-f]{40}\$'; then\n" .
+        "        echo \"Failed to resolve a valid system-tests commit: \$SYSTEM_TESTS_SHA\"\n" .
+        "        exit 1\n" .
+        "      fi",
+    'resolved system-tests revision validation'
+);
+require_contains(
+    $prepare_code,
+    "printf 'SYSTEM_TESTS_SHA=%s\\n' \"\$SYSTEM_TESTS_SHA\" > system-tests.env",
+    'system-tests dotenv creation'
+);
+require_contains(
+    $prepare_code,
+    "  artifacts:\n" .
+        "    paths:\n" .
+        "      - VERSION\n" .
+        "      - ./src/bridge/_generated*.php\n" .
+        "    reports:\n" .
+        "      dotenv: system-tests.env",
+    'system-tests dotenv artifact report'
+);
+
+$system_tests = generated_definition($configuration, '.system_tests');
+require_contains(
+    $system_tests,
+    "- job: \"prepare code\"\n      artifacts: true",
+    'prepare code artifact dependency'
+);
+require_contains(
+    $system_tests,
+    "if ! printf '%s\\n' \"\${SYSTEM_TESTS_SHA:-}\" | grep -Eq '^[0-9a-f]{40}\$'; then\n" .
+        "        echo \"Missing or invalid SYSTEM_TESTS_SHA: \${SYSTEM_TESTS_SHA:-}\"\n" .
+        "        exit 1\n" .
+        "      fi",
+    'checkout revision validation'
+);
+require_contains(
+    $system_tests,
+    "git init -q system-tests\n" .
+        "      git -C system-tests remote add origin https://github.com/DataDog/system-tests.git",
+    'system-tests checkout initialization'
+);
+require_contains(
+    $system_tests,
+    'git -C system-tests fetch --depth=1 origin "$SYSTEM_TESTS_SHA"',
+    'exact shallow system-tests fetch'
+);
+require_contains(
+    $system_tests,
+    'git -C system-tests checkout --detach "$SYSTEM_TESTS_SHA"',
+    'detached system-tests checkout'
+);
+require_contains(
+    $system_tests,
+    'CHECKED_OUT_SYSTEM_TESTS_SHA=$(git -C system-tests rev-parse HEAD)',
+    'checked-out system-tests revision lookup'
+);
+require_contains(
+    $system_tests,
+    "if [ \"\$CHECKED_OUT_SYSTEM_TESTS_SHA\" != \"\$SYSTEM_TESTS_SHA\" ]; then\n" .
+        "        echo \"Checked out system-tests \$CHECKED_OUT_SYSTEM_TESTS_SHA, expected \$SYSTEM_TESTS_SHA\"\n" .
+        "        exit 1\n" .
+        "      fi",
+    'checked-out system-tests revision mismatch failure'
+);
+
+if (!preg_match_all(
+    '/^"System Tests: \[[^,\]\n]+, tracer-release\]":$/m',
+    $configuration,
+    $tracer_release_jobs
+) || count($tracer_release_jobs[0]) !== 25) {
+    fail('Generated pipeline must contain 25 tracer-release definitions');
+}
+
+foreach ($tracer_release_jobs[0] as $heading) {
+    $name = substr($heading, 0, -1);
+    $definition = generated_definition($configuration, $name);
+    require_contains($definition, "  parallel: 4\n", "$name four-way parallel expansion");
+    require_contains($definition, "      set -o pipefail\n", "$name scenario pipeline failure detection");
+    require_contains(
+        $definition,
+        "PYTHONPATH=. venv/bin/python utils/scripts/compute-workflow-parameters.py php -g tracer_release -f json |\n" .
+            "          python3 \"\$CI_PROJECT_DIR/.gitlab/select-system-tests-shard.py\"",
+        "$name scenario producer-to-selector pipeline"
+    );
+    require_contains($definition, ') || exit $?', "$name selector failure propagation");
+}
+
+echo "Generated pipeline system-tests pinning contract: OK\n";

--- a/.gitlab/tests/test_package_system_tests_sharding.py
+++ b/.gitlab/tests/test_package_system_tests_sharding.py
@@ -1,0 +1,109 @@
+import collections
+import json
+import os
+from pathlib import Path
+import subprocess
+import sys
+import unittest
+
+
+ROOT = Path(__file__).resolve().parents[2]
+SELECTOR = ROOT / ".gitlab/select-system-tests-shard.py"
+
+
+def canonical_workflow(scenarios):
+    midpoint = len(scenarios) // 2
+    return {
+        "endtoend_defs": {
+            "parallel_jobs": [
+                {"scenarios": scenarios[:midpoint]},
+                {"scenarios": scenarios[midpoint:]},
+            ]
+        },
+        "parametric": {"scenarios": []},
+    }
+
+
+def run_selector(workflow, shard_number, shard_count="4"):
+    environment = os.environ.copy()
+    environment.update(CI_NODE_INDEX=str(shard_number), CI_NODE_TOTAL=str(shard_count))
+    return subprocess.run(
+        [sys.executable, str(SELECTOR)],
+        input=json.dumps(workflow),
+        env=environment,
+        capture_output=True,
+        text=True,
+    )
+
+
+def select_scenarios(scenarios, shard_number, shard_count="4"):
+    return run_selector(canonical_workflow(scenarios), shard_number, shard_count)
+
+
+class PackageSystemTestsShardingTest(unittest.TestCase):
+    def test_pinned_canonical_revision_runs_every_scenario_exactly_once(self):
+        endtoend_scenarios = [f"SCENARIO_{index:03d}" for index in range(96)] + [
+            "000_REVISION_2",
+            "000_REVISION_3_A",
+            "000_REVISION_3_B",
+            "000_REVISION_4_A",
+            "000_REVISION_4_B",
+            "000_REVISION_4_C",
+        ]
+        workflow = canonical_workflow(endtoend_scenarios)
+        workflow["parametric"]["scenarios"] = ["PARAMETRIC"]
+        scenarios = endtoend_scenarios + ["PARAMETRIC"]
+        executions = collections.Counter()
+
+        for shard_number in range(1, 5):
+            result = run_selector(workflow, shard_number)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            executions.update(result.stdout.split())
+
+        self.assertEqual(executions, collections.Counter({scenario: 1 for scenario in scenarios}))
+
+    def test_staggered_unpinned_revisions_are_not_exactly_once(self):
+        common = [f"SCENARIO_{index:03d}" for index in range(96)]
+        revisions = [
+            common,
+            common + ["000_REVISION_2"],
+            common + ["000_REVISION_3_A", "000_REVISION_3_B"],
+            common + ["000_REVISION_4_A", "000_REVISION_4_B", "000_REVISION_4_C"],
+        ]
+        visible = set().union(*map(set, revisions))
+        executions = collections.Counter()
+
+        for shard_number, scenarios in enumerate(revisions, start=1):
+            result = run_selector(canonical_workflow(scenarios), shard_number)
+            self.assertEqual(result.returncode, 0, result.stderr)
+            executions.update(result.stdout.split())
+
+        self.assertEqual(len(visible), 102)
+        self.assertNotEqual(
+            executions,
+            collections.Counter({scenario: 1 for scenario in visible}),
+        )
+        self.assertTrue(visible - executions.keys())
+
+    def test_invalid_selection_fails(self):
+        result = select_scenarios(["ONLY_ONE"], 4)
+        self.assertNotEqual(result.returncode, 0)
+        self.assertIn("Failed to select tracer-release scenarios:", result.stderr)
+
+    def test_invalid_canonical_schema_fails(self):
+        invalid_workflows = [
+            {"endtoend": {"scenarios": ["LEGACY_ONLY"]}},
+            {"endtoend_defs": {"parallel_jobs": []}},
+            {"endtoend_defs": {"parallel_jobs": [{}]}},
+            {"endtoend_defs": {"parallel_jobs": [{"scenarios": ["HAS WHITESPACE"]}]}},
+        ]
+
+        for workflow in invalid_workflows:
+            with self.subTest(workflow=workflow):
+                result = run_selector(workflow, 1)
+                self.assertNotEqual(result.returncode, 0)
+                self.assertIn("Failed to select tracer-release scenarios:", result.stderr)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
### Description

> [Link](https://chonk.us1.prod.dog/v2/get/chonk-uploads-prod/brian.marks/0fc3fcc9-7c41-485d-9284-5550e9b35ccc) (AppGate required)

Each of the 25 tracer-release system-test definitions currently runs its scenario list serially. This adds native `parallel: 4`, producing 100 execution lanes. A checked-in selector sorts and deduplicates the canonical scenario set, then assigns disjoint round-robin slices using GitLab's 1-based node index.

One system-tests SHA is resolved in `prepare code`, published as a dotenv artifact, and checked out exactly by every shard. Required Python and PHP tests cover selector behavior, exact-once coverage, the shared pin, and all 25 generated job definitions. Valgrind is unchanged.

Current producer output splits 96 scenario executions into `[24, 24, 24, 24]`. Scenario-phase wall clock can approach one quarter of the current time; setup and weblog build work are repeated, and the slowest shard still sets wall clock.

Draft integration note: merge this after [#4144](https://github.com/DataDog/dd-trace-php/pull/4144) and [#4142](https://github.com/DataDog/dd-trace-php/pull/4142), then rebase. During conflict resolution, keep the fixed source/image pair from #4144, retain the shard selector, add producer-level `PARAMETRIC` exclusion, and remove the redundant unsharded extractor path.

Tested with:

- Selector suite: 4 passed, including exact-once and real staggered-input coverage
- Generated-pipeline pin/wiring contract under PHP 8.2
- Generated package YAML: 25 definitions × 4 shards; all pin and selector contracts present
- Exact shallow checkout, origin-advance simulation, PHP lint, and `git diff --check`

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
