### PR TITLE
fix: support stable OTel deployment environment

### DIFF
--- a/ext/otel_config.c
+++ b/ext/otel_config.c
@@ -93,7 +93,8 @@ static bool ddtrace_conf_otel_resource_attributes_special(const char *tag, int l
 }
 
 bool ddtrace_conf_otel_resource_attributes_env(zai_env_buffer *buf, bool pre_rinit) {
-    return ddtrace_conf_otel_resource_attributes_special(ZEND_STRL("deployment.environment"), buf, pre_rinit);
+    return ddtrace_conf_otel_resource_attributes_special(ZEND_STRL("deployment.environment.name"), buf, pre_rinit)
+        || ddtrace_conf_otel_resource_attributes_special(ZEND_STRL("deployment.environment"), buf, pre_rinit);
 }
 
 bool ddtrace_conf_otel_resource_attributes_version(zai_env_buffer *buf, bool pre_rinit) {
@@ -124,13 +125,20 @@ bool ddtrace_conf_otel_resource_attributes_tags(zai_env_buffer *buf, bool pre_ri
                 ++cur;
             }
             key_start = cur + 1;
+            if (key_end - key == strlen("deployment.environment.name") && memcmp(key, ZEND_STRL("deployment.environment.name")) == 0) {
+                --cur;
+                continue;
+            }
             if (key_end - key == strlen("deployment.environment") && memcmp(key, ZEND_STRL("deployment.environment")) == 0) {
+                --cur;
                 continue;
             }
             if (key_end - key == strlen("service.name") && memcmp(key, ZEND_STRL("service.name")) == 0) {
+                --cur;
                 continue;
             }
             if (key_end - key == strlen("service.version") && memcmp(key, ZEND_STRL("service.version")) == 0) {
+                --cur;
                 continue;
             }
             memmove(out, key, cur - key);

--- a/tests/ext/otel_config_deployment_environment_name.phpt
+++ b/tests/ext/otel_config_deployment_environment_name.phpt
@@ -1,0 +1,18 @@
+--TEST--
+Test stable OpenTelemetry deployment environment config remapping
+--ENV--
+OTEL_RESOURCE_ATTRIBUTES=foo=bar,deployment.environment.name=stable,service.name=service,xyz=abc,service.version=1.2.3,baz=qux
+--FILE--
+<?php
+
+var_dump(ini_get("datadog.env"));
+var_dump(ini_get("datadog.service"));
+var_dump(ini_get("datadog.version"));
+var_dump(ini_get("datadog.tags"));
+
+?>
+--EXPECT--
+string(6) "stable"
+string(7) "service"
+string(5) "1.2.3"
+string(23) "foo:bar,xyz:abc,baz:qux"

--- a/tests/ext/otel_config_deployment_environment_name_dd_env.phpt
+++ b/tests/ext/otel_config_deployment_environment_name_dd_env.phpt
@@ -1,0 +1,15 @@
+--TEST--
+Test DD_ENV takes precedence over OpenTelemetry deployment environment attributes
+--ENV--
+DD_ENV=datadog
+OTEL_RESOURCE_ATTRIBUTES=foo=bar,deployment.environment=legacy,deployment.environment.name=stable,baz=qux
+--FILE--
+<?php
+
+var_dump(ini_get("datadog.env"));
+var_dump(ini_get("datadog.tags"));
+
+?>
+--EXPECT--
+string(7) "datadog"
+string(15) "foo:bar,baz:qux"

--- a/tests/ext/otel_config_deployment_environment_name_last.phpt
+++ b/tests/ext/otel_config_deployment_environment_name_last.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Test stable OpenTelemetry deployment environment as the final resource attribute
+--ENV--
+OTEL_RESOURCE_ATTRIBUTES=foo=bar,deployment.environment.name=stable
+--FILE--
+<?php
+
+var_dump(ini_get("datadog.env"));
+var_dump(ini_get("datadog.tags"));
+
+?>
+--EXPECT--
+string(6) "stable"
+string(7) "foo:bar"

--- a/tests/ext/otel_config_deployment_environment_name_legacy_first.phpt
+++ b/tests/ext/otel_config_deployment_environment_name_legacy_first.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Test stable OpenTelemetry deployment environment takes precedence when listed after legacy
+--ENV--
+OTEL_RESOURCE_ATTRIBUTES=foo=bar,deployment.environment=legacy,deployment.environment.name=stable,xyz=abc
+--FILE--
+<?php
+
+var_dump(ini_get("datadog.env"));
+var_dump(ini_get("datadog.tags"));
+
+?>
+--EXPECT--
+string(6) "stable"
+string(15) "foo:bar,xyz:abc"

--- a/tests/ext/otel_config_deployment_environment_name_stable_first.phpt
+++ b/tests/ext/otel_config_deployment_environment_name_stable_first.phpt
@@ -1,0 +1,14 @@
+--TEST--
+Test stable OpenTelemetry deployment environment takes precedence when listed first
+--ENV--
+OTEL_RESOURCE_ATTRIBUTES=foo=bar,deployment.environment.name=stable,deployment.environment=legacy,xyz=abc
+--FILE--
+<?php
+
+var_dump(ini_get("datadog.env"));
+var_dump(ini_get("datadog.tags"));
+
+?>
+--EXPECT--
+string(6) "stable"
+string(15) "foo:bar,xyz:abc"


### PR DESCRIPTION
### Description

Map the stable OpenTelemetry resource attribute `deployment.environment.name` to `DD_ENV`. Keep `deployment.environment` as a fallback and `DD_ENV` as the highest-precedence source.

The scanner records stable and legacy values separately so attribute order does not change the result. It consumes both environment aliases, keeps unrelated attributes, and handles the stable attribute when it is the final entry.

Related PRs:

- DataDog/system-tests#7613
- DataDog/dd-trace-go#5285
- DataDog/dd-trace-dotnet#9150
- DataDog/dd-trace-rb#6261
- DataDog/dd-trace-php#4148
- DataDog/dd-trace-js#10050
- DataDog/dd-trace-rs#300
- DataDog/dd-trace-java#12324
- DataDog/dd-trace-py#19901

All five focused PHPTs passed in `datadog/dd-trace-ci:php-8.3_bookworm-10`.

### Reviewer checklist

- [x] Test coverage seems ok.
- [ ] Appropriate labels assigned.
