### PR TITLE
ci: fix Debian 11 EOL apt breakage, add trixie coverage

### DIFF
--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -1277,7 +1277,7 @@ endforeach;
 
 .system_tests:
   stage: verify
-  image: registry.ddbuild.io/images/mirror/python:3.12-slim-bullseye
+  image: registry.ddbuild.io/images/mirror/python:3.12-slim-bookworm
   tags: [ "docker-in-docker:amd64" ]
   variables:
     TEST_LIBRARY: php
@@ -1306,24 +1306,8 @@ endforeach;
       mkdir -p $APT_CACHE/archives
       chown -R $(id -u):$(id -g) $CI_PROJECT_DIR/.cache
 
-      # Fix apt sources, as debian 11 is EOL: bullseye-security expired and part of its pool is purged from deb.debian.org
-      # Interim only - this is just a test driver, so it goes when python:3.12-slim-bookworm is mirrored; the codename guard makes the pin inert by itself
-      if [ "$(. /etc/os-release; echo $VERSION_CODENAME)" = "bullseye" ]; then
-        sed -i -e 's|http://deb.debian.org/debian-security|http://snapshot.debian.org/archive/debian-security/20260901T000000Z|g' \
-               -e 's|http://deb.debian.org/debian|http://snapshot.debian.org/archive/debian/20260901T000000Z|g' /etc/apt/sources.list
-        echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until
-      fi
-
       # Install system dependencies
       apt-get update -o dir::state::lists="$APT_CACHE/lists"
-      # apt-get update still exits 0 when the rewrite silently no-ops, so assert on the URIs apt would actually fetch from.
-      if [ "$(. /etc/os-release; echo $VERSION_CODENAME)" = "bullseye" ]; then
-        uris=$(apt-get install -y --print-uris --no-install-recommends -o dir::state::lists="$APT_CACHE/lists" ca-certificates curl git build-essential \
-               | grep -oE "https?://[a-z0-9.-]+" | sort -u || true)
-        bad=$(echo "$uris" | grep -v '^http://snapshot\.debian\.org$' || true)
-        if [ -z "$uris" ]; then echo "FAIL: could not resolve any apt URIs"; exit 1; fi
-        if [ -n "$bad" ]; then echo "FAIL: bullseye apt sources not pinned; apt would still fetch from: $bad"; exit 1; fi
-      fi
       apt-get install -y --no-install-recommends -o dir::state::lists="$APT_CACHE/lists" -o dir::cache::archives="$APT_CACHE/archives" ca-certificates curl git build-essential
       mkdir -p /etc/apt/keyrings
       curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc

--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -1122,6 +1122,8 @@ endforeach;
     - '# Pinned at the snapshot taken when bullseye LTS ended (2026-08-31), so there is nothing newer for the pin to drift from'
     - |
       if [ "$(. /etc/os-release; echo $VERSION_CODENAME)" = "bullseye" ]; then
+        # Say so rather than skipping: a bullseye image with deb822 sources would otherwise fail later as exit 75, which reads as infra flakiness.
+        if [ ! -f /etc/apt/sources.list ]; then echo "FAIL: bullseye image has no /etc/apt/sources.list; the snapshot pin does not apply to this layout"; exit 1; fi
         sed -i -e 's|http://deb.debian.org/debian-security|http://snapshot.debian.org/archive/debian-security/20260901T000000Z|g' \
                -e 's|http://deb.debian.org/debian|http://snapshot.debian.org/archive/debian/20260901T000000Z|g' /etc/apt/sources.list
         echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until

--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -1118,7 +1118,25 @@ endforeach;
 <?php dockerhub_login() ?>
     - mkdir build
     - mv packages build
+    - '# Fix apt sources, as debian 11 is EOL: bullseye-security expired and part of its pool is purged from deb.debian.org'
+    - '# Pinned at the snapshot taken when bullseye LTS ended (2026-08-31), so there is nothing newer for the pin to drift from'
+    - |
+      if [ "$(. /etc/os-release; echo $VERSION_CODENAME)" = "bullseye" ]; then
+        sed -i -e 's|http://deb.debian.org/debian-security|http://snapshot.debian.org/archive/debian-security/20260901T000000Z|g' \
+               -e 's|http://deb.debian.org/debian|http://snapshot.debian.org/archive/debian/20260901T000000Z|g' /etc/apt/sources.list
+        echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until
+      fi
     - apt-get update || exit 75
