### PR TITLE
test: reduce sidecar testing flakes

### DIFF
--- a/tests/Common/TracerTestTrait.php
+++ b/tests/Common/TracerTestTrait.php
@@ -178,9 +178,9 @@ trait TracerTestTrait
      * This method executes a request into an ad-hoc web server configured with the provided envs and inis that is
      * created and destroyed with the scope of this test.
      */
-    public function inWebServer($fn, $rootPath, $envs = [], $inis = [], &$curlInfo = null)
+    public function inWebServer($fn, $rootPath, $envs = [], $inis = [], $retryOnEmptyTraces = true, &$curlInfo = null)
     {
-        $retries = 1;
+        $retries = $retryOnEmptyTraces ? 1 : 0;
         do {
             self::putEnv('DD_TRACE_SHUTDOWN_TIMEOUT=666666'); // Arbitrarily high value to avoid flakiness
             self::putEnv('DD_TRACE_AGENT_RETRIES=3');

--- a/tests/Composer/ComposerInteroperabilityTest.php
+++ b/tests/Composer/ComposerInteroperabilityTest.php
@@ -30,6 +30,8 @@ class ComposerInteroperabilityTest extends BaseTestCase
 
     public function testComposerInteroperabilityWhenNoInitHook()
     {
+        // Empty traces are the expected result, so they must not trigger the retry
+        // used by tests which expect the agent to receive a trace.
         $traces = $this->inWebServer(
             function ($execute) {
                 $output = $execute(GetSpec::create('default', '/'));
@@ -43,7 +45,8 @@ class ComposerInteroperabilityTest extends BaseTestCase
             ],
             [
                 'datadog.trace.sources_path' => 'do_not_exists',
-            ]
+            ],
+            false
         );
 
         // Will fallback to installed sources, which does not include DDTrace, only api/, thus doing a Noop

--- a/tests/DistributedTracing/GH1070OriginHeaderSegfault/GH1070OriginHeaderSegfaultTest.php
+++ b/tests/DistributedTracing/GH1070OriginHeaderSegfault/GH1070OriginHeaderSegfaultTest.php
@@ -31,6 +31,7 @@ final class GH1070OriginHeaderSegfaultTest extends IntegrationTestCase
                 'DD_TRACE_DEBUG' => 1,
             ],
             [],
+            true,
             $curlInfo
         );
 

--- a/tests/ext/background-sender/agent_sampling_sidecar.phpt
+++ b/tests/ext/background-sender/agent_sampling_sidecar.phpt
@@ -18,6 +18,9 @@ datadog.trace.agent_test_session_token=background-sender/agent_sampling_sidecar
 <?php
 include __DIR__ . '/../includes/request_replayer.inc';
 
+$contents = [];
+$filename = null;
+
 // Wait until the sidecar has published this test invocation's response. Each
 // invocation uses random markers so a repeated or parallel run cannot match a
 // stale shared-memory file left by an earlier process.
@@ -29,6 +32,9 @@ function checkUpdated($marker) {
                 if (@filesize($f) < 5000) {
                     $file = @file_get_contents($f);
                     if (@strpos($file, $marker) !== false) {
+                        global $contents, $filename;
+                        $filename = $f;
+                        $contents[] = bin2hex($file);
                         return;
                     }
                 }
@@ -36,19 +42,30 @@ function checkUpdated($marker) {
             $fn = "us" . "leep"; // do not retry
             $fn(100000);
         } while (--$retries);
+        foreach (glob("/dev/shm/*") as $f) {
+            var_dump($f, bin2hex(file_get_contents($f)));
+        }
         throw new RuntimeException("Timed out waiting for sidecar sampling configuration marker: {$marker}");
+    }
+}
+
+function recordContents() {
+    if (PHP_OS === "Linux") {
+        global $contents, $filename;
+        $contents[] = bin2hex(file_get_contents($filename));
     }
 }
 
 $rr = new RequestReplayer();
 $rr->replayRequest(); // cleanup possible leftover
 
