### PR TITLE
Fix SSI MSHUTDOWN on PHP 7.3

### DIFF
--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -1524,9 +1524,11 @@ $system_tests_weblogs = [
       artifacts: true
   parallel:
     matrix:
-      # 7.4 is the version the crash was reported on and reproduces reliably; the newer ones are
-      # there to keep the mod_php reload path covered going forward.
+      # 7.4 is the version the first crash was reported on and reproduces reliably. 7.3 is the one
+      # where opcache still frees its shared memory in MSHUTDOWN, which is what APMS-20476 tripped
+      # over. The newer ones keep the mod_php reload path covered going forward.
       - MAJOR_MINOR:
+          - "7.3"
           - "7.4"
           - "8.3"
           - "8.5"

--- a/appsec/src/extension/ddappsec.c
+++ b/appsec/src/extension/ddappsec.c
@@ -133,7 +133,8 @@ static void ddappsec_sort_modules(void *base, size_t count, size_t siz,
     for (Bucket *module = base, *end = module + count, *ddappsec_module = NULL;
         module < end; ++module) {
         zend_module_entry *m = (zend_module_entry *)Z_PTR(module->val);
-        if (m->name == ddappsec_module_entry.name) {
+        // Compare by value to avoid confusion with the SSI replaced name
+        if (strcmp(m->name, PHP_DDAPPSEC_EXTNAME) == 0) {
             ddappsec_module = module;
             continue;
         }

--- a/ext/datadog.c
+++ b/ext/datadog.c
@@ -80,7 +80,8 @@ static void datadog_sort_modules(void *base, size_t count, size_t siz, compare_f
     // swap ddtrace and opcache for the rest of the modules lifecycle, so that opcache is always executed after ddtrace
     for (Bucket *module = base, *end = module + count, *datadog_module = NULL; module < end; ++module) {
         zend_module_entry *m = (zend_module_entry *)Z_PTR(module->val);
-        if (m->name == datadog_module_entry.name) {
+        // Compare by value to avoid confusion with the SSI replaced name
+        if (strcmp(m->name, PHP_DDTRACE_EXTNAME) == 0) {
             datadog_module = module;
         }
         if (datadog_module && strcmp(m->name, "Zend OPcache") == 0) {

--- a/loader/bin/test_apache_reload.sh
+++ b/loader/bin/test_apache_reload.sh
@@ -11,12 +11,19 @@
 # and the Apache parent dies with SIGSEGV (and the userland DDTrace\* functions disappear, because
 # the "original" function table was captured as NULL).
 #
+# opcache is enabled on purpose: it relocates every module_registry key into shared memory at the
+# end of php_module_startup() and maps them back out at the start of php_module_shutdown(). A key
+# the loader installed that is not a permanent interned string cannot be mapped back, so it keeps
+# pointing into a segment opcache unmaps in its own MSHUTDOWN, and zend_destroy_modules() dies
+# while releasing the module names (APMS-20476, PHP 7.3).
+#
 # This test therefore asserts, after each of several consecutive graceful reloads:
 #   1. the Apache *parent* pid is unchanged and still alive (apachectl graceful silently cold-starts
 #      a fresh httpd when the parent died, so the response alone proves nothing),
 #   2. requests still report ddtrace loaded, with the same phpversion('ddtrace'),
 #   3. function_exists('DDTrace\trace_function') is still true,
-#   4. the profiler is still loaded (it takes part in the resident-image situation).
+#   4. the profiler is still loaded (it takes part in the resident-image situation),
+#   5. opcache is loaded, so the run really did cover the shared memory interaction above.
 #
 # Required: DD_LOADER_PACKAGE_PATH pointing at an extracted dd-library-php-ssi package.
 # Optional: DD_LOADER_SO (defaults to ./modules/dd_library_loader.so), APACHE_RELOADS (default 3),
@@ -62,6 +69,8 @@ if [[ -z "${INI_SCAN_DIR}" || "${INI_SCAN_DIR}" == "(none)" ]]; then
     exit 1
 fi
 INI_FILE="${INI_SCAN_DIR}/98-dd-loader-reload-test.ini"
+OPCACHE_INI_FILE="${INI_SCAN_DIR}/10-dd-loader-reload-test-opcache.ini"
+LOG_CONF="/etc/apache2/conf-enabled/zz-dd-loader-reload-test-log.conf"
 
 # Apache reads the env of the process that starts it; mod_php then hands it to the loader.
 export DD_INJECTION_ENABLED=tracing
@@ -74,6 +83,10 @@ export DD_TRACE_STARTUP_LOGS=0
 . /etc/apache2/envvars
 $SUDO mkdir -p "${APACHE_RUN_DIR}" "${APACHE_LOCK_DIR}" "${APACHE_LOG_DIR}"
 
+# The images symlink Apache's error.log to /dev/stderr, which cannot be read back (and makes tail
+# block forever), so point it at a real file in the same directory for the diagnostics at the end.
+ERROR_LOG="${APACHE_LOG_DIR}/dd-loader-reload-test-error.log"
+
 PORTS_CONF="/etc/apache2/ports.conf"
 DEFAULT_SITE="/etc/apache2/sites-available/000-default.conf"
 BACKUP_SUFFIX=".dd-reload-test.bak"
@@ -81,7 +94,8 @@ BACKUP_SUFFIX=".dd-reload-test.bak"
 cleanup() {
     local rc=$?
     $SUDO -E apachectl stop >/dev/null 2>&1
-    $SUDO rm -f "${INI_FILE}" "${DOCROOT}/${TEST_SCRIPT_NAME}"
+    $SUDO rm -f "${INI_FILE}" "${OPCACHE_INI_FILE}" "${LOG_CONF}" "${ERROR_LOG}" \
+        "${DOCROOT}/${TEST_SCRIPT_NAME}"
     for conf in "${PORTS_CONF}" "${DEFAULT_SITE}"; do
         if [[ -f "${conf}${BACKUP_SUFFIX}" ]]; then
             $SUDO mv "${conf}${BACKUP_SUFFIX}" "${conf}"
@@ -104,15 +118,30 @@ echo "INI scan dir: ${INI_SCAN_DIR}"
 
 echo "zend_extension=${LOADER_SO}" | $SUDO tee "${INI_FILE}" >/dev/null
 
+# Loaded from a lower-numbered file, i.e. before the loader, like a distribution would.
+EXPECT_OPCACHE=0
+if [[ -f "$(php-config --extension-dir)/opcache.so" ]]; then
+    EXPECT_OPCACHE=1
+    cat <<'INI' | $SUDO tee "${OPCACHE_INI_FILE}" >/dev/null
+zend_extension=opcache.so
+opcache.enable=1
+opcache.interned_strings_buffer=8
+opcache.memory_consumption=64
+INI
+else
+    echo "WARNING: opcache.so not found; the shared memory interned string path is NOT covered"
+fi
+
 $SUDO mkdir -p "${DOCROOT}"
 cat <<'PHP' | $SUDO tee "${DOCROOT}/${TEST_SCRIPT_NAME}" >/dev/null
 <?php
 printf(
-    "ddtrace=%s version=%s trace_function=%s profiling=%s\n",
+    "ddtrace=%s version=%s trace_function=%s profiling=%s opcache=%s\n",
     extension_loaded('ddtrace') ? 'yes' : 'no',
     phpversion('ddtrace') ?: '-',
     function_exists('DDTrace\\trace_function') ? 'yes' : 'no',
-    extension_loaded('datadog-profiling') ? 'yes' : 'no'
+    extension_loaded('datadog-profiling') ? 'yes' : 'no',
+    extension_loaded('Zend OPcache') ? 'yes' : 'no'
 );
 PHP
 
@@ -134,6 +163,15 @@ parent_pid() {
     [[ -f "${APACHE_PID_FILE}" ]] && cat "${APACHE_PID_FILE}" 2>/dev/null
 }
 
+# "kill -0" also succeeds for a zombie, and a crashed Apache parent stays one until something
+# reaps it -- which nothing does when the container's pid 1 is not an init. Read the state instead.
+parent_alive() {
+    local pid="$1" state
+    [[ -n "${pid}" ]] || return 1
+    state="$(awk '{print $3}' "/proc/${pid}/stat" 2>/dev/null)" || return 1
+    [[ -n "${state}" && "${state}" != "Z" ]]
+}
+
 # ServerName goes in here too, so the log doesn't start with AH00558.
 $SUDO cp "${PORTS_CONF}" "${PORTS_CONF}${BACKUP_SUFFIX}"
 printf 'Listen %s:%s\nServerName %s\n' "${LISTEN_ADDR}" "${LISTEN_PORT}" "${LISTEN_ADDR}" \
@@ -142,6 +180,8 @@ if [[ -f "${DEFAULT_SITE}" && "${LISTEN_PORT}" != "80" ]]; then
     $SUDO cp "${DEFAULT_SITE}" "${DEFAULT_SITE}${BACKUP_SUFFIX}"
     $SUDO sed -i "s/\*:80/*:${LISTEN_PORT}/" "${DEFAULT_SITE}"
 fi
+printf 'ErrorLog %s\n' "${ERROR_LOG}" | $SUDO tee "${LOG_CONF}" >/dev/null
+$SUDO rm -f "${ERROR_LOG}"
 
 echo
 echo "Starting Apache on ${LISTEN_ADDR}:${LISTEN_PORT}"
@@ -175,6 +215,10 @@ assert_response() {
         echo "ERROR (${label}): the profiler is not loaded"
         failed=1
     fi
+    if [[ ${EXPECT_OPCACHE} -eq 1 && "${resp}" != *"opcache=yes"* ]]; then
+        echo "ERROR (${label}): opcache is not loaded, so this run did not cover it"
+        failed=1
+    fi
     if [[ "${resp}" != "${BASELINE}" ]]; then
         echo "ERROR (${label}): response changed"
         echo "  expected: ${BASELINE}"
@@ -198,9 +242,8 @@ for i in $(seq 1 "${RELOADS}"); do
     sleep 2
 
     NEW_PID="$(parent_pid)"
-    # Apache runs as root, so signal it through sudo (kill -0 would give EPERM otherwise).
-    if [[ -z "${NEW_PID}" ]] || ! $SUDO kill -0 "${NEW_PID}" 2>/dev/null; then
-        echo "ERROR: the Apache parent is gone after reload ${i} (pid file: '${NEW_PID:-missing}')"
+    if ! parent_alive "${NEW_PID}"; then
+        echo "ERROR: the Apache parent died during reload ${i} (pid file: '${NEW_PID:-missing}')"
         FAILED=1
         break
     fi
@@ -220,7 +263,7 @@ done
 echo
 if [[ ${FAILED} -ne 0 ]]; then
     echo "Apache error log tail:"
-    $SUDO tail -n 50 "${APACHE_LOG_DIR}/error.log" 2>/dev/null || true
+    tail -n 50 "${ERROR_LOG}" 2>/dev/null || true
     exit 1
 fi
 

--- a/loader/compat_php.c
+++ b/loader/compat_php.c
@@ -15,12 +15,22 @@ ZEND_API zend_result ZEND_FASTCALL zend_hash_str_del(HashTable *ht, const char *
 ZEND_API zval* ZEND_FASTCALL zend_hash_str_find(const HashTable *ht, const char *key, size_t len) __attribute__((weak));
 extern __typeof__(__zend_malloc) __zend_malloc __attribute__((weak));
 
-static bool ddloader_zstr_is_interned(int php_api_no, zend_string *key) {
+bool ddloader_zstr_is_interned(int php_api_no, zend_string *key) {
     if (php_api_no <= 20170718) {  // PHP 7.0 - 7.2
         return GC_TYPE_INFO(key) & (PHP_70_71_72_IS_STR_INTERNED << 8);
     }
 
     return ZSTR_IS_INTERNED(key);
+}
+
+zend_string *ddloader_zend_new_interned_string(int php_api_no, zend_string *str) {
+    UNUSED(php_api_no);
+
+    if (!zend_new_interned_string) {
+        return str;
+    }
+
+    return zend_new_interned_string(str);
 }
 
 static zend_string *php70_71_72_zend_string_alloc(size_t len, int persistent) {

--- a/loader/compat_php.h
+++ b/loader/compat_php.h
@@ -6,6 +6,8 @@
 zend_string *ddloader_zend_string_alloc(int php_api_no, size_t len, int persistent);
 zend_string *ddloader_zend_string_init(int php_api_no, const char *str, size_t len, bool persistent);
 void ddloader_zend_string_release(int php_api_no, zend_string *s);
+bool ddloader_zstr_is_interned(int php_api_no, zend_string *str);
+zend_string *ddloader_zend_new_interned_string(int php_api_no, zend_string *str);
 zval *ddloader_zend_hash_set_bucket_key(int php_api_no, HashTable *ht, Bucket *b, zend_string *key);
 void *ddloader_zend_hash_str_find_ptr(int php_api_no, const HashTable *ht, const char *str, size_t len);
 void ddloader_zend_hash_str_del(int php_api_no, HashTable *ht, const char *str, size_t len);

--- a/loader/dd_library_loader.c
+++ b/loader/dd_library_loader.c
@@ -730,10 +730,21 @@ static PHP_MINIT_FUNCTION(ddloader_injected_extension_minit) {
     zend_string *old_name = ddloader_zend_string_init(php_api_no, config->tmp_name, strlen(config->tmp_name), 1);
     Bucket *bucket = (Bucket *)zend_hash_find(&module_registry, old_name);
     ddloader_zend_string_release(php_api_no, old_name);
+    if (!bucket) {
+        TELEMETRY(REASON_ERROR, config, "injected_ext_not_found", "Extension '%s' not found in the module registry", config->tmp_name);
+        return SUCCESS;
+    }
 
+    /**
+     * The new key must be a *permanent interned* string, exactly like the ones zend_register_module_ex() creates for every other module.
+     * Opcache moves every module_registry key into its shared memory interned string buffer at the end of php_module_startup(), and maps them back out again at the start of php_module_shutdown() by looking each one up in the permanent interned string table.
+     */
     zend_string *new_name = ddloader_zend_string_init(php_api_no, config->ext_name, strlen(config->ext_name), 1);
+    new_name = ddloader_zend_new_interned_string(php_api_no, new_name);
     ddloader_zend_hash_set_bucket_key(php_api_no, &module_registry, bucket, new_name);
-    ddloader_zend_string_release(php_api_no, new_name);
+    if (!ddloader_zstr_is_interned(php_api_no, new_name)) {
+        ddloader_zend_string_release(php_api_no, new_name);
+    }
 
     module = ddloader_zend_hash_str_find_ptr(php_api_no, &module_registry, config->ext_name, strlen(config->ext_name));
     if (!module) {
@@ -774,12 +785,13 @@ static void ddloader_restore_so_module_entry(injected_ext *config) {
         return;
     }
 
-    module_entry->name = config->ext_name;
+    module_entry->name = config->orig_module_name;
     module_entry->module_startup_func = config->orig_module_startup_func;
     module_entry->deps = config->orig_module_deps;
     module_entry->functions = config->orig_module_functions;
 
     config->so_module_entry = NULL;
+    config->orig_module_name = NULL;
     config->orig_module_startup_func = NULL;
     config->orig_module_deps = NULL;
     config->orig_module_functions = NULL;
@@ -847,8 +859,9 @@ static int ddloader_load_extension(unsigned int php_api_no, char *module_build_i
      * our injected extension will be started up after the real one (if it's loaded!), and finally we
      * wrap the MINIT function to perform our checks there.
      */
-    module_entry->name = config->tmp_name;
     config->so_module_entry = module_entry;
+    config->orig_module_name = module_entry->name;
+    module_entry->name = config->tmp_name;
 
     config->orig_module_startup_func = module_entry->module_startup_func;
     module_entry->module_startup_func = ZEND_MODULE_STARTUP_N(ddloader_injected_extension_minit);

--- a/loader/php_dd_library_loader.h
+++ b/loader/php_dd_library_loader.h
@@ -41,6 +41,7 @@ typedef enum {
         .ext_name = name, .ext_dir = dir, .ext_min_version = min_version, .tmp_name = name "_injected", .tmp_deps = deps,           \
         .pre_load_hook = _pre_load_hook, .pre_minit_hook = _pre_minit_hook,                         \
         .so_module_entry = NULL,                                                                    \
+        .orig_module_name = NULL,                                                                   \
         .orig_module_startup_func = NULL, .orig_module_deps = NULL, .orig_module_functions = NULL,  \
         .module_number = -1, .version = NULL,                                                       \
         .injection_success = false, .injection_error = NULL, .extra_config = {0}, .logs = {0}       \
@@ -64,6 +65,7 @@ typedef struct _injected_ext {
     zend_result (*orig_module_startup_func)(INIT_FUNC_ARGS);
     const zend_module_dep *orig_module_deps;
     const zend_function_entry *orig_module_functions;
+    const char *orig_module_name;
     int module_number;
     char *version;
     void *so_handle; // dlopen handle of the loaded .so


### PR DESCRIPTION
On PHP 7.3 specifically, we sort ourselves behind opcache, but opcache replaces the module names by interned strings in opcaches own table, but executed in MSHUTDOWN instead of post_shutdown_cb. This will cause any extensions after opcache to crash when freeing the zend_string keying the module_registry.