### PR TITLE
fix(drupal): hook the theme engine service and guarantee render hook removal

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -12,7 +12,7 @@
 compile_rust.sh @Datadog/libdatadog-apm @DataDog/apm-php-core
 
 # APM IDM Team
-/src/ @DataDog/apm-idm-php
+/src/ @DataDog/apm-idm-php @DataDog/apm-php-core
 
 # FFE (Feature Flagging & Experimentation) SDK Team
 /components-rs/ffe.rs @Datadog/libdatadog-apm @DataDog/feature-flagging-and-experimentation-sdk @DataDog/apm-php-core

--- a/src/DDTrace/Integrations/Drupal/DrupalIntegration.php
+++ b/src/DDTrace/Integrations/Drupal/DrupalIntegration.php
@@ -259,8 +259,11 @@ class DrupalIntegration extends Integration
             [
                 'recurse' => true,
                 'prehook' => function (SpanData $span, $args) use (&$renderHookIds) {
-                    // Reset first, so a stale entry left by a dropped span can never be reused.
+                    // A dropped span skips the posthook, so its hook may still be installed.
                     $spanKey = \spl_object_hash($span);
+                    if (!empty($renderHookIds[$spanKey])) {
+                        remove_hook($renderHookIds[$spanKey]);
+                    }
                     $renderHookIds[$spanKey] = 0;
 
                     $span->name = 'drupal.theme.render';

--- a/src/DDTrace/Integrations/Drupal/DrupalIntegration.php
+++ b/src/DDTrace/Integrations/Drupal/DrupalIntegration.php
@@ -228,14 +228,12 @@ class DrupalIntegration extends Integration
             }
         );
 
-        // The span of the ThemeManager::render frame currently executing, or null when that
-        // frame has none of its own. An ancestor render span carries the same name under
-        // 'recurse' => true, so the tag target can only be matched by identity.
+        // The span of the executing ThemeManager::render frame, or null when it has none of its own.
+        // Ancestors share its name under 'recurse' => true, so it can only be matched by identity.
         $renderSpan = null;
 
         $tagTemplateFile = static function ($file) use (&$renderSpan) {
-            // A nested render whose span was dropped leaves active_span() on its ancestor,
-            // which would otherwise take the inner template.
+            // A nested render whose span was dropped leaves active_span() on an ancestor.
             if ($renderSpan && $renderSpan === active_span()) {
                 $renderSpan->meta['drupal.template.file'] = $file;
             }
@@ -246,8 +244,7 @@ class DrupalIntegration extends Integration
             'Drupal\Core\Theme\ThemeEngineInterface::renderTemplate',
             static function (HookData $hook) use ($tagTemplateFile) {
                 $file = $hook->args[0];
-                // Core passes the path without its extension here; re-append it so the tag keeps
-                // the value it had before 11.3.
+                // Core passes the path without its extension here; re-append it to keep the pre-11.3 value.
                 if (isset($hook->instance) && $hook->instance instanceof \Drupal\Core\Template\TwigThemeEngine) {
                     $file .= '.html.twig';
                 }
@@ -352,25 +349,21 @@ class DrupalIntegration extends Integration
             ]
         );
 
+        // Drupal <= 11.2 renders through the {engine}_render_template() global; unlike the tracing
+        // posthook, this end hook also runs for a dropped or span-limited render.
+
         // Must follow the trace_method: begin hooks run in install order, so active_span() is our own span.
-        // Drupal <= 11.2 renders through the {engine}_render_template() global; the per-render
-        // hook id travels in $hook->data, which is per-invocation and therefore nests without
-        // bookkeeping, and this end hook still runs when the tracing posthook is skipped,
-        // i.e. for a dropped or span-limited render.
         install_hook(
             'Drupal\Core\Theme\ThemeManager::render',
             function (HookData $hook) use (&$renderSpan, $tagTemplateFile) {
                 $enclosing = $renderSpan;
-                // Past the span limit this frame gets no span of its own and active_span()
-                // would be its parent's, so claim nothing.
+                // Past the span limit this frame gets no span of its own, so claim nothing.
                 $span = \dd_trace_tracer_is_limited() ? null : active_span();
                 $renderSpan = ($span && $span->name === 'drupal.theme.render') ? $span : null;
                 $hook->data = [$enclosing, null];
 
                 /** @var \Drupal\Core\Theme\ThemeManager $this */
                 $themeEngine = $this->getActiveTheme()->getEngine();
-                // The theme engine may use a different extension and a different renderer
-                // Moreover, Drupal can use different themes in the same application
                 if (empty($themeEngine) || !\function_exists("{$themeEngine}_render_template")) {
                     return;
                 }
@@ -390,8 +383,7 @@ class DrupalIntegration extends Integration
             },
             static function (HookData $hook) use (&$renderSpan) {
                 $renderSpan = $hook->data[0];
-                // render() can return without ever calling the render function (unknown theme
-                // hook, exception), so the callback's self-removal cannot be the only one.
+                // render() can return without calling the render function, so self-removal is not enough.
                 if (!empty($hook->data[1])) {
                     remove_hook($hook->data[1]);
                 }

--- a/src/DDTrace/Integrations/Drupal/DrupalIntegration.php
+++ b/src/DDTrace/Integrations/Drupal/DrupalIntegration.php
@@ -228,44 +228,74 @@ class DrupalIntegration extends Integration
             }
         );
 
