### PR TITLE
ci: gate notify-slo-breaches like check-slo-breaches

### DIFF
--- a/.gitlab/benchmarks.yml
+++ b/.gitlab/benchmarks.yml
@@ -131,7 +131,9 @@ workflow:
   - if: '($CI_COMMIT_REF_NAME == "master" && ($NIGHTLY_BENCHMARKS || $CI_PIPELINE_SOURCE != "schedule")) || $CI_COMMIT_REF_NAME =~ /^ddtrace-/'
     when: always
     interruptible: false
-  - interruptible: true
+  - when: manual
+    allow_failure: true
+    interruptible: true
 
 .microbenchmarks:
   stage: benchmarks


### PR DESCRIPTION
### Description

On [this pipeline](https://gitlab.ddbuild.io/DataDog/apm-reliability/dd-trace-php/-/pipelines/135758189), check-slo-breaches was skipped due to it being a nightly benchmark pipeline, but notify-slo-breaches ran and incorrectly notified a failure.

notify-slo-breaches should not run on nightly benchmarks, and this PR disables it.

- Add `when: manual` and `allow_failure: true` to the fallthrough rule of `.notify-slo-breaches-rules`, matching `.macrobenchmarks-rules`.
  - The fallthrough carried no `when:`, so the job inherited `when: always` from the template and ran even when its shared `if:` condition was false.
  - On a scheduled master pipeline with `NIGHTLY_BENCHMARKS` unset, macrobenchmarks and check-slo-breaches fall through to manual and are never triggered. notify-slo-breaches ran anyway.
  - The notifier reads no exit code: it tests for the `fail-on-breach.status.check-completed` marker file, so a check that never ran looks the same as one that failed.
- Leave the first rule untouched, so `when: always` still holds on master and release branches, where a check failure means a breach was detected.

Nightly pipelines now send no notification, which is intended: there is no check result to report.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.