### PR TITLE
Fix #4163: broken frankenphp shutdown signal on musl

### DIFF
--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -2,7 +2,7 @@
 
 include "generate-common.php";
 
-const FRANKENPHP_ALPINE_PHP_VERSION = "8.5";
+const FRANKENPHP_ALPINE_PHP_VERSION = "8.3.12";
 
 $build_platforms = [
     [
@@ -834,6 +834,8 @@ endforeach;
   needs:
     - job: "package extension: [arm64, aarch64-alpine-linux-musl]"
       artifacts: true
+    - job: "prepare code"
+      artifacts: true
   services:
     - !reference [.services, test-agent]
     - !reference [.services, request-replayer]
@@ -843,6 +845,7 @@ endforeach;
     KUBERNETES_MEMORY_REQUEST: 4Gi
     KUBERNETES_MEMORY_LIMIT: 4Gi
     COMPOSER_PROCESS_TIMEOUT: 0
+    DD_TRACE_ASSUME_COMPILED: "1"
     DD_AGENT_HOST: test-agent
     DD_TRACE_AGENT_PORT: 9126
     HTTPBIN_HOSTNAME: httpbin-integration

--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -853,8 +853,14 @@ endforeach;
     WAIT_FOR: test-agent:9126
   before_script:
 <?php unset_dd_runner_env_vars() ?>
-    # coreutils/findutils/grep: the Makefile and the artifact-collection scripts rely on GNU flags that BusyBox does not implement.
-    - apk add --no-cache bash composer coreutils curl findutils git grep libgcc make || exit 75
+    # coreutils/findutils/grep: the Makefile and the artifact-collection scripts rely on GNU flags
+    # that BusyBox does not implement. Deliberately not apk's `composer`: that pulls in Alpine's
+    # own php83, and composer would then resolve the test requirements against that PHP instead of
+    # the image's ZTS build (which is the one under test).
+    - apk add --no-cache bash coreutils curl findutils git grep libgcc make || exit 75
+    - install-php-extensions zip || exit 75
+    - php -r "copy('https://getcomposer.org/installer', '/tmp/composer-setup.php');"
+    - php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer
     - git config --global --add safe.directory "${CI_PROJECT_DIR}"
     - git config --global --add safe.directory "${CI_PROJECT_DIR}/*"
     - mkdir -p tmp/build_extension/modules artifacts

--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -2,6 +2,8 @@
 
 include "generate-common.php";
 
+const FRANKENPHP_ALPINE_PHP_VERSION = "8.5";
+
 $build_platforms = [
     [
         "triplet" => "x86_64-alpine-linux-musl",
@@ -822,6 +824,54 @@ endforeach;
     - phpize # run phpize just to get run-tests.php
   script:
     - php run-tests.php -p $(which php) -d datadog.remote_config_enabled=false --show-diff -g "FAIL,XFAIL,BORK,WARN,LEAK,XLEAK,SKIP" tests/ext/profiling
+
+# The tracer pipeline only runs the FrankenPHP suite on amd64/glibc. musl differs in ways that bite specifically here - see issue #4163, where the SIGTERM handler's clone() is rejected outright by musl and FrankenPHP consequently never shuts down.
+# Thus we so run the same suite once against the official FrankenPHP image on arm64/Alpine.
+"frankenphp test on arm64 alpine":
+  stage: verify
+  image: registry.ddbuild.io/images/mirror/dunglas/frankenphp:php<?= FRANKENPHP_ALPINE_PHP_VERSION ?>-alpine
+  tags: [ "arch:arm64" ]
+  needs:
+    - job: "package extension: [arm64, aarch64-alpine-linux-musl]"
+      artifacts: true
+  services:
+    - !reference [.services, test-agent]
+    - !reference [.services, request-replayer]
+    - !reference [.services, httpbin-integration]
+  variables:
+    KUBERNETES_CPU_REQUEST: 2 # one for PHP and one for the webserver
+    KUBERNETES_MEMORY_REQUEST: 4Gi
+    KUBERNETES_MEMORY_LIMIT: 4Gi
+    COMPOSER_PROCESS_TIMEOUT: 0
+    DD_AGENT_HOST: test-agent
+    DD_TRACE_AGENT_PORT: 9126
+    HTTPBIN_HOSTNAME: httpbin-integration
+    HTTPBIN_PORT: 8080
+    WAIT_FOR: test-agent:9126
+  before_script:
+<?php unset_dd_runner_env_vars() ?>
+    # coreutils/findutils/grep: the Makefile and the artifact-collection scripts rely on GNU flags that BusyBox does not implement.
+    - apk add --no-cache bash composer coreutils curl findutils git grep libgcc make || exit 75
+    - git config --global --add safe.directory "${CI_PROJECT_DIR}"
+    - git config --global --add safe.directory "${CI_PROJECT_DIR}/*"
+    - mkdir -p tmp/build_extension/modules artifacts
+    - tar -xzf packages/dd-library-php-*-aarch64-linux-musl.tar.gz
+    - php_api=$(php -i | awk '/^PHP[ \t]+API[ \t]+=>/ { print $NF }')
+    - cp "dd-library-php/trace/ext/${php_api}/ddtrace-zts.so" tmp/build_extension/modules/ddtrace.so
+    - COMPOSER_MEMORY_LIMIT=-1 composer update --no-interaction
+    - make composer_tests_update
+    - .gitlab/wait-for-service-ready.sh
+  script:
+    # The Fabric proxy changes network failure semantics in integration tests.
+    - unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy ALL_PROXY all_proxy
+    - DD_TRACE_AGENT_TIMEOUT=1000 make test_integrations_frankenphp PHPUNIT_JUNIT="artifacts/tests/results.xml"
+  after_script:
+    - .gitlab/collect_artifacts.sh .
+    - find tests -type f \( -name 'frankenphp_error.log' -o -name 'phpunit_error.log' \) -exec cp --parents '{}' artifacts \;
+  artifacts:
+    paths:
+      - "artifacts/"
+    when: "always"
 
 .randomized_tests:
   stage: verify

--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -858,7 +858,9 @@ endforeach;
     # own php83, and composer would then resolve the test requirements against that PHP instead of
     # the image's ZTS build (which is the one under test).
     - apk add --no-cache bash coreutils curl findutils git grep libgcc make || exit 75
-    - install-php-extensions zip || exit 75
+    # The only two the official image lacks out of what composer.json and tests/composer.json ask
+    # for (zip for the root install, sockets for tests/).
+    - install-php-extensions sockets zip || exit 75
     - php -r "copy('https://getcomposer.org/installer', '/tmp/composer-setup.php');"
     - php /tmp/composer-setup.php --install-dir=/usr/local/bin --filename=composer
     - git config --global --add safe.directory "${CI_PROJECT_DIR}"

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -657,34 +657,9 @@ foreach ($matches as $m) {
     }
 }
 
-// Only build the ZTS extension for the versions that actually have a ZTS-only suite, so this does
-// not add a build for every PHP version in the matrix.
-$zts_versions = [];
-foreach ($jobs as $type_jobs) {
-    foreach ($type_jobs as $target => $versions) {
-        if (in_array($target, ZTS_MAKE_TARGETS, true)) {
-            $zts_versions = array_merge($zts_versions, $versions);
-        }
-    }
-}
-$zts_versions = array_values(array_unique($zts_versions));
-if ($zts_versions):
-?>
-"compile extension: zts":
-  extends: "compile extension: debug"
-  variables:
-    SWITCH_PHP_VERSION: "zts"
-  parallel:
-    matrix:
-      - PHP_MAJOR_MINOR: <?= json_encode($zts_versions), "\n" ?>
-        ARCH: "amd64"
-
-<?php
-endif;
-
 foreach ($jobs as $type => $type_jobs):
     foreach ($type_jobs as $target => $versions):
-        $php_variant = in_array($target, ZTS_MAKE_TARGETS, true) ? "zts" : "debug";
+        $php_variant = in_array($target, ZTS_MAKE_TARGETS, true) ? "debug-zts-asan" : "debug";
         foreach ($versions as $major_minor):
             $sapis = $type == "web" && version_compare($major_minor, "7.2", ">=") ? ["cli-server", "cgi-fcgi", "apache2handler"] : [""];
             if ($target == "test_web_custom" && in_array("cli-server", $sapis)) {
@@ -723,6 +698,11 @@ foreach ($services as $part => $service) {
     MAKE_TARGET: "<?= $target ?>"
     ARCH: "amd64"
     SWITCH_PHP_VERSION: "<?= $php_variant ?>"
+<?php if ($php_variant === "debug-zts-asan"): ?>
+    # These are inherited by the SAPI the harness spawns, which is where we need them. detect_leaks is off on purpose: PHP and Go both leak plenty on a killed server.
+    _DD_SIDECAR_WATCHDOG_MAX_MEMORY: 2147483648
+    ASAN_OPTIONS: abort_on_error=1:disable_coredump=0:unmap_shadow_on_exit=1:detect_leaks=0
+<?php endif; ?>
 <?php if ($sapi): ?>
     DD_TRACE_TEST_SAPI: "<?= $sapi ?>"
 <?php endif; ?>

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -630,7 +630,7 @@ endforeach;
     - unset HTTP_PROXY HTTPS_PROXY http_proxy https_proxy ALL_PROXY all_proxy
     - DD_TRACE_AGENT_TIMEOUT=1000 make $MAKE_TARGET RUST_DEBUG_BUILD=1 PHPUNIT_JUNIT="artifacts/tests/results.xml" <?= ASSERT_NO_MEMLEAKS ?>
 <?php after_script(".", true); ?>
-    - find tests -type f \( -name 'phpunit_error.log' -o -name 'nginx_*.log' -o -name 'apache_*.log' -o -name 'php_fpm_*.log' -o -name 'dd_php_error.log' \) -exec cp --parents '{}' artifacts \;
+    - find tests -type f \( -name 'phpunit_error.log' -o -name 'nginx_*.log' -o -name 'apache_*.log' -o -name 'php_fpm_*.log' -o -name 'frankenphp_error.log' -o -name 'dd_php_error.log' \) -exec cp --parents '{}' artifacts \;
     - make tested_versions && cp tests/tested_versions/tested_versions.json artifacts/tested_versions_${MAKE_TARGET}_${PHP_MAJOR_MINOR}_${DD_TRACE_TEST_SAPI:-cli}.json
 
 <?php

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -9,6 +9,8 @@ $services = array_combine($m[1], $m[1]);
 
 const ASSERT_NO_MEMLEAKS = ' 2>&1 | tee /dev/stderr | { ! grep -qe "=== Total [0-9]+ memory leaks detected ==="; }';
 
+const ZTS_MAKE_TARGETS = ['test_integrations_frankenphp'];
+
 function after_script($execute_dir = ".", $has_test_agent = false) {
 ?>
 
@@ -655,8 +657,34 @@ foreach ($matches as $m) {
     }
 }
 
+// Only build the ZTS extension for the versions that actually have a ZTS-only suite, so this does
+// not add a build for every PHP version in the matrix.
+$zts_versions = [];
+foreach ($jobs as $type_jobs) {
+    foreach ($type_jobs as $target => $versions) {
+        if (in_array($target, ZTS_MAKE_TARGETS, true)) {
+            $zts_versions = array_merge($zts_versions, $versions);
+        }
+    }
+}
+$zts_versions = array_values(array_unique($zts_versions));
+if ($zts_versions):
+?>
+"compile extension: zts":
+  extends: "compile extension: debug"
+  variables:
+    SWITCH_PHP_VERSION: "zts"
+  parallel:
+    matrix:
+      - PHP_MAJOR_MINOR: <?= json_encode($zts_versions), "\n" ?>
+        ARCH: "amd64"
+
+<?php
+endif;
+
 foreach ($jobs as $type => $type_jobs):
     foreach ($type_jobs as $target => $versions):
+        $php_variant = in_array($target, ZTS_MAKE_TARGETS, true) ? "zts" : "debug";
         foreach ($versions as $major_minor):
             $sapis = $type == "web" && version_compare($major_minor, "7.2", ">=") ? ["cli-server", "cgi-fcgi", "apache2handler"] : [""];
             if ($target == "test_web_custom" && in_array("cli-server", $sapis)) {
@@ -668,7 +696,7 @@ foreach ($jobs as $type => $type_jobs):
   extends: .cli_integration_test
   stage: "<?= $type ?> test"
   needs:
-    - job: "compile extension: debug"
+    - job: "compile extension: <?= $php_variant ?>"
       parallel:
         matrix:
           - PHP_MAJOR_MINOR: "<?= $major_minor ?>"
@@ -694,6 +722,7 @@ foreach ($services as $part => $service) {
     PHP_MAJOR_MINOR: "<?= $major_minor ?>"
     MAKE_TARGET: "<?= $target ?>"
     ARCH: "amd64"
+    SWITCH_PHP_VERSION: "<?= $php_variant ?>"
 <?php if ($sapi): ?>
     DD_TRACE_TEST_SAPI: "<?= $sapi ?>"
 <?php endif; ?>

--- a/.gitlab/wait-for-service-ready.sh
+++ b/.gitlab/wait-for-service-ready.sh
@@ -17,6 +17,27 @@ detect_service_type() {
   esac
 }
 
+# `wait-for` ships in the dd-trace-ci images, but not in every image we run jobs in -- the official
+# FrankenPHP one, for instance. Fall back to bash's /dev/tcp, so this needs no external tool.
+tcp_wait() {
+  local HOST=${1}
+  local PORT=${2}
+  local TIMEOUT=${3:-180}
+
+  if command -v wait-for > /dev/null 2>&1; then
+    if wait-for "${HOST}:${PORT}" --timeout="${TIMEOUT}"; then return 0; else return 1; fi
+  fi
+
+  local DEADLINE=$((SECONDS + TIMEOUT))
+  while [ ${SECONDS} -lt ${DEADLINE} ]; do
+    if (exec 3<> "/dev/tcp/${HOST}/${PORT}") 2> /dev/null; then
+      return 0
+    fi
+    sleep 1
+  done
+  return 1
+}
+
 wait_for_single_service() {
   local HOST=${1}
   local PORT=${2}
@@ -25,7 +46,7 @@ wait_for_single_service() {
   local RETRY_DELAY=${5:-5}
 
   echo "Waiting for ${HOST}:${PORT} to be reachable..."
-  if ! wait-for "${HOST}:${PORT}" --timeout=180; then
+  if ! tcp_wait "${HOST}" "${PORT}" 180; then
       echo "ERROR: Could not reach ${HOST}:${PORT}" >&2
       return 1
   fi

--- a/components-rs/datadog.h
+++ b/components-rs/datadog.h
@@ -528,6 +528,20 @@ ddog_Configurator *ddog_library_configurator_new_dummy(bool debug_logs, ddog_Cha
 
 uint64_t dd_fnv1a_64(const uint8_t *data, uintptr_t len);
 
+/**
+ * Sets the endpoint's test session token, but only when it actually differs from the one already
+ * there.
+ *
+ * `ddog_endpoint_set_test_token` assigns unconditionally, which drops the previous `String`. The
+ * endpoints are process-globals in the PHP extension while the writers run per thread (an INI
+ * change handler, and the sidecar connect path), so another thread cloning the same `Endpoint`
+ * reads a freed string -- a use-after-free that only shows up on ZTS with concurrent requests.
+ *
+ * A test run assigns the same token throughout, so comparing first means the swap, and therefore
+ * the race, never happens. Assigning a genuinely different token from a thread remains unsafe.
+ */
+void ddog_endpoint_set_test_token_if_changed(struct ddog_Endpoint *endpoint, ddog_CharSlice token);
+
 const char *ddog_normalize_process_tag_value(ddog_CharSlice tag_value);
 
 void ddog_free_normalized_tag_value(const char *ptr);

--- a/components-rs/lib.rs
+++ b/components-rs/lib.rs
@@ -515,6 +515,34 @@ pub unsafe extern "C" fn dd_fnv1a_64(data: *const u8, len: usize) -> u64 {
     hash
 }
 
+/// Sets the endpoint's test session token, but only when it actually differs from the one already
+/// there.
+///
+/// In our ZTS runs we sometimes set it, but always to the same value. This extra check prevents
+/// possible use-after-free in our test suite, given that it there only ever transitions from None
+/// to Some().
+#[no_mangle]
+pub extern "C" fn ddog_endpoint_set_test_token_if_changed(
+    endpoint: &mut Endpoint,
+    token: CharSlice,
+) {
+    let new_token = token.to_utf8_lossy();
+    let unchanged = match &endpoint.test_token {
+        Some(current) => current.as_ref() == new_token.as_ref(),
+        None => new_token.is_empty(),
+    };
+
+    if unchanged {
+        return;
+    }
+
+    endpoint.test_token = if new_token.is_empty() {
+        None
+    } else {
+        Some(Cow::Owned(new_token.into_owned()))
+    };
+}
+
 #[no_mangle]
 pub extern "C" fn ddog_normalize_process_tag_value(tag_value: CharSlice) -> *const c_char {
     let value = tag_value.to_utf8_lossy();

--- a/ext/sidecar.c
+++ b/ext/sidecar.c
@@ -27,22 +27,6 @@ ddog_Endpoint *datadog_endpoint;
 ddog_Endpoint *dogstatsd_endpoint; // always set when datadog_endpoint is set
 struct ddog_InstanceId *datadog_sidecar_instance_id;
 
-#if ZTS
-static MUTEX_T dd_test_session_token_mutex = NULL;
-#endif
-
-static void dd_endpoint_set_test_token_locked(ddog_Endpoint *endpoint, ddog_CharSlice token) {
-#if ZTS
-    if (dd_test_session_token_mutex) {
-        tsrm_mutex_lock(dd_test_session_token_mutex);
-        ddog_endpoint_set_test_token(endpoint, token);
-        tsrm_mutex_unlock(dd_test_session_token_mutex);
-        return;
-    }
-#endif
-    ddog_endpoint_set_test_token(endpoint, token);
-}
-
 // Best-effort pointer for the signal handler (SIGTERM/SIGINT). Set to the first
 // per-thread connection; never cleared until MSHUTDOWN. Not atomic: concurrent
 // shutdown is already a best-effort race for signal handlers, so atomicity of
@@ -56,10 +40,10 @@ int32_t datadog_sidecar_master_pid = 0;
 static inline void dd_set_endpoint_test_token(ddog_Endpoint *endpoint) {
     if (zai_config_is_initialized()) {
         if (ZSTR_LEN(get_DD_TRACE_AGENT_TEST_SESSION_TOKEN())) {
-            dd_endpoint_set_test_token_locked(endpoint, dd_zend_string_to_CharSlice(get_DD_TRACE_AGENT_TEST_SESSION_TOKEN()));
+            ddog_endpoint_set_test_token_if_changed(endpoint, dd_zend_string_to_CharSlice(get_DD_TRACE_AGENT_TEST_SESSION_TOKEN()));
         }
     } else if (ZSTR_LEN(get_global_DD_TRACE_AGENT_TEST_SESSION_TOKEN())) {
-        dd_endpoint_set_test_token_locked(endpoint, dd_zend_string_to_CharSlice(get_global_DD_TRACE_AGENT_TEST_SESSION_TOKEN()));
+        ddog_endpoint_set_test_token_if_changed(endpoint, dd_zend_string_to_CharSlice(get_global_DD_TRACE_AGENT_TEST_SESSION_TOKEN()));
     }
 }
 
@@ -489,10 +473,6 @@ void datadog_sidecar_setup(ddog_RemoteConfigFlags flags) {
 }
 
 void datadog_sidecar_minit(void) {
-#if ZTS
-    dd_test_session_token_mutex = tsrm_mutex_alloc();
-#endif
-
 #ifdef _WIN32
     datadog_sidecar_master_pid = (int32_t)GetCurrentProcessId();
 #else
@@ -604,11 +584,6 @@ void datadog_sidecar_finalize(bool clear_id) {
 
 void datadog_sidecar_shutdown(void) {
     datadog_sidecar_for_signal = NULL;
-
-#if ZTS
-    tsrm_mutex_free(dd_test_session_token_mutex);
-    dd_test_session_token_mutex = NULL;
-#endif
 
     // In thread mode, drop the main thread's connection before shutting down the
     // listener to avoid deadlock.  GSHUTDOWN owns transport cleanup for all other
@@ -907,7 +882,7 @@ void datadog_sidecar_gshutdown(zend_datadog_globals *datadog_globals) {
 bool datadog_alter_test_session_token(zval *old_value, zval *new_value, zend_string *new_str) {
     UNUSED(old_value, new_str);
     if (datadog_endpoint) {
-        dd_endpoint_set_test_token_locked(datadog_endpoint, dd_zend_string_to_CharSlice(Z_STR_P(new_value)));
+        ddog_endpoint_set_test_token_if_changed(datadog_endpoint, dd_zend_string_to_CharSlice(Z_STR_P(new_value)));
     }
     if (DATADOG_G(sidecar)) {
         datadog_ffi_try("Failed updating test session token",

--- a/ext/sidecar.c
+++ b/ext/sidecar.c
@@ -27,6 +27,22 @@ ddog_Endpoint *datadog_endpoint;
 ddog_Endpoint *dogstatsd_endpoint; // always set when datadog_endpoint is set
 struct ddog_InstanceId *datadog_sidecar_instance_id;
 
+#if ZTS
+static MUTEX_T dd_test_session_token_mutex = NULL;
+#endif
+
+static void dd_endpoint_set_test_token_locked(ddog_Endpoint *endpoint, ddog_CharSlice token) {
+#if ZTS
+    if (dd_test_session_token_mutex) {
+        tsrm_mutex_lock(dd_test_session_token_mutex);
+        ddog_endpoint_set_test_token(endpoint, token);
+        tsrm_mutex_unlock(dd_test_session_token_mutex);
+        return;
+    }
+#endif
+    ddog_endpoint_set_test_token(endpoint, token);
+}
+
 // Best-effort pointer for the signal handler (SIGTERM/SIGINT). Set to the first
 // per-thread connection; never cleared until MSHUTDOWN. Not atomic: concurrent
 // shutdown is already a best-effort race for signal handlers, so atomicity of
@@ -40,10 +56,10 @@ int32_t datadog_sidecar_master_pid = 0;
 static inline void dd_set_endpoint_test_token(ddog_Endpoint *endpoint) {
     if (zai_config_is_initialized()) {
         if (ZSTR_LEN(get_DD_TRACE_AGENT_TEST_SESSION_TOKEN())) {
-            ddog_endpoint_set_test_token(endpoint, dd_zend_string_to_CharSlice(get_DD_TRACE_AGENT_TEST_SESSION_TOKEN()));
+            dd_endpoint_set_test_token_locked(endpoint, dd_zend_string_to_CharSlice(get_DD_TRACE_AGENT_TEST_SESSION_TOKEN()));
         }
     } else if (ZSTR_LEN(get_global_DD_TRACE_AGENT_TEST_SESSION_TOKEN())) {
-        ddog_endpoint_set_test_token(endpoint, dd_zend_string_to_CharSlice(get_global_DD_TRACE_AGENT_TEST_SESSION_TOKEN()));
+        dd_endpoint_set_test_token_locked(endpoint, dd_zend_string_to_CharSlice(get_global_DD_TRACE_AGENT_TEST_SESSION_TOKEN()));
     }
 }
 
@@ -473,6 +489,10 @@ void datadog_sidecar_setup(ddog_RemoteConfigFlags flags) {
 }
 
 void datadog_sidecar_minit(void) {
+#if ZTS
+    dd_test_session_token_mutex = tsrm_mutex_alloc();
+#endif
+
 #ifdef _WIN32
     datadog_sidecar_master_pid = (int32_t)GetCurrentProcessId();
 #else
@@ -584,6 +604,11 @@ void datadog_sidecar_finalize(bool clear_id) {
 
 void datadog_sidecar_shutdown(void) {
     datadog_sidecar_for_signal = NULL;
+
+#if ZTS
+    tsrm_mutex_free(dd_test_session_token_mutex);
+    dd_test_session_token_mutex = NULL;
+#endif
 
     // In thread mode, drop the main thread's connection before shutting down the
     // listener to avoid deadlock.  GSHUTDOWN owns transport cleanup for all other
@@ -882,7 +907,7 @@ void datadog_sidecar_gshutdown(zend_datadog_globals *datadog_globals) {
 bool datadog_alter_test_session_token(zval *old_value, zval *new_value, zend_string *new_str) {
     UNUSED(old_value, new_str);
     if (datadog_endpoint) {
-        ddog_endpoint_set_test_token(datadog_endpoint, dd_zend_string_to_CharSlice(Z_STR_P(new_value)));
+        dd_endpoint_set_test_token_locked(datadog_endpoint, dd_zend_string_to_CharSlice(Z_STR_P(new_value)));
     }
     if (DATADOG_G(sidecar)) {
         datadog_ffi_try("Failed updating test session token",

--- a/ext/signals.c
+++ b/ext/signals.c
@@ -19,6 +19,7 @@
 #include "datadog.h"
 #include "ffi_utils.h"
 #include "sidecar.h"
+#include "threads.h"
 #include "version.h"
 #include <components/log/log.h>
 #include "logging.h"
@@ -355,8 +356,11 @@ static void dd_sigint_sigterm_handler(int sig, siginfo_t *si, void *uc) {
     if (datadog_sidecar_for_signal) {
         // Spawn a thread using clone() to perform sidecar cleanup asynchronously to avoid async unsafeness in the signal handler
         void *stack_top = dd_signal_async_stack + dd_signal_async_stack_size;
-        int flags = CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND | CLONE_THREAD;
-        clone(dd_sigterm_cleanup_thread, stack_top, flags, NULL);
+        int flags = CLONE_VM | CLONE_FS | CLONE_FILES | CLONE_SIGHAND | CLONE_THREAD | CLONE_SYSVSEM;
+        if (datadog_clone_thread(dd_sigterm_cleanup_thread, stack_top, flags, NULL) < 0) {
+            // If the cleanup thread could not be started, we just do it ourselves. Will block, but that's okay then.
+            dd_call_prev_handler(true);
+        }
     } else {
         dd_call_prev_handler(false);
     }

--- a/ext/threads.c
+++ b/ext/threads.c
@@ -140,3 +140,77 @@ int tsrm_mutex_unlock(MUTEX_T mutexp)
 
 
 #endif
+
+#ifdef __linux__
+
+/* datadog_clone_thread(): clone(2), issued directly rather than through libc.
+ *
+ * We cannot use the libc wrapper. musl refuses CLONE_THREAD (as well as CLONE_SETTLS and CLONE_CHILD_CLEARTID) with EINVAL and never issues the syscall at all.
+ * Hence we have to do the gruntwork ourselves, to work around that musl limitation.
+ */
+
+#if defined(__x86_64__)
+__asm__(
+    ".text\n"
+    ".globl datadog_clone_thread\n"
+    ".hidden datadog_clone_thread\n"
+    ".type datadog_clone_thread,@function\n"
+    "datadog_clone_thread:\n"
+    /* in: rdi = fn, rsi = stack_top, edx = flags, rcx = arg */
+    "   andq  $-16, %rsi\n"           /* align the child stack */
+    "   subq  $16, %rsi\n"            /* hand fn and arg over on it */
+    "   movq  %rdi, 0(%rsi)\n"
+    "   movq  %rcx, 8(%rsi)\n"
+    /* syscall: rdi = flags, rsi = newsp, rdx = parent_tid, r10 = child_tid, r8 = tls */
+    "   movl  %edx, %edi\n"
+    "   xorl  %edx, %edx\n"
+    "   xorl  %r10d, %r10d\n"
+    "   xorl  %r8d, %r8d\n"
+    "   movl  $56, %eax\n"            /* SYS_clone */
+    "   syscall\n"
+    "   testq %rax, %rax\n"           /* parent: tid or -errno; child: 0 */
+    "   jnz   1f\n"
+    "   xorl  %ebp, %ebp\n"           /* end the frame pointer chain */
+    "   popq  %rax\n"                 /* fn */
+    "   popq  %rdi\n"                 /* arg */
+    "   callq *%rax\n"
+    "   movl  %eax, %edi\n"           /* fn's return value is the thread's exit status */
+    "   movl  $60, %eax\n"            /* SYS_exit -- this thread only, not exit_group */
+    "   syscall\n"
+    "   hlt\n"                        /* unreachable */
+    "1: ret\n"
+    ".size datadog_clone_thread,.-datadog_clone_thread\n");
+#elif defined(__aarch64__)
+__asm__(
+    ".text\n"
+    ".globl datadog_clone_thread\n"
+    ".hidden datadog_clone_thread\n"
+    ".type datadog_clone_thread,%function\n"
+    "datadog_clone_thread:\n"
+    /* in: x0 = fn, x1 = stack_top, w2 = flags, x3 = arg */
+    "   and   x1, x1, #-16\n"         /* align the child stack */
+    "   stp   x0, x3, [x1, #-16]!\n"  /* hand fn and arg over on it; x1 becomes newsp */
+    /* syscall: x0 = flags, x1 = newsp, x2 = parent_tid, x3 = tls, x4 = child_tid */
+    "   mov   w0, w2\n"
+    "   mov   x2, #0\n"
+    "   mov   x3, #0\n"
+    "   mov   x4, #0\n"
+    "   mov   x8, #220\n"             /* SYS_clone */
+    "   svc   #0\n"
+    "   cbz   x0, 1f\n"               /* parent: tid or -errno; child: 0 */
+    "   ret\n"
+    "1: ldp   x1, x0, [sp], #16\n"    /* x1 = fn, x0 = arg */
+    "   mov   x29, #0\n"              /* end the frame pointer chain */
+    "   blr   x1\n"                   /* fn's return value is left in w0 */
+    "   mov   w8, #93\n"              /* SYS_exit -- this thread only, not exit_group */
+    "   svc   #0\n"
+    "   brk   #0\n"                   /* unreachable */
+    ".size datadog_clone_thread,.-datadog_clone_thread\n");
+#else
+#include <sched.h>
+int datadog_clone_thread(int (*fn)(void *), void *stack_top, int flags, void *arg) {
+    return clone(fn, stack_top, flags, arg);
+}
+#endif
+
+#endif

--- a/ext/threads.h
+++ b/ext/threads.h
@@ -26,4 +26,8 @@ TSRM_API int tsrm_mutex_lock(MUTEX_T mutexp);
 TSRM_API int tsrm_mutex_unlock(MUTEX_T mutexp);
 #endif
 
+#ifdef __linux__
+int datadog_clone_thread(int (*fn)(void *), void *stack_top, int flags, void *arg);
+#endif
+
 #endif // DATADOG_THREADS_H

--- a/src/DDTrace/Integrations/Frankenphp/FrankenphpIntegration.php
+++ b/src/DDTrace/Integrations/Frankenphp/FrankenphpIntegration.php
@@ -106,19 +106,24 @@ class FrankenphpIntegration extends Integration
 
                     $res = notify_commit(
                         $rootSpan,
-                        // TODO: http_response_code() can return false - we want to report the real status here: appsec's response_committed listeners currently see 200 whenever the actual code is unavailable. Just a fallback for now.
-                        \http_response_code() ?: 200,
+                        // http_response_code() returns false once the per-request SAPI state has
+                        // been reset, and notify_commit() rejects anything outside 100..599. Infer
+                        // it the same way the serializer already does for this SAPI (see
+                        // dd_set_entrypoint_root_span_props_end in tracer/serializer.c): a flat 200
+                        // would report success for a request that threw.
+                        // TODO: report the real status instead of inferring it.
+                        \http_response_code() ?: (isset($rootSpan->exception) ? 500 : 200),
                         self::convertHeaders(\headers_list()),
                         null /* response body is available through special mechanisms */
                     );
 
                     // we did not block before and were now told to block
-                    if (!$hookData->data && $res) {
+                    if (!isset($hookData->data) && $res) {
                         $hookData->data = new FrankenphpAppSecException();
                         self::commitBlockingResponse($res);
                     }
 
-                    if ($hookData->data && !$rootSpan->exception) {
+                    if (isset($hookData->data) && !isset($rootSpan->exception)) {
                         $rootSpan->exception = $hookData->data;
                     }
                 },

--- a/src/DDTrace/Integrations/Frankenphp/FrankenphpIntegration.php
+++ b/src/DDTrace/Integrations/Frankenphp/FrankenphpIntegration.php
@@ -51,6 +51,7 @@ class FrankenphpIntegration extends Integration
                     $rootSpan = $hook->span(new SpanStack());
                     $rootSpan->name = "web.request";
                     $rootSpan->service = \ddtrace_config_app_name('frankenphp');
+                    Integration::tagFrameworkServiceSource($rootSpan, self::NAME);
                     $rootSpan->type = Type::WEB_SERVLET;
                     $rootSpan->meta[Tag::COMPONENT] = self::NAME;
                     $rootSpan->meta[Tag::SPAN_KIND] = Tag::SPAN_KIND_VALUE_SERVER;

--- a/src/DDTrace/Integrations/Frankenphp/FrankenphpIntegration.php
+++ b/src/DDTrace/Integrations/Frankenphp/FrankenphpIntegration.php
@@ -112,7 +112,9 @@ class FrankenphpIntegration extends Integration
                         // dd_set_entrypoint_root_span_props_end in tracer/serializer.c): a flat 200
                         // would report success for a request that threw.
                         // TODO: report the real status instead of inferring it.
-                        \http_response_code() ?: (isset($rootSpan->exception) ? 500 : 200),
+                        // $hookData->exception is the throwable the handler raised, and is set by
+                        // the time this end-hook runs; $rootSpan->exception is not yet.
+                        \http_response_code() ?: (isset($hookData->exception) ? 500 : 200),
                         self::convertHeaders(\headers_list()),
                         null /* response body is available through special mechanisms */
                     );

--- a/src/DDTrace/Integrations/Frankenphp/FrankenphpIntegration.php
+++ b/src/DDTrace/Integrations/Frankenphp/FrankenphpIntegration.php
@@ -106,7 +106,8 @@ class FrankenphpIntegration extends Integration
 
                     $res = notify_commit(
                         $rootSpan,
-                        \http_response_code(),
+                        // TODO: http_response_code() can return false - we want to report the real status here: appsec's response_committed listeners currently see 200 whenever the actual code is unavailable. Just a fallback for now.
+                        \http_response_code() ?: 200,
                         self::convertHeaders(\headers_list()),
                         null /* response body is available through special mechanisms */
                     );

--- a/src/DDTrace/Integrations/Frankenphp/FrankenphpIntegration.php
+++ b/src/DDTrace/Integrations/Frankenphp/FrankenphpIntegration.php
@@ -106,15 +106,13 @@ class FrankenphpIntegration extends Integration
 
                     $res = notify_commit(
                         $rootSpan,
-                        // http_response_code() returns false once the per-request SAPI state has
-                        // been reset, and notify_commit() rejects anything outside 100..599. Infer
-                        // it the same way the serializer already does for this SAPI (see
-                        // dd_set_entrypoint_root_span_props_end in tracer/serializer.c): a flat 200
-                        // would report success for a request that threw.
-                        // TODO: report the real status instead of inferring it.
-                        // $hookData->exception is the throwable the handler raised, and is set by
-                        // the time this end-hook runs; $rootSpan->exception is not yet.
-                        \http_response_code() ?: (isset($hookData->exception) ? 500 : 200),
+                        // The response has not been committed yet at this point, so the SAPI has
+                        // no status code and http_response_code() returns false -- which
+                        // notify_commit() rejects, as it only accepts 100..599. Fall back to the
+                        // status this SAPI ends up sending anyway.
+                        // TODO: report the real status rather than a fallback; appsec's
+                        // response_committed listeners see 200 whenever it is unavailable here.
+                        \http_response_code() ?: 200,
                         self::convertHeaders(\headers_list()),
                         null /* response body is available through special mechanisms */
                     );

--- a/src/DDTrace/Integrations/Swoole/SwooleIntegration.php
+++ b/src/DDTrace/Integrations/Swoole/SwooleIntegration.php
@@ -37,6 +37,7 @@ class SwooleIntegration extends Integration
                 $rootSpan = $hook->span(new SpanStack());
                 $rootSpan->name = "web.request";
                 $rootSpan->service = \ddtrace_config_app_name('swoole');
+                Integration::tagFrameworkServiceSource($rootSpan, self::NAME);
                 $rootSpan->type = Type::WEB_SERVLET;
                 $rootSpan->meta[Tag::COMPONENT] = self::NAME;
                 $rootSpan->meta[Tag::SPAN_KIND] = Tag::SPAN_KIND_VALUE_SERVER;

--- a/tests/Frameworks/Frankenphp/index.php
+++ b/tests/Frameworks/Frankenphp/index.php
@@ -6,6 +6,9 @@ ignore_user_abort(true);
 $handler = static function () {
     switch (explode("?", $_SERVER["REQUEST_URI"])[0]) {
         case "/error":
+            // Worker mode does not turn a thrown exception into a 500 by itself, so set it the way
+            // a real app's error handling would.
+            http_response_code(500);
             throw new \Exception("Error page");
         default:
             echo "Hello FrankenPHP!";
@@ -14,6 +17,13 @@ $handler = static function () {
 };
 
 for ($running = true; $running;) {
-    $running = \frankenphp_handle_request($handler);
+    // A worker has to survive a request that throws. Letting the exception escape here would end
+    // the worker script and make FrankenPHP spin up a replacement on every failing request, which
+    // is not how a real worker-mode app behaves.
+    try {
+        $running = \frankenphp_handle_request($handler);
+    } catch (\Throwable $e) {
+        error_log("[fixture] request threw: " . $e->getMessage());
+    }
 //    error_log(var_export(\dd_trace_serialize_closed_spans(), true));
 }

--- a/tests/Integrations/Frankenphp/CommonScenariosTest.php
+++ b/tests/Integrations/Frankenphp/CommonScenariosTest.php
@@ -50,6 +50,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '200',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'frankenphp',
+                        '_dd.svc_src' => 'frankenphp',
                     ]),
                 ],
                 'A GET request with an exception' => [
@@ -64,6 +65,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         'http.status_code' => '500',
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'frankenphp',
+                        '_dd.svc_src' => 'frankenphp',
                     ])->setError('Exception', 'Uncaught Exception: Error page', true),
                 ],
             ],

--- a/tests/Integrations/Frankenphp/CommonScenariosTest.php
+++ b/tests/Integrations/Frankenphp/CommonScenariosTest.php
@@ -66,7 +66,7 @@ class CommonScenariosTest extends WebFrameworkTestCase
                         Tag::SPAN_KIND => 'server',
                         Tag::COMPONENT => 'frankenphp',
                         '_dd.svc_src' => 'frankenphp',
-                    ])->setError('Exception', 'Uncaught Exception: Error page', true),
+                    ])->setError('Exception', 'Uncaught Exception (500): Error page in %s:%d', true),
                 ],
             ],
             true

--- a/tests/Integrations/Frankenphp/GracefulShutdownTest.php
+++ b/tests/Integrations/Frankenphp/GracefulShutdownTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace DDTrace\Tests\Integrations\Frankenphp;
+
+use DDTrace\Tests\Common\WebFrameworkTestCase;
+use DDTrace\Tests\Frameworks\Util\Request\GetSpec;
+
+/**
+ * Covers the tracer's SIGTERM handler (ext/signals.c) under FrankenPHP.
+ *
+ * With DD_TRACE_FORCE_FLUSH_ON_SIGTERM on and a sidecar connected, dd_sigint_sigterm_handler()
+ * starts a cleanup thread that flushes the sidecar and then hands the signal back to whatever
+ * handler was installed before -- here, the Go runtime's, which is what makes Caddy shut down.
+ * When that hand-off does not happen, FrankenPHP never observes the signal at all and just keeps
+ * running until something SIGKILLs it (issue #4163).
+ *
+ * The failure is completely silent -- no error, no log line -- so the only thing that catches it is
+ * asserting that the server actually terminates on SIGTERM alone. This matters most on musl, where
+ * clone() rejects CLONE_THREAD outright, which is why the arm64/Alpine CI job runs this suite.
+ */
+class GracefulShutdownTest extends WebFrameworkTestCase
+{
+    /** Generous enough to absorb a slow sidecar flush, far below any plausible hang. */
+    const SHUTDOWN_TIMEOUT_SECONDS = 20;
+
+    public static function getAppIndexScript()
+    {
+        return __DIR__ . '/../../Frameworks/Frankenphp/index.php';
+    }
+
+    protected static function isFrankenphp()
+    {
+        return true;
+    }
+
+    protected static function getEnvs()
+    {
+        return array_merge(parent::getEnvs(), [
+            // Route traces through the sidecar so datadog_sidecar_for_signal is non-NULL and the
+            // handler takes the cleanup-thread branch rather than the inline one.
+            'DD_TRACE_SIDECAR_TRACE_SENDER' => '1',
+            // Normally defaulted on when pid/ppid is 1 (i.e. in a container); the test server is
+            // neither, so ask for it explicitly.
+            'DD_TRACE_FORCE_FLUSH_ON_SIGTERM' => '1',
+        ]);
+    }
+
+    public function testShutsDownGracefullyOnSigtermWithSidecar()
+    {
+        // The sidecar connection is only established while serving, and the branch under test is
+        // only reached once it exists -- so a request has to come first.
+        $this->call(GetSpec::create('Warm up the sidecar connection', '/simple'));
+
+        $exitedOnItsOwn = self::$appServer->stopGracefully(self::SHUTDOWN_TIMEOUT_SECONDS);
+
+        // The server is gone either way now, so stop ddTearDown() from reporting it as a crash.
+        $this->checkWebserverErrors = false;
+
+        $this->assertTrue(
+            $exitedOnItsOwn,
+            sprintf(
+                'FrankenPHP was still running %d seconds after SIGTERM. The tracer most likely '
+                    . 'swallowed the signal instead of passing it to the Go runtime -- see '
+                    . 'dd_sigint_sigterm_handler() in ext/signals.c.',
+                self::SHUTDOWN_TIMEOUT_SECONDS
+            )
+        );
+    }
+}

--- a/tests/Sapi/Frankenphp/FrankenphpServer.php
+++ b/tests/Sapi/Frankenphp/FrankenphpServer.php
@@ -89,7 +89,14 @@ final class FrankenphpServer implements Sapi
 
     private static function installFrankenphp()
     {
-        exec(__DIR__ . "/../../../tooling/bin/install-frankenphp.sh");
+        // Check the exit code: otherwise a failed build lets start() go on to exec a binary that
+        // is not there, and the suite reports every request as a bare connection failure instead
+        // of the build error that caused it.
+        exec(__DIR__ . "/../../../tooling/bin/install-frankenphp.sh 2>&1", $output, $exitCode);
+        if ($exitCode !== 0) {
+            $tail = implode("\n", array_slice($output, -30));
+            throw new \Exception("install-frankenphp.sh failed (exit {$exitCode}):\n" . $tail);
+        }
     }
 
     /**
@@ -114,6 +121,11 @@ final class FrankenphpServer implements Sapi
     {
         if (!self::isFrankenphpInstalled()) {
             self::installFrankenphp();
+            if (!self::isFrankenphpInstalled()) {
+                throw new \Exception(
+                    "install-frankenphp.sh succeeded but /usr/local/bin/frankenphp is still not runnable"
+                );
+            }
         }
 
         $cmd = sprintf(

--- a/tests/Sapi/Frankenphp/FrankenphpServer.php
+++ b/tests/Sapi/Frankenphp/FrankenphpServer.php
@@ -134,7 +134,12 @@ final class FrankenphpServer implements Sapi
         }
 
         $this->process = new Process($processCmd);
-        $this->process->start();
+        // Persist whatever Caddy/FrankenPHP write to stdout/stderr to have CI artifacts.
+        $logWriter = fopen(dirname($this->indexFile) . '/' . self::ERROR_LOG, "a");
+        $this->process->start(function ($type, $buffer) use ($logWriter) {
+            fwrite($logWriter, $buffer);
+            fflush($logWriter);
+        });
     }
 
     public function stop()

--- a/tests/Sapi/Frankenphp/FrankenphpServer.php
+++ b/tests/Sapi/Frankenphp/FrankenphpServer.php
@@ -178,7 +178,10 @@ final class FrankenphpServer implements Sapi
         }
 
         error_log("[frankenphp] Sending SIGTERM, waiting up to {$timeout}s for a graceful exit...");
-        $this->process->signal(SIGTERM);
+        // SIGTERM is a pcntl constant, and pcntl is not loaded in every image this suite runs in
+        // (the official FrankenPHP one has posix but not pcntl). Process::signal() only wants the
+        // number, and Symfony sends it through posix_kill, so don't make the harness need pcntl.
+        $this->process->signal(defined('SIGTERM') ? \SIGTERM : 15);
 
         $deadline = microtime(true) + $timeout;
         while (microtime(true) < $deadline) {

--- a/tests/Sapi/Frankenphp/FrankenphpServer.php
+++ b/tests/Sapi/Frankenphp/FrankenphpServer.php
@@ -92,9 +92,27 @@ final class FrankenphpServer implements Sapi
         exec(__DIR__ . "/../../../tooling/bin/install-frankenphp.sh");
     }
 
+    /**
+     * The CI images ship /usr/local/bin/frankenphp as a symlink pointing at the binary that
+     * install-frankenphp.sh still has to produce, while the official FrankenPHP images ship a real
+     * binary there. readlink() fails on the latter, so only resolve the link when there is one --
+     * otherwise we would rebuild FrankenPHP from source in an image that already has it.
+     *
+     * @return bool
+     */
+    private static function isFrankenphpInstalled()
+    {
+        $path = "/usr/local/bin/frankenphp";
+        if (is_link($path)) {
+            $target = readlink($path);
+            return $target !== false && file_exists($target);
+        }
+        return is_executable($path);
+    }
+
     public function start()
     {
-        if (!file_exists(readlink("/usr/local/bin/frankenphp"))) {
+        if (!self::isFrankenphpInstalled()) {
             self::installFrankenphp();
         }
 
@@ -123,6 +141,40 @@ final class FrankenphpServer implements Sapi
     {
         error_log("[frankenphp] Stopping...");
         $this->process->stop(0);
+    }
+
+    /**
+     * Sends SIGTERM and gives the server up to $timeout seconds to shut down by itself, rather than
+     * following up with SIGKILL right away like stop() does.
+     *
+     * This is what exercises the tracer's SIGTERM handler (ext/signals.c): with a sidecar attached
+     * it has to hand the signal back to the Go runtime, and if it fails to, FrankenPHP never sees
+     * the signal and only dies once something SIGKILLs it.
+     *
+     * @param int $timeout seconds to wait for a graceful exit
+     * @return bool whether the server exited on its own within $timeout
+     */
+    public function stopGracefully($timeout = 15)
+    {
+        if (!$this->process || !$this->process->isRunning()) {
+            return true;
+        }
+
+        error_log("[frankenphp] Sending SIGTERM, waiting up to {$timeout}s for a graceful exit...");
+        $this->process->signal(SIGTERM);
+
+        $deadline = microtime(true) + $timeout;
+        while (microtime(true) < $deadline) {
+            if (!$this->process->isRunning()) {
+                error_log("[frankenphp] Exited with code " . var_export($this->process->getExitCode(), true));
+                return true;
+            }
+            usleep(50 * 1000);
+        }
+
+        error_log("[frankenphp] Still running {$timeout}s after SIGTERM; killing it.");
+        $this->process->stop(0);
+        return false;
     }
 
     public function isFastCgi()

--- a/tests/Sapi/Frankenphp/FrankenphpServer.php
+++ b/tests/Sapi/Frankenphp/FrankenphpServer.php
@@ -136,6 +136,15 @@ final class FrankenphpServer implements Sapi
         foreach ($this->envs as $env => $val) {
             $envString .= " $env=\"$val\"";
         }
+        // Hand the test-session token over at startup. Otherwise the only thing that sets it is the
+        // auto-prepend ini_set() from tests/bootstrap_common.php, which every FrankenPHP worker
+        // thread runs concurrently -- turning a one-shot "no token yet" -> "token" transition inside
+        // the tracer into an N-way race. Given it up front, MINIT applies it once while still
+        // single-threaded and each later ini_set() is a no-op.
+        $sessionToken = ini_get("datadog.trace.agent_test_session_token");
+        if (!empty($sessionToken)) {
+            $envString .= " DD_TRACE_AGENT_TEST_SESSION_TOKEN=\"$sessionToken\"";
+        }
         $processCmd = "$envString exec $cmd";
 
 

--- a/tests/WebServer.php
+++ b/tests/WebServer.php
@@ -301,6 +301,21 @@ final class WebServer
     }
 
     /**
+     * Ask the SAPI to shut down on SIGTERM alone, without an immediate SIGKILL behind it.
+     *
+     * @param int $timeout seconds to wait for a graceful exit
+     * @return bool whether the SAPI exited on its own within $timeout
+     */
+    public function stopGracefully($timeout = 15)
+    {
+        if (!$this->sapi || !\method_exists($this->sapi, "stopGracefully")) {
+            Assert::markTestSkipped("Graceful webserver shutdown not supported for this SAPI");
+        }
+
+        return $this->sapi->stopGracefully($timeout);
+    }
+
+    /**
      * Teardown promptly.
      */
     public function stop()

--- a/tooling/bin/install-frankenphp.sh
+++ b/tooling/bin/install-frankenphp.sh
@@ -20,6 +20,7 @@ else
   ASAN=""
 fi
 
-CGO_CFLAGS="$(php-config --includes) $ASAN" CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs) $ASAN" go build
+# CGO_ENABLED=1 is not redundant: the CI images bake CGO_ENABLED=0 into the Go env, which drops every cgo file...
+CGO_ENABLED=1 CC="${CC:-cc}" CGO_CFLAGS="$(php-config --includes) $ASAN" CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs) $ASAN" go build
 
 mv frankenphp $(readlink /usr/local/bin/frankenphp)

--- a/tooling/bin/install-frankenphp.sh
+++ b/tooling/bin/install-frankenphp.sh
@@ -2,9 +2,11 @@
 
 set -eux
 
-frankenphpTarGzUrl=https://github.com/dunglas/frankenphp/archive/refs/tags/v1.1.2.tar.gz
+FRANKENPHP_VERSION=${FRANKENPHP_VERSION:-v1.12.7}
+frankenphpTarGzUrl=https://github.com/dunglas/frankenphp/archive/refs/tags/${FRANKENPHP_VERSION}.tar.gz
 FRANKENPHP_SRC_DIR=/usr/local/src/frankenphp
 
+rm -rf $FRANKENPHP_SRC_DIR
 mkdir -p $FRANKENPHP_SRC_DIR
 
 curl -Lo /tmp/frankenphp.tar.gz ${frankenphpTarGzUrl}
@@ -14,13 +16,25 @@ rm -f /tmp/frankenphp.tar.gz
 cd ${FRANKENPHP_SRC_DIR}
 cd caddy/frankenphp
 
-if ldd $(which php) 2>/dev/null | grep -q libasan; then
-  ASAN="-fsanitize=address"
+# The CI images are clang-built and clang links the ASAN runtime statically by default, so `ldd`
+# alone never sees it -- check for the runtime's init symbol as well, or ASAN silently stays off.
+php_bin=$(readlink -f "$(command -v php)")
+if ldd "$php_bin" 2>/dev/null | grep -qE 'libasan|libclang_rt\.asan' || nm -a "$php_bin" 2>/dev/null | grep -q __asan_init; then
+  # -shared-libasan is required, not optional: libphp.so links the shared ASAN runtime, while clang
+  # links the static one into executables by default, and mixing the two makes ASAN abort at startup
+  # with "Your application is linked against incompatible ASan runtimes".
+  ASAN="-fsanitize=address -shared-libasan"
+  # That runtime lives in clang's resource dir, which is not on the default loader path.
+  asan_rt_dir=$("${CC:-cc}" -print-runtime-dir 2>/dev/null || true)
+  ASAN_LD=${asan_rt_dir:+-Wl,-rpath,${asan_rt_dir}}
 else
   ASAN=""
+  ASAN_LD=""
 fi
 
 # CGO_ENABLED=1 is not redundant: the CI images bake CGO_ENABLED=0 into the Go env, which drops every cgo file...
-CGO_ENABLED=1 CC="${CC:-cc}" CGO_CFLAGS="$(php-config --includes) $ASAN" CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs) $ASAN" go build
+# -tags nowatcher: the file watcher pulls in a cgo module whose C headers are not vendored in the
+# release tarball, and we do not need worker file watching in tests.
+CGO_ENABLED=1 CC="${CC:-cc}" CGO_CFLAGS="$(php-config --includes) $ASAN" CGO_LDFLAGS="$(php-config --ldflags) $(php-config --libs) $ASAN $ASAN_LD" go build -tags nowatcher
 
 mv frankenphp $(readlink /usr/local/bin/frankenphp)

--- a/tracer/vendor/mt19937/mt19937-64.c
+++ b/tracer/vendor/mt19937/mt19937-64.c
@@ -56,16 +56,30 @@
 
 #include <stdio.h>
 
+#include <php.h>
+
 #define NN 312
 #define MM 156
 #define MATRIX_A 0xB5026F5AA96619E9ULL
 #define UM 0xFFFFFFFF80000000ULL /* Most significant 33 bits */
 #define LM 0x7FFFFFFFULL /* Least significant 31 bits */
 
+/* Local modification: the state is thread-local (ZEND_TLS, so only on ZTS builds -- an NTS process
+ * never runs two requests at once).
+ *
+ * ddtrace seeds this per request (ddtrace_seed_prng from RINIT) and draws from it per span, so on
+ * ZTS several threads hit it at once -- FrankenPHP runs dozens of PHP threads. Sharing the state
+ * then indexes mt[] out of bounds, because `mti` is both the loop counter of init_genrand64() and
+ * the cursor of genrand64_int64(): a thread can pass the `mti >= NN` check and then index mt[]
+ * after another thread has already advanced `mti` past the end.
+ *
+ * Per-thread state removes the sharing instead of guarding it, so no lock lands on the span-id
+ * path. Each thread just draws from its own stream.
+ */
 /* The array for the state vector */
-static unsigned long long mt[NN]; 
+ZEND_TLS unsigned long long mt[NN];
 /* mti==NN+1 means mt[NN] is not initialized */
-static int mti=NN+1; 
+ZEND_TLS int mti=NN+1;
 
 /* initializes mt[NN] with a seed */
 void init_genrand64(unsigned long long seed)


### PR DESCRIPTION
That's ugly with the manual assembly trampolines, but seems it's needed. Boo musl, boo.

Also making sure that we *actually* run the frankenphp tests, which are skipped under NTS...