### PR TITLE
Build with lto

### DIFF
--- a/.gitlab/build-tracing.sh
+++ b/.gitlab/build-tracing.sh
@@ -19,7 +19,7 @@ catch_warnings="${2:-1}"
 mkdir -p extensions_$(uname -m) standalone_$(uname -m)
 
 ECHO_ARG="-e"
-CFLAGS="-std=gnu11 -O2 -g -Wall -Wextra"
+export CFLAGS="-std=gnu11 -O2 -g -Wall -Wextra -flto=auto -ffat-lto-objects"
 if [ "${suffix}" = "-alpine" ]; then
   CFLAGS="${CFLAGS} -Wno-error=return-local-addr"
 fi


### PR DESCRIPTION
Aside from being a lto build, in particular this serves as regression that it doesn't break the distro build of ddtrace anymore.