### PR TITLE
fix(profiling): Restore I/O GOT hooks on module shutdown

### DIFF
--- a/profiling/src/io/got_elf64.rs
+++ b/profiling/src/io/got_elf64.rs
@@ -1,7 +1,9 @@
-use super::{restore_slot_if_owned, GotHookState, GotSlotRestore};
+use super::{
+    restore_matches_image, restore_slot_if_owned, slot_fits_range, GotHookState, GotSlotRestore,
+};
 use crate::profiling::bindings::{
     Elf64_Dyn, Elf64_Rela, Elf64_Sym, Elf64_Xword, DT_JMPREL, DT_NULL, DT_PLTRELSZ, DT_STRTAB,
-    DT_SYMTAB, PT_DYNAMIC, R_AARCH64_JUMP_SLOT, R_X86_64_JUMP_SLOT,
+    DT_SYMTAB, PT_DYNAMIC, PT_LOAD, R_AARCH64_JUMP_SLOT, R_X86_64_JUMP_SLOT,
 };
 use libc::{c_char, c_int, c_void, dl_phdr_info};
 use log::{error, trace};
@@ -26,7 +28,11 @@ fn elf64_r_sym(info: Elf64_Xword) -> u32 {
 /// arithmetics are safe because the dynamic library the `info` is pointing to was loaded by the
 /// dynamic linker prior to us messing with the global offset table. If the dynamic library would
 /// not be a valid ELF64, the dynamic linker would have not loaded it.
-unsafe fn override_got_entry(info: *mut dl_phdr_info, state: &mut GotHookState) -> bool {
+unsafe fn override_got_entry(
+    info: *mut dl_phdr_info,
+    image_name: &[u8],
+    state: &mut GotHookState,
+) -> bool {
     let phdr = (*info).dlpi_phdr;
 
     // Locate the dynamic programm header (`PT_DYNAMIC`)
@@ -170,6 +176,7 @@ unsafe fn override_got_entry(info: *mut dl_phdr_info, state: &mut GotHookState) 
                 }
                 state.restores.push(GotSlotRestore {
                     image: (*info).dlpi_addr as usize,
+                    image_name: image_name.into(),
                     slot: got_entry as usize,
                     original: original as usize,
                     replacement: overwrite.new_func as usize,
@@ -204,12 +211,15 @@ pub unsafe extern "C" fn callback(
         return 0;
     }
 
-    let name = if (*info).dlpi_name.is_null() || *(*info).dlpi_name == 0 {
+    let image_name = if (*info).dlpi_name.is_null() {
+        &[][..]
+    } else {
+        CStr::from_ptr((*info).dlpi_name).to_bytes()
+    };
+    let name = if image_name.is_empty() {
         "[Executable]"
     } else {
-        CStr::from_ptr((*info).dlpi_name)
-            .to_str()
-            .unwrap_or("[Unknown]")
+        std::str::from_utf8(image_name).unwrap_or("[Unknown]")
     };
 
     // I guess if we try to hook into GOT from `linux-vdso` or `ld-linux` our best outcome will be
@@ -218,7 +228,7 @@ pub unsafe extern "C" fn callback(
         return 0;
     }
 
-    if override_got_entry(info, state) {
+    if override_got_entry(info, image_name, state) {
         trace!("Hooked into {name}");
     } else {
         trace!("Hooking {name} failed");
@@ -235,6 +245,20 @@ pub unsafe fn restore_symbols(restores: &mut Vec<GotSlotRestore>) {
     restores.clear();
 }
 
+unsafe fn slot_belongs_to_image(info: *mut dl_phdr_info, slot: usize) -> bool {
+    for i in 0..(*info).dlpi_phnum {
+        let phdr = &*(*info).dlpi_phdr.add(i as usize);
+        if phdr.p_type != PT_LOAD {
+            continue;
+        }
+        let start = ((*info).dlpi_addr as usize).wrapping_add(phdr.p_vaddr as usize);
+        if slot_fits_range(slot, start, phdr.p_memsz as usize) {
+            return true;
+        }
+    }
+    false
+}
+
 unsafe extern "C" fn restore_callback(
     info: *mut dl_phdr_info,
     _size: usize,
@@ -242,13 +266,25 @@ unsafe extern "C" fn restore_callback(
 ) -> c_int {
     let restores = &mut *(data as *mut Vec<GotSlotRestore>);
     let image = (*info).dlpi_addr as usize;
+    let image_name = if (*info).dlpi_name.is_null() {
+        &[][..]
+    } else {
+        CStr::from_ptr((*info).dlpi_name).to_bytes()
+    };
     let page_size = libc::sysconf(libc::_SC_PAGESIZE) as usize;
 
     for restore in restores
         .iter()
         .rev()
-        .filter(|restore| restore.image == image)
+        .filter(|restore| restore_matches_image(restore, image, image_name))
     {
+        if !slot_belongs_to_image(info, restore.slot) {
+            trace!(
+                "Not restoring GOT entry at {:#x}: it is outside the loaded image",
+                restore.slot
+            );
+            continue;
+        }
         let slot = restore.slot as *mut *mut ();
         if *slot as usize != restore.replacement {
             trace!(

--- a/profiling/src/io/got_elf64.rs
+++ b/profiling/src/io/got_elf64.rs
@@ -237,12 +237,25 @@ pub unsafe extern "C" fn callback(
     0
 }
 
-pub unsafe fn restore_symbols(restores: &mut Vec<GotSlotRestore>) {
-    libc::dl_iterate_phdr(
-        Some(restore_callback),
-        restores as *mut _ as *mut libc::c_void,
-    );
+struct RestoreState<'a> {
+    restores: &'a [GotSlotRestore],
+    complete: bool,
+}
+
+pub unsafe fn restore_symbols(restores: &mut Vec<GotSlotRestore>) -> bool {
+    let complete = {
+        let mut state = RestoreState {
+            restores,
+            complete: true,
+        };
+        libc::dl_iterate_phdr(
+            Some(restore_callback),
+            &mut state as *mut _ as *mut libc::c_void,
+        );
+        state.complete
+    };
     restores.clear();
+    complete
 }
 
 unsafe fn slot_belongs_to_image(info: *mut dl_phdr_info, slot: usize) -> bool {
@@ -264,7 +277,9 @@ unsafe extern "C" fn restore_callback(
     _size: usize,
     data: *mut c_void,
 ) -> c_int {
-    let restores = &mut *(data as *mut Vec<GotSlotRestore>);
+    let state = &mut *(data as *mut RestoreState<'_>);
+    let restores = state.restores;
+    let complete = &mut state.complete;
     let image = (*info).dlpi_addr as usize;
     let image_name = if (*info).dlpi_name.is_null() {
         &[][..]
@@ -283,6 +298,7 @@ unsafe extern "C" fn restore_callback(
                 "Not restoring GOT entry at {:#x}: it is outside the loaded image",
                 restore.slot
             );
+            *complete = false;
             continue;
         }
         let slot = restore.slot as *mut *mut ();
@@ -291,6 +307,7 @@ unsafe extern "C" fn restore_callback(
                 "Not restoring GOT entry at {:p}: it was replaced after our hook",
                 slot
             );
+            *complete = false;
             continue;
         }
 
@@ -303,11 +320,14 @@ unsafe extern "C" fn restore_callback(
         {
             let err = *libc::__errno_location();
             trace!("mprotect failed while restoring GOT entry at {slot:p}: {err}");
+            *complete = false;
             continue;
         }
 
         if restore_slot_if_owned(restore) {
             trace!("Restored GOT entry at {slot:p}");
+        } else {
+            *complete = false;
         }
     }
 

--- a/profiling/src/io/got_elf64.rs
+++ b/profiling/src/io/got_elf64.rs
@@ -1,4 +1,4 @@
-use super::GotSymbolOverwrite;
+use super::{restore_slot_if_owned, GotHookState, GotSlotRestore};
 use crate::profiling::bindings::{
     Elf64_Dyn, Elf64_Rela, Elf64_Sym, Elf64_Xword, DT_JMPREL, DT_NULL, DT_PLTRELSZ, DT_STRTAB,
     DT_SYMTAB, PT_DYNAMIC, R_AARCH64_JUMP_SLOT, R_X86_64_JUMP_SLOT,
@@ -26,10 +26,7 @@ fn elf64_r_sym(info: Elf64_Xword) -> u32 {
 /// arithmetics are safe because the dynamic library the `info` is pointing to was loaded by the
 /// dynamic linker prior to us messing with the global offset table. If the dynamic library would
 /// not be a valid ELF64, the dynamic linker would have not loaded it.
-unsafe fn override_got_entry(
-    info: *mut dl_phdr_info,
-    overwrites: *mut Vec<GotSymbolOverwrite>,
-) -> bool {
+unsafe fn override_got_entry(info: *mut dl_phdr_info, state: &mut GotHookState) -> bool {
     let phdr = (*info).dlpi_phdr;
 
     // Locate the dynamic programm header (`PT_DYNAMIC`)
@@ -111,7 +108,7 @@ unsafe fn override_got_entry(
 
     // For each symbol we want to overwrite (from `overwrites`), we scan the relocation entries.
     // Once the matching symbol name is found, patch its GOT entry to point to our new function.
-    for overwrite in &mut *overwrites {
+    for overwrite in state.overwrites.iter_mut() {
         for i in 0..num_relocs {
             let rel = rel_plt.add(i);
             let r_type = elf64_r_type((*rel).r_info);
@@ -151,12 +148,17 @@ unsafe fn override_got_entry(
                     return false;
                 }
 
+                let original = *got_entry;
+                if original == overwrite.new_func {
+                    continue;
+                }
+
                 trace!(
                     "Overriding GOT entry for {} at offset {:?} (abs: {:p}) pointing to {:p} (orig function at {:p})",
                     overwrite.symbol_name,
                     (*rel).r_offset,
                     got_entry,
-                    *got_entry,
+                    original,
                     *overwrite.orig_func
                 );
 
@@ -164,8 +166,14 @@ unsafe fn override_got_entry(
                 *overwrite.orig_func = libc::dlsym(libc::RTLD_NEXT, name_ptr) as *mut ();
                 if (*overwrite.orig_func).is_null() {
                     // libc linux fallback
-                    *overwrite.orig_func = *got_entry;
+                    *overwrite.orig_func = original;
                 }
+                state.restores.push(GotSlotRestore {
+                    image: (*info).dlpi_addr as usize,
+                    slot: got_entry as usize,
+                    original: original as usize,
+                    replacement: overwrite.new_func as usize,
+                });
                 *got_entry = overwrite.new_func;
                 continue;
             }
@@ -181,7 +189,7 @@ pub unsafe extern "C" fn callback(
     _size: usize,
     data: *mut c_void,
 ) -> c_int {
-    let overwrites = &mut *(data as *mut Vec<GotSymbolOverwrite>);
+    let state = &mut *(data as *mut GotHookState);
 
     // detect myself ...
     let mut my_info: libc::Dl_info = std::mem::zeroed();
@@ -210,10 +218,61 @@ pub unsafe extern "C" fn callback(
         return 0;
     }
 
-    if override_got_entry(info, overwrites) {
+    if override_got_entry(info, state) {
         trace!("Hooked into {name}");
     } else {
         trace!("Hooking {name} failed");
+    }
+
+    0
+}
+
+pub unsafe fn restore_symbols(restores: &mut Vec<GotSlotRestore>) {
+    libc::dl_iterate_phdr(
+        Some(restore_callback),
+        restores as *mut _ as *mut libc::c_void,
+    );
+    restores.clear();
+}
+
+unsafe extern "C" fn restore_callback(
+    info: *mut dl_phdr_info,
+    _size: usize,
+    data: *mut c_void,
+) -> c_int {
+    let restores = &mut *(data as *mut Vec<GotSlotRestore>);
+    let image = (*info).dlpi_addr as usize;
+    let page_size = libc::sysconf(libc::_SC_PAGESIZE) as usize;
+
+    for restore in restores
+        .iter()
+        .rev()
+        .filter(|restore| restore.image == image)
+    {
+        let slot = restore.slot as *mut *mut ();
+        if *slot as usize != restore.replacement {
+            trace!(
+                "Not restoring GOT entry at {:p}: it was replaced after our hook",
+                slot
+            );
+            continue;
+        }
+
+        let aligned_addr = restore.slot & !(page_size - 1);
+        if libc::mprotect(
+            aligned_addr as *mut c_void,
+            page_size,
+            libc::PROT_READ | libc::PROT_WRITE,
+        ) != 0
+        {
+            let err = *libc::__errno_location();
+            trace!("mprotect failed while restoring GOT entry at {slot:p}: {err}");
+            continue;
+        }
+
+        if restore_slot_if_owned(restore) {
+            trace!("Restored GOT entry at {slot:p}");
+        }
     }
 
     0

--- a/profiling/src/io/got_macho.rs
+++ b/profiling/src/io/got_macho.rs
@@ -49,7 +49,10 @@
 // - Apple dyld source: https://opensource.apple.com/source/dyld/
 // - Mach-O headers: <mach-o/loader.h>, <mach-o/nlist.h>
 
-use super::{restore_slot_if_owned, GotHookState, GotSlotRestore, GotSymbolOverwrite};
+use super::{
+    restore_matches_image, restore_slot_if_owned, slot_fits_range, GotHookState, GotSlotRestore,
+    GotSymbolOverwrite,
+};
 use libc::{c_char, c_void};
 use log::{error, trace};
 use mach2::loader;
@@ -259,13 +262,14 @@ pub unsafe fn rebind_symbols(state: &mut GotHookState) {
 
         let slide = _dyld_get_image_vmaddr_slide(i);
         let name_ptr = _dyld_get_image_name(i);
-        let name = if name_ptr.is_null() {
-            "[Unknown]"
+        let image_name = if name_ptr.is_null() {
+            &[][..]
         } else {
-            CStr::from_ptr(name_ptr).to_str().unwrap_or("[Unknown]")
+            CStr::from_ptr(name_ptr).to_bytes()
         };
+        let name = std::str::from_utf8(image_name).unwrap_or("[Unknown]");
 
-        if rebind_symbols_for_image(header, slide, state) {
+        if rebind_symbols_for_image(header, slide, image_name, state) {
             trace!("Hooked into {name}");
         } else {
             trace!("Hooking {name} skipped or failed");
@@ -287,6 +291,7 @@ pub unsafe fn rebind_symbols(state: &mut GotHookState) {
 unsafe fn rebind_symbols_for_image(
     header: *const loader::mach_header,
     slide: isize,
+    image_name: &[u8],
     state: &mut GotHookState,
 ) -> bool {
     if (*header).magic != libc::MH_MAGIC_64 {
@@ -387,6 +392,7 @@ unsafe fn rebind_symbols_for_image(
 
                     if rebind_symbols_in_section(
                         header as usize,
+                        image_name,
                         section,
                         slide,
                         symtab,
@@ -421,6 +427,7 @@ unsafe fn rebind_symbols_for_image(
 ///    function and replace it with our instrumented version.
 unsafe fn rebind_symbols_in_section(
     image: usize,
+    image_name: &[u8],
     section: &Section64,
     slide: isize,
     symtab: *const Nlist64,
@@ -512,6 +519,7 @@ unsafe fn rebind_symbols_in_section(
             *overwrite.orig_func = original as *mut ();
             restores.push(GotSlotRestore {
                 image,
+                image_name: image_name.into(),
                 slot: slot as usize,
                 original: original as usize,
                 replacement: overwrite.new_func as usize,
@@ -540,6 +548,32 @@ unsafe fn rebind_symbols_in_section(
     hooked
 }
 
+unsafe fn slot_belongs_to_image(
+    header: *const loader::mach_header,
+    slide: isize,
+    slot: usize,
+) -> bool {
+    if (*header).magic != libc::MH_MAGIC_64 {
+        return false;
+    }
+
+    let mut cmd_ptr = (header as *const u8).add(std::mem::size_of::<MachHeader64>());
+    for _ in 0..(*header).ncmds {
+        let lc = &*(cmd_ptr as *const libc::load_command);
+        if lc.cmd == LC_SEGMENT_64 {
+            let seg = &*(cmd_ptr as *const libc::segment_command_64);
+            let start = (slide as usize).wrapping_add(seg.vmaddr as usize);
+            if seg.initprot != libc::VM_PROT_NONE
+                && slot_fits_range(slot, start, seg.vmsize as usize)
+            {
+                return true;
+            }
+        }
+        cmd_ptr = cmd_ptr.add(lc.cmdsize as usize);
+    }
+    false
+}
+
 pub unsafe fn restore_symbols(restores: &mut Vec<GotSlotRestore>) {
     let image_count = _dyld_image_count();
     let page_size = libc::sysconf(libc::_SC_PAGESIZE) as usize;
@@ -549,12 +583,26 @@ pub unsafe fn restore_symbols(restores: &mut Vec<GotSlotRestore>) {
         if header.is_null() {
             continue;
         }
+        let slide = _dyld_get_image_vmaddr_slide(i);
+        let name_ptr = _dyld_get_image_name(i);
+        let image_name = if name_ptr.is_null() {
+            &[][..]
+        } else {
+            CStr::from_ptr(name_ptr).to_bytes()
+        };
 
         for restore in restores
             .iter()
             .rev()
-            .filter(|restore| restore.image == header as usize)
+            .filter(|restore| restore_matches_image(restore, header as usize, image_name))
         {
+            if !slot_belongs_to_image(header, slide, restore.slot) {
+                trace!(
+                    "Not restoring symbol pointer at {:#x}: it is outside the loaded image",
+                    restore.slot
+                );
+                continue;
+            }
             let slot = restore.slot as *mut *mut ();
             if *slot as usize != restore.replacement {
                 trace!(

--- a/profiling/src/io/got_macho.rs
+++ b/profiling/src/io/got_macho.rs
@@ -49,7 +49,7 @@
 // - Apple dyld source: https://opensource.apple.com/source/dyld/
 // - Mach-O headers: <mach-o/loader.h>, <mach-o/nlist.h>
 
-use super::GotSymbolOverwrite;
+use super::{restore_slot_if_owned, GotHookState, GotSlotRestore, GotSymbolOverwrite};
 use libc::{c_char, c_void};
 use log::{error, trace};
 use mach2::loader;
@@ -234,7 +234,7 @@ extern "C" {
 /// initialization, from a single thread, before the hooked functions are called concurrently.
 /// The pointer arithmetic is safe because all images were successfully loaded by dyld — if an
 /// image had an invalid Mach-O structure, dyld would have rejected it.
-pub unsafe fn rebind_symbols(overwrites: &mut Vec<GotSymbolOverwrite>) {
+pub unsafe fn rebind_symbols(state: &mut GotHookState) {
     // Use dladdr on one of our own functions to find our image's base address, so we can
     // skip patching our own image (we don't want to hook our own calls to libc).
     let mut my_info: libc::Dl_info = std::mem::zeroed();
@@ -265,7 +265,7 @@ pub unsafe fn rebind_symbols(overwrites: &mut Vec<GotSymbolOverwrite>) {
             CStr::from_ptr(name_ptr).to_str().unwrap_or("[Unknown]")
         };
 
-        if rebind_symbols_for_image(header, slide, overwrites) {
+        if rebind_symbols_for_image(header, slide, state) {
             trace!("Hooked into {name}");
         } else {
             trace!("Hooking {name} skipped or failed");
@@ -287,7 +287,7 @@ pub unsafe fn rebind_symbols(overwrites: &mut Vec<GotSymbolOverwrite>) {
 unsafe fn rebind_symbols_for_image(
     header: *const loader::mach_header,
     slide: isize,
-    overwrites: &mut Vec<GotSymbolOverwrite>,
+    state: &mut GotHookState,
 ) -> bool {
     if (*header).magic != libc::MH_MAGIC_64 {
         trace!(
@@ -386,12 +386,14 @@ unsafe fn rebind_symbols_for_image(
                     }
 
                     if rebind_symbols_in_section(
+                        header as usize,
                         section,
                         slide,
                         symtab,
                         strtab,
                         indirect_symtab,
-                        overwrites,
+                        &mut *state.overwrites,
+                        &mut *state.restores,
                         segname == "__DATA_CONST",
                     ) {
                         hooked = true;
@@ -418,12 +420,14 @@ unsafe fn rebind_symbols_for_image(
 /// 4. If the name matches one of our overwrites, save the current pointer as the "original"
 ///    function and replace it with our instrumented version.
 unsafe fn rebind_symbols_in_section(
+    image: usize,
     section: &Section64,
     slide: isize,
     symtab: *const Nlist64,
     strtab: *const c_char,
     indirect_symtab: *const u32,
     overwrites: &mut [GotSymbolOverwrite],
+    restores: &mut Vec<GotSlotRestore>,
     is_data_const: bool,
 ) -> bool {
     // Each slot in the section is one pointer (8 bytes on 64-bit). The number of slots is
@@ -471,6 +475,10 @@ unsafe fn rebind_symbols_in_section(
             }
 
             let slot = symbol_ptrs.add(i);
+            let original = *slot;
+            if original as *mut () == overwrite.new_func {
+                continue;
+            }
 
             // __DATA_CONST is read-only at this point (dyld marks it read-only after initial
             // binding). We need to temporarily make the page writable using vm_protect with
@@ -499,11 +507,16 @@ unsafe fn rebind_symbols_in_section(
                 *overwrite.orig_func,
             );
 
-            // Save the original function pointer from the slot before we overwrite it.
-            // This is written on every matching image (last writer wins), but that's fine:
-            // by first RINIT all lazy bindings for common libc functions are resolved, so
-            // every image's slot points to the same canonical address in libSystem.
-            *overwrite.orig_func = *slot as *mut ();
+            // Keep the existing single call-through pointer, but record the exact value of every
+            // slot so MSHUTDOWN can restore images which resolve this symbol differently.
+            *overwrite.orig_func = original as *mut ();
+            restores.push(GotSlotRestore {
+                image,
+                slot: slot as usize,
+                original: original as usize,
+                replacement: overwrite.new_func as usize,
+                is_data_const,
+            });
             *slot = overwrite.new_func as *mut c_void;
             hooked = true;
 
@@ -525,6 +538,67 @@ unsafe fn rebind_symbols_in_section(
     }
 
     hooked
+}
+
+pub unsafe fn restore_symbols(restores: &mut Vec<GotSlotRestore>) {
+    let image_count = _dyld_image_count();
+    let page_size = libc::sysconf(libc::_SC_PAGESIZE) as usize;
+
+    for i in 0..image_count {
+        let header = _dyld_get_image_header(i);
+        if header.is_null() {
+            continue;
+        }
+
+        for restore in restores
+            .iter()
+            .rev()
+            .filter(|restore| restore.image == header as usize)
+        {
+            let slot = restore.slot as *mut *mut ();
+            if *slot as usize != restore.replacement {
+                trace!(
+                    "Not restoring symbol pointer at {:p}: it was replaced after our hook",
+                    slot
+                );
+                continue;
+            }
+
+            if restore.is_data_const {
+                let page_start = restore.slot & !(page_size - 1);
+                let result = vm_protect(
+                    mach_task_self(),
+                    page_start as libc::mach_vm_address_t,
+                    page_size as libc::mach_vm_size_t,
+                    0,
+                    libc::VM_PROT_READ | libc::VM_PROT_WRITE | VM_PROT_COPY,
+                );
+                if result != 0 {
+                    trace!(
+                        "vm_protect failed while restoring symbol pointer at {slot:p}: kern_return {result}"
+                    );
+                    continue;
+                }
+            }
+
+            if restore_slot_if_owned(restore) {
+                trace!("Restored symbol pointer at {slot:p}");
+            }
+
+            if restore.is_data_const {
+                let page_start = restore.slot & !(page_size - 1);
+                vm_protect(
+                    mach_task_self(),
+                    page_start as libc::mach_vm_address_t,
+                    page_size as libc::mach_vm_size_t,
+                    0,
+                    libc::VM_PROT_READ,
+                );
+            }
+        }
+    }
+
+    restores.clear();
 }
 
 /// Extract the segment name from a `segment_command_64` as a `&str`.

--- a/profiling/src/io/got_macho.rs
+++ b/profiling/src/io/got_macho.rs
@@ -574,9 +574,10 @@ unsafe fn slot_belongs_to_image(
     false
 }
 
-pub unsafe fn restore_symbols(restores: &mut Vec<GotSlotRestore>) {
+pub unsafe fn restore_symbols(restores: &mut Vec<GotSlotRestore>) -> bool {
     let image_count = _dyld_image_count();
     let page_size = libc::sysconf(libc::_SC_PAGESIZE) as usize;
+    let mut complete = true;
 
     for i in 0..image_count {
         let header = _dyld_get_image_header(i);
@@ -601,6 +602,7 @@ pub unsafe fn restore_symbols(restores: &mut Vec<GotSlotRestore>) {
                     "Not restoring symbol pointer at {:#x}: it is outside the loaded image",
                     restore.slot
                 );
+                complete = false;
                 continue;
             }
             let slot = restore.slot as *mut *mut ();
@@ -609,6 +611,7 @@ pub unsafe fn restore_symbols(restores: &mut Vec<GotSlotRestore>) {
                     "Not restoring symbol pointer at {:p}: it was replaced after our hook",
                     slot
                 );
+                complete = false;
                 continue;
             }
 
@@ -625,12 +628,15 @@ pub unsafe fn restore_symbols(restores: &mut Vec<GotSlotRestore>) {
                     trace!(
                         "vm_protect failed while restoring symbol pointer at {slot:p}: kern_return {result}"
                     );
+                    complete = false;
                     continue;
                 }
             }
 
             if restore_slot_if_owned(restore) {
                 trace!("Restored symbol pointer at {slot:p}");
+            } else {
+                complete = false;
             }
 
             if restore.is_data_const {
@@ -647,6 +653,7 @@ pub unsafe fn restore_symbols(restores: &mut Vec<GotSlotRestore>) {
     }
 
     restores.clear();
+    complete
 }
 
 /// Extract the segment name from a `segment_command_64` as a `&str`.

--- a/profiling/src/io/mod.rs
+++ b/profiling/src/io/mod.rs
@@ -59,6 +59,31 @@ pub struct GotSymbolOverwrite {
     pub orig_func: *mut *mut (),
 }
 
+pub struct GotHookState<'a> {
+    pub overwrites: &'a mut [GotSymbolOverwrite],
+    pub restores: &'a mut Vec<GotSlotRestore>,
+}
+
+pub struct GotSlotRestore {
+    pub image: usize,
+    pub slot: usize,
+    pub original: usize,
+    pub replacement: usize,
+    #[cfg(target_os = "macos")]
+    pub is_data_const: bool,
+}
+
+static GOT_SLOT_RESTORES: Mutex<Vec<GotSlotRestore>> = Mutex::new(Vec::new());
+
+unsafe fn restore_slot_if_owned(restore: &GotSlotRestore) -> bool {
+    let slot = restore.slot as *mut *mut ();
+    if *slot as usize != restore.replacement {
+        return false;
+    }
+    *slot = restore.original as *mut ();
+    true
+}
+
 static mut ORIG_POLL: unsafe extern "C" fn(*mut libc::pollfd, libc::nfds_t, c_int) -> i32 =
     libc::poll;
 
@@ -709,15 +734,32 @@ pub fn io_prof_first_rinit() {
                     orig_func: ptr::addr_of_mut!(ORIG_POLL) as *mut _ as *mut *mut (),
                 },
             ];
+            let mut restores = GOT_SLOT_RESTORES.lock().unwrap();
+            let mut state = GotHookState {
+                overwrites: &mut overwrites,
+                restores: &mut restores,
+            };
+
             #[cfg(target_os = "linux")]
             libc::dl_iterate_phdr(
                 Some(got_elf64::callback),
-                &mut overwrites as *mut _ as *mut libc::c_void,
+                &mut state as *mut _ as *mut libc::c_void,
             );
 
             #[cfg(target_os = "macos")]
-            got_macho::rebind_symbols(&mut overwrites);
+            got_macho::rebind_symbols(&mut state);
         };
+    }
+}
+
+pub fn io_prof_mshutdown() {
+    let mut restores = GOT_SLOT_RESTORES.lock().unwrap();
+    unsafe {
+        #[cfg(target_os = "linux")]
+        got_elf64::restore_symbols(&mut restores);
+
+        #[cfg(target_os = "macos")]
+        got_macho::restore_symbols(&mut restores);
     }
 }
 

--- a/profiling/src/io/mod.rs
+++ b/profiling/src/io/mod.rs
@@ -66,6 +66,7 @@ pub struct GotHookState<'a> {
 
 pub struct GotSlotRestore {
     pub image: usize,
+    pub image_name: Box<[u8]>,
     pub slot: usize,
     pub original: usize,
     pub replacement: usize,
@@ -74,6 +75,20 @@ pub struct GotSlotRestore {
 }
 
 static GOT_SLOT_RESTORES: Mutex<Vec<GotSlotRestore>> = Mutex::new(Vec::new());
+
+fn restore_matches_image(restore: &GotSlotRestore, image: usize, image_name: &[u8]) -> bool {
+    restore.image == image && restore.image_name.as_ref() == image_name
+}
+
+fn slot_fits_range(slot: usize, start: usize, size: usize) -> bool {
+    let Some(end) = start.checked_add(size) else {
+        return false;
+    };
+    let Some(slot_end) = slot.checked_add(std::mem::size_of::<*mut ()>()) else {
+        return false;
+    };
+    slot >= start && slot_end <= end
+}
 
 unsafe fn restore_slot_if_owned(restore: &GotSlotRestore) -> bool {
     let slot = restore.slot as *mut *mut ();
@@ -765,8 +780,28 @@ pub fn io_prof_mshutdown() {
 
 #[cfg(test)]
 mod tests {
-    use super::ErrnoBackup;
+    use super::{restore_matches_image, slot_fits_range, ErrnoBackup, GotSlotRestore};
     use static_assertions::assert_not_impl_any;
 
     assert_not_impl_any!(ErrnoBackup: Send, Sync);
+
+    #[test]
+    fn restore_requires_same_image_and_mapped_slot() {
+        let restore = GotSlotRestore {
+            image: 0x1000,
+            image_name: Box::from(&b"image"[..]),
+            slot: 0x1800,
+            original: 0,
+            replacement: 1,
+            #[cfg(target_os = "macos")]
+            is_data_const: false,
+        };
+
+        assert!(restore_matches_image(&restore, 0x1000, b"image"));
+        assert!(!restore_matches_image(&restore, 0x2000, b"image"));
+        assert!(!restore_matches_image(&restore, 0x1000, b"replacement"));
+        assert!(slot_fits_range(0x1800, 0x1000, 0x1000));
+        assert!(!slot_fits_range(0x2000, 0x1000, 0x1000));
+        assert!(!slot_fits_range(usize::MAX, 0x1000, 0x1000));
+    }
 }

--- a/profiling/src/io/mod.rs
+++ b/profiling/src/io/mod.rs
@@ -767,14 +767,18 @@ pub fn io_prof_first_rinit() {
     }
 }
 
-pub fn io_prof_mshutdown() {
+pub fn io_prof_mshutdown() -> bool {
     let mut restores = GOT_SLOT_RESTORES.lock().unwrap();
     unsafe {
         #[cfg(target_os = "linux")]
-        got_elf64::restore_symbols(&mut restores);
+        {
+            got_elf64::restore_symbols(&mut restores)
+        }
 
         #[cfg(target_os = "macos")]
-        got_macho::restore_symbols(&mut restores);
+        {
+            got_macho::restore_symbols(&mut restores)
+        }
     }
 }
 
@@ -803,5 +807,14 @@ mod tests {
         assert!(slot_fits_range(0x1800, 0x1000, 0x1000));
         assert!(!slot_fits_range(0x2000, 0x1000, 0x1000));
         assert!(!slot_fits_range(usize::MAX, 0x1000, 0x1000));
+    }
+
+    #[test]
+    fn no_hooks_are_safe_to_unload() {
+        let mut restores = Vec::new();
+        #[cfg(target_os = "linux")]
+        assert!(unsafe { super::got_elf64::restore_symbols(&mut restores) });
+        #[cfg(target_os = "macos")]
+        assert!(unsafe { super::got_macho::restore_symbols(&mut restores) });
     }
 }

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -1029,6 +1029,12 @@ extern "C" fn mshutdown(_type: c_int, _module_number: c_int) -> ZendResult {
     // SAFETY: calling in mshutdown as required.
     unsafe { Profiler::stop(Duration::from_secs(1)) };
 
+    #[cfg(all(
+        feature = "io_profiling",
+        any(target_os = "linux", target_os = "macos")
+    ))]
+    io::io_prof_mshutdown();
+
     ZendResult::Success
 }
 

--- a/profiling/src/lib.rs
+++ b/profiling/src/lib.rs
@@ -80,6 +80,12 @@ static PROFILER_VERSION_STR: &str = const {
 /// compile-time. Its value is overwritten during minit.
 static RUNTIME_PHP_VERSION_ID: AtomicU32 = AtomicU32::new(zend::PHP_VERSION_ID);
 
+#[cfg(all(
+    feature = "io_profiling",
+    any(target_os = "linux", target_os = "macos")
+))]
+static IO_HOOKS_SAFE_TO_UNLOAD: AtomicBool = AtomicBool::new(true);
+
 /// Version str of PHP at run-time, not the version it was built against at
 /// compile-time. Its value is overwritten during minit, unless there are
 /// errors at run-time, and then the compile-time value will still remain.
@@ -1033,7 +1039,9 @@ extern "C" fn mshutdown(_type: c_int, _module_number: c_int) -> ZendResult {
         feature = "io_profiling",
         any(target_os = "linux", target_os = "macos")
     ))]
-    io::io_prof_mshutdown();
+    if !io::io_prof_mshutdown() {
+        IO_HOOKS_SAFE_TO_UNLOAD.store(false, Ordering::Relaxed);
+    }
 
     ZendResult::Success
 }
@@ -1084,6 +1092,18 @@ extern "C" fn shutdown(extension: *mut ZendExtension) {
         // SAFETY: during mshutdown, we have ownership of the extension struct.
         // Our threads (which failed to join) do not mutate this struct at all
         // either, providing no races.
+        unsafe { (*extension).handle = ptr::null_mut() }
+    }
+
+    #[cfg(all(
+        feature = "io_profiling",
+        any(target_os = "linux", target_os = "macos")
+    ))]
+    if !IO_HOOKS_SAFE_TO_UNLOAD.load(Ordering::Relaxed) {
+        error!(
+            "I/O hooks could not be fully restored, intentionally leaking the extension's handle to prevent unloading"
+        );
+        // SAFETY: during shutdown, we have ownership of the extension struct.
         unsafe { (*extension).handle = ptr::null_mut() }
     }
 


### PR DESCRIPTION
### Description

Store the exact original value for each GOT or Mach-O slot changed by I/O profiling and restore it during MSHUTDOWN. Restoration only touches slots still pointing to our hook and only visits loaded images, so it does not clobber later hooks or dereference unloaded images.

If any loaded hook cannot be safely removed, keep the profiler extension loaded to prevent dangling function pointers.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.

PROF-15878
