### PR TITLE
ci: add team freeze guard workflow

### DIFF
--- a/.github/workflows/team-freeze-guard.yml
+++ b/.github/workflows/team-freeze-guard.yml
@@ -1,0 +1,41 @@
+# How to configure:
+#
+# When no team is frozen, set `frozen-teams` to an empty string:
+# frozen-teams: ""
+#
+# When one or more teams are frozen, add them one per line with the @DataDog prefix:
+#
+# frozen-teams: |
+#   @DataDog/team-a
+#   @DataDog/team-b
+
+name: Team freeze guard
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - labeled
+      - unlabeled
+      - ready_for_review
+
+permissions:
+  id-token: write
+  contents: read
+
+jobs:
+  team-freeze-guard:
+    name: Team freeze guard
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: DataDog/team-freeze-guard@29e92069c40f38088e636f27df70d10c24e647b6  # v0.0.2
+        with:
+          bypass-labels: |
+            ci
+            ci-infrastructure
+            dev/testing
+            github_actions
+          frozen-teams: ""


### PR DESCRIPTION
### Description

Adds a GitHub Action that will fail if the PR author or last committer is part of a frozen team. Please read https://github.com/DataDog/team-freeze-guard on how it works.

RFC: https://docs.google.com/document/d/1qIhh1MHY08Vbn34MZXiGXwVaMvYSQkfgmBb9j2tqf-0/edit?tab=t.0#heading=h.o9e3y54cla5b

**Testing**

The workflow runs on `pull_request_target` (read DataDog/team-freeze-guard to understand why), so you can't test it on this PR. I've tested a lot on DataDog/team-freeze-guard itself, and system-tests, and I'll closely monitor actions once merged.

**Risks**

Freeze the entire repo if I mess up. But easy to revert. Already deployed on dd-trace-py with success.

**FAQ**

- The list of frozen teams should be in a central way to have better control on it.
  - This is a first iteration to have this code freeze available as soon as possible. I'll then start working on a place to store this list, with a restricted access on who can change it.
- Why in github action?
  - Most commonly used CI engine, already used by most small PR checks on almost all repos (labels, PR title, etc...) and easier to set up.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.

🤖 Generated with [Claude Code](https://claude.com/claude-code)