### PR TITLE
ci: use HTTPS for Alpine package repositories

### DIFF
--- a/.gitlab/generate-package.php
+++ b/.gitlab/generate-package.php
@@ -1106,6 +1106,10 @@ endforeach;
 <?php dockerhub_login() ?>
     - mkdir build
     - mv packages build
+    # Older Alpine images bake HTTP repository URLs into /etc/apk/repositories.
+    # Use HTTPS before the first apk invocation so package installation works
+    # when plaintext HTTP egress is blocked.
+    - sed -i 's|^http://|https://|' /etc/apk/repositories
     - apk add --no-cache ca-certificates || exit 75 # see https://support.circleci.com/hc/en-us/articles/360016505753-Resolve-Certificate-Signed-By-Unknown-Authority-error-in-Alpine-images?flash_digest=39b76521a337cecacac0cc10cb28f3747bb5fc6a
     - apk add curl ${INSTALL_PACKAGES:-} || exit 75
 

--- a/.gitlab/generate-tracer.php
+++ b/.gitlab/generate-tracer.php
@@ -200,16 +200,12 @@ windows_test_c_job("windows test_c: zts", "zts", [
 
 "Prepare code":
   stage: compile
-  image: registry.ddbuild.io/images/mirror/php:8.2-cli
+  image: registry.ddbuild.io/images/mirror/composer:2
   tags: [ "arch:amd64" ]
   needs: []
   variables:
     KUBERNETES_CPU_REQUEST: 1
     KUBERNETES_MEMORY_REQUEST: 2Gi
-  before_script:
-    - apt update && apt install -y unzip
-    - php -r "copy('https://getcomposer.org/installer', 'composer-setup.php');" && php composer-setup.php && mv composer.phar /usr/local/bin/composer
-    - composer update --no-interaction
   script:
     - make generate
   artifacts:


### PR DESCRIPTION
### Description

We started enforcing some egress restrictions in our CI. Older alpine images use `http` rather than `https` by default in their `apk` commands. This PR replaces `http://` with `https://` in `/etc/apk/repositories`. Let's see if this does the trick, as we should use `https://`!

This also fixes `Prepare code` which installs `unzip` which ends up using `http` in Debian packages. In this case we fix it by moving the base image from `php:8.2-cli` to `composer:2`. Note that `prepare code` (lowercase) already uses `composer:2` to run `make generate`. These jobs are in different pipelines but they're doing the same thing in those pipelines.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