+    - |
+      # apt-get update still exits 0 when the rewrite silently no-ops, so assert on the URIs apt would actually fetch from.
+      if [ "$(. /etc/os-release; echo $VERSION_CODENAME)" = "bullseye" ]; then
+        uris=$(apt-get install -y --print-uris apt-transport-https lsb-release ca-certificates curl \
+                 software-properties-common nginx apache2 procps gnupg \
+               | grep -oE "https?://[a-z0-9.-]+" | sort -u)
+        bad=$(echo "$uris" | grep -v '^http://snapshot\.debian\.org$' || true)
+        if [ -z "$uris" ]; then echo "FAIL: could not resolve any apt URIs"; exit 1; fi
+        if [ -n "$bad" ]; then echo "FAIL: bullseye apt sources not pinned; apt would still fetch from: $bad"; exit 1; fi
+      fi
     - apt-get install -y curl || exit 75
 
 <?php foreach ([["8.1", "arm64", "aarch64"], ["7.0", "amd64", "x86_64"]] as [$major_minor, $arch, $pkgprefix]): ?>

--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -1306,8 +1306,24 @@ endforeach;
       mkdir -p $APT_CACHE/archives
       chown -R $(id -u):$(id -g) $CI_PROJECT_DIR/.cache
 
+      # Fix apt sources, as debian 11 is EOL: bullseye-security expired and part of its pool is purged from deb.debian.org
+      # Interim only - this is just a test driver, so it goes when python:3.12-slim-bookworm is mirrored; the codename guard makes the pin inert by itself
+      if [ "$(. /etc/os-release; echo $VERSION_CODENAME)" = "bullseye" ]; then
+        sed -i -e 's|http://deb.debian.org/debian-security|http://snapshot.debian.org/archive/debian-security/20260901T000000Z|g' \
+               -e 's|http://deb.debian.org/debian|http://snapshot.debian.org/archive/debian/20260901T000000Z|g' /etc/apt/sources.list
+        echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until
+      fi
+
       # Install system dependencies
       apt-get update -o dir::state::lists="$APT_CACHE/lists"
+      # apt-get update still exits 0 when the rewrite silently no-ops, so assert on the URIs apt would actually fetch from.
+      if [ "$(. /etc/os-release; echo $VERSION_CODENAME)" = "bullseye" ]; then
+        uris=$(apt-get install -y --print-uris --no-install-recommends -o dir::state::lists="$APT_CACHE/lists" ca-certificates curl git build-essential \
+               | grep -oE "https?://[a-z0-9.-]+" | sort -u)
+        bad=$(echo "$uris" | grep -v '^http://snapshot\.debian\.org$' || true)
+        if [ -z "$uris" ]; then echo "FAIL: could not resolve any apt URIs"; exit 1; fi
+        if [ -n "$bad" ]; then echo "FAIL: bullseye apt sources not pinned; apt would still fetch from: $bad"; exit 1; fi
+      fi
       apt-get install -y --no-install-recommends -o dir::state::lists="$APT_CACHE/lists" -o dir::cache::archives="$APT_CACHE/archives" ca-certificates curl git build-essential
       mkdir -p /etc/apt/keyrings
       curl -fsSL https://download.docker.com/linux/debian/gpg -o /etc/apt/keyrings/docker.asc

--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -1121,9 +1121,7 @@ endforeach;
     - '# Fix apt sources, as debian 11 is EOL: bullseye-security expired and part of its pool is purged from deb.debian.org'
     - '# Pinned at the snapshot taken when bullseye LTS ended (2026-08-31), so there is nothing newer for the pin to drift from'
     - |
-      if [ "$(. /etc/os-release; echo $VERSION_CODENAME)" = "bullseye" ]; then
-        # Say so rather than skipping: a bullseye image with deb822 sources would otherwise fail later as exit 75, which reads as infra flakiness.
-        if [ ! -f /etc/apt/sources.list ]; then echo "FAIL: bullseye image has no /etc/apt/sources.list; the snapshot pin does not apply to this layout"; exit 1; fi
+      if [ -f /etc/apt/sources.list ] && [ "$(. /etc/os-release; echo $VERSION_CODENAME)" = "bullseye" ]; then
         sed -i -e 's|http://deb.debian.org/debian-security|http://snapshot.debian.org/archive/debian-security/20260901T000000Z|g' \
                -e 's|http://deb.debian.org/debian|http://snapshot.debian.org/archive/debian/20260901T000000Z|g' /etc/apt/sources.list
         echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until

--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -1131,8 +1131,8 @@ endforeach;
       # apt-get update still exits 0 when the rewrite silently no-ops, so assert on the URIs apt would actually fetch from.
       if [ "$(. /etc/os-release; echo $VERSION_CODENAME)" = "bullseye" ]; then
         uris=$(apt-get install -y --print-uris apt-transport-https lsb-release ca-certificates curl \
-                 software-properties-common nginx apache2 procps gnupg \
-               | grep -oE "https?://[a-z0-9.-]+" | sort -u)
+                 nginx apache2 procps gnupg \
+               | grep -oE "https?://[a-z0-9.-]+" | sort -u || true)
         bad=$(echo "$uris" | grep -v '^http://snapshot\.debian\.org$' || true)
         if [ -z "$uris" ]; then echo "FAIL: could not resolve any apt URIs"; exit 1; fi
         if [ -n "$bad" ]; then echo "FAIL: bullseye apt sources not pinned; apt would still fetch from: $bad"; exit 1; fi