+        // install_hook's callbacks are not gated by the span limit while trace_method is, so
+        // past the limit a nested render gets no span and active_span() is the outer render's:
+        // tagging it would attribute the wrong template.
+        $tagTemplateFile = static function ($file) {
+            $span = active_span();
+            if (!$span || $span->name !== 'drupal.theme.render' || \dd_trace_tracer_is_limited()) {
+                return;
+            }
+            $span->meta['drupal.template.file'] = $file;
+        };
+
         // Drupal 11.3+ renders through a theme_engine service instead of {engine}_render_template().
         install_hook(
             'Drupal\Core\Theme\ThemeEngineInterface::renderTemplate',
-            static function (HookData $hook) {
-                $span = active_span();
-                // Past the span limit a nested render gets no span, so active_span() would be
-                // the outer render's and tagging it would attribute the wrong template.
-                if (!$span || $span->name !== 'drupal.theme.render' || \dd_trace_tracer_is_limited()) {
-                    return;
-                }
-
+            static function (HookData $hook) use ($tagTemplateFile) {
                 $file = $hook->args[0];
                 // Core passes the path without its extension here; re-append it so the tag keeps
                 // the value it had before 11.3.
                 if (isset($hook->instance) && $hook->instance instanceof \Drupal\Core\Template\TwigThemeEngine) {
                     $file .= '.html.twig';
                 }
-                $span->meta['drupal.template.file'] = $file;
+                $tagTemplateFile($file);
             }
         );
 
-        // Legacy per-render hook ids, keyed by render span: the posthook is skipped for a
-        // dropped span, which would desync a positional stack.
-        $renderHookIds = [];
+        // Drupal <= 11.2 renders through the {engine}_render_template() global. The per-render
+        // hook id travels in $hook->data, which is per-invocation and therefore nests without
+        // bookkeeping; and this end hook still runs when the tracing posthook is skipped,
+        // i.e. for a dropped or span-limited render.
+        install_hook(
+            'Drupal\Core\Theme\ThemeManager::render',
+            function (HookData $hook) use ($tagTemplateFile) {
+                /** @var \Drupal\Core\Theme\ThemeManager $this */
+                $themeEngine = $this->getActiveTheme()->getEngine();
+                // The theme engine may use a different extension and a different renderer
+                // Moreover, Drupal can use different themes in the same application
+                if (empty($themeEngine) || !\function_exists("{$themeEngine}_render_template")) {
+                    return;
+                }
+                // Take the legacy branch only when no engine service resolves, as core does.
+                if (\property_exists($this, 'themeEngines') && $this->themeEngines->has($themeEngine)) {
+                    return;
+                }
+
+                $hook->data = install_hook(
+                    "{$themeEngine}_render_template",
+                    static function (HookData $renderHook) use ($tagTemplateFile) {
+                        $tagTemplateFile($renderHook->args[0]);
+                        // Self-removal keeps outer/inner render pairing correct.
+                        remove_hook($renderHook->id);
+                    }
+                );
+            },
+            static function (HookData $hook) {
+                // render() can return without ever calling the render function (unknown theme
+                // hook, exception), so the callback's self-removal cannot be the only one.
+                if (!empty($hook->data)) {
+                    remove_hook($hook->data);
+                }
+            }
+        );
 
         trace_method(
             'Drupal\Core\Theme\ThemeManager',
             'render',
             [
                 'recurse' => true,
-                'prehook' => function (SpanData $span, $args) use (&$renderHookIds) {
-                    // A dropped span skips the posthook, so its hook may still be installed.
-                    $spanKey = \spl_object_hash($span);
-                    if (!empty($renderHookIds[$spanKey])) {
-                        remove_hook($renderHookIds[$spanKey]);
-                    }
-                    $renderHookIds[$spanKey] = 0;
-
+                'prehook' => function (SpanData $span, $args) {
                     $span->name = 'drupal.theme.render';
                     $span->service = \ddtrace_config_app_name('drupal');
                     Integration::tagFrameworkServiceSource($span, 'drupal');
@@ -283,32 +313,9 @@ class DrupalIntegration extends Integration
 
                     if (!empty($themeEngine)) {
                         $span->meta['drupal.render.engine'] = $themeEngine;
-                        // The theme engine may use a different extension and a different renderer
-                        // Moreover, Drupal can use different themes in the same application
-                        // Take the legacy branch only when no engine service resolves, as core does.
-                        $hasEngineService = \property_exists($this, 'themeEngines')
-                            && $this->themeEngines->has($themeEngine);
-                        if (!$hasEngineService && \function_exists("{$themeEngine}_render_template")) {
-                            $renderHookIds[$spanKey] = install_hook(
-                                "{$themeEngine}_render_template",
-                                static function (HookData $hook) use ($span) {
-                                    $span->meta['drupal.template.file'] = $hook->args[0];
-                                    // Self-removal keeps outer/inner render pairing correct.
-                                    remove_hook($hook->id);
-                                }
-                            );
-                        }
                     }
                 },
-                'posthook' => function (SpanData $span, $args) use (&$renderHookIds) {
-                    // render() can return without ever calling the render function (unknown theme
-                    // hook, exception), so the callback's self-removal cannot be the only one.
-                    $spanKey = \spl_object_hash($span);
-                    if (!empty($renderHookIds[$spanKey])) {
-                        remove_hook($renderHookIds[$spanKey]);
-                    }
-                    unset($renderHookIds[$spanKey]);
-
+                'posthook' => function (SpanData $span, $args) {
                     /** @var null|\Drupal\Core\Theme\Registry $themeRegistry */
                     $themeRegistry = ObjectKVStore::get($this, 'theme_registry');
                     if ($themeRegistry) {

--- a/src/DDTrace/Integrations/Drupal/DrupalIntegration.php
+++ b/src/DDTrace/Integrations/Drupal/DrupalIntegration.php
@@ -228,15 +228,17 @@ class DrupalIntegration extends Integration
             }
         );
 
-        // install_hook's callbacks are not gated by the span limit while trace_method is, so
-        // past the limit a nested render gets no span and active_span() is the outer render's:
-        // tagging it would attribute the wrong template.
-        $tagTemplateFile = static function ($file) {
-            $span = active_span();
-            if (!$span || $span->name !== 'drupal.theme.render' || \dd_trace_tracer_is_limited()) {
-                return;
+        // The span of the ThemeManager::render frame currently executing, or null when that
+        // frame has none of its own. An ancestor render span carries the same name under
+        // 'recurse' => true, so the tag target can only be matched by identity.
+        $renderSpan = null;
+
+        $tagTemplateFile = static function ($file) use (&$renderSpan) {
+            // A nested render whose span was dropped leaves active_span() on its ancestor,
+            // which would otherwise take the inner template.
+            if ($renderSpan && $renderSpan === active_span()) {
+                $renderSpan->meta['drupal.template.file'] = $file;
             }
-            $span->meta['drupal.template.file'] = $file;
         };
 
         // Drupal 11.3+ renders through a theme_engine service instead of {engine}_render_template().
@@ -250,43 +252,6 @@ class DrupalIntegration extends Integration
                     $file .= '.html.twig';
                 }
                 $tagTemplateFile($file);
-            }
-        );
-
-        // Drupal <= 11.2 renders through the {engine}_render_template() global. The per-render
-        // hook id travels in $hook->data, which is per-invocation and therefore nests without
-        // bookkeeping; and this end hook still runs when the tracing posthook is skipped,
-        // i.e. for a dropped or span-limited render.
-        install_hook(
-            'Drupal\Core\Theme\ThemeManager::render',
-            function (HookData $hook) use ($tagTemplateFile) {
-                /** @var \Drupal\Core\Theme\ThemeManager $this */
-                $themeEngine = $this->getActiveTheme()->getEngine();
-                // The theme engine may use a different extension and a different renderer
-                // Moreover, Drupal can use different themes in the same application
-                if (empty($themeEngine) || !\function_exists("{$themeEngine}_render_template")) {
-                    return;
-                }
-                // Take the legacy branch only when no engine service resolves, as core does.
-                if (\property_exists($this, 'themeEngines') && $this->themeEngines->has($themeEngine)) {
-                    return;
-                }
-
-                $hook->data = install_hook(
-                    "{$themeEngine}_render_template",
-                    static function (HookData $renderHook) use ($tagTemplateFile) {
-                        $tagTemplateFile($renderHook->args[0]);
-                        // Self-removal keeps outer/inner render pairing correct.
-                        remove_hook($renderHook->id);
-                    }
-                );
-            },
-            static function (HookData $hook) {
-                // render() can return without ever calling the render function (unknown theme
-                // hook, exception), so the callback's self-removal cannot be the only one.
-                if (!empty($hook->data)) {
-                    remove_hook($hook->data);
-                }
             }
         );
 
@@ -385,6 +350,52 @@ class DrupalIntegration extends Integration
                     }
                 }
             ]
+        );
+
+        // Must follow the trace_method: begin hooks run in install order, so active_span() is our own span.
+        // Drupal <= 11.2 renders through the {engine}_render_template() global; the per-render
+        // hook id travels in $hook->data, which is per-invocation and therefore nests without
+        // bookkeeping, and this end hook still runs when the tracing posthook is skipped,
+        // i.e. for a dropped or span-limited render.
+        install_hook(
+            'Drupal\Core\Theme\ThemeManager::render',
+            function (HookData $hook) use (&$renderSpan, $tagTemplateFile) {
+                $enclosing = $renderSpan;
+                // Past the span limit this frame gets no span of its own and active_span()
+                // would be its parent's, so claim nothing.
+                $span = \dd_trace_tracer_is_limited() ? null : active_span();
+                $renderSpan = ($span && $span->name === 'drupal.theme.render') ? $span : null;
+                $hook->data = [$enclosing, null];
+
+                /** @var \Drupal\Core\Theme\ThemeManager $this */
+                $themeEngine = $this->getActiveTheme()->getEngine();
+                // The theme engine may use a different extension and a different renderer
+                // Moreover, Drupal can use different themes in the same application
+                if (empty($themeEngine) || !\function_exists("{$themeEngine}_render_template")) {
+                    return;
+                }
+                // Take the legacy branch only when no engine service resolves, as core does.
+                if (\property_exists($this, 'themeEngines') && $this->themeEngines->has($themeEngine)) {
+                    return;
+                }
+
+                $hook->data = [$enclosing, install_hook(
+                    "{$themeEngine}_render_template",
+                    static function (HookData $renderHook) use ($tagTemplateFile) {
+                        $tagTemplateFile($renderHook->args[0]);
+                        // Self-removal keeps outer/inner render pairing correct.
+                        remove_hook($renderHook->id);
+                    }
+                )];
+            },
+            static function (HookData $hook) use (&$renderSpan) {
+                $renderSpan = $hook->data[0];
+                // render() can return without ever calling the render function (unknown theme
+                // hook, exception), so the callback's self-removal cannot be the only one.
+                if (!empty($hook->data[1])) {
+                    remove_hook($hook->data[1]);
+                }
+            }
         );
 
         hook_method(

--- a/src/DDTrace/Integrations/Drupal/DrupalIntegration.php
+++ b/src/DDTrace/Integrations/Drupal/DrupalIntegration.php
@@ -231,12 +231,20 @@ class DrupalIntegration extends Integration
         // The span of the executing ThemeManager::render frame. The render function is hooked in its
         // own frame, so it cannot reach that span on its own.
         $renderSpan = null;
+        $legacyRenderHooks = [];
 
         $tagTemplateFile = static function ($file) use (&$renderSpan) {
             if ($renderSpan) {
                 $renderSpan->meta['drupal.template.file'] = $file;
             }
         };
+
+        $tagLegacyRender = static function (HookData $renderHook) use ($tagTemplateFile) {
+            $tagTemplateFile($renderHook->args[0]);
+        };
+        // Twig is both the default engine and core's fallback when {engine}_render_template() is
+        // missing, and the deprecated global does not delegate to the 11.3+ service.
+        $legacyRenderHooks['twig'] = install_hook('twig_render_template', $tagLegacyRender);
 
         // Drupal 11.3+ renders through a theme_engine service instead of {engine}_render_template().
         install_hook(
@@ -253,11 +261,18 @@ class DrupalIntegration extends Integration
 
         install_hook(
             'Drupal\Core\Theme\ThemeManager::render',
-            function (HookData $hookData) use (&$renderSpan, $tagTemplateFile) {
+            function (HookData $hookData) use (&$renderSpan, &$legacyRenderHooks, $tagLegacyRender) {
+                // install_hook, unlike trace_method, still runs both callbacks past the span limit;
+                // clearing $renderSpan keeps this frame's template off the enclosing render's span.
+                if (\dd_trace_tracer_is_limited()) {
+                    $hookData->data = $renderSpan;
+                    $renderSpan = null;
+                    return;
+                }
+
                 $span = $hookData->span();
-                $enclosing = $renderSpan;
+                $hookData->data = $renderSpan;
                 $renderSpan = $span;
-                $hookData->data = [$enclosing, null];
 
                 $span->name = 'drupal.theme.render';
                 $span->service = \ddtrace_config_app_name('drupal');
@@ -279,29 +294,20 @@ class DrupalIntegration extends Integration
                 }
                 $span->meta['drupal.render.engine'] = $themeEngine;
 
-                // Drupal <= 11.2 renders through the {engine}_render_template() global.
-                if (!\function_exists("{$themeEngine}_render_template")) {
-                    return;
+                // Drupal <= 11.2 renders through the {engine}_render_template() global. One hook per
+                // engine name for the whole request; $renderSpan does the attribution.
+                if (!isset($legacyRenderHooks[$themeEngine])) {
+                    $legacyRenderHooks[$themeEngine] =
+                        install_hook("{$themeEngine}_render_template", $tagLegacyRender);
                 }
-                // Take that branch only when no engine service resolves, as core does.
-                if (\property_exists($this, 'themeEngines') && $this->themeEngines->has($themeEngine)) {
-                    return;
-                }
-
-                $hookData->data = [$enclosing, install_hook(
-                    "{$themeEngine}_render_template",
-                    static function (HookData $renderHook) use ($tagTemplateFile) {
-                        $tagTemplateFile($renderHook->args[0]);
-                        // Self-removal keeps outer/inner render pairing correct.
-                        remove_hook($renderHook->id);
-                    }
-                )];
             },
             function (HookData $hookData) use (&$renderSpan) {
-                $renderSpan = $hookData->data[0];
-                // render() can return without calling the render function, so self-removal is not enough.
-                if (!empty($hookData->data[1])) {
-                    remove_hook($hookData->data[1]);
+                // $renderSpan is this frame's span, or null when the begin callback bailed out
+                // past the span limit. $hookData->data holds the enclosing render's span.
+                $span = $renderSpan;
+                $renderSpan = $hookData->data;
+                if (!$span) {
+                    return;
                 }
 
                 /** @var null|\Drupal\Core\Theme\Registry $themeRegistry */
@@ -310,7 +316,6 @@ class DrupalIntegration extends Integration
                     return;
                 }
 
-                $span = $hookData->span();
                 $runtimeThemeRegistry = $themeRegistry->getRuntime();
                 $hook = $hookData->args[0];
 

--- a/src/DDTrace/Integrations/Drupal/DrupalIntegration.php
+++ b/src/DDTrace/Integrations/Drupal/DrupalIntegration.php
@@ -228,12 +228,41 @@ class DrupalIntegration extends Integration
             }
         );
 
+        // Drupal 11.3+ renders through a theme_engine service instead of {engine}_render_template().
+        install_hook(
+            'Drupal\Core\Theme\ThemeEngineInterface::renderTemplate',
+            static function (HookData $hook) {
+                $span = active_span();
+                // Past the span limit a nested render gets no span, so active_span() would be
+                // the outer render's and tagging it would attribute the wrong template.
+                if (!$span || $span->name !== 'drupal.theme.render' || \dd_trace_tracer_is_limited()) {
+                    return;
+                }
+
+                $file = $hook->args[0];
+                // Core passes the path without its extension here; re-append it so the tag keeps
+                // the value it had before 11.3.
+                if (isset($hook->instance) && $hook->instance instanceof \Drupal\Core\Template\TwigThemeEngine) {
+                    $file .= '.html.twig';
+                }
+                $span->meta['drupal.template.file'] = $file;
+            }
+        );
+
+        // Legacy per-render hook ids, keyed by render span: the posthook is skipped for a
+        // dropped span, which would desync a positional stack.
+        $renderHookIds = [];
+
         trace_method(
             'Drupal\Core\Theme\ThemeManager',
             'render',
             [
                 'recurse' => true,
-                'prehook' => function (SpanData $span, $args) {
+                'prehook' => function (SpanData $span, $args) use (&$renderHookIds) {
+                    // Reset first, so a stale entry left by a dropped span can never be reused.
+                    $spanKey = \spl_object_hash($span);
+                    $renderHookIds[$spanKey] = 0;
+
                     $span->name = 'drupal.theme.render';
                     $span->service = \ddtrace_config_app_name('drupal');
                     Integration::tagFrameworkServiceSource($span, 'drupal');
@@ -251,23 +280,32 @@ class DrupalIntegration extends Integration
 
                     if (!empty($themeEngine)) {
                         $span->meta['drupal.render.engine'] = $themeEngine;
-                        if (function_exists("{$themeEngine}_render_template")) {
-                            $renderFunction = "{$themeEngine}_render_template";
-
-                            // The theme engine may use a different extension and a different renderer
-                            // Moreover, Drupal can use different themes in the same application
-                            // The render function will always be called during the ThemeManager::render call
-                            install_hook(
-                                $renderFunction,
+                        // The theme engine may use a different extension and a different renderer
+                        // Moreover, Drupal can use different themes in the same application
+                        // Take the legacy branch only when no engine service resolves, as core does.
+                        $hasEngineService = \property_exists($this, 'themeEngines')
+                            && $this->themeEngines->has($themeEngine);
+                        if (!$hasEngineService && \function_exists("{$themeEngine}_render_template")) {
+                            $renderHookIds[$spanKey] = install_hook(
+                                "{$themeEngine}_render_template",
                                 static function (HookData $hook) use ($span) {
                                     $span->meta['drupal.template.file'] = $hook->args[0];
+                                    // Self-removal keeps outer/inner render pairing correct.
                                     remove_hook($hook->id);
                                 }
                             );
                         }
                     }
                 },
-                'posthook' => function (SpanData $span, $args) {
+                'posthook' => function (SpanData $span, $args) use (&$renderHookIds) {
+                    // render() can return without ever calling the render function (unknown theme
+                    // hook, exception), so the callback's self-removal cannot be the only one.
+                    $spanKey = \spl_object_hash($span);
+                    if (!empty($renderHookIds[$spanKey])) {
+                        remove_hook($renderHookIds[$spanKey]);
+                    }
+                    unset($renderHookIds[$spanKey]);
+
                     /** @var null|\Drupal\Core\Theme\Registry $themeRegistry */
                     $themeRegistry = ObjectKVStore::get($this, 'theme_registry');
                     if ($themeRegistry) {

--- a/src/DDTrace/Integrations/Drupal/DrupalIntegration.php
+++ b/src/DDTrace/Integrations/Drupal/DrupalIntegration.php
@@ -228,13 +228,12 @@ class DrupalIntegration extends Integration
             }
         );
 
-        // The span of the executing ThemeManager::render frame, or null when it has none of its own.
-        // Ancestors share its name under 'recurse' => true, so it can only be matched by identity.
+        // The span of the executing ThemeManager::render frame. The render function is hooked in its
+        // own frame, so it cannot reach that span on its own.
         $renderSpan = null;
 
         $tagTemplateFile = static function ($file) use (&$renderSpan) {
-            // A nested render whose span was dropped leaves active_span() on an ancestor.
-            if ($renderSpan && $renderSpan === active_span()) {
+            if ($renderSpan) {
                 $renderSpan->meta['drupal.template.file'] = $file;
             }
         };
@@ -252,127 +251,44 @@ class DrupalIntegration extends Integration
             }
         );
 
-        trace_method(
-            'Drupal\Core\Theme\ThemeManager',
-            'render',
-            [
-                'recurse' => true,
-                'prehook' => function (SpanData $span, $args) {
-                    $span->name = 'drupal.theme.render';
-                    $span->service = \ddtrace_config_app_name('drupal');
-                    Integration::tagFrameworkServiceSource($span, 'drupal');
-                    $span->type = Type::WEB_SERVLET;
-                    $span->meta[Tag::COMPONENT] = DrupalIntegration::NAME;
-
-                    /** @var \Drupal\Core\Theme\ThemeManager $this */
-                    $activeTheme = $this->getActiveTheme();
-                    $themeName = $activeTheme->getName();
-                    $themeEngine = $activeTheme->getEngine();
-
-                    if (!empty($themeName)) {
-                        $span->meta['drupal.render.theme'] = $themeName;
-                    }
-
-                    if (!empty($themeEngine)) {
-                        $span->meta['drupal.render.engine'] = $themeEngine;
-                    }
-                },
-                'posthook' => function (SpanData $span, $args) {
-                    /** @var null|\Drupal\Core\Theme\Registry $themeRegistry */
-                    $themeRegistry = ObjectKVStore::get($this, 'theme_registry');
-                    if ($themeRegistry) {
-                        $runtimeThemeRegistry = $themeRegistry->getRuntime();
-                        $hook = $args[0];
-
-                        if (is_array($hook)) {
-                            foreach ($hook as $candidate) {
-                                if ($runtimeThemeRegistry->has($candidate)) {
-                                    break;
-                                }
-                            }
-                            $hook = $candidate;
-                        }
-
-                        $originalHook = $hook;
-
-                        if (!$runtimeThemeRegistry->has($hook)) {
-                            // Iteratively strip everything after the last '__' delimiter, until an
-                            // implementation is found
-                            while ($pos = strrpos($hook, '__')) {
-                                $hook = substr($hook, 0, $pos);
-                                if ($runtimeThemeRegistry->has($hook)) {
-                                    break;
-                                }
-                            }
-                        }
-
-                        if ($runtimeThemeRegistry->has($hook)) {
-                            $span->meta['drupal.render.hook'] = $span->resource = $hook;
-                            $info = $runtimeThemeRegistry->get($hook);
-
-                            if (isset($info['base hook'])) {
-                                $span->meta['drupal.render.base_hook'] = $info['base hook'];
-                            }
-
-                            if (isset($info['type'])) {
-                                $span->meta['drupal.render.type'] = $info['type'];
-                            }
-
-                            if (isset($info['render element'])) {
-                                $span->meta['drupal.render.element'] = $info['render element'];
-                            }
-
-                            if (isset($info['template'])) {
-                                $span->meta['drupal.template.template'] = $info['template'];
-                            }
-
-                            if (isset($info['function'])) {
-                                $span->meta['drupal.render.theme_function'] = $info['function'];
-                            }
-
-                            if (isset($info['path'])) {
-                                // The template can be from a different theme than the active one
-                                // Format: '.../themes/<theme_name>/...'
-                                $path = $info['path'];
-                                $themePathStart = strpos($path, '/themes/');
-                                if ($themePathStart !== false) {
-                                    $themePath = substr($path,  $themePathStart + 8); // Between '/themes/', 8 = strlen('/themes/')
-                                    $themePath = substr($themePath, 0, strpos($themePath, '/')); // Until the next '/'
-                                    $span->meta['drupal.template.theme'] = $themePath;
-                                }
-                            }
-                        } else {
-                            $span->meta['drupal.render.hook'] = $span->resource = $originalHook;
-                        }
-                    }
-                }
-            ]
-        );
-
-        // Drupal <= 11.2 renders through the {engine}_render_template() global; unlike the tracing
-        // posthook, this end hook also runs for a dropped or span-limited render.
-
-        // Must follow the trace_method: begin hooks run in install order, so active_span() is our own span.
         install_hook(
             'Drupal\Core\Theme\ThemeManager::render',
-            function (HookData $hook) use (&$renderSpan, $tagTemplateFile) {
+            function (HookData $hookData) use (&$renderSpan, $tagTemplateFile) {
+                $span = $hookData->span();
                 $enclosing = $renderSpan;
-                // Past the span limit this frame gets no span of its own, so claim nothing.
-                $span = \dd_trace_tracer_is_limited() ? null : active_span();
-                $renderSpan = ($span && $span->name === 'drupal.theme.render') ? $span : null;
-                $hook->data = [$enclosing, null];
+                $renderSpan = $span;
+                $hookData->data = [$enclosing, null];
+
+                $span->name = 'drupal.theme.render';
+                $span->service = \ddtrace_config_app_name('drupal');
+                Integration::tagFrameworkServiceSource($span, 'drupal');
+                $span->type = Type::WEB_SERVLET;
+                $span->meta[Tag::COMPONENT] = DrupalIntegration::NAME;
 
                 /** @var \Drupal\Core\Theme\ThemeManager $this */
-                $themeEngine = $this->getActiveTheme()->getEngine();
-                if (empty($themeEngine) || !\function_exists("{$themeEngine}_render_template")) {
+                $activeTheme = $this->getActiveTheme();
+                $themeName = $activeTheme->getName();
+                $themeEngine = $activeTheme->getEngine();
+
+                if (!empty($themeName)) {
+                    $span->meta['drupal.render.theme'] = $themeName;
+                }
+
+                if (empty($themeEngine)) {
                     return;
                 }
-                // Take the legacy branch only when no engine service resolves, as core does.
+                $span->meta['drupal.render.engine'] = $themeEngine;
+
+                // Drupal <= 11.2 renders through the {engine}_render_template() global.
+                if (!\function_exists("{$themeEngine}_render_template")) {
+                    return;
+                }
+                // Take that branch only when no engine service resolves, as core does.
                 if (\property_exists($this, 'themeEngines') && $this->themeEngines->has($themeEngine)) {
                     return;
                 }
 
-                $hook->data = [$enclosing, install_hook(
+                $hookData->data = [$enclosing, install_hook(
                     "{$themeEngine}_render_template",
                     static function (HookData $renderHook) use ($tagTemplateFile) {
                         $tagTemplateFile($renderHook->args[0]);
@@ -381,11 +297,83 @@ class DrupalIntegration extends Integration
                     }
                 )];
             },
-            static function (HookData $hook) use (&$renderSpan) {
-                $renderSpan = $hook->data[0];
+            function (HookData $hookData) use (&$renderSpan) {
+                $renderSpan = $hookData->data[0];
                 // render() can return without calling the render function, so self-removal is not enough.
-                if (!empty($hook->data[1])) {
-                    remove_hook($hook->data[1]);
+                if (!empty($hookData->data[1])) {
+                    remove_hook($hookData->data[1]);
+                }
+
+                /** @var null|\Drupal\Core\Theme\Registry $themeRegistry */
+                $themeRegistry = ObjectKVStore::get($this, 'theme_registry');
+                if (!$themeRegistry) {
+                    return;
+                }
+
+                $span = $hookData->span();
+                $runtimeThemeRegistry = $themeRegistry->getRuntime();
+                $hook = $hookData->args[0];
+
+                if (is_array($hook)) {
+                    foreach ($hook as $candidate) {
+                        if ($runtimeThemeRegistry->has($candidate)) {
+                            break;
+                        }
+                    }
+                    $hook = $candidate;
+                }
+
+                $originalHook = $hook;
+
+                if (!$runtimeThemeRegistry->has($hook)) {
+                    // Iteratively strip everything after the last '__' delimiter, until an
+                    // implementation is found
+                    while ($pos = strrpos($hook, '__')) {
+                        $hook = substr($hook, 0, $pos);
+                        if ($runtimeThemeRegistry->has($hook)) {
+                            break;
+                        }
+                    }
+                }
+
+                if (!$runtimeThemeRegistry->has($hook)) {
+                    $span->meta['drupal.render.hook'] = $span->resource = $originalHook;
+                    return;
+                }
+
+                $span->meta['drupal.render.hook'] = $span->resource = $hook;
+                $info = $runtimeThemeRegistry->get($hook);
+
+                if (isset($info['base hook'])) {
+                    $span->meta['drupal.render.base_hook'] = $info['base hook'];
+                }
+
+                if (isset($info['type'])) {
+                    $span->meta['drupal.render.type'] = $info['type'];
+                }
+
+                if (isset($info['render element'])) {
+                    $span->meta['drupal.render.element'] = $info['render element'];
+                }
+
+                if (isset($info['template'])) {
+                    $span->meta['drupal.template.template'] = $info['template'];
+                }
+
+                if (isset($info['function'])) {
+                    $span->meta['drupal.render.theme_function'] = $info['function'];
+                }
+
+                if (isset($info['path'])) {
+                    // The template can be from a different theme than the active one
+                    // Format: '.../themes/<theme_name>/...'
+                    $path = $info['path'];
+                    $themePathStart = strpos($path, '/themes/');
+                    if ($themePathStart !== false) {
+                        $themePath = substr($path,  $themePathStart + 8); // Between '/themes/', 8 = strlen('/themes/')
+                        $themePath = substr($themePath, 0, strpos($themePath, '/')); // Until the next '/'
+                        $span->meta['drupal.template.theme'] = $themePath;
+                    }
                 }
             }
         );

--- a/tests/ext/integrations/drupal/drupal_integration.inc
+++ b/tests/ext/integrations/drupal/drupal_integration.inc
@@ -4,8 +4,7 @@ require_once __DIR__ . '/drupal_root.inc';
 
 $root = dd_drupal_tracer_root();
 
-// Declared on demand, never eagerly: Drupal autoloads the engine mid-request, so this is
-// what exercises hook re-registration on class declaration rather than early binding.
+// Declared on demand: only a mid-request class declaration exercises hook re-registration.
 spl_autoload_register(function ($class) {
     if ($class === 'Drupal\Core\Template\TwigThemeEngine') {
         require __DIR__ . '/drupal_twig_engine.inc';
@@ -30,12 +29,7 @@ spl_autoload_register(function ($class) use ($root) {
     echo "autoload miss: $class\n";
 });
 
-/**
- * @param array $spans          Serialized closed spans.
- * @param array $probeTargets   Hook targets whose remaining budget should be reported. Each
- *                              install site needs its own entry: the budget is per target, so
- *                              probing only the legacy global would miss a leak on the method.
- */
+// The hook budget is per target, so $probeTargets needs an entry per install site.
 function dd_drupal_render_report(array $spans, array $probeTargets)
 {
     $tags = [];

--- a/tests/ext/integrations/drupal/drupal_integration.inc
+++ b/tests/ext/integrations/drupal/drupal_integration.inc
@@ -40,7 +40,7 @@ function dd_drupal_render_report(array $spans, array $probeTargets)
         }
         $file = isset($span['meta']['drupal.template.file']) ? $span['meta']['drupal.template.file'] : '<missing>';
         $tags[$file] = (isset($tags[$file]) ? $tags[$file] : 0) + 1;
-        // Also reported so that a prehook exception swallowed by the sandbox cannot pass silently.
+        // Also reported so that a begin hook exception swallowed by the sandbox cannot pass silently.
         $engine = isset($span['meta']['drupal.render.engine']) ? $span['meta']['drupal.render.engine'] : '<missing>';
         $engines[$engine] = (isset($engines[$engine]) ? $engines[$engine] : 0) + 1;
     }

--- a/tests/ext/integrations/drupal/drupal_integration.inc
+++ b/tests/ext/integrations/drupal/drupal_integration.inc
@@ -1,0 +1,71 @@
+<?php
+
+require_once __DIR__ . '/drupal_root.inc';
+
+$root = dd_drupal_tracer_root();
+
+// Declared on demand, never eagerly: Drupal autoloads the engine mid-request, so this is
+// what exercises hook re-registration on class declaration rather than early binding.
+spl_autoload_register(function ($class) {
+    if ($class === 'Drupal\Core\Template\TwigThemeEngine') {
+        require __DIR__ . '/drupal_twig_engine.inc';
+    }
+});
+
+spl_autoload_register(function ($class) use ($root) {
+    if (strpos($class, 'DDTrace\\') !== 0) {
+        return;
+    }
+    $candidates = [
+        $root . '/src/' . str_replace('\\', '/', $class) . '.php',
+        // DDTrace\Tag, DDTrace\Type and friends live outside the PSR-4 tree.
+        $root . '/src/api/' . substr(strrchr($class, '\\'), 1) . '.php',
+    ];
+    foreach ($candidates as $file) {
+        if (is_file($file)) {
+            require $file;
+            return;
+        }
+    }
+    echo "autoload miss: $class\n";
+});
+
+/**
+ * @param array $spans          Serialized closed spans.
+ * @param array $probeTargets   Hook targets whose remaining budget should be reported. Each
+ *                              install site needs its own entry: the budget is per target, so
+ *                              probing only the legacy global would miss a leak on the method.
+ */
+function dd_drupal_render_report(array $spans, array $probeTargets)
+{
+    $tags = [];
+    $engines = [];
+    foreach ($spans as $span) {
+        if ($span['name'] !== 'drupal.theme.render') {
+            continue;
+        }
+        $file = isset($span['meta']['drupal.template.file']) ? $span['meta']['drupal.template.file'] : '<missing>';
+        $tags[$file] = (isset($tags[$file]) ? $tags[$file] : 0) + 1;
+        // Also reported so that a prehook exception swallowed by the sandbox cannot pass silently.
+        $engine = isset($span['meta']['drupal.render.engine']) ? $span['meta']['drupal.render.engine'] : '<missing>';
+        $engines[$engine] = (isset($engines[$engine]) ? $engines[$engine] : 0) + 1;
+    }
+    ksort($tags);
+    ksort($engines);
+    foreach ($engines as $engine => $count) {
+        echo "drupal.render.engine[$engine] = $count\n";
+    }
+    foreach ($tags as $file => $count) {
+        echo "drupal.template.file[$file] = $count\n";
+    }
+
+    // A leaked per-render hook shows up as an exhausted budget on its target.
+    foreach ($probeTargets as $target) {
+        $probe = DDTrace\install_hook($target, function () {
+        });
+        echo "hook budget left [$target]: " . ($probe ? "yes" : "no") . "\n";
+        if ($probe) {
+            DDTrace\remove_hook($probe);
+        }
+    }
+}

--- a/tests/ext/integrations/drupal/drupal_root.inc
+++ b/tests/ext/integrations/drupal/drupal_root.inc
@@ -1,0 +1,16 @@
+<?php
+
+// Locates the repository root so the tests can load the Drupal integration straight from
+// src/, without depending on datadog.trace.sources_path pointing at the working tree.
+function dd_drupal_tracer_root()
+{
+    $dir = __DIR__;
+    while (!is_file($dir . '/src/DDTrace/Integrations/Drupal/DrupalIntegration.php')) {
+        $parent = dirname($dir);
+        if ($parent === $dir) {
+            return false;
+        }
+        $dir = $parent;
+    }
+    return $dir;
+}

--- a/tests/ext/integrations/drupal/drupal_root.inc
+++ b/tests/ext/integrations/drupal/drupal_root.inc
@@ -1,7 +1,6 @@
 <?php
 
-// Locates the repository root so the tests can load the Drupal integration straight from
-// src/, without depending on datadog.trace.sources_path pointing at the working tree.
+// Load the integration straight from src/, without relying on datadog.trace.sources_path.
 function dd_drupal_tracer_root()
 {
     $dir = __DIR__;

--- a/tests/ext/integrations/drupal/drupal_twig_engine.inc
+++ b/tests/ext/integrations/drupal/drupal_twig_engine.inc
@@ -2,13 +2,8 @@
 
 namespace Drupal\Core\Template;
 
-/**
- * Autoloaded on demand so the interface hook has to resolve against a class declared
- * after DrupalIntegration::init() ran, as it does in a real Drupal request.
- *
- * Core appends the extension inside renderTemplate() and passes $template_file without
- * it (TwigThemeEngine::EXTENSION, ThemeManager sets $extension = '' on this path).
- */
+// Autoloaded on demand so the interface hook resolves against a class declared after init(),
+// as in a real request. Core passes $template_file without the extension; renderTemplate() appends it.
 class TwigThemeEngine implements \Drupal\Core\Theme\ThemeEngineInterface
 {
     const EXTENSION = '.html.twig';

--- a/tests/ext/integrations/drupal/drupal_twig_engine.inc
+++ b/tests/ext/integrations/drupal/drupal_twig_engine.inc
@@ -1,0 +1,29 @@
+<?php
+
+namespace Drupal\Core\Template;
+
+/**
+ * Autoloaded on demand so the interface hook has to resolve against a class declared
+ * after DrupalIntegration::init() ran, as it does in a real Drupal request.
+ *
+ * Core appends the extension inside renderTemplate() and passes $template_file without
+ * it (TwigThemeEngine::EXTENSION, ThemeManager sets $extension = '' on this path).
+ */
+class TwigThemeEngine implements \Drupal\Core\Theme\ThemeEngineInterface
+{
+    const EXTENSION = '.html.twig';
+
+    /** @var null|callable Invoked mid-render to model a template embedding another theme hook. */
+    public $nested;
+
+    public function renderTemplate(string $template_file, array $variables): string
+    {
+        $rendered = 'rendered ' . $template_file . self::EXTENSION;
+        if ($this->nested) {
+            $nested = $this->nested;
+            $this->nested = null;
+            $rendered .= $nested();
+        }
+        return $rendered;
+    }
+}

--- a/tests/ext/integrations/drupal/theme_engine_service.phpt
+++ b/tests/ext/integrations/drupal/theme_engine_service.phpt
@@ -1,0 +1,119 @@
+--TEST--
+Drupal 11.3+ renders through the theme engine service (APMS-20395)
+--SKIPIF--
+<?php
+require __DIR__ . '/drupal_root.inc';
+if (!dd_drupal_tracer_root()) {
+    die("skip tracer sources not found from " . __DIR__ . "\n");
+}
+?>
+--ENV--
+DD_TRACE_AUTO_FLUSH_ENABLED=0
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_CODE_ORIGIN_FOR_SPANS_ENABLED=0
+DD_TRACE_LOG_LEVEL=warn,startup=off
+--INI--
+datadog.trace.hook_limit=20
+--FILE--
+<?php
+
+namespace Drupal\Core\Theme
+{
+    interface ThemeEngineInterface
+    {
+        public function renderTemplate(string $template_file, array $variables): string;
+    }
+
+    class ActiveTheme
+    {
+        public function getName()
+        {
+            return 'claro';
+        }
+
+        public function getEngine()
+        {
+            return 'twig';
+        }
+    }
+
+    // Stands in for the ServiceCollectionInterface injected as ThemeManager::$themeEngines
+    // in Drupal 11.3+; has() must not instantiate the service.
+    class ThemeEngineCollection
+    {
+        private $engines;
+
+        public function __construct(array $engines)
+        {
+            $this->engines = $engines;
+        }
+
+        public function has($name)
+        {
+            return isset($this->engines[$name]);
+        }
+
+        public function get($name)
+        {
+            return $this->engines[$name];
+        }
+    }
+
+    class ThemeManager
+    {
+        // Protected upstream, so the prehook only reaches it when rebound to this scope.
+        protected $themeEngines;
+
+        public function __construct(ThemeEngineCollection $themeEngines)
+        {
+            $this->themeEngines = $themeEngines;
+        }
+
+        public function getActiveTheme()
+        {
+            return new ActiveTheme();
+        }
+
+        public function render($hook, array $variables = [])
+        {
+            $render_function = [$this->themeEngines->get('twig'), 'renderTemplate'];
+            return $render_function("core/themes/claro/templates/$hook", $variables);
+        }
+    }
+}
+
+namespace
+{
+    // twig.engine is still included on 11.3+, so the deprecated global exists but is dead.
+    function twig_render_template($template_file, array $variables)
+    {
+        return "legacy $template_file";
+    }
+
+    include __DIR__ . '/drupal_integration.inc';
+
+    DDTrace\Integrations\Drupal\DrupalIntegration::init();
+
+    // Only touched after init(), so the engine class is autoloaded mid-request.
+    var_dump(class_exists('Drupal\Core\Template\TwigThemeEngine', false));
+    $engines = new Drupal\Core\Theme\ThemeEngineCollection([
+        'twig' => new Drupal\Core\Template\TwigThemeEngine(),
+    ]);
+
+    $themeManager = new Drupal\Core\Theme\ThemeManager($engines);
+    for ($i = 0; $i < 30; ++$i) {
+        $themeManager->render('page');
+    }
+
+    dd_drupal_render_report(dd_trace_serialize_closed_spans(), [
+        'Drupal\Core\Template\TwigThemeEngine::renderTemplate',
+        'twig_render_template',
+    ]);
+}
+?>
+--EXPECT--
+bool(false)
+drupal.render.engine[twig] = 30
+drupal.template.file[core/themes/claro/templates/page.html.twig] = 30
+hook budget left [Drupal\Core\Template\TwigThemeEngine::renderTemplate]: yes
+hook budget left [twig_render_template]: yes

--- a/tests/ext/integrations/drupal/theme_engine_service.phpt
+++ b/tests/ext/integrations/drupal/theme_engine_service.phpt
@@ -37,8 +37,7 @@ namespace Drupal\Core\Theme
         }
     }
 
-    // Stands in for the ServiceCollectionInterface injected as ThemeManager::$themeEngines
-    // in Drupal 11.3+; has() must not instantiate the service.
+    // Stands in for ThemeManager::$themeEngines (Drupal 11.3+); has() must not instantiate.
     class ThemeEngineCollection
     {
         private $engines;

--- a/tests/ext/integrations/drupal/theme_engine_service_dropped_nested_span.phpt
+++ b/tests/ext/integrations/drupal/theme_engine_service_dropped_nested_span.phpt
@@ -1,0 +1,128 @@
+--TEST--
+Drupal render span is not tagged with a dropped nested render's template, engine service (APMS-20395)
+--SKIPIF--
+<?php
+require __DIR__ . '/drupal_root.inc';
+if (!dd_drupal_tracer_root()) {
+    die("skip tracer sources not found from " . __DIR__ . "\n");
+}
+?>
+--ENV--
+DD_TRACE_AUTO_FLUSH_ENABLED=0
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_CODE_ORIGIN_FOR_SPANS_ENABLED=0
+DD_TRACE_LOG_LEVEL=warn,startup=off
+--INI--
+datadog.trace.hook_limit=20
+--FILE--
+<?php
+
+namespace Drupal\Core\Theme
+{
+    interface ThemeEngineInterface
+    {
+        public function renderTemplate(string $template_file, array $variables): string;
+    }
+
+    class ActiveTheme
+    {
+        public function getName()
+        {
+            return 'claro';
+        }
+
+        public function getEngine()
+        {
+            return 'twig';
+        }
+    }
+
+    class ThemeEngineCollection
+    {
+        private $engines;
+
+        public function __construct(array $engines)
+        {
+            $this->engines = $engines;
+        }
+
+        public function has($name)
+        {
+            return isset($this->engines[$name]);
+        }
+
+        public function get($name)
+        {
+            return $this->engines[$name];
+        }
+    }
+
+    class ThemeManager
+    {
+        protected $themeEngines;
+
+        public function __construct(ThemeEngineCollection $themeEngines)
+        {
+            $this->themeEngines = $themeEngines;
+        }
+
+        public function getActiveTheme()
+        {
+            return new ActiveTheme();
+        }
+
+        public function render($hook, array $variables = [])
+        {
+            if ($hook === 'block') {
+                // Dropped after the tracing prehook ran, so the tracer is not limited;
+                // active_span() now points at the OUTER render.
+                \DDTrace\try_drop_span(\DDTrace\active_span());
+            }
+
+            $render_function = [$this->themeEngines->get('twig'), 'renderTemplate'];
+            return $render_function("core/themes/claro/templates/$hook", $variables);
+        }
+    }
+}
+
+namespace
+{
+    include __DIR__ . '/drupal_integration.inc';
+
+    DDTrace\Integrations\Drupal\DrupalIntegration::init();
+
+    $engine = new Drupal\Core\Template\TwigThemeEngine();
+    $engines = new Drupal\Core\Theme\ThemeEngineCollection(['twig' => $engine]);
+    $themeManager = new Drupal\Core\Theme\ThemeManager($engines);
+
+    // An outer span is required: dropping a stack's root span closes it instead.
+    $root = DDTrace\start_span();
+    $root->name = 'test.root';
+
+    // Twig renders an embedded theme hook from inside the outer template.
+    $engine->nested = function () use ($themeManager) {
+        return $themeManager->render('block');
+    };
+
+    $themeManager->render('page');
+
+    DDTrace\close_span();
+
+    $spans = dd_trace_serialize_closed_spans();
+    foreach ($spans as $span) {
+        if ($span['name'] !== 'drupal.theme.render') {
+            continue;
+        }
+        echo "surviving render span template.file = ",
+            isset($span['meta']['drupal.template.file']) ? $span['meta']['drupal.template.file'] : '<none>',
+            "\n";
+    }
+    dd_drupal_render_report($spans, ['Drupal\Core\Template\TwigThemeEngine::renderTemplate']);
+}
+?>
+--EXPECTF--
+[ddtrace] [error] [%d] Cannot run tracing closure for render(); spans out of sync; This message is only displayed once. Specify DD_TRACE_ONCE_LOGS=0 to show all messages.
+surviving render span template.file = core/themes/claro/templates/page.html.twig
+drupal.render.engine[twig] = 1
+drupal.template.file[core/themes/claro/templates/page.html.twig] = 1
+hook budget left [Drupal\Core\Template\TwigThemeEngine::renderTemplate]: yes

--- a/tests/ext/integrations/drupal/theme_engine_service_dropped_nested_span.phpt
+++ b/tests/ext/integrations/drupal/theme_engine_service_dropped_nested_span.phpt
@@ -74,8 +74,7 @@ namespace Drupal\Core\Theme
         public function render($hook, array $variables = [])
         {
             if ($hook === 'block') {
-                // Dropped after the tracing prehook ran, so the tracer is not limited;
-                // active_span() now points at the OUTER render.
+                // Dropped after the prehook ran (so not span-limited); active_span() is the OUTER render.
                 \DDTrace\try_drop_span(\DDTrace\active_span());
             }
 

--- a/tests/ext/integrations/drupal/theme_engine_service_dropped_nested_span.phpt
+++ b/tests/ext/integrations/drupal/theme_engine_service_dropped_nested_span.phpt
@@ -74,7 +74,8 @@ namespace Drupal\Core\Theme
         public function render($hook, array $variables = [])
         {
             if ($hook === 'block') {
-                // Dropped after the prehook ran (so not span-limited); active_span() is the OUTER render.
+                // Dropped after the begin hook ran, so the interface hook still fires, against a
+                // dropped span rather than the surviving outer one.
                 \DDTrace\try_drop_span(\DDTrace\active_span());
             }
 
@@ -119,8 +120,7 @@ namespace
     dd_drupal_render_report($spans, ['Drupal\Core\Template\TwigThemeEngine::renderTemplate']);
 }
 ?>
---EXPECTF--
-[ddtrace] [error] [%d] Cannot run tracing closure for render(); spans out of sync; This message is only displayed once. Specify DD_TRACE_ONCE_LOGS=0 to show all messages.
+--EXPECT--
 surviving render span template.file = core/themes/claro/templates/page.html.twig
 drupal.render.engine[twig] = 1
 drupal.template.file[core/themes/claro/templates/page.html.twig] = 1

--- a/tests/ext/integrations/drupal/theme_engine_service_preprocess.phpt
+++ b/tests/ext/integrations/drupal/theme_engine_service_preprocess.phpt
@@ -73,9 +73,8 @@ namespace Drupal\Core\Theme
 
         public function render($hook, array $variables = [])
         {
-            // A preprocess callback renders a sub-element before the outer template itself
-            // (ThemeManager.php:366 vs :428), so the child's renderTemplate() fires first.
-            // This is why the tag cannot be first-write-wins.
+            // A preprocess renders a sub-element before the outer template (ThemeManager.php:366
+            // vs :428), so the child's renderTemplate() fires first: the tag cannot be first-write-wins.
             if ($hook === 'page') {
                 $this->render('child');
             }

--- a/tests/ext/integrations/drupal/theme_engine_service_preprocess.phpt
+++ b/tests/ext/integrations/drupal/theme_engine_service_preprocess.phpt
@@ -1,0 +1,112 @@
+--TEST--
+Drupal render spans keep their own template when a sub-element renders first (APMS-20395)
+--SKIPIF--
+<?php
+require __DIR__ . '/drupal_root.inc';
+if (!dd_drupal_tracer_root()) {
+    die("skip tracer sources not found from " . __DIR__ . "\n");
+}
+?>
+--ENV--
+DD_TRACE_AUTO_FLUSH_ENABLED=0
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_CODE_ORIGIN_FOR_SPANS_ENABLED=0
+DD_TRACE_LOG_LEVEL=warn,startup=off
+--INI--
+datadog.trace.hook_limit=20
+--FILE--
+<?php
+
+namespace Drupal\Core\Theme
+{
+    interface ThemeEngineInterface
+    {
+        public function renderTemplate(string $template_file, array $variables): string;
+    }
+
+    class ActiveTheme
+    {
+        public function getName()
+        {
+            return 'claro';
+        }
+
+        public function getEngine()
+        {
+            return 'twig';
+        }
+    }
+
+    class ThemeEngineCollection
+    {
+        private $engines;
+
+        public function __construct(array $engines)
+        {
+            $this->engines = $engines;
+        }
+
+        public function has($name)
+        {
+            return isset($this->engines[$name]);
+        }
+
+        public function get($name)
+        {
+            return $this->engines[$name];
+        }
+    }
+
+    class ThemeManager
+    {
+        protected $themeEngines;
+
+        public function __construct(ThemeEngineCollection $themeEngines)
+        {
+            $this->themeEngines = $themeEngines;
+        }
+
+        public function getActiveTheme()
+        {
+            return new ActiveTheme();
+        }
+
+        public function render($hook, array $variables = [])
+        {
+            // A preprocess callback renders a sub-element before the outer template itself
+            // (ThemeManager.php:366 vs :428), so the child's renderTemplate() fires first.
+            // This is why the tag cannot be first-write-wins.
+            if ($hook === 'page') {
+                $this->render('child');
+            }
+            $render_function = [$this->themeEngines->get('twig'), 'renderTemplate'];
+            return $render_function("core/themes/claro/templates/$hook", $variables);
+        }
+    }
+}
+
+namespace
+{
+    include __DIR__ . '/drupal_integration.inc';
+
+    DDTrace\Integrations\Drupal\DrupalIntegration::init();
+
+    $engines = new Drupal\Core\Theme\ThemeEngineCollection([
+        'twig' => new Drupal\Core\Template\TwigThemeEngine(),
+    ]);
+    $themeManager = new Drupal\Core\Theme\ThemeManager($engines);
+
+    for ($i = 0; $i < 10; ++$i) {
+        $themeManager->render('page');
+    }
+
+    dd_drupal_render_report(dd_trace_serialize_closed_spans(), [
+        'Drupal\Core\Template\TwigThemeEngine::renderTemplate',
+    ]);
+}
+?>
+--EXPECT--
+drupal.render.engine[twig] = 20
+drupal.template.file[core/themes/claro/templates/child.html.twig] = 10
+drupal.template.file[core/themes/claro/templates/page.html.twig] = 10
+hook budget left [Drupal\Core\Template\TwigThemeEngine::renderTemplate]: yes

--- a/tests/ext/integrations/drupal/theme_engine_service_span_limit.phpt
+++ b/tests/ext/integrations/drupal/theme_engine_service_span_limit.phpt
@@ -94,14 +94,16 @@ namespace
         return $themeManager->render('block');
     };
 
-    // install_hook's callback is not span-limit gated, but trace_method is: with room for one span
-    // the nested render fires the hook while active_span() is the outer's. init() forces >= 1500.
+    // Room for exactly one more span: the outer render gets a real one, the nested render only a
+    // dummy that is never pushed, so it must not reach the outer's tag. init() forces >= 1500.
     ini_set('datadog.trace.spans_limit', 2);
     DDTrace\start_span();
     DDTrace\close_span();
 
-    $themeManager->render('page');
+    $rendered = $themeManager->render('page');
 
+    // Proves the nested render really ran, so the tag assertion below cannot pass vacuously.
+    echo "nested rendered: ", var_export(strpos($rendered, 'block.html.twig') !== false, true), "\n";
     echo "limited: ", var_export((bool) dd_trace_tracer_is_limited(), true), "\n";
     dd_drupal_render_report(dd_trace_serialize_closed_spans(), [
         'Drupal\Core\Template\TwigThemeEngine::renderTemplate',
@@ -109,7 +111,8 @@ namespace
 }
 ?>
 --EXPECT--
+nested rendered: true
 limited: true
 drupal.render.engine[twig] = 1
-drupal.template.file[<missing>] = 1
+drupal.template.file[core/themes/claro/templates/page.html.twig] = 1
 hook budget left [Drupal\Core\Template\TwigThemeEngine::renderTemplate]: yes

--- a/tests/ext/integrations/drupal/theme_engine_service_span_limit.phpt
+++ b/tests/ext/integrations/drupal/theme_engine_service_span_limit.phpt
@@ -89,16 +89,13 @@ namespace
     $engines = new Drupal\Core\Theme\ThemeEngineCollection(['twig' => $engine]);
     $themeManager = new Drupal\Core\Theme\ThemeManager($engines);
 
-    // Twig renders an embedded theme hook from inside the outer template, i.e. a nested
-    // ThemeManager::render() during the outer renderTemplate().
+    // Twig renders an embedded theme hook, i.e. a nested render during the outer renderTemplate().
     $engine->nested = function () use ($themeManager) {
         return $themeManager->render('block');
     };
 
-    // install_hook's callback is not gated by the span limit, but trace_method is. Leave room
-    // for exactly one span so the outer render is traced and the nested one is not: the nested
-    // renderTemplate() then still fires the interface hook while active_span() is the outer
-    // render's span. init() forces spans_limit >= 1500, so shrink it afterwards.
+    // install_hook's callback is not span-limit gated, but trace_method is: with room for one span
+    // the nested render fires the hook while active_span() is the outer's. init() forces >= 1500.
     ini_set('datadog.trace.spans_limit', 2);
     DDTrace\start_span();
     DDTrace\close_span();

--- a/tests/ext/integrations/drupal/theme_engine_service_span_limit.phpt
+++ b/tests/ext/integrations/drupal/theme_engine_service_span_limit.phpt
@@ -1,0 +1,118 @@
+--TEST--
+Drupal render span is not tagged with a nested template past the span limit (APMS-20395)
+--SKIPIF--
+<?php
+require __DIR__ . '/drupal_root.inc';
+if (!dd_drupal_tracer_root()) {
+    die("skip tracer sources not found from " . __DIR__ . "\n");
+}
+?>
+--ENV--
+DD_TRACE_AUTO_FLUSH_ENABLED=0
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_CODE_ORIGIN_FOR_SPANS_ENABLED=0
+DD_TRACE_LOG_LEVEL=warn,startup=off
+--INI--
+datadog.trace.hook_limit=20
+--FILE--
+<?php
+
+namespace Drupal\Core\Theme
+{
+    interface ThemeEngineInterface
+    {
+        public function renderTemplate(string $template_file, array $variables): string;
+    }
+
+    class ActiveTheme
+    {
+        public function getName()
+        {
+            return 'claro';
+        }
+
+        public function getEngine()
+        {
+            return 'twig';
+        }
+    }
+
+    class ThemeEngineCollection
+    {
+        private $engines;
+
+        public function __construct(array $engines)
+        {
+            $this->engines = $engines;
+        }
+
+        public function has($name)
+        {
+            return isset($this->engines[$name]);
+        }
+
+        public function get($name)
+        {
+            return $this->engines[$name];
+        }
+    }
+
+    class ThemeManager
+    {
+        protected $themeEngines;
+
+        public function __construct(ThemeEngineCollection $themeEngines)
+        {
+            $this->themeEngines = $themeEngines;
+        }
+
+        public function getActiveTheme()
+        {
+            return new ActiveTheme();
+        }
+
+        public function render($hook, array $variables = [])
+        {
+            $render_function = [$this->themeEngines->get('twig'), 'renderTemplate'];
+            return $render_function("core/themes/claro/templates/$hook", $variables);
+        }
+    }
+}
+
+namespace
+{
+    include __DIR__ . '/drupal_integration.inc';
+
+    DDTrace\Integrations\Drupal\DrupalIntegration::init();
+
+    $engine = new Drupal\Core\Template\TwigThemeEngine();
+    $engines = new Drupal\Core\Theme\ThemeEngineCollection(['twig' => $engine]);
+    $themeManager = new Drupal\Core\Theme\ThemeManager($engines);
+
+    // Twig renders an embedded theme hook from inside the outer template, i.e. a nested
+    // ThemeManager::render() during the outer renderTemplate().
+    $engine->nested = function () use ($themeManager) {
+        return $themeManager->render('block');
+    };
+
+    // install_hook's callback is not gated by the span limit, but trace_method is. Leave room
+    // for exactly one span so the outer render is traced and the nested one is not: the nested
+    // renderTemplate() then still fires the interface hook while active_span() is the outer
+    // render's span. init() forces spans_limit >= 1500, so shrink it afterwards.
+    ini_set('datadog.trace.spans_limit', 2);
+    DDTrace\start_span();
+    DDTrace\close_span();
+
+    $themeManager->render('page');
+
+    echo "limited: ", var_export((bool) dd_trace_tracer_is_limited(), true), "\n";
+    dd_drupal_render_report(dd_trace_serialize_closed_spans(), [
+        'Drupal\Core\Template\TwigThemeEngine::renderTemplate',
+    ]);
+}
+?>
+--EXPECT--
+limited: true
+drupal.render.engine[twig] = 1
+drupal.template.file[<missing>] = 1
+hook budget left [Drupal\Core\Template\TwigThemeEngine::renderTemplate]: yes

--- a/tests/ext/integrations/drupal/theme_render_dropped_nested_span.phpt
+++ b/tests/ext/integrations/drupal/theme_render_dropped_nested_span.phpt
@@ -1,0 +1,100 @@
+--TEST--
+Drupal legacy render span is not tagged with a dropped nested render's template (APMS-20395)
+--SKIPIF--
+<?php
+require __DIR__ . '/drupal_root.inc';
+if (!dd_drupal_tracer_root()) {
+    die("skip tracer sources not found from " . __DIR__ . "\n");
+}
+?>
+--ENV--
+DD_TRACE_AUTO_FLUSH_ENABLED=0
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_CODE_ORIGIN_FOR_SPANS_ENABLED=0
+DD_TRACE_LOG_LEVEL=warn,startup=off
+--INI--
+datadog.trace.hook_limit=20
+--FILE--
+<?php
+
+namespace Drupal\Core\Theme
+{
+    class ActiveTheme
+    {
+        public function getName()
+        {
+            return 'olivero';
+        }
+
+        public function getEngine()
+        {
+            return 'twig';
+        }
+    }
+
+    // Drupal <= 11.2 shape: no theme engine service, the global render function is used.
+    class ThemeManager
+    {
+        public function getActiveTheme()
+        {
+            return new ActiveTheme();
+        }
+
+        public function render($hook, array $variables = [])
+        {
+            if ($hook === 'block') {
+                // Dropped after the tracing prehook ran, so the render hook is installed and
+                // the tracer is not limited; active_span() now points at the OUTER render.
+                \DDTrace\try_drop_span(\DDTrace\active_span());
+            }
+
+            return twig_render_template("core/themes/olivero/templates/$hook.html.twig", $variables);
+        }
+    }
+}
+
+namespace
+{
+    function twig_render_template($template_file, array $variables)
+    {
+        $rendered = "rendered $template_file";
+        if (isset($variables['nested'])) {
+            $nested = $variables['nested'];
+            $rendered .= $nested();
+        }
+        return $rendered;
+    }
+
+    include __DIR__ . '/drupal_integration.inc';
+
+    DDTrace\Integrations\Drupal\DrupalIntegration::init();
+
+    // An outer span is required: dropping a stack's root span closes it instead.
+    $root = DDTrace\start_span();
+    $root->name = 'test.root';
+
+    $themeManager = new Drupal\Core\Theme\ThemeManager();
+    $themeManager->render('page', ['nested' => function () use ($themeManager) {
+        return $themeManager->render('block');
+    }]);
+
+    DDTrace\close_span();
+
+    $spans = dd_trace_serialize_closed_spans();
+    foreach ($spans as $span) {
+        if ($span['name'] !== 'drupal.theme.render') {
+            continue;
+        }
+        echo "surviving render span template.file = ",
+            isset($span['meta']['drupal.template.file']) ? $span['meta']['drupal.template.file'] : '<none>',
+            "\n";
+    }
+    dd_drupal_render_report($spans, ['twig_render_template']);
+}
+?>
+--EXPECTF--
+[ddtrace] [error] [%d] Cannot run tracing closure for render(); spans out of sync; This message is only displayed once. Specify DD_TRACE_ONCE_LOGS=0 to show all messages.
+surviving render span template.file = core/themes/olivero/templates/page.html.twig
+drupal.render.engine[twig] = 1
+drupal.template.file[core/themes/olivero/templates/page.html.twig] = 1
+hook budget left [twig_render_template]: yes

--- a/tests/ext/integrations/drupal/theme_render_dropped_nested_span.phpt
+++ b/tests/ext/integrations/drupal/theme_render_dropped_nested_span.phpt
@@ -43,8 +43,7 @@ namespace Drupal\Core\Theme
         public function render($hook, array $variables = [])
         {
             if ($hook === 'block') {
-                // Dropped after the tracing prehook ran, so the render hook is installed and
-                // the tracer is not limited; active_span() now points at the OUTER render.
+                // Dropped after the prehook ran, so the hook is installed and active_span() is the OUTER render.
                 \DDTrace\try_drop_span(\DDTrace\active_span());
             }
 

--- a/tests/ext/integrations/drupal/theme_render_dropped_nested_span.phpt
+++ b/tests/ext/integrations/drupal/theme_render_dropped_nested_span.phpt
@@ -43,7 +43,8 @@ namespace Drupal\Core\Theme
         public function render($hook, array $variables = [])
         {
             if ($hook === 'block') {
-                // Dropped after the prehook ran, so the hook is installed and active_span() is the OUTER render.
+                // Dropped after the begin hook ran, so this frame's render hook is installed and
+                // fires against a dropped span rather than the surviving outer one.
                 \DDTrace\try_drop_span(\DDTrace\active_span());
             }
 
@@ -91,8 +92,7 @@ namespace
     dd_drupal_render_report($spans, ['twig_render_template']);
 }
 ?>
---EXPECTF--
-[ddtrace] [error] [%d] Cannot run tracing closure for render(); spans out of sync; This message is only displayed once. Specify DD_TRACE_ONCE_LOGS=0 to show all messages.
+--EXPECT--
 surviving render span template.file = core/themes/olivero/templates/page.html.twig
 drupal.render.engine[twig] = 1
 drupal.template.file[core/themes/olivero/templates/page.html.twig] = 1

--- a/tests/ext/integrations/drupal/theme_render_dropped_span.phpt
+++ b/tests/ext/integrations/drupal/theme_render_dropped_span.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Drupal render hook is removed when the render span is dropped (APMS-20395)
+Drupal render tagging survives a dropped render span (APMS-20395)
 --SKIPIF--
 <?php
 require __DIR__ . '/drupal_root.inc';
@@ -44,7 +44,7 @@ namespace Drupal\Core\Theme
         {
             if ($hook === 'dropped') {
                 // A sampling filter or another integration can drop the render span; the end hook
-                // must still run and remove the render hook.
+                // must still run and restore the enclosing render's span.
                 \DDTrace\try_drop_span(\DDTrace\active_span());
                 return false;
             }
@@ -74,7 +74,7 @@ namespace
     for ($i = 0; $i < 30; ++$i) {
         $themeManager->render('dropped');
     }
-    // A leak above exhausts the budget, so this render can no longer tag its own template.
+    // Were a hook leaked above, the budget would be exhausted and this render left untagged.
     $themeManager->render('page');
 
     DDTrace\close_span();

--- a/tests/ext/integrations/drupal/theme_render_dropped_span.phpt
+++ b/tests/ext/integrations/drupal/theme_render_dropped_span.phpt
@@ -1,0 +1,101 @@
+--TEST--
+Drupal render hook is removed when the render span is dropped (APMS-20395)
+--SKIPIF--
+<?php
+require __DIR__ . '/drupal_root.inc';
+if (!dd_drupal_tracer_root()) {
+    die("skip tracer sources not found from " . __DIR__ . "\n");
+}
+?>
+--ENV--
+DD_TRACE_AUTO_FLUSH_ENABLED=0
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_CODE_ORIGIN_FOR_SPANS_ENABLED=0
+DD_TRACE_LOG_LEVEL=warn,startup=off
+--INI--
+datadog.trace.hook_limit=20
+--FILE--
+<?php
+
+namespace Drupal\Core\Theme
+{
+    class ActiveTheme
+    {
+        public function getName()
+        {
+            return 'olivero';
+        }
+
+        public function getEngine()
+        {
+            return 'twig';
+        }
+    }
+
+    // Drupal <= 11.2 shape: no theme engine service, the global render function is used.
+    class ThemeManager
+    {
+        public function getActiveTheme()
+        {
+            return new ActiveTheme();
+        }
+
+        public function render($hook, array $variables = [])
+        {
+            if ($hook === 'dropped') {
+                // A sampling filter or another integration can drop the render span. The
+                // tracing posthook is then skipped, so it cannot be what removes the hook.
+                \DDTrace\try_drop_span(\DDTrace\active_span());
+                return false;
+            }
+
+            return twig_render_template("core/themes/olivero/templates/$hook.html.twig", $variables);
+        }
+    }
+}
+
+namespace
+{
+    function twig_render_template($template_file, array $variables)
+    {
+        return "rendered $template_file";
+    }
+
+    include __DIR__ . '/drupal_integration.inc';
+
+    DDTrace\Integrations\Drupal\DrupalIntegration::init();
+
+    // The render spans must not be root spans: dropping a root span rejects the trace instead
+    // of marking the span dropped, which would leave the posthook running.
+    $root = DDTrace\start_span();
+    $root->name = 'test.root';
+
+    $themeManager = new Drupal\Core\Theme\ThemeManager();
+    for ($i = 0; $i < 30; ++$i) {
+        $themeManager->render('dropped');
+    }
+    // A leak above exhausts the budget, so this render can no longer tag its own template.
+    $themeManager->render('page');
+
+    DDTrace\close_span();
+
+    $spans = dd_trace_serialize_closed_spans();
+    $names = [];
+    foreach ($spans as $span) {
+        $names[$span['name']] = (isset($names[$span['name']]) ? $names[$span['name']] : 0) + 1;
+    }
+    ksort($names);
+    foreach ($names as $name => $count) {
+        echo "span[$name] = $count\n";
+    }
+
+    dd_drupal_render_report($spans, ['twig_render_template']);
+}
+?>
+--EXPECTF--
+[ddtrace] [error] [%d] Cannot run tracing closure for render(); spans out of sync; This message is only displayed once. Specify DD_TRACE_ONCE_LOGS=0 to show all messages.
+span[drupal.theme.render] = 1
+span[test.root] = 1
+drupal.render.engine[twig] = 1
+drupal.template.file[core/themes/olivero/templates/page.html.twig] = 1
+hook budget left [twig_render_template]: yes

--- a/tests/ext/integrations/drupal/theme_render_dropped_span.phpt
+++ b/tests/ext/integrations/drupal/theme_render_dropped_span.phpt
@@ -43,8 +43,8 @@ namespace Drupal\Core\Theme
         public function render($hook, array $variables = [])
         {
             if ($hook === 'dropped') {
-                // A sampling filter or another integration can drop the render span; the tracing
-                // posthook is then skipped, so it cannot be what removes the hook.
+                // A sampling filter or another integration can drop the render span; the end hook
+                // must still run and remove the render hook.
                 \DDTrace\try_drop_span(\DDTrace\active_span());
                 return false;
             }
@@ -66,7 +66,7 @@ namespace
     DDTrace\Integrations\Drupal\DrupalIntegration::init();
 
     // The render spans must not be root spans: dropping a root span rejects the trace instead
-    // of marking the span dropped, which would leave the posthook running.
+    // of marking the span dropped.
     $root = DDTrace\start_span();
     $root->name = 'test.root';
 
@@ -92,8 +92,7 @@ namespace
     dd_drupal_render_report($spans, ['twig_render_template']);
 }
 ?>
---EXPECTF--
-[ddtrace] [error] [%d] Cannot run tracing closure for render(); spans out of sync; This message is only displayed once. Specify DD_TRACE_ONCE_LOGS=0 to show all messages.
+--EXPECT--
 span[drupal.theme.render] = 1
 span[test.root] = 1
 drupal.render.engine[twig] = 1

--- a/tests/ext/integrations/drupal/theme_render_dropped_span.phpt
+++ b/tests/ext/integrations/drupal/theme_render_dropped_span.phpt
@@ -43,8 +43,8 @@ namespace Drupal\Core\Theme
         public function render($hook, array $variables = [])
         {
             if ($hook === 'dropped') {
-                // A sampling filter or another integration can drop the render span. The
-                // tracing posthook is then skipped, so it cannot be what removes the hook.
+                // A sampling filter or another integration can drop the render span; the tracing
+                // posthook is then skipped, so it cannot be what removes the hook.
                 \DDTrace\try_drop_span(\DDTrace\active_span());
                 return false;
             }

--- a/tests/ext/integrations/drupal/theme_render_early_return.phpt
+++ b/tests/ext/integrations/drupal/theme_render_early_return.phpt
@@ -1,5 +1,5 @@
 --TEST--
-Drupal render hooks are removed when the render function is never called (APMS-20395)
+Drupal renders that never call the render function do not mis-tag later ones (APMS-20395)
 --SKIPIF--
 <?php
 require __DIR__ . '/drupal_root.inc';

--- a/tests/ext/integrations/drupal/theme_render_early_return.phpt
+++ b/tests/ext/integrations/drupal/theme_render_early_return.phpt
@@ -1,0 +1,90 @@
+--TEST--
+Drupal render hooks are removed when the render function is never called (APMS-20395)
+--SKIPIF--
+<?php
+require __DIR__ . '/drupal_root.inc';
+if (!dd_drupal_tracer_root()) {
+    die("skip tracer sources not found from " . __DIR__ . "\n");
+}
+?>
+--ENV--
+DD_TRACE_AUTO_FLUSH_ENABLED=0
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_CODE_ORIGIN_FOR_SPANS_ENABLED=0
+DD_TRACE_LOG_LEVEL=warn,startup=off
+--INI--
+datadog.trace.hook_limit=20
+--FILE--
+<?php
+
+namespace Drupal\Core\Theme
+{
+    class ActiveTheme
+    {
+        public function getName()
+        {
+            return 'olivero';
+        }
+
+        public function getEngine()
+        {
+            return 'twig';
+        }
+    }
+
+    // Drupal <= 11.2 shape: no theme engine service, the global render function is used.
+    class ThemeManager
+    {
+        public function getActiveTheme()
+        {
+            return new ActiveTheme();
+        }
+
+        public function render($hook, array $variables = [])
+        {
+            if ($hook === 'missing') {
+                // The theme registry has no implementation for the hook: ThemeManager::render()
+                // returns FALSE without ever calling the render function.
+                return false;
+            }
+
+            $rendered = twig_render_template("core/themes/olivero/templates/$hook.html.twig", $variables);
+            if ($hook === 'page') {
+                $rendered .= $this->render('block');
+            }
+            return $rendered;
+        }
+    }
+}
+
+namespace
+{
+    function twig_render_template($template_file, array $variables)
+    {
+        return "rendered $template_file";
+    }
+
+    include __DIR__ . '/drupal_integration.inc';
+
+    DDTrace\Integrations\Drupal\DrupalIntegration::init();
+
+    $themeManager = new Drupal\Core\Theme\ThemeManager();
+    // Renders that never reach the render function must not exhaust the hook budget...
+    for ($i = 0; $i < 30; ++$i) {
+        $themeManager->render('missing');
+    }
+    // ...nor leave a hook behind that later mis-tags an unrelated render.
+    for ($i = 0; $i < 30; ++$i) {
+        $themeManager->render('page');
+    }
+
+    // Only the legacy global is installed on this shape, so it is the only budget to probe.
+    dd_drupal_render_report(dd_trace_serialize_closed_spans(), ['twig_render_template']);
+}
+?>
+--EXPECT--
+drupal.render.engine[twig] = 90
+drupal.template.file[<missing>] = 30
+drupal.template.file[core/themes/olivero/templates/block.html.twig] = 30
+drupal.template.file[core/themes/olivero/templates/page.html.twig] = 30
+hook budget left [twig_render_template]: yes

--- a/tests/ext/integrations/drupal/theme_render_engine_fallback.phpt
+++ b/tests/ext/integrations/drupal/theme_render_engine_fallback.phpt
@@ -1,0 +1,79 @@
+--TEST--
+Drupal render span is tagged when core falls back to twig's render function (APMS-20395)
+--SKIPIF--
+<?php
+require __DIR__ . '/drupal_root.inc';
+if (!dd_drupal_tracer_root()) {
+    die("skip tracer sources not found from " . __DIR__ . "\n");
+}
+?>
+--ENV--
+DD_TRACE_AUTO_FLUSH_ENABLED=0
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_CODE_ORIGIN_FOR_SPANS_ENABLED=0
+DD_TRACE_LOG_LEVEL=warn,startup=off
+--INI--
+datadog.trace.hook_limit=20
+--FILE--
+<?php
+
+namespace Drupal\Core\Theme
+{
+    class ActiveTheme
+    {
+        public function getName()
+        {
+            return 'claro';
+        }
+
+        public function getEngine()
+        {
+            // No phptemplate_render_template() is ever declared.
+            return 'phptemplate';
+        }
+    }
+
+    class ThemeManager
+    {
+        public function getActiveTheme()
+        {
+            return new ActiveTheme();
+        }
+
+        public function render($hook, array $variables = [])
+        {
+            // ThemeManager::render() falls back to twig's render function when the active engine
+            // has no {engine}_render_template() of its own.
+            return twig_render_template("core/themes/claro/templates/$hook.html.twig", $variables);
+        }
+    }
+}
+
+namespace
+{
+    function twig_render_template($template_file, array $variables)
+    {
+        return "rendered $template_file";
+    }
+
+    include __DIR__ . '/drupal_integration.inc';
+
+    DDTrace\Integrations\Drupal\DrupalIntegration::init();
+
+    $themeManager = new Drupal\Core\Theme\ThemeManager();
+    // Repeated so that a per-render install would show up as an exhausted hook budget.
+    for ($i = 0; $i < 30; ++$i) {
+        $themeManager->render('fallback');
+    }
+
+    dd_drupal_render_report(dd_trace_serialize_closed_spans(), [
+        'twig_render_template',
+        'phptemplate_render_template',
+    ]);
+}
+?>
+--EXPECT--
+drupal.render.engine[phptemplate] = 30
+drupal.template.file[core/themes/claro/templates/fallback.html.twig] = 30
+hook budget left [twig_render_template]: yes
+hook budget left [phptemplate_render_template]: yes

--- a/tests/ext/integrations/drupal/theme_render_span_limit.phpt
+++ b/tests/ext/integrations/drupal/theme_render_span_limit.phpt
@@ -66,22 +66,25 @@ namespace
 
     $themeManager = new Drupal\Core\Theme\ThemeManager();
 
-    // The legacy hook is installed from an install_hook callback, which is not span-limit gated,
-    // so the nested render fires it while active_span() is the outer's. init() forces >= 1500.
+    // Room for exactly one more span: the outer render gets a real one, the nested render only a
+    // dummy that is never pushed, so it must not reach the outer's tag. init() forces >= 1500.
     ini_set('datadog.trace.spans_limit', 2);
     DDTrace\start_span();
     DDTrace\close_span();
 
-    $themeManager->render('page', ['nested' => function () use ($themeManager) {
+    $rendered = $themeManager->render('page', ['nested' => function () use ($themeManager) {
         return $themeManager->render('block');
     }]);
 
+    // Proves the nested render really ran, so the tag assertion below cannot pass vacuously.
+    echo "nested rendered: ", var_export(strpos($rendered, 'block.html.twig') !== false, true), "\n";
     echo "limited: ", var_export((bool) dd_trace_tracer_is_limited(), true), "\n";
     dd_drupal_render_report(dd_trace_serialize_closed_spans(), ['twig_render_template']);
 }
 ?>
 --EXPECT--
+nested rendered: true
 limited: true
 drupal.render.engine[twig] = 1
-drupal.template.file[<missing>] = 1
+drupal.template.file[core/themes/olivero/templates/page.html.twig] = 1
 hook budget left [twig_render_template]: yes

--- a/tests/ext/integrations/drupal/theme_render_span_limit.phpt
+++ b/tests/ext/integrations/drupal/theme_render_span_limit.phpt
@@ -53,8 +53,7 @@ namespace
     {
         $rendered = "rendered $template_file";
         if (isset($variables['nested'])) {
-            // A template embedding another theme hook, i.e. a nested ThemeManager::render()
-            // from inside the render function.
+            // A template embedding another theme hook: a nested render from the render function.
             $nested = $variables['nested'];
             $rendered .= $nested();
         }
@@ -67,9 +66,8 @@ namespace
 
     $themeManager = new Drupal\Core\Theme\ThemeManager();
 
-    // The legacy hook is installed from an install_hook callback, which is not gated by the
-    // span limit, so the nested render still fires it while active_span() is the outer
-    // render's span. init() forces spans_limit >= 1500, so shrink it afterwards.
+    // The legacy hook is installed from an install_hook callback, which is not span-limit gated,
+    // so the nested render fires it while active_span() is the outer's. init() forces >= 1500.
     ini_set('datadog.trace.spans_limit', 2);
     DDTrace\start_span();
     DDTrace\close_span();

--- a/tests/ext/integrations/drupal/theme_render_span_limit.phpt
+++ b/tests/ext/integrations/drupal/theme_render_span_limit.phpt
@@ -1,0 +1,89 @@
+--TEST--
+Drupal legacy render span is not tagged with a nested template past the span limit (APMS-20395)
+--SKIPIF--
+<?php
+require __DIR__ . '/drupal_root.inc';
+if (!dd_drupal_tracer_root()) {
+    die("skip tracer sources not found from " . __DIR__ . "\n");
+}
+?>
+--ENV--
+DD_TRACE_AUTO_FLUSH_ENABLED=0
+DD_TRACE_GENERATE_ROOT_SPAN=0
+DD_CODE_ORIGIN_FOR_SPANS_ENABLED=0
+DD_TRACE_LOG_LEVEL=warn,startup=off
+--INI--
+datadog.trace.hook_limit=20
+--FILE--
+<?php
+
+namespace Drupal\Core\Theme
+{
+    class ActiveTheme
+    {
+        public function getName()
+        {
+            return 'olivero';
+        }
+
+        public function getEngine()
+        {
+            return 'twig';
+        }
+    }
+
+    // Drupal <= 11.2 shape: no theme engine service, the global render function is used.
+    class ThemeManager
+    {
+        public function getActiveTheme()
+        {
+            return new ActiveTheme();
+        }
+
+        public function render($hook, array $variables = [])
+        {
+            return twig_render_template("core/themes/olivero/templates/$hook.html.twig", $variables);
+        }
+    }
+}
+
+namespace
+{
+    function twig_render_template($template_file, array $variables)
+    {
+        $rendered = "rendered $template_file";
+        if (isset($variables['nested'])) {
+            // A template embedding another theme hook, i.e. a nested ThemeManager::render()
+            // from inside the render function.
+            $nested = $variables['nested'];
+            $rendered .= $nested();
+        }
+        return $rendered;
+    }
+
+    include __DIR__ . '/drupal_integration.inc';
+
+    DDTrace\Integrations\Drupal\DrupalIntegration::init();
+
+    $themeManager = new Drupal\Core\Theme\ThemeManager();
+
+    // The legacy hook is installed from an install_hook callback, which is not gated by the
+    // span limit, so the nested render still fires it while active_span() is the outer
+    // render's span. init() forces spans_limit >= 1500, so shrink it afterwards.
+    ini_set('datadog.trace.spans_limit', 2);
+    DDTrace\start_span();
+    DDTrace\close_span();
+
+    $themeManager->render('page', ['nested' => function () use ($themeManager) {
+        return $themeManager->render('block');
+    }]);
+
+    echo "limited: ", var_export((bool) dd_trace_tracer_is_limited(), true), "\n";
+    dd_drupal_render_report(dd_trace_serialize_closed_spans(), ['twig_render_template']);
+}
+?>
+--EXPECT--
+limited: true
+drupal.render.engine[twig] = 1
+drupal.template.file[<missing>] = 1
+hook budget left [twig_render_template]: yes


### PR DESCRIPTION
# Description

Fixes APMS-20395.

On Drupal >= 11.3, `drupal.template.file` was never set on any `drupal.theme.render` span, and hooks accumulated on `twig_render_template` until `DD_TRACE_HOOK_LIMIT`. A customer measured the tag present on **0 of 61,160** render spans.

**Root cause.** Drupal 11.3.0 switched `ThemeManager::render()` to a theme-engine *service* (`[$engine, 'renderTemplate']`), falling back to the global `{engine}_render_template()` only when no service is registered. Core ships a Twig service, so the global is never called — but it is still *defined*, because `ThemeInitialization` unconditionally includes `twig.engine`. So `function_exists()` returned true, the integration installed a hook on every render, the hook never fired, and it was never removed.

A second defect, on **every** Drupal version: `render()` can return early (theme hook not found, exception) without calling the render function. Those hooks leaked and then fired on *later* renders, overwriting unrelated spans' tags — measured 19 spans mis-tagged in a 30-render test.

# Changes

- Hook `ThemeEngineInterface::renderTemplate` once at `init()` — covers Twig, contrib engines, and module templates in one install. The service path passes the template path without its extension, so `.html.twig` is re-appended for Twig to keep the tag value identical to pre-11.3.
- Install the legacy `{engine}_render_template` hook once per engine instead of once per render, seeded on `twig_render_template` at `init()`. This also fixes a pre-existing gap: core falls back to `twig_render_template` when `{engine}_render_template` is absent, which was previously untagged.
- Create the `drupal.theme.render` span from `install_hook` + `$hook->span()` rather than `trace_method`. `$hook->span()` is per-invocation, so the frame's own span is known directly — no `active_span()` lookup and no guessing which frame a tag belongs to.
- Bail early when `dd_trace_tracer_is_limited()`. Unlike `trace_method`, `install_hook` callbacks are not limit-gated, so without this the whole body ran on every render past the span limit (measured 200x on a 200-render probe).

# Reviewer notes

- `allowNestedHook()` is not needed: it escapes reentrancy initiated *from inside a callback*, not the hooked function recursing. `install_hook` holds `running` only across the callback, so it is already recursive — measured 7/7 begins on a nested render chain, versus 1/1 for `trace_method` with `recurse => false`.
- Tag attribution is by frame, not by span name — an ancestor render span carries the same name under recursion, so a name check would mis-attribute a nested template to its parent.