-$get_sampling = function($label, $expected) use ($rr) {
+$errors = [];
+$get_sampling = function($label, $expected) use ($rr, &$errors) {
     $root = json_decode($rr->waitForDataAndReplay()["body"], true);
     $spans = $root["chunks"][0]["spans"] ?? $root[0];
     $priority = $spans[0]["metrics"]["_sampling_priority_v1"];
     if ($priority != $expected) {
-        throw new RuntimeException("{$label} sampling priority: expected {$expected}, got {$priority}");
+        $errors[] = "{$label} sampling priority: expected {$expected}, got {$priority}";
     }
     return $priority;
 };
@@ -68,8 +85,10 @@ checkUpdated($firstMarker);
 
 $rr->setResponse(["rate_by_service" => ["service:,env:" => 0, "service:foo,env:none" => 1, $secondMarker => 0]]);
 
+recordContents();
 \DDTrace\start_span();
 \DDTrace\close_span();
+recordContents();
 
 checkUpdated($secondMarker);
 
@@ -78,12 +97,23 @@ echo "Generic sampling: {$get_sampling('Generic', 0)}\n";
 // reset it for other tests
 $rr->setResponse(["rate_by_service" => []]);
 
+recordContents();
 $s = \DDTrace\start_span();
 $s->service = "foo";
 $s->env = "none";
 \DDTrace\close_span();
+recordContents();
 
 echo "Specific sampling: {$get_sampling('Specific', 1)}\n";
+
+if ($errors) {
+    foreach ($errors as $error) {
+        echo "{$error}\n";
+    }
+    if (PHP_OS === "Linux") {
+        var_dump($contents);
+    }
+}
 
 ?>
 --EXPECTF--

--- a/tests/ext/background-sender/agent_sampling_sidecar.phpt
+++ b/tests/ext/background-sender/agent_sampling_sidecar.phpt
@@ -18,10 +18,9 @@ datadog.trace.agent_test_session_token=background-sender/agent_sampling_sidecar
 <?php
 include __DIR__ . '/../includes/request_replayer.inc';
 
-$contents = [];
-$filename = null;
-
-// Race conditions are annoying, especially with parallel test runs
+// Wait until the sidecar has published this test invocation's response. Each
+// invocation uses random markers so a repeated or parallel run cannot match a
+// stale shared-memory file left by an earlier process.
 function checkUpdated($marker) {
     if (PHP_OS === "Linux") {
         $retries = 100;
@@ -30,9 +29,6 @@ function checkUpdated($marker) {
                 if (@filesize($f) < 5000) {
                     $file = @file_get_contents($f);
                     if (@strpos($file, $marker) !== false) {
-                        global $contents, $filename;
-                        $filename = $f;
-                        $contents[] = bin2hex($file);
                         return;
                     }
                 }
@@ -40,69 +36,54 @@ function checkUpdated($marker) {
             $fn = "us" . "leep"; // do not retry
             $fn(100000);
         } while (--$retries);
-        foreach (glob("/dev/shm/*") as $f) {
-            var_dump($f, bin2hex(file_get_contents($f)));
-        }
-    }
-}
-
-function recordContents() {
-    if (PHP_OS === "Linux") {
-        global $contents, $filename;
-        $contents[] = bin2hex(file_get_contents($filename));
+        throw new RuntimeException("Timed out waiting for sidecar sampling configuration marker: {$marker}");
     }
 }
 
 $rr = new RequestReplayer();
 $rr->replayRequest(); // cleanup possible leftover
 
-$expected = [1,0,1];
-$error = false;
-$get_sampling = function() use ($rr, &$expected, &$error) {
+$get_sampling = function($label, $expected) use ($rr) {
     $root = json_decode($rr->waitForDataAndReplay()["body"], true);
     $spans = $root["chunks"][0]["spans"] ?? $root[0];
     $priority = $spans[0]["metrics"]["_sampling_priority_v1"];
-    if ($priority != array_shift($expected)) {
-        $error = true;
+    if ($priority != $expected) {
+        throw new RuntimeException("{$label} sampling priority: expected {$expected}, got {$priority}");
     }
     return $priority;
 };
 
-$rr->setResponse(["rate_by_service" => ["service:,env:" => 0, "service:agent_sampling_sidecar_test,env:first" => 1]]);
+$nonce = getmypid() . "-" . bin2hex(random_bytes(8));
+$firstMarker = "service:agent-sampling-sidecar-sync-{$nonce},env:first";
+$secondMarker = "service:agent-sampling-sidecar-sync-{$nonce},env:second";
+
+$rr->setResponse(["rate_by_service" => ["service:,env:" => 0, $firstMarker => 1]]);
 
 \DDTrace\start_span();
 \DDTrace\close_span();
 
-echo "Initial sampling: {$get_sampling()}\n";
+echo "Initial sampling: {$get_sampling('Initial', 1)}\n";
 
-checkUpdated("service:agent_sampling_sidecar_test,env:first");
+checkUpdated($firstMarker);
 
-$rr->setResponse(["rate_by_service" => ["service:,env:" => 0, "service:foo,env:none" => 1, "service:agent_sampling_sidecar_test,env:second" => 0]]);
+$rr->setResponse(["rate_by_service" => ["service:,env:" => 0, "service:foo,env:none" => 1, $secondMarker => 0]]);
 
-recordContents();
 \DDTrace\start_span();
 \DDTrace\close_span();
-recordContents();
 
-checkUpdated("service:agent_sampling_sidecar_test,env:second");
+checkUpdated($secondMarker);
 
-echo "Generic sampling: {$get_sampling()}\n";
+echo "Generic sampling: {$get_sampling('Generic', 0)}\n";
 
 // reset it for other tests
 $rr->setResponse(["rate_by_service" => []]);
 
-recordContents();
 $s = \DDTrace\start_span();
 $s->service = "foo";
 $s->env = "none";
 \DDTrace\close_span();
-recordContents();
 
-echo "Specific sampling: {$get_sampling()}\n";
-
-if ($error && PHP_OS === "Linux") {
-    var_dump($contents);
-}
+echo "Specific sampling: {$get_sampling('Specific', 1)}\n";
 
 ?>
 --EXPECTF--


### PR DESCRIPTION
### Description

This fixes two different sidecar flakes.

1.  `inWebServer()` retries the entire server lifecycle when no traces are received, but `testComposerInteroperabilityWhenNoInitHook` expects no traces. It then kills a healthy PHP server and immediately restarts it on the same port. With telemetry enabled, the extension can start a sidecar that briefly outlives the forcibly stopped PHP process and may retain the server socket. The unnecessary retry then fails with Server never came up. Fixed by setting `retries=0` for this test. There are no other tests I could find that also assert that no traces are made.
2. Fixes a race in the `agent_sampling_sidecar.phpt` caused by matching stale shared-memory data from earlier or parallel test processes. Each invocation now uses unique sampling configuration markers, ensuring
 it waits for its own sidecar updates. Failures also report concise, actionable messages instead of dumping large shared-memory buffers.

### Reviewer checklist
- [ ] Test coverage seems ok.
- [ ] Appropriate labels assigned.