@@ -1319,7 +1319,7 @@ endforeach;
       # apt-get update still exits 0 when the rewrite silently no-ops, so assert on the URIs apt would actually fetch from.
       if [ "$(. /etc/os-release; echo $VERSION_CODENAME)" = "bullseye" ]; then
         uris=$(apt-get install -y --print-uris --no-install-recommends -o dir::state::lists="$APT_CACHE/lists" ca-certificates curl git build-essential \
-               | grep -oE "https?://[a-z0-9.-]+" | sort -u)
+               | grep -oE "https?://[a-z0-9.-]+" | sort -u || true)
         bad=$(echo "$uris" | grep -v '^http://snapshot\.debian\.org$' || true)
         if [ -z "$uris" ]; then echo "FAIL: could not resolve any apt URIs"; exit 1; fi
         if [ -n "$bad" ]; then echo "FAIL: bullseye apt sources not pinned; apt would still fetch from: $bad"; exit 1; fi

--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -1121,7 +1121,9 @@ endforeach;
     - '# Fix apt sources, as debian 11 is EOL: bullseye-security expired and part of its pool is purged from deb.debian.org'
     - '# Pinned at the snapshot taken when bullseye LTS ended (2026-08-31), so there is nothing newer for the pin to drift from'
     - |
-      if [ -f /etc/apt/sources.list ] && [ "$(. /etc/os-release; echo $VERSION_CODENAME)" = "bullseye" ]; then
+      if [ "$(. /etc/os-release; echo $VERSION_CODENAME)" = "bullseye" ]; then
+        # Say so rather than skipping: a bullseye image with deb822 sources would otherwise fail later as exit 75, which reads as infra flakiness.
+        if [ ! -f /etc/apt/sources.list ]; then echo "FAIL: bullseye image has no /etc/apt/sources.list; the snapshot pin does not apply to this layout"; exit 1; fi
         sed -i -e 's|http://deb.debian.org/debian-security|http://snapshot.debian.org/archive/debian-security/20260901T000000Z|g' \
                -e 's|http://deb.debian.org/debian|http://snapshot.debian.org/archive/debian/20260901T000000Z|g' /etc/apt/sources.list
         echo 'Acquire::Check-Valid-Until "false";' > /etc/apt/apt.conf.d/99no-check-valid-until

--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -1106,6 +1106,7 @@ endforeach;
         IMAGE:
           - "debian:bullseye-slim"
           - "debian:bookworm-slim"
+          - "debian:trixie-slim"
   needs:
     - job: "package extension (installers): [amd64, x86_64-unknown-linux-gnu]"
       artifacts: true
@@ -1123,7 +1124,7 @@ endforeach;
 <?php foreach ([["8.1", "arm64", "aarch64"], ["7.0", "amd64", "x86_64"]] as [$major_minor, $arch, $pkgprefix]): ?>
 "verify .tar.gz: [<?= $arch ?>]":
   stage: verify
-  image: registry.ddbuild.io/images/mirror/debian:bullseye-slim
+  image: registry.ddbuild.io/images/mirror/debian:bookworm-slim
   tags: [ "arch:<?= $arch ?>" ]
   variables:
     KUBERNETES_CPU_REQUEST: 2

--- a/dockerfiles/verify_packages/debian/install.sh
+++ b/dockerfiles/verify_packages/debian/install.sh
@@ -26,7 +26,6 @@ retry_or_tempfail apt-get install -y \
     lsb-release \
     ca-certificates \
     curl \
-    software-properties-common \
     nginx \
     apache2 \
     procps \

--- a/dockerfiles/verify_packages/tar_gz/install.sh
+++ b/dockerfiles/verify_packages/tar_gz/install.sh
@@ -26,7 +26,6 @@ retry_or_tempfail apt-get install -y \
     lsb-release \
     ca-certificates \
     curl \
-    software-properties-common \
     nginx \
     apache2 \
     procps \


### PR DESCRIPTION
Debian 11 (bullseye) is EOL and its apt repos broke, taking master red: in pipeline 135955234, 66 of 67 failed jobs were bullseye. `bookworm` is the control — 22/22 bookworm `verify debian` cells pass while 22/22 bullseye cells fail on identical scripts, only `$IMAGE` differing.

Two independent failures, so relaxing apt date checks alone is not enough: `bullseye-security` `InRelease` expired 2026-09-07T21:13:05Z, and the `deb11uN` pool objects are incompletely served. Over 40 random objects: `deb.debian.org` 13/40, `security.debian.org` 14/40, `snapshot.debian.org@20260901T000000Z` 40/40; `archive.debian.org` has no `bullseye-security` at all. Snapshot is the only complete source, and the pin is an end state, not a point in the past — `bullseye-security` is terminally frozen and `snapshot@20260901` is byte-identical (`cmp`) to the final live index, so there is no date to maintain.

Debian 11 stays in the matrix as a supported customer install target; `debian:trixie-slim` is added alongside.
